### PR TITLE
Assembler refactoring

### DIFF
--- a/indra/pysb_assembler.py
+++ b/indra/pysb_assembler.py
@@ -49,6 +49,7 @@ class BaseAgentSet(object):
     def __getitem__(self, name):
         return self.agents[name]
 
+
 class BaseAgent(object):
     def __init__(self, name):
         self.name = name
@@ -133,9 +134,11 @@ default_mod_site_names = {
     'Phosphatase': 'phospho',
 }
 
+
 def get_binding_site_name(name):
     binding_site = name.lower()
     return binding_site
+
 
 def site_name(stmt):
     """Return all site names for a modification-type statement."""
@@ -152,6 +155,7 @@ def site_name(stmt):
 
     return names
 
+
 def get_activating_mods(agent, agent_set):
     act_mods = agent_set[agent.name].activating_mods
     if not act_mods:
@@ -167,6 +171,7 @@ def add_rule_to_model(model, rule):
     except ComponentDuplicateNameError:
         msg = "Rule %s already in model! Skipping." % rule.name
         warnings.warn(msg)
+
 
 def get_create_parameter(model, name, value, unique=True):
     """Return parameter with given name, creating it if needed.
@@ -195,16 +200,15 @@ def get_create_parameter(model, name, value, unique=True):
     model.add_component(parameter)
     return parameter
 
-def get_complex_pattern(model, agent, agent_set, extra_fields=None):
-    '''
-    Constructs a PySB ComplexPattern from an Agent
-    '''
-    monomer = model.monomers[agent.name]
 
+def get_complex_pattern(model, agent, agent_set, extra_fields=None):
+    """Constructs a PySB ComplexPattern from an Agent"""
+
+    monomer = model.monomers[agent.name]
     pattern = {}
 
     if extra_fields is not None:
-        for k,v in extra_fields.iteritems():
+        for k, v in extra_fields.iteritems():
             pattern[k] = v
     if agent.bound_to:
         # Here we make the assumption that the binding site
@@ -226,10 +230,12 @@ def get_complex_pattern(model, agent, agent_set, extra_fields=None):
     complex_pattern = monomer(**pattern)
     return complex_pattern
 
+
 def add_default_initial_conditions(model):
     # Iterate over all monomers
     for m in model.monomers:
         set_base_initial_condition(model, m, 100.0)
+
 
 def set_base_initial_condition(model, monomer, value):
     # Build up monomer pattern dict
@@ -248,6 +254,7 @@ def set_base_initial_condition(model, monomer, value):
         p = Parameter(pname, value)
         model.add_component(p)
         model.initial(mp, p)
+
 
 def get_annotation(component, db_name, db_ref):
     '''
@@ -276,6 +283,7 @@ def get_annotation(component, db_name, db_ref):
 
 class UnknownPolicyError(Exception):
     pass
+
 
 class PysbAssembler(object):
     def __init__(self, policies=None):
@@ -390,12 +398,13 @@ def complex_monomers_one_step(stmt, agent_set):
 complex_monomers_interactions_only = complex_monomers_one_step
 complex_monomers_default = complex_monomers_one_step
 
+
 def complex_assemble_one_step(stmt, model, agent_set):
     pairs = itertools.combinations(stmt.members, 2)
     for pair in pairs:
         agent1 = pair[0]
         agent2 = pair[1]
-        param_name = agent1.name[0].lower() +\
+        param_name = agent1.name[0].lower() + \
                      agent2.name[0].lower() + '_bind'
         kf_bind = get_create_parameter(model, 'kf_' + param_name, 1e-6)
         kr_bind = get_create_parameter(model, 'kr_' + param_name, 1e-6)
@@ -417,9 +426,9 @@ def complex_assemble_one_step(stmt, model, agent_set):
         agent2_pattern = get_complex_pattern(model, agent2, agent_set)
         agent1_bs = get_binding_site_name(agent2.name)
         agent2_bs = get_binding_site_name(agent1.name)
-        r = Rule(rule_name, agent1_pattern(**{agent1_bs: None}) +\
+        r = Rule(rule_name, agent1_pattern(**{agent1_bs: None}) + \
                             agent2_pattern(**{agent2_bs: None}) >>
-                            agent1_pattern(**{agent1_bs: 1}) %\
+                            agent1_pattern(**{agent1_bs: 1}) % \
                             agent2_pattern(**{agent2_bs: 1}),
                             kf_bind)
         add_rule_to_model(model, r)
@@ -430,12 +439,13 @@ def complex_assemble_one_step(stmt, model, agent_set):
                                             agent_set)
         agent2_uncond = get_complex_pattern(model, ist.Agent(agent2.name),
                                             agent_set)
-        r = Rule(rule_name, agent1_uncond(**{agent1_bs: 1}) %\
+        r = Rule(rule_name, agent1_uncond(**{agent1_bs: 1}) % \
                             agent2_uncond(**{agent2_bs: 1}) >>
-                            agent1_uncond(**{agent1_bs: None}) +\
+                            agent1_uncond(**{agent1_bs: None}) + \
                             agent2_uncond(**{agent2_bs: None}),
                             kr_bind)
         add_rule_to_model(model, r)
+
 
 def complex_assemble_multi_way(stmt, model, agent_set):
     # Get the rate parameter
@@ -513,14 +523,14 @@ def complex_assemble_multi_way(stmt, model, agent_set):
                 right_pattern = mono(**right_site_dict)
             else:
                 bound = model.monomers[bound_name]
-                left_site_dict[bound_bs] =\
+                left_site_dict[bound_bs] = \
                     bond_counter
-                right_site_dict[bound_bs] =\
+                right_site_dict[bound_bs] = \
                     bond_counter
                 left_pattern = mono(**left_site_dict) % \
-                                bound(**{gene_bs:bond_counter})
+                                bound(**{gene_bs: bond_counter})
                 right_pattern = mono(**right_site_dict) % \
-                                bound(**{gene_bs:bond_counter})
+                                bound(**{gene_bs: bond_counter})
                 bond_counter += 1
         else:
             left_pattern = mono(**left_site_dict)
@@ -545,6 +555,7 @@ def phosphorylation_monomers_interactions_only(stmt, agent_set):
     # See NOTE in monomers_one_step, below
     sub.create_site(site_name(stmt)[0], ('u', 'p'))
 
+
 def phosphorylation_monomers_one_step(stmt, agent_set):
     enz = agent_set.get_create_base_agent(stmt.enz)
     sub = agent_set.get_create_base_agent(stmt.sub)
@@ -556,6 +567,7 @@ def phosphorylation_monomers_one_step(stmt, agent_set):
     # be revisited.
     sub.create_site(site_name(stmt)[0], ('u', 'p'))
 
+
 def phosphorylation_monomers_two_step(stmt, agent_set):
     enz = agent_set.get_create_base_agent(stmt.enz)
     sub = agent_set.get_create_base_agent(stmt.sub)
@@ -566,6 +578,7 @@ def phosphorylation_monomers_two_step(stmt, agent_set):
     sub.create_site(get_binding_site_name(enz.name))
 
 phosphorylation_monomers_default = phosphorylation_monomers_one_step
+
 
 def phosphorylation_assemble_interactions_only(stmt, model, agent_set):
     kf_bind = get_create_parameter(model, 'kf_bind', 1.0, unique=False)
@@ -582,13 +595,14 @@ def phosphorylation_assemble_interactions_only(stmt, model, agent_set):
     # Create a rule specifying that the substrate binds to the kinase at
     # its active site
     r = Rule(rule_name,
-                enz(**{active_site:None}) + sub(**{site:None}) <>
-                enz(**{active_site:1}) + sub(**{site:1}),
+                enz(**{active_site: None}) + sub(**{site: None}) <>
+                enz(**{active_site: 1}) + sub(**{site: 1}),
                 kf_bind, kr_bind)
     add_rule_to_model(model, r)
 
+
 def phosphorylation_assemble_one_step(stmt, model, agent_set):
-    param_name = 'kf_' + stmt.enz.name[0].lower() +\
+    param_name = 'kf_' + stmt.enz.name[0].lower() + \
                     stmt.sub.name[0].lower() + '_phos'
     kf_phospho = get_create_parameter(model, param_name, 1e-6)
 
@@ -596,27 +610,28 @@ def phosphorylation_assemble_one_step(stmt, model, agent_set):
     site = site_name(stmt)[0]
 
     enz_pattern = get_complex_pattern(model, stmt.enz, agent_set)
-    sub_unphos = get_complex_pattern(model, stmt.sub, agent_set, 
+    sub_unphos = get_complex_pattern(model, stmt.sub, agent_set,
         extra_fields={site: 'u'})
-    sub_phos = get_complex_pattern(model, stmt.sub, agent_set, 
+    sub_phos = get_complex_pattern(model, stmt.sub, agent_set,
         extra_fields={site: 'p'})
 
     enz_act_mods = get_activating_mods(stmt.enz, agent_set)
     for i, am in enumerate(enz_act_mods):
-        rule_name = '%s_phospho_%s_%s_%d' %\
-            (stmt.enz.name, stmt.sub.name, site, i+1)
+        rule_name = '%s_phospho_%s_%s_%d' % \
+            (stmt.enz.name, stmt.sub.name, site, i + 1)
         r = Rule(rule_name,
                 enz_pattern(am) + sub_unphos >>
                 enz_pattern(am) + sub_phos,
                 kf_phospho)
         add_rule_to_model(model, r)
 
+
 def phosphorylation_assemble_two_step(stmt, model, agent_set):
     sub_bs = get_binding_site_name(stmt.sub.name)
     enz_bound = get_complex_pattern(model, stmt.enz, agent_set,
-        extra_fields = {sub_bs: 1})
+        extra_fields={sub_bs: 1})
     enz_unbound = get_complex_pattern(model, stmt.enz, agent_set,
-        extra_fields = {sub_bs: None})
+        extra_fields={sub_bs: None})
     sub_pattern = get_complex_pattern(model, stmt.sub, agent_set)
 
     param_name = ('kf_' + stmt.enz.name[0].lower() +
@@ -634,30 +649,30 @@ def phosphorylation_assemble_two_step(stmt, model, agent_set):
     enz_act_mods = get_activating_mods(stmt.enz, agent_set)
     enz_bs = get_binding_site_name(stmt.enz.name)
     for i, am in enumerate(enz_act_mods):
-        rule_name = '%s_phospho_bind_%s_%s_%d' %\
-            (stmt.enz.name, stmt.sub.name, site, i+1)
+        rule_name = '%s_phospho_bind_%s_%s_%d' % \
+            (stmt.enz.name, stmt.sub.name, site, i + 1)
         r = Rule(rule_name,
-            enz_unbound(am) +\
+            enz_unbound(am) + \
             sub_pattern(**{site: 'u', enz_bs: None}) >>
-            enz_bound(am) %\
+            enz_bound(am) % \
             sub_pattern(**{site: 'u', enz_bs: 1}),
             kf_bind)
         add_rule_to_model(model, r)
 
-        rule_name = '%s_phospho_%s_%s_%d' %\
-            (stmt.enz.name, stmt.sub.name, site, i+1)
+        rule_name = '%s_phospho_%s_%s_%d' % \
+            (stmt.enz.name, stmt.sub.name, site, i + 1)
         r = Rule(rule_name,
-            enz_bound(am) %\
+            enz_bound(am) % \
                 sub_pattern(**{site: 'u', enz_bs: 1}) >>
-            enz_unbound(am) +\
+            enz_unbound(am) + \
                 sub_pattern(**{site: 'p', enz_bs: None}),
             kf_phospho)
         add_rule_to_model(model, r)
 
     rule_name = '%s_dissoc_%s' % (stmt.enz.name, stmt.sub.name)
-    r = Rule(rule_name, model.monomers[stmt.enz.name](**{sub_bs: 1}) %\
+    r = Rule(rule_name, model.monomers[stmt.enz.name](**{sub_bs: 1}) % \
              model.monomers[stmt.sub.name](**{enz_bs: 1}) >>
-             model.monomers[stmt.enz.name](**{sub_bs: None}) +\
+             model.monomers[stmt.enz.name](**{sub_bs: None}) + \
              model.monomers[stmt.sub.name](**{enz_bs: None}), kr_bind)
     add_rule_to_model(model, r)
 
@@ -668,6 +683,7 @@ phosphorylation_assemble_default = phosphorylation_assemble_one_step
 def autophosphorylation_monomers_interactions_only(stmt, agent_set):
     enz = agent_set.get_create_base_agent(stmt.enz)
     enz.create_site(site_name(stmt)[0], ('u', 'p'))
+
 
 def autophosphorylation_monomers_one_step(stmt, agent_set):
     enz = agent_set.get_create_base_agent(stmt.enz)
@@ -681,8 +697,10 @@ def autophosphorylation_monomers_one_step(stmt, agent_set):
 
 autophosphorylation_monomers_default = autophosphorylation_monomers_one_step
 
+
 def autophosphorylation_assemble_interactions_only(stmt, model, agent_set):
     stmt.assemble_one_step(model, agent_set)
+
 
 def autophosphorylation_assemble_one_step(stmt, model, agent_set):
     param_name = 'kf_' + stmt.enz.name[0].lower() + '_autophos'
@@ -708,6 +726,7 @@ def transphosphorylation_monomers_interactions_only(stmt, agent_set):
     sub = agent_set.get_create_base_agent(stmt.enz)
     sub.create_site(site_name(stmt)[0], ('u', 'p'))
 
+
 def transphosphorylation_monomers_one_step(stmt, agent_set):
     enz = agent_set.get_create_base_agent(stmt.enz)
     # NOTE: This assumes that a Phosphorylation statement will only ever
@@ -715,30 +734,32 @@ def transphosphorylation_monomers_one_step(stmt, agent_set):
     # if there is more than one site, they will be parsed into separate
     # Phosphorylation statements, i.e., phosphorylation is assumed to be
     # distributive. If this is not the case, this assumption will need to
-    # be revisited. 
+    # be revisited.
     sub = agent_set.get_create_base_agent(ist.Agent(stmt.enz.bound_to))
     sub.create_site(site_name(stmt)[0], ('u', 'p'))
 
 transphosphorylation_monomers_default = transphosphorylation_monomers_one_step
 
+
 def transphosphorylation_assemble_interactions_only(stmt, model, agent_set):
     stmt.assemble_one_step(model, agent_set)
+
 
 def transphosphorylation_assemble_one_step(stmt, model, agent_set):
     param_name = ('kf_' + stmt.enz.name[0].lower() +
                   stmt.enz.bound_to[0].lower() + '_transphos')
-    kf  = get_create_parameter(model, param_name, 1e-3)
+    kf = get_create_parameter(model, param_name, 1e-3)
 
     site = site_name(stmt)[0]
     enz_pattern = get_complex_pattern(model, stmt.enz, agent_set)
     sub_unphos = get_complex_pattern(model, ist.Agent(stmt.enz.bound_to),
-        agent_set, extra_fields = {site: 'u'})
+        agent_set, extra_fields={site: 'u'})
     sub_phos = get_complex_pattern(model, ist.Agent(stmt.enz.bound_to),
-        agent_set, extra_fields = {site: 'p'})
+        agent_set, extra_fields={site: 'p'})
 
     rule_name = '%s_transphospho_%s_%s' % (stmt.enz.name,
                                            stmt.enz.bound_to, site)
-    r = Rule(rule_name, enz_pattern % sub_unphos >>\
+    r = Rule(rule_name, enz_pattern % sub_unphos >> \
                     enz_pattern % sub_phos, kf)
     add_rule_to_model(model, r)
 
@@ -753,6 +774,7 @@ def activityactivity_monomers_interactions_only(stmt, agent_set):
     obj.create_site(active_site_names[stmt.obj_activity])
     obj.create_site(default_mod_site_names[stmt.subj_activity])
 
+
 def activityactivity_monomers_one_step(stmt, agent_set):
     subj = agent_set.get_create_base_agent(stmt.subj)
     subj.create_site(stmt.subj_activity, ('inactive', 'active'))
@@ -760,6 +782,7 @@ def activityactivity_monomers_one_step(stmt, agent_set):
     obj.create_site(stmt.obj_activity, ('inactive', 'active'))
 
 activityactivity_monomers_default = activityactivity_monomers_one_step
+
 
 def activityactivity_assemble_interactions_only(stmt, model):
     kf_bind = get_create_parameter(model, 'kf_bind', 1.0, unique=False)
@@ -777,29 +800,30 @@ def activityactivity_assemble_interactions_only(stmt, model):
              kf_bind)
     add_rule_to_model(model, r)
 
+
 def activityactivity_assemble_one_step(stmt, model, agent_set):
-    subj_pattern = get_complex_pattern(model, stmt.subj, agent_set, 
+    subj_pattern = get_complex_pattern(model, stmt.subj, agent_set,
         extra_fields={stmt.subj_activity: 'active'})
-    obj_inactive = get_complex_pattern(model, stmt.obj, agent_set, 
+    obj_inactive = get_complex_pattern(model, stmt.obj, agent_set,
         extra_fields={stmt.obj_activity: 'inactive'})
-    obj_active = get_complex_pattern(model, stmt.obj, agent_set, 
+    obj_active = get_complex_pattern(model, stmt.obj, agent_set,
         extra_fields={stmt.obj_activity: 'active'})
 
-    param_name = 'kf_' + stmt.subj.name[0].lower() +\
+    param_name = 'kf_' + stmt.subj.name[0].lower() + \
                         stmt.obj.name[0].lower() + '_act'
     kf_one_step_activate = \
                    get_create_parameter(model, param_name, 1e-6)
 
-    rule_name = '%s_%s_activates_%s_%s' %\
+    rule_name = '%s_%s_activates_%s_%s' % \
         (stmt.subj.name, stmt.subj_activity, stmt.obj.name,
          stmt.obj_activity)
 
     if stmt.relationship == 'increases':
-       r = Rule(rule_name,
+        r = Rule(rule_name,
             subj_pattern + obj_inactive >> subj_pattern + obj_active,
             kf_one_step_activate)
     else:
-       r = Rule(rule_name,
+        r = Rule(rule_name,
             subj_pattern + obj_active >> subj_pattern + obj_inactive,
             kf_one_step_activate)
 
@@ -815,10 +839,12 @@ def dephosphorylation_monomers_interactions_only(stmt, agent_set):
     sub = agent_set.get_create_base_agent(stmt.sub)
     sub.create_site(site_name(stmt)[0], ('u', 'p'))
 
+
 def dephosphorylation_monomers_one_step(stmt, agent_set):
     phos = agent_set.get_create_base_agent(stmt.phos)
     sub = agent_set.get_create_base_agent(stmt.sub)
     sub.create_site(site_name(stmt)[0], ('u', 'p'))
+
 
 def dephosphorylation_monomers_two_step(stmt, agent_set):
     phos = agent_set.get_create_base_agent(stmt.phos)
@@ -830,6 +856,7 @@ def dephosphorylation_monomers_two_step(stmt, agent_set):
     sub.create_site(get_binding_site_name(phos.name))
 
 dephosphorylation_monomers_default = dephosphorylation_monomers_one_step
+
 
 def dephosphorylation_assemble_interactions_only(stmt, model, agent_set):
     kf_bind = get_create_parameter(model, 'kf_bind', 1.0, unique=False)
@@ -845,16 +872,17 @@ def dephosphorylation_assemble_interactions_only(stmt, model, agent_set):
              kf_bind)
     add_rule_to_model(model, r)
 
+
 def dephosphorylation_assemble_one_step(stmt, model, agent_set):
-    param_name = 'kf_' + stmt.phos.name[0].lower() +\
+    param_name = 'kf_' + stmt.phos.name[0].lower() + \
                 stmt.sub.name[0].lower() + '_dephos'
     kf_dephospho = get_create_parameter(model, param_name, 1e-6)
 
     site = site_name(stmt)[0]
     phos_pattern = get_complex_pattern(model, stmt.phos, agent_set)
-    sub_phos = get_complex_pattern(model, stmt.sub, agent_set, 
+    sub_phos = get_complex_pattern(model, stmt.sub, agent_set,
         extra_fields={site: 'p'})
-    sub_unphos = get_complex_pattern(model, stmt.sub, agent_set, 
+    sub_unphos = get_complex_pattern(model, stmt.sub, agent_set,
         extra_fields={site: 'u'})
 
     r = Rule('%s_dephospho_%s_%s' %
@@ -864,22 +892,23 @@ def dephosphorylation_assemble_one_step(stmt, model, agent_set):
              kf_dephospho)
     add_rule_to_model(model, r)
 
+
 def dephosphorylation_assemble_two_step(stmt, model, agent_set):
     sub_bs = get_binding_site_name(stmt.sub.name)
     phos_bs = get_binding_site_name(stmt.phos.name)
     phos_bound = get_complex_pattern(model, stmt.phos, agent_set,
-        extra_fields = {sub_bs: 1})
+        extra_fields={sub_bs: 1})
     phos_unbound = get_complex_pattern(model, stmt.phos, agent_set,
-        extra_fields = {sub_bs: None})
+        extra_fields={sub_bs: None})
     sub_pattern = get_complex_pattern(model, stmt.sub, agent_set)
 
-    param_name = 'kf_' + stmt.phos.name[0].lower() +\
+    param_name = 'kf_' + stmt.phos.name[0].lower() + \
         stmt.sub.name[0].lower() + '_bind'
     kf_bind = get_create_parameter(model, param_name, 1e-6)
-    param_name = 'kr_' + stmt.phos.name[0].lower() +\
+    param_name = 'kr_' + stmt.phos.name[0].lower() + \
         stmt.sub.name[0].lower() + '_bind'
     kr_bind = get_create_parameter(model, param_name, 1e-3)
-    param_name = 'kc_' + stmt.phos.name[0].lower() +\
+    param_name = 'kc_' + stmt.phos.name[0].lower() + \
         stmt.sub.name[0].lower() + '_dephos'
     kf_phospho = get_create_parameter(model, param_name, 1e-3)
 
@@ -887,30 +916,30 @@ def dephosphorylation_assemble_two_step(stmt, model, agent_set):
 
     phos_act_mods = get_activating_mods(stmt.phos, agent_set)
     for i, am in enumerate(phos_act_mods):
-        rule_name = '%s_dephos_bind_%s_%s_%d' %\
-            (stmt.phos.name, stmt.sub.name, site, i+1)
+        rule_name = '%s_dephos_bind_%s_%s_%d' % \
+            (stmt.phos.name, stmt.sub.name, site, i + 1)
         r = Rule(rule_name,
-            phos_unbound(am) +\
+            phos_unbound(am) + \
             sub_pattern(**{site: 'p', phos_bs: None}) >>
-            phos_bound(am) %\
+            phos_bound(am) % \
             sub_pattern(**{site: 'p', phos_bs: 1}),
             kf_bind, kr_bind)
         add_rule_to_model(model, r)
-    
-        rule_name = '%s_dephos_%s_%s_%d' %\
-            (stmt.phos.name, stmt.sub.name, site, i+1)
+
+        rule_name = '%s_dephos_%s_%s_%d' % \
+            (stmt.phos.name, stmt.sub.name, site, i + 1)
         r = Rule(rule_name,
-            phos_bound(am) %\
+            phos_bound(am) % \
                 sub_pattern(**{site: 'p', phos_bs: 1}) >>
-            phos_unbound(am) +\
+            phos_unbound(am) + \
                 sub_pattern(**{site: 'u', phos_bs: None}),
             kf_phospho)
         add_rule_to_model(model, r)
-    
+
     rule_name = '%s_dissoc_%s' % (stmt.phos.name, stmt.sub.name)
-    r = Rule(rule_name, model.monomers[stmt.phos.name](**{sub_bs: 1}) %\
+    r = Rule(rule_name, model.monomers[stmt.phos.name](**{sub_bs: 1}) % \
              model.monomers[stmt.sub.name](**{phos_bs: 1}) >>
-             model.monomers[stmt.phos.name](**{sub_bs: None}) +\
+             model.monomers[stmt.phos.name](**{sub_bs: None}) + \
              model.monomers[stmt.sub.name](**{phos_bs: None}), kr_bind)
     add_rule_to_model(model, r)
 
@@ -924,6 +953,7 @@ def rasgef_monomers_interactions_only(stmt, agent_set):
     ras = agent_set.get_create_base_agent(stmt.ras)
     ras.create_site('p_loop')
 
+
 def rasgef_monomers_one_step(stmt, agent_set):
     gef = agent_set.get_create_base_agent(stmt.gef)
     gef.create_site(stmt.gef_activity, ('inactive', 'active'))
@@ -932,28 +962,30 @@ def rasgef_monomers_one_step(stmt, agent_set):
 
 rasgef_monomers_default = rasgef_monomers_one_step
 
+
 def rasgef_assemble_interactions_only(stmt, model, agent_set):
     kf_bind = get_create_parameter(model, 'kf_bind', 1.0, unique=False)
     gef = model.monomers[stmt.gef.name]
     ras = model.monomers[stmt.ras.name]
     r = Rule('%s_activates_%s' %
              (stmt.gef.name, stmt.ras.name),
-             gef(**{'gef_site':None}) +
-             ras(**{'p_loop':None}) >>
+             gef(**{'gef_site': None}) +
+             ras(**{'p_loop': None}) >>
              gef(**{'gef_site': 1}) +
              ras(**{'p_loop': 1}),
              kf_bind)
     add_rule_to_model(model, r)
 
+
 def rasgef_assemble_one_step(stmt, model, agent_set):
-    gef_pattern = get_complex_pattern(model, stmt.gef, agent_set, 
+    gef_pattern = get_complex_pattern(model, stmt.gef, agent_set,
         extra_fields={stmt.gef_activity: 'active'})
     ras_inactive = get_complex_pattern(model, stmt.ras, agent_set,
         extra_fields={'GtpBound': 'inactive'})
     ras_active = get_complex_pattern(model, stmt.ras, agent_set,
         extra_fields={'GtpBound': 'active'})
 
-    param_name = 'kf_' + stmt.gef.name[0].lower() +\
+    param_name = 'kf_' + stmt.gef.name[0].lower() + \
                     stmt.ras.name[0].lower() + '_gef'
     kf_gef = get_create_parameter(model, param_name, 1e-6)
 
@@ -974,6 +1006,7 @@ def rasgap_monomers_interactions_only(stmt, agent_set):
     ras = agent_set.get_create_base_agent(stmt.ras)
     ras.create_site('gtp_site')
 
+
 def rasgap_monomers_one_step(stmt, agent_set):
     gap = agent_set.get_create_base_agent(stmt.gap)
     gap.create_site(stmt.gap_activity, ('inactive', 'active'))
@@ -981,6 +1014,7 @@ def rasgap_monomers_one_step(stmt, agent_set):
     ras.create_site('GtpBound', ('inactive', 'active'))
 
 rasgap_monomers_default = rasgap_monomers_one_step
+
 
 def rasgap_assemble_interactions_only(stmt, model, agent_set):
     kf_bind = get_create_parameter(model, 'kf_bind', 1.0, unique=False)
@@ -995,15 +1029,16 @@ def rasgap_assemble_interactions_only(stmt, model, agent_set):
              kf_bind)
     add_rule_to_model(model, r)
 
+
 def rasgap_assemble_one_step(stmt, model, agent_set):
-    gap_pattern = get_complex_pattern(model, stmt.gap, agent_set, 
+    gap_pattern = get_complex_pattern(model, stmt.gap, agent_set,
         extra_fields={stmt.gap_activity: 'active'})
     ras_inactive = get_complex_pattern(model, stmt.ras, agent_set,
         extra_fields={'GtpBound': 'inactive'})
     ras_active = get_complex_pattern(model, stmt.ras, agent_set,
         extra_fields={'GtpBound': 'active'})
 
-    param_name = 'kf_' + stmt.gap.name[0].lower() +\
+    param_name = 'kf_' + stmt.gap.name[0].lower() + \
                     stmt.ras.name[0].lower() + '_gap'
     kf_gap = get_create_parameter(model, param_name, 1e-6)
 
@@ -1020,6 +1055,7 @@ rasgap_assemble_default = rasgap_assemble_one_step
 
 def activitymodification_monomers_interactions_only(stmt, agent_set):
     pass
+
 
 def activitymodification_monomers_one_step(stmt, agent_set):
     agent = agent_set.get_create_base_agent(stmt.monomer)
@@ -1044,8 +1080,10 @@ def activitymodification_monomers_one_step(stmt, agent_set):
 
 activitymodification_monomers_default = activitymodification_monomers_one_step
 
+
 def activitymodification_assemble_interactions_only(stmt, model, agent_set):
     pass
+
 
 def activitymodification_assemble_one_step(stmt, model, agent_set):
     pass

--- a/indra/pysb_assembler.py
+++ b/indra/pysb_assembler.py
@@ -1009,6 +1009,42 @@ def rasgap_assemble_one_step(stmt, model, agent_set):
 
 rasgap_assemble_default = rasgap_assemble_one_step
 
+# ACTIVITYMODIFICATION ######################################
+
+def activitymodification_monomers_interactions_only(stmt, agent_set):
+    pass
+
+def activitymodification_monomers_one_step(stmt, agent_set):
+    agent = agent_set.get_create_base_agent(stmt.monomer)
+    sites = site_name(stmt)
+    active_states = [states[m][1] for m in stmt.mod]
+
+    activity_pattern = {}
+    for i, s in enumerate(sites):
+        site_states = states[stmt.mod[i]]
+        active_state = site_states[1]
+        agent.create_site(s, site_states)
+        activity_pattern[s] = active_state
+
+    # Add this activity modification explicitly to the agent's list
+    # of activating modifications
+    agent.add_activating_modification(activity_pattern)
+    # Inactivating modifications will require a different treatment
+    # of the resolution of when the agent is active
+    if stmt.relationship == 'decreases':
+        warnings.warn('Inactivating modifications not currently '
+                      'implemented!')
+
+activitymodification_monomers_default = activitymodification_monomers_one_step
+
+def activitymodification_assemble_interactions_only(stmt, model, agent_set):
+    pass
+
+def activitymodification_assemble_one_step(stmt, model, agent_set):
+    pass
+
+activitymodification_assemble_default = activitymodification_assemble_one_step
+
 
 if __name__ == '__main__':
     pa = PysbAssembler()

--- a/indra/pysb_assembler.py
+++ b/indra/pysb_assembler.py
@@ -9,6 +9,7 @@ from bel import bel_api
 from biopax import biopax_api
 from trips import trips_api
 from indra import statements as ist
+import warnings
 
 SelfExporter.do_export = False
 

--- a/indra/pysb_assembler.py
+++ b/indra/pysb_assembler.py
@@ -1,15 +1,23 @@
-from pysb import Model, Monomer, Parameter, Annotation
+import itertools
+from sets import ImmutableSet
+
+from pysb import (Model, Monomer, Parameter, Rule, Annotation,
+        ComponentDuplicateNameError, ANY)
 from pysb.core import SelfExporter
 import pysb.export
 from bel import bel_api
 from biopax import biopax_api
 from trips import trips_api
-from indra.statements import Agent
+from indra import statements as ist
 
 SelfExporter.do_export = False
 
 class BaseAgentSet(object):
-    """A container for a set of BaseAgents. Wraps a dict of BaseAgent instances."""
+    """Container for a set of BaseAgents.
+
+    Wraps a dict of BaseAgent instances.
+    """
+
     def __init__(self):
         self.agents = {}
 
@@ -20,12 +28,12 @@ class BaseAgentSet(object):
         except KeyError:
             base_agent = BaseAgent(agent.name)
             self.agents[agent.name] = base_agent
-        
+
         if agent.bound_to:
-            bound_to = self.get_create_base_agent(Agent(agent.bound_to))
+            bound_to = self.get_create_base_agent(ist.Agent(agent.bound_to))
             bound_to.create_site(get_binding_site_name(agent.name))
             base_agent.create_site(get_binding_site_name(agent.bound_to))
-       
+
         # There might be overwrites here
         for db_name, db_ref in agent.db_refs.iteritems():
             base_agent.db_refs[db_name] = db_ref
@@ -74,6 +82,72 @@ def get_binding_site_name(name):
     binding_site = name.lower()
     return binding_site
 
+def add_rule_to_model(model, rule):
+    try:
+        model.add_component(rule)
+    # If this rule is already in the model, issue a warning and continue
+    except ComponentDuplicateNameError:
+        msg = "Rule %s already in model! Skipping." % rule.name
+        warnings.warn(msg)
+
+def get_create_parameter(model, name, value, unique=True):
+    """Return parameter with given name, creating it if needed.
+
+    If unique is false and the parameter exists, the value is not changed; if
+    it does not exist, it will be created. If unique is true then upon conflict
+    a number is added to the end of the parameter name.
+    """
+
+    parameter = model.parameters.get(name)
+
+    if not unique and parameter is not None:
+        return parameter
+
+    if unique:
+        pnum = 1
+        while True:
+            pname = name + '_%d' % pnum
+            if model.parameters.get(pname) is None:
+                break
+            pnum += 1
+    else:
+        pname = name
+
+    parameter = Parameter(pname, value)
+    model.add_component(parameter)
+    return parameter
+
+def get_complex_pattern(model, agent, agent_set, extra_fields=None):
+    '''
+    Constructs a PySB ComplexPattern from an Agent
+    '''
+    monomer = model.monomers[agent.name]
+
+    pattern = {}
+
+    if extra_fields is not None:
+        for k,v in extra_fields.iteritems():
+            pattern[k] = v
+    if agent.bound_to:
+        # Here we make the assumption that the binding site
+        # is simply named after the binding partner
+        if agent.bound_neg:
+            pattern[get_binding_site_name(agent.bound_to)] = None
+        else:
+            pattern[get_binding_site_name(agent.bound_to)] = ANY
+
+    # Add the pattern for the modifications of the agent
+    # TODO: This is specific to phosphorylation but we should be
+    # able to support other types as well
+    for m, mp in zip(agent.mods, agent.mod_sites):
+        mod = abbrevs[m]
+        mod_pos = mp if mp is not None else ''
+        mod_site = ('%s%s' % (mod, mod_pos))
+        pattern[mod_site] = 'p'
+
+    complex_pattern = monomer(**pattern)
+    return complex_pattern
+
 def add_default_initial_conditions(model):
     # Iterate over all monomers
     for m in model.monomers:
@@ -96,10 +170,10 @@ def set_base_initial_condition(model, monomer, value):
         p = Parameter(pname, value)
         model.add_component(p)
         model.initial(mp, p)
-    
+
 def get_annotation(component, db_name, db_ref):
     '''
-    Construct Annotation following format guidelines 
+    Construct Annotation following format guidelines
     given at http://identifiers.org/.
     '''
     url = 'http://identifiers.org/'
@@ -120,11 +194,15 @@ def get_annotation(component, db_name, db_ref):
         return None
     return Annotation(subj, obj, pred)
 
+class UnknownPolicyError(Exception):
+    pass
+
 class PysbAssembler(object):
-    def __init__(self):
+    def __init__(self, policies=None):
         self.statements = []
         self.agent_set = None
         self.model = None
+        self.policies = policies
 
     def statement_exists(self, stmt):
         for s in self.statements:
@@ -137,37 +215,54 @@ class PysbAssembler(object):
             if not self.statement_exists(stmt):
                 self.statements.append(stmt)
 
-    def make_model(self, initial_conditions=True, policies=None):
-        model = Model()
-        # Keep track of which policies we're using
-        self.policies = policies
+    def dispatch(self, stmt, stage, *args):
+        class_name = stmt.__class__.__name__
+        if not self.policies:
+            policy = 'default'
+        else:
+            policy = policies.get(class_name, 'default')
+        func_name = '%s_%s_%s' % (class_name.lower(), stage, policy)
+        func = globals().get(func_name)
+        if func is None:
+            raise UnknownPolicyError('%s function %s not defined' %
+                                     (stage, func_name))
+        return func(stmt, *args)
+
+    def monomers(self):
+        """Calls the appropriate monomers method based on policies."""
+        for stmt in self.statements:
+            self.dispatch(stmt, 'monomers', self.agent_set)
+
+    def assemble(self):
+        for stmt in self.statements:
+            self.dispatch(stmt, 'assemble', self.model, self.agent_set)
+
+    def make_model(self, initial_conditions=True):
+        self.model = Model()
         self.agent_set = BaseAgentSet()
         # Collect information about the monomers/self.agent_set from the
         # statements
-        for stmt in self.statements:
-            stmt.monomers(self.agent_set, policies=policies)
+        self.monomers()
         # Add the monomers to the model based on our BaseAgentSet
         for agent_name, agent in self.agent_set.iteritems():
             m = Monomer(agent_name, agent.sites, agent.site_states)
-            model.add_component(m)
+            self.model.add_component(m)
             for db_name, db_ref in agent.db_refs.iteritems():
                 a = get_annotation(m, db_name, db_ref)
                 if a is not None:
-                    model.add_annotation(a)
+                    self.model.add_annotation(a)
         # Iterate over the statements to generate rules
-        for stmt in self.statements:
-            stmt.assemble(model, self.agent_set, policies=policies)
+        self.assemble()
         # Add initial conditions
         if initial_conditions:
-            add_default_initial_conditions(model)
-        self.model = model
+            add_default_initial_conditions(self.model)
         return self.model
-    
+
     def print_model(self, fname='pysb_model.py'):
         if self.model is not None:
             with open(fname, 'wt') as fh:
                 fh.write(pysb.export.export(self.model, 'pysb_flat'))
-    
+
     def print_rst(self, fname='pysb_model.rst', module_name='pysb_module'):
         if self.model is not None:
             with open(fname, 'wt') as fh:
@@ -178,6 +273,183 @@ class PysbAssembler(object):
                 model_str = pysb.export.export(self.model, 'pysb_flat')
                 model_str = '\t' + model_str.replace('\n', '\n\t')
                 fh.write(model_str)
+
+
+# COMPLEX ##############################################
+
+def complex_monomers_one_step(stmt, agent_set):
+    """In this (very simple) implementation, proteins in a complex are
+    each given site names corresponding to each of the other members
+    of the complex (lower case). So the resulting complex can be
+    "fully connected" in that each member can be bound to
+    all the others."""
+    for i, member in enumerate(stmt.members):
+        gene_mono = agent_set.get_create_base_agent(member)
+        # Add sites for agent modifications
+        # TODO: This assumes phosphorylation, but in principle
+        # it could be some other modification
+        for m, mp in zip(member.mods, member.mod_sites):
+            mod = abbrevs[m]
+            mod_pos = mp if mp is not None else ''
+            mod_site = ('%s%s' % (mod, mod_pos))
+            gene_mono.create_site(mod_site, ['u', 'p'])
+
+        # Specify a binding site for each of the other complex members
+        # bp = abbreviation for "binding partner"
+        for j, bp in enumerate(stmt.members):
+            # The protein doesn't bind to itstmt!
+            if i == j:
+                continue
+            gene_mono.create_site(get_binding_site_name(bp.name))
+
+complex_monomers_interactions_only = complex_monomers_one_step
+complex_monomers_default = complex_monomers_one_step
+
+def complex_assemble_one_step(stmt, model, agent_set):
+    pairs = itertools.combinations(stmt.members, 2)
+    for pair in pairs:
+        agent1 = pair[0]
+        agent2 = pair[1]
+        param_name = agent1.name[0].lower() +\
+                     agent2.name[0].lower() + '_bind'
+        kf_bind = get_create_parameter(model, 'kf_' + param_name, 1e-6)
+        kr_bind = get_create_parameter(model, 'kr_' + param_name, 1e-6)
+
+        # Make a rule name
+        name_components = []
+        for m in pair:
+            if m.bound_to:
+                if m.bound_neg:
+                    name_components.append(m.name + '_n' + m.bound_to)
+                else:
+                    name_components.append(m.name + '_' + m.bound_to)
+            else:
+                name_components.append(m.name)
+
+        # Construct full patterns of each agent with conditions
+        rule_name = '_'.join(name_components) + '_bind'
+        agent1_pattern = get_complex_pattern(model, agent1, agent_set)
+        agent2_pattern = get_complex_pattern(model, agent2, agent_set)
+        agent1_bs = get_binding_site_name(agent2.name)
+        agent2_bs = get_binding_site_name(agent1.name)
+        r = Rule(rule_name, agent1_pattern(**{agent1_bs: None}) +\
+                            agent2_pattern(**{agent2_bs: None}) >>
+                            agent1_pattern(**{agent1_bs: 1}) %\
+                            agent2_pattern(**{agent2_bs: 1}),
+                            kf_bind)
+        add_rule_to_model(model, r)
+
+        # In reverse reaction, assume that dissocition is unconditional
+        rule_name = '_'.join(name_components) + '_dissociate'
+        agent1_uncond = get_complex_pattern(model, ist.Agent(agent1.name),
+                                            agent_set)
+        agent2_uncond = get_complex_pattern(model, ist.Agent(agent2.name),
+                                            agent_set)
+        r = Rule(rule_name, agent1_uncond(**{agent1_bs: 1}) %\
+                            agent2_uncond(**{agent2_bs: 1}) >>
+                            agent1_uncond(**{agent1_bs: None}) +\
+                            agent2_uncond(**{agent2_bs: None}),
+                            kr_bind)
+        add_rule_to_model(model, r)
+
+def complex_assemble_multi_way(stmt, model, agent_set):
+    # Get the rate parameter
+    abbr_name = ''.join([m.name[0].lower() for m in stmt.members])
+    kf_bind = get_create_parameter(model, 'kf_' + abbr_name + '_bind', 1e-6)
+    kr_bind = get_create_parameter(model, 'kr_' + abbr_name + '_bind', 1e-6)
+
+    # Make a rule name
+    name_components = []
+    for m in stmt.members:
+        if m.bound_to:
+            if m.bound_neg:
+                name_components.append(m.name + '_n' + m.bound_to)
+            else:
+                name_components.append(m.name + '_' + m.bound_to)
+        else:
+            name_components.append(m.name)
+    rule_name = '_'.join(name_components) + '_bind'
+    # Initialize the left and right-hand sides of the rule
+    lhs = ReactionPattern([])
+    rhs = ComplexPattern([], None)
+    # We need a unique bond index for each pair of proteins in the
+    # complex, resulting in n(n-1)/2 bond indices for a n-member complex.
+    # We keep track of the bond indices using the bond_indices dict,
+    # which maps each unique pair of members to a bond index.
+    bond_indices = {}
+    bond_counter = 1
+    for i, member in enumerate(stmt.members):
+        gene_name = member.name
+        mono = model.monomers[gene_name]
+        # Specify free and bound states for binding sites for each of
+        # the other complex members
+        # (bp = abbreviation for "binding partner")
+        left_site_dict = {}
+        right_site_dict = {}
+        for j, bp in enumerate(stmt.members):
+            bp_bs = get_binding_site_name(bp.name)
+            # The protein doesn't bind to itstmt!
+            if i == j:
+                continue
+            # Check to see if we've already created a bond index for these
+            # two binding partners
+            bp_set = ImmutableSet([i, j])
+            if bp_set in bond_indices:
+                bond_ix = bond_indices[bp_set]
+            # If we haven't see this pair of proteins yet, add a new bond
+            # index to the dict
+            else:
+                bond_ix = bond_counter
+                bond_indices[bp_set] = bond_ix
+                bond_counter += 1
+            # Fill in the entries for the site dicts
+            left_site_dict[bp_bs] = None
+            right_site_dict[bp_bs] = bond_ix
+
+        # Add the pattern for the modifications of the member
+        # TODO: This is specific to phosphorylation but we should be
+        # able to support other types as well
+        for m, mp in zip(member.mods, member.mod_sites):
+            mod = abbrevs[m]
+            mod_pos = mp if mp is not None else ''
+            mod_site = ('%s%s' % (mod, mod_pos))
+            left_site_dict[mod_site] = 'p'
+            right_site_dict[mod_site] = 'p'
+
+        # Add the pattern for the member being bound
+        if member.bound_to:
+            bound_name = member.bound_to
+            bound_bs = get_binding_site_name(bound_name)
+            gene_bs = get_binding_site_name(gene_name)
+            if member.bound_neg:
+                left_site_dict[bound_bs] = None
+                right_site_dict[bound_bs] = None
+                left_pattern = mono(**left_site_dict)
+                right_pattern = mono(**right_site_dict)
+            else:
+                bound = model.monomers[bound_name]
+                left_site_dict[bound_bs] =\
+                    bond_counter
+                right_site_dict[bound_bs] =\
+                    bond_counter
+                left_pattern = mono(**left_site_dict) % \
+                                bound(**{gene_bs:bond_counter})
+                right_pattern = mono(**right_site_dict) % \
+                                bound(**{gene_bs:bond_counter})
+                bond_counter += 1
+        else:
+            left_pattern = mono(**left_site_dict)
+            right_pattern = mono(**right_site_dict)
+        # Build up the left- and right-hand sides of the rule from
+        # monomer patterns with the appropriate site dicts
+        lhs = lhs + left_pattern
+        rhs = rhs % right_pattern
+    # Finally, create the rule and add it to the model
+    rule = Rule(rule_name, lhs <> rhs, kf_bind, kr_bind)
+    add_rule_to_model(model, rule)
+
+complex_assemble_interactions_only = complex_assemble_one_step
+complex_assemble_default = complex_assemble_one_step
 
 if __name__ == '__main__':
     pa = PysbAssembler()

--- a/indra/pysb_assembler.py
+++ b/indra/pysb_assembler.py
@@ -281,7 +281,13 @@ class PysbAssembler(object):
         self.statements = []
         self.agent_set = None
         self.model = None
-        self.policies = policies
+        if policies is None:
+            self.policies = {'other': 'default'}
+        elif isinstance(policies, basestring):
+            self.policies = {'other': policies}
+        else:
+            self.policies = {'other': 'default'}
+            self.policies.update(policies)
 
     def statement_exists(self, stmt):
         for s in self.statements:
@@ -296,10 +302,10 @@ class PysbAssembler(object):
 
     def dispatch(self, stmt, stage, *args):
         class_name = stmt.__class__.__name__
-        if not self.policies:
-            policy = 'default'
-        else:
-            policy = policies.get(class_name, 'default')
+        try:
+            policy = self.policies[class_name]
+        except KeyError:
+            policy = self.policies['other']
         func_name = '%s_%s_%s' % (class_name.lower(), stage, policy)
         func = globals().get(func_name)
         if func is None:

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1,7 +1,9 @@
 from pysb import *
 from pysb import ReactionPattern, ComplexPattern, ComponentDuplicateNameError
 
+
 class Agent(object):
+
     def __init__(self, name, mods=None, mod_sites=None, active=None,
                  bound_to=None, bound_neg=None, db_refs=None):
         self.name = name
@@ -44,7 +46,8 @@ class Agent(object):
 
 class Statement(object):
     """The parent class of all statements"""
-    def __init__(self, stmt=None, citation=None, evidence=None, 
+
+    def __init__(self, stmt=None, citation=None, evidence=None,
                  annotations=None):
         self.stmt = stmt
         self.citation = citation
@@ -55,9 +58,9 @@ class Statement(object):
         return self.__str__()
 
     def __eq__(self, other):
-        if self.citation == other.citation and\
-            self.evidence == other.evidence and\
-            self.annotations == other.annotations and\
+        if self.citation == other.citation and \
+            self.evidence == other.evidence and \
+            self.annotations == other.annotations and \
             self.stmt == other.stmt:
             return True
         else:
@@ -66,6 +69,7 @@ class Statement(object):
 
 class Modification(Statement):
     """Generic statement representing the modification of a protein"""
+
     def __init__(self, enz, sub, mod, mod_pos, stmt=None,
                  citation=None, evidence=None, annotations=None):
         super(Modification, self).__init__(stmt, citation, evidence,
@@ -81,10 +85,10 @@ class Modification(Statement):
                  self.mod_pos))
 
     def __eq__(self, other):
-        if isinstance(other, Modification) and\
-            self.enz == other.enz and\
-            self.sub == other.sub and\
-            self.mod == other.mod and\
+        if isinstance(other, Modification) and \
+            self.enz == other.enz and \
+            self.sub == other.sub and \
+            self.mod == other.mod and \
             self.mod_pos == other.mod_pos:
             return True
         else:
@@ -93,6 +97,7 @@ class Modification(Statement):
 
 class SelfModification(Statement):
     """Generic statement representing the self modification of a protein"""
+
     def __init__(self, enz, mod, mod_pos, stmt=None,
                  citation=None, evidence=None, annotations=None):
         super(SelfModification, self).__init__(stmt, citation, evidence,
@@ -106,9 +111,9 @@ class SelfModification(Statement):
                 (type(self).__name__, self.enz.name, self.mod, self.mod_pos))
 
     def __eq__(self, other):
-        if isinstance(other, SelfModification) and\
-            self.enz == other.enz and\
-            self.mod == other.mod and\
+        if isinstance(other, SelfModification) and \
+            self.enz == other.enz and \
+            self.mod == other.mod and \
             self.mod_pos == other.mod_pos:
             return True
         else:
@@ -161,6 +166,7 @@ class Ubiquitination(Modification):
 class ActivityActivity(Statement):
     """Statement representing the activation of a protein as a result of the
     activity of another protein."""
+
     def __init__(self, subj, subj_activity, relationship, obj,
                  obj_activity, stmt=None, citation=None, evidence=None,
                  annotations=None):
@@ -173,10 +179,10 @@ class ActivityActivity(Statement):
         self.relationship = relationship
 
     def __eq__(self, other):
-        if isinstance(other, ActivityActivity) and\
-            self.subj == other.subj and\
-            self.subj_activity == other.subj_activity and\
-            self.obj == other.obj and\
+        if isinstance(other, ActivityActivity) and \
+            self.subj == other.subj and \
+            self.subj_activity == other.subj_activity and \
+            self.obj == other.obj and \
             self.obj_activity == other.obj_activity:
             return True
         else:
@@ -193,6 +199,7 @@ class RasGtpActivityActivity(ActivityActivity):
 
 
 class Dephosphorylation(Statement):
+
     def __init__(self, phos, sub, mod, mod_pos, stmt=None,
                  citation=None, evidence=None, annotations=None):
         super(Dephosphorylation, self).__init__(stmt, citation,
@@ -203,10 +210,10 @@ class Dephosphorylation(Statement):
         self.mod_pos = mod_pos
 
     def __eq__(self, other):
-        if isinstance(other, Dephosphorylation) and\
-            self.phos == other.phos and\
-            self.sub == other.sub and\
-            self.mod == other.mod and\
+        if isinstance(other, Dephosphorylation) and \
+            self.phos == other.phos and \
+            self.sub == other.sub and \
+            self.mod == other.mod and \
             self.mod_pos == other.mod_pos:
             return True
         else:
@@ -220,6 +227,7 @@ class Dephosphorylation(Statement):
 class ActivityModification(Statement):
     """Statement representing the activation of a protein as a result
     of a residue modification"""
+
     def __init__(self, monomer, mod, mod_pos, relationship, activity,
                  stmt=None, citation=None, evidence=None, annotations=None):
         super(ActivityModification, self).__init__(stmt, citation,
@@ -231,11 +239,11 @@ class ActivityModification(Statement):
         self.activity = activity
 
     def __eq__(self, other):
-        if isinstance(other, ActivityModification) and\
-            self.monomer == other.monomer and\
-            self.mod == other.mod and\
-            self.mod_pos == other.mod_pos and\
-            self.relationship == other.relationship and\
+        if isinstance(other, ActivityModification) and \
+            self.monomer == other.monomer and \
+            self.mod == other.mod and \
+            self.mod_pos == other.mod_pos and \
+            self.relationship == other.relationship and \
             self.activity == other.activity:
             return True
         else:
@@ -250,6 +258,7 @@ class ActivityModification(Statement):
 class ActivatingSubstitution(Statement):
     """Statement representing the activation of a protein as a result
     of a residue substitution"""
+
     def __init__(self, monomer, wt_residue, pos, sub_residue, activity, rel,
                  stmt=None, citation=None, evidence=None, annotations=None):
         super(ActivatingSubstitution, self).__init__(stmt, citation,
@@ -262,11 +271,11 @@ class ActivatingSubstitution(Statement):
         self.rel = rel
 
     def __eq__(self, other):
-        if isinstance(other, ActivatingSubstitution) and\
-            self.monomer == other.monomer and\
-            self.wt_residue == other.wt_residue and\
-            self.pos == other.pos and\
-            self.sub_residue == other.sub_residue and\
+        if isinstance(other, ActivatingSubstitution) and \
+            self.monomer == other.monomer and \
+            self.wt_residue == other.wt_residue and \
+            self.pos == other.pos and \
+            self.sub_residue == other.sub_residue and \
             self.activity == other.activity:
             return True
         else:
@@ -297,9 +306,9 @@ class RasGef(Statement):
         self.ras = ras
 
     def __eq__(self, other):
-        if isinstance(other, RasGef) and\
-            self.gef == other.gef and\
-            self.gef_activity == other.gef_activity and\
+        if isinstance(other, RasGef) and \
+            self.gef == other.gef and \
+            self.gef_activity == other.gef_activity and \
             self.ras == other.ras:
             return True
         else:
@@ -313,6 +322,7 @@ class RasGef(Statement):
 class RasGap(Statement):
     """Statement representing the inactivation of a GTP-bound protein
     upon Gap activity."""
+
     def __init__(self, gap, gap_activity, ras,
                  stmt=None, citation=None, evidence=None, annotations=None):
         super(RasGap, self).__init__(stmt, citation, evidence,
@@ -322,9 +332,9 @@ class RasGap(Statement):
         self.ras = ras
 
     def __eq__(self, other):
-        if isinstance(other, RasGap) and\
-            self.gap == other.gap and\
-            self.gap_activity == other.gap_activity and\
+        if isinstance(other, RasGap) and \
+            self.gap == other.gap and \
+            self.gap_activity == other.gap_activity and \
             self.ras == other.ras:
             return True
         else:
@@ -337,7 +347,8 @@ class RasGap(Statement):
 
 class Complex(Statement):
     """Statement representing complex formation between a set of members"""
-    def __init__(self, members, stmt=None, citation=None, 
+
+    def __init__(self, members, stmt=None, citation=None,
                  evidence=None, annotations=None):
         super(Complex, self).__init__(stmt, citation, evidence, annotations)
         self.members = members

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -149,43 +149,6 @@ class Statement(object):
             return False
 
 
-    def assemble(self, model, agent_set, policies=None):
-        """Calls the appropriate assemble method based on policies."""
-        if policies is None or policies == 'one_step':
-            self.assemble_one_step(model, agent_set)
-        elif policies == 'interactions_only':
-            self.assemble_interactions_only(model, agent_set)
-        elif policies == 'two_step':
-            self.assemble_two_step(model, agent_set)
-        else:
-            raise UnknownPolicyException(policies)
-
-    def monomers_one_step(self, agent_set):
-        warnings.warn("%s.monomers_one_step not implemented" %
-                      self.__class__.__name__)
-
-    def assemble_one_step(self, model, agent_set):
-        warnings.warn("%s.assemble_one_step not implemented" %
-                      self.__class__.__name__)
-    
-    def monomers_two_step(self, agent_set):
-        warnings.warn("%s.monomers_two_step not implemented, reverting to one-step" %
-                      self.__class__.__name__)
-        self.monomers_one_step(agent_set)
-    
-    def assemble_two_step(self, model, agent_set):
-        warnings.warn("%s.assemble_two_step not implemented, reverting to one-step" %
-                      self.__class__.__name__)
-        self.assemble_one_step(model, agent_set)
-
-    def monomers_interactions_only(self, agent_set):
-        warnings.warn("%s.monomers_interactions_only not implemented" %
-                      self.__class__.__name__)
-
-    def assemble_interactions_only(self, model, agent_set):
-        warnings.warn("%s.assemble_interactions_only not implemented" %
-                      self.__class__.__name__)
-
 class Modification(Statement):
     """Generic statement representing the modification of a protein"""
     def __init__(self, enz, sub, mod, mod_pos, stmt=None,

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -231,7 +231,7 @@ class ActivityModification(Statement):
         self.mod_pos = mod_pos
         self.relationship = relationship
         self.activity = activity
-    
+
     def __eq__(self, other):
         if isinstance(other, ActivityModification) and\
             self.monomer == other.monomer and\
@@ -242,36 +242,6 @@ class ActivityModification(Statement):
             return True
         else:
             return False
-
-    def monomers_interactions_only(self, agent_set):
-        pass
-
-    def assemble_interactions_only(self, model, agent_set):
-        pass
-
-    def monomers_one_step(self, agent_set):
-        agent = agent_set.get_create_base_agent(self.monomer)
-        sites = site_name(self)
-        active_states = [states[m][1] for m in self.mod]
-
-        activity_pattern = {}
-        for i, s in enumerate(sites):
-            site_states = states[self.mod[i]]
-            active_state = site_states[1]
-            agent.create_site(s, site_states)
-            activity_pattern[s] = active_state
-
-        # Add this activity modification explicitly to the agent's list
-        # of activating modifications
-        agent.add_activating_modification(activity_pattern)
-        # Inactivating modifications will require a different treatment
-        # of the resolution of when the agent is active
-        if self.relationship == 'decreases':
-            warnings.warn('Inactivating modifications not currently '
-                          'implemented!')
-
-    def assemble_one_step(self, model, agent_set):
-        pass
 
     def __str__(self):
         return ("ActivityModification(%s, %s, %s, %s, %s)" %

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1,7 +1,5 @@
-import warnings
 from pysb import *
 from pysb import ReactionPattern, ComplexPattern, ComponentDuplicateNameError
-
 
 class Agent(object):
     def __init__(self, name, mods=None, mod_sites=None, active=None,

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -292,7 +292,7 @@ class ActivatingSubstitution(Statement):
         self.sub_residue = sub_residue
         self.activity = activity
         self.rel = rel
-    
+
     def __eq__(self, other):
         if isinstance(other, ActivatingSubstitution) and\
             self.monomer == other.monomer and\

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -275,7 +275,7 @@ class Dephosphorylation(Statement):
         phos_unbound = get_complex_pattern(model, self.phos, agent_set,
             extra_fields = {sub_bs: None})
         sub_pattern = get_complex_pattern(model, self.sub, agent_set)
-        
+
         param_name = 'kf_' + self.phos.name[0].lower() +\
             self.sub.name[0].lower() + '_bind'
         kf_bind = get_create_parameter(model, param_name, 1e-6)
@@ -285,7 +285,7 @@ class Dephosphorylation(Statement):
         param_name = 'kc_' + self.phos.name[0].lower() +\
             self.sub.name[0].lower() + '_dephos'
         kf_phospho = get_create_parameter(model, param_name, 1e-3)
-        
+
         site = site_name(self)[0]
 
         phos_act_mods = get_activating_mods(self.phos, agent_set)

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -239,6 +239,22 @@ def test_pysb_assembler_dephos_twostep1():
     assert(len(model.rules)==3)
     assert(len(model.monomers)==2)
 
+def test_statement_specific_policies():
+    enz = Agent('BRAF')
+    sub = Agent('MEK1')
+    phos = Agent('PP2A')
+    stmt1 = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222',
+                            '', '', '', '')
+    stmt2 = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222')
+    policies = {'Phosphorylation': 'two_step',
+                'Dephosphorylation': 'interactions_only'}
+    pa = PysbAssembler(policies=policies)
+    pa.add_statements([stmt1, stmt2])
+    model = pa.make_model()
+    print model.rules
+    assert(len(model.rules)==4)
+    assert(len(model.monomers)==3)
+
 # TODO: Test for one or more statement-specific policies
 # TODO: Test for setting of default policy using a dict
 # TODO: Test for setting of both statement-specific and default policies

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -255,7 +255,19 @@ def test_statement_specific_policies():
     assert(len(model.rules)==4)
     assert(len(model.monomers)==3)
 
-# TODO: Test for one or more statement-specific policies
-# TODO: Test for setting of default policy using a dict
-# TODO: Test for setting of both statement-specific and default policies
+def test_unspecified_statement_policies():
+    enz = Agent('BRAF')
+    sub = Agent('MEK1')
+    phos = Agent('PP2A')
+    stmt1 = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222',
+                            '', '', '', '')
+    stmt2 = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222')
+    policies = {'Phosphorylation': 'two_step',
+                'other': 'interactions_only'}
+    pa = PysbAssembler(policies=policies)
+    pa.add_statements([stmt1, stmt2])
+    model = pa.make_model()
+    print model.rules
+    assert(len(model.rules)==4)
+    assert(len(model.monomers)==3)
 

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -36,7 +36,8 @@ def test_pysb_assembler_complex3():
 def test_pysb_assembler_phos1():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222', '', '', '', '')
+    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine',
+                           '222', '', '', '', '')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -46,7 +47,8 @@ def test_pysb_assembler_phos1():
 def test_pysb_assembler_phos2():
     enz = Agent('BRAF', bound_to='HRAS')
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222', '', '', '', '')
+    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222',
+                           '', '', '', '')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -56,7 +58,8 @@ def test_pysb_assembler_phos2():
 def test_pysb_assembler_phos3():
     enz = Agent('BRAF', bound_to='HRAS')
     sub = Agent('MEK1', bound_to='ERK1')
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222', '', '', '', '')
+    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222',
+                           '', '', '', '')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -66,7 +69,8 @@ def test_pysb_assembler_phos3():
 def test_pysb_assembler_phos4():
     enz = Agent('BRAF', bound_to='HRAS')
     sub = Agent('MEK1', bound_to='ERK1', bound_neg=True)
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222', '', '', '', '')
+    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222',
+                           '', '', '', '')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -75,7 +79,8 @@ def test_pysb_assembler_phos4():
 
 def test_pysb_assembler_autophos1():
     enz = Agent('MEK1')
-    stmt = Autophosphorylation(enz, 'PhosphorylationSerine', '222', '', '', '', '')
+    stmt = Autophosphorylation(enz, 'PhosphorylationSerine', '222',
+                               '', '', '', '')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -84,7 +89,8 @@ def test_pysb_assembler_autophos1():
 
 def test_pysb_assembler_autophos2():
     enz = Agent('MEK1', bound_to='RAF1')
-    stmt = Autophosphorylation(enz, 'PhosphorylationSerine', '222', '', '', '', '')
+    stmt = Autophosphorylation(enz, 'PhosphorylationSerine', '222',
+                               '', '', '', '')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -94,7 +100,8 @@ def test_pysb_assembler_autophos2():
 
 def test_pysb_assembler_autophos3():
     enz = Agent('EGFR', bound_to='EGFR')
-    stmt = Autophosphorylation(enz, 'PhosphorylationTyrosine', None, '', '', '', '')
+    stmt = Autophosphorylation(enz, 'PhosphorylationTyrosine', None,
+                               '', '', '', '')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -104,7 +111,8 @@ def test_pysb_assembler_autophos3():
 
 def test_pysb_assembler_transphos1():
     enz = Agent('EGFR', bound_to='EGFR')
-    stmt = Transphosphorylation(enz, 'PhosphorylationTyrosine', None, '', '', '', '')
+    stmt = Transphosphorylation(enz, 'PhosphorylationTyrosine', None,
+                                '', '', '', '')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -115,7 +123,8 @@ def test_pysb_assembler_transphos1():
 def test_pysb_assembler_actact1():
     subj = Agent('GRB2', bound_to='EGFR')
     obj = Agent('SOS1')
-    stmt = ActivityActivity(subj, 'act', 'increase', obj, 'act', '', '', '', '')
+    stmt = ActivityActivity(subj, 'act', 'increase', obj, 'act',
+                            '', '', '', '')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -126,7 +135,8 @@ def test_pysb_assembler_actact1():
 def test_pysb_assembler_dephos1():
     phos = Agent('PP2A')
     sub = Agent('MEK1')
-    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222', '', '', '', '')
+    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222',
+                             '', '', '', '')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -137,7 +147,8 @@ def test_pysb_assembler_dephos1():
 def test_pysb_assembler_dephos2():
     phos = Agent('PP2A')
     sub = Agent('MEK1', bound_to='RAF1')
-    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222', '', '', '', '')
+    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222',
+                             '', '', '', '')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -172,10 +183,12 @@ def test_pysb_assembler_actmod1():
     erk = Agent('ERK')
     stmts = []
     stmts.append(ActivityModification(mek, ['PhosphorylationSerine', 
-        'PhosphorylationSerine'], [218,222], 'increases', 'act', '', '', '', ''))
-    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationThreonine', '185', '', '', '', ''))
-    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationTyrosine', '187', '', '', '', ''))
-    
+                                      'PhosphorylationSerine'], [218,222],
+                                      'increases', 'act', '', '', '', ''))
+    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationThreonine', '185',
+                                 '', '', '', ''))
+    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationTyrosine', '187',
+                                 '', '', '', ''))
     pa = PysbAssembler()
     pa.add_statements(stmts)
     model = pa.make_model()
@@ -191,9 +204,10 @@ def test_pysb_assembler_actmod2():
         [218], 'increases', 'act', '', '', '', ''))
     stmts.append(ActivityModification(mek, ['PhosphorylationSerine'], 
         [222], 'increases', 'act', '', '', '', ''))
-    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationThreonine', '185', '', '', '', ''))
-    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationTyrosine', '187', '', '', '', ''))
-    
+    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationThreonine', '185',
+                                 '', '', '', ''))
+    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationTyrosine', '187',
+                                 '', '', '', ''))
     pa = PysbAssembler()
     pa.add_statements(stmts)
     model = pa.make_model()
@@ -204,7 +218,8 @@ def test_pysb_assembler_actmod2():
 def test_pysb_assembler_phos_twostep1():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222', '', '', '', '')
+    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222',
+                           '', '', '', '')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model(policies='two_step')
@@ -215,10 +230,12 @@ def test_pysb_assembler_phos_twostep1():
 def test_pysb_assembler_dephos_twostep1():
     phos = Agent('PP2A')
     sub = Agent('MEK1')
-    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222', '', '', '', '')
+    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222',
+                             '', '', '', '')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model(policies='two_step')
     print model.rules
     assert(len(model.rules)==3)
     assert(len(model.monomers)==2)
+

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -22,7 +22,7 @@ def test_pysb_assembler_complex2():
     assert(len(model.rules)==6)
     assert(len(model.monomers)==3)
 
-def test_pysb_assembler_complex2():
+def test_pysb_assembler_complex3():
     member1 = Agent('BRAF', bound_to='HRAS')
     member2 = Agent('MEK1')
     stmt = Complex([member1, member2])

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -220,9 +220,9 @@ def test_pysb_assembler_phos_twostep1():
     sub = Agent('MEK1')
     stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222',
                            '', '', '', '')
-    pa = PysbAssembler()
+    pa = PysbAssembler(policies='two_step')
     pa.add_statements([stmt])
-    model = pa.make_model(policies='two_step')
+    model = pa.make_model()
     print model.rules
     assert(len(model.rules)==3)
     assert(len(model.monomers)==2)
@@ -232,10 +232,14 @@ def test_pysb_assembler_dephos_twostep1():
     sub = Agent('MEK1')
     stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222',
                              '', '', '', '')
-    pa = PysbAssembler()
+    pa = PysbAssembler(policies='two_step')
     pa.add_statements([stmt])
-    model = pa.make_model(policies='two_step')
+    model = pa.make_model()
     print model.rules
     assert(len(model.rules)==3)
     assert(len(model.monomers)==2)
+
+# TODO: Test for one or more statement-specific policies
+# TODO: Test for setting of default policy using a dict
+# TODO: Test for setting of both statement-specific and default policies
 


### PR DESCRIPTION
In this pull request we refactored pysb_assembler and statements.py so that the PySB assembly specific code would be decoupled from the Statement classes. The Statement classes now only serve as data structures to record the arguments associated with each interaction type; policies and procedures for assembly will now be implemented in specific assembler code.

Rather than create a registry-type data structure in pysb_assembler to define the monomers and assembly function for specific statements and policies, we used a naming convention in which assembly functions followed the pattern classname_assemble_policyname. If a function with the name corresponding to a specific statement/policy does not exist, then an exception is raised.

In addition, this pull request also implements a slightly more sophisticated approach to specification of policies: policies can now be specific globally using a string (e.g., 'interactions_only') or on a statement-specific basis using a dict (e.g. {'Phosphorylation': 'two_step', 'Dephosphorylation': 'interactions_only'}).