### PR TITLE
Evidence struct

### DIFF
--- a/indra/bel/processor.py
+++ b/indra/bel/processor.py
@@ -120,7 +120,9 @@ class BelProcessor(object):
         for stmt in res_annotations:
             annotations.append(stmt[0].format())
 
-        return (citation, evidence, annotations)
+        ev = Evidence(source_api='bel', source_id=statement, pmid=citation,
+                      text=evidence, annotations=annotations)
+        return ev
 
     def get_modifications(self):
         q_phospho = prefixes + """
@@ -148,7 +150,7 @@ class BelProcessor(object):
         res_phospho = self.g.query(q_phospho)
 
         for stmt in res_phospho:
-            (citation, evidence, annotations) = self.get_evidence(stmt[5])
+            evidence = self.get_evidence(stmt[5])
             # Parse out the elements of the query
             enz_name = gene_name_from_uri(stmt[0])
             enz = Agent(enz_name)
@@ -163,25 +165,20 @@ class BelProcessor(object):
 
             if act_type == 'Kinase' and mod in phospho_mods:
                 self.statements.append(
-                        Phosphorylation(enz, sub, mod, mod_pos, stmt_str,
-                                        citation, evidence, annotations))
+                        Phosphorylation(enz, sub, mod, mod_pos, evidence))
             elif act_type == 'Catalytic':
                 if mod == 'Hydroxylation':
                     self.statements.append(
-                            Hydroxylation(enz, sub, mod, mod_pos, stmt_str,
-                                          citation, evidence, annotations))
+                            Hydroxylation(enz, sub, mod, mod_pos, evidence))
                 elif mod == 'Sumoylation':
                     self.statements.append(
-                            Sumoylation(enz, sub, mod, mod_pos, stmt_str,
-                                        citation, evidence, annotations))
+                            Sumoylation(enz, sub, mod, mod_pos, evidence))
                 elif mod == 'Acetylation':
                     self.statements.append(
-                            Acetylation(enz, sub, mod, mod_pos, stmt_str,
-                                        citation, evidence, annotations))
+                            Acetylation(enz, sub, mod, mod_pos, evidence))
                 elif mod == 'Ubiquitination':
                     self.statements.append(
-                            Ubiquitination(enz, sub, mod, mod_pos, stmt_str,
-                                           citation, evidence, annotations))
+                            Ubiquitination(enz, sub, mod, mod_pos, evidence))
                 else:
                     print "Warning: Unknown modification type!"
                     print("Activity: %s, Mod: %s, Mod_Pos: %s" %

--- a/indra/biopax/processor.py
+++ b/indra/biopax/processor.py
@@ -134,10 +134,8 @@ class BiopaxProcessor(object):
             if force_contains is not None:
                 if momomer not in force_contains:
                     continue
-            stmt_str = ''
             citation = self._get_citation(r[p.indexOf('Conversion')])
-            evidence = ''
-            annotations = ''
+            ev = Evidence(source_api='biopax', pmid=citation)
             out_pe = r[p.indexOf('output PE')]
             activity = 'Activity'
             relationship = 'increases' 
@@ -145,8 +143,7 @@ class BiopaxProcessor(object):
             if mod:
                 stmt = ActivityModification(monomer, mod, mod_pos, 
                                             relationship, activity,
-                                            stmt_str, citation, evidence, 
-                                            annotations)
+                                            evidence=ev)
                 self.statements.append(stmt)
 
     def _get_modification_site(self, modPE):
@@ -216,10 +213,8 @@ class BiopaxProcessor(object):
                 if (enz.name not in force_contains) and \
                     (sub.name not in force_contains):
                     continue
-            stmt_str = ''
             citation = self._get_citation(r[p.indexOf('Conversion')])
-            evidence = ''
-            annotations = ''
+            ev = Evidence(source_api='biopax', pmid=citation)
 
             # Get the modification (s)
             # Should this be simple PE?
@@ -233,8 +228,7 @@ class BiopaxProcessor(object):
             # is not equal to r[p.indexOf('output PE')].getRDFId()
             mod, mod_pos = self._get_modification_site(modPE)
             for m, mp in zip(mod, mod_pos):
-                stmt = (enz, sub, m, mp,
-                        stmt_str, citation, evidence, annotations)
+                stmt = (enz, sub, m, mp, ev)
                 stmts.append(stmt)
         return stmts
 

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -89,10 +89,12 @@ class Evidence(object):
         self.epistemics = epistemics
 
     def __str__(self):
-        ev_str = 'Evidence(%s, %s, %s):\n' % \
+        ev_str = 'Evidence(%s, %s, %s)' % \
                  (self.source_api, self.pmid, self.annotations)
-        ev_str += textwrap.fill(self.text.strip(), initial_indent='    ',
-                                subsequent_indent='    ', width=80)
+        if self.text:
+            ev_str += ':\n'
+            ev_str += textwrap.fill(self.text.strip(), initial_indent='    ',
+                                    subsequent_indent='    ', width=80)
         return ev_str
 
 class Statement(object):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1,6 +1,7 @@
 from pysb import *
 from pysb import ReactionPattern, ComplexPattern, ComponentDuplicateNameError
 from collections import namedtuple
+import textwrap
 
 BoundCondition = namedtuple('BoundCondition', ['agent', 'is_bound'])
 
@@ -51,6 +52,49 @@ class Agent(object):
         attr_str = ', '.join(attr_strs)
         return '%s(%s)' % (self.name, attr_str)
 
+
+class Evidence(object):
+    """Container for evidence supporting a given statement.
+
+    Attributes
+    ----------
+    source_api : string or None
+        String identifying the INDRA API used to capture the statement,
+        e.g., 'trips', 'biopax', 'bel'.
+    source_id : string or None
+        For statements drawn from databases, ID of the database entity
+        corresponding to the statement.
+    pmid : string or None
+        String indicating the Pubmed ID of the source of the statement.
+    text : string
+        Natural language text supporting the statement.
+    annotations : dict
+        Dict containing additional information on the context of the statement,
+        e.g., species, cell line, tissue type, etc. The entries may vary
+        depending on the source of the information.
+    epistemics : string
+        An identifier describing the epistemic certainty associated with the
+        statement.
+    """
+
+    def __init__(self, source_api=None, pmid=None, text=None,
+                 annotations=None, epistemics=None):
+        self.source_api = source_api
+        self.pmid = pmid
+        self.text =text
+        if annotations:
+            self.annotations = annotations
+        else:
+            self.annotations = {}
+        self.epistemics = epistemics
+
+    def __str__(self):
+        ev_str = 'Evidence(%s, %s, %s):\n' % \
+                 (self.source_api, self.pmid, self.annotations)
+        ev_str += textwrap.fill(self.text.strip(), initial_indent='    ',
+                                subsequent_indent='    ', width=80)
+        ev_str += '\n'
+        return ev_str
 
 class Statement(object):
     """The parent class of all statements"""
@@ -371,3 +415,8 @@ class Complex(Statement):
 
     def __str__(self):
         return ("Complex(%s)" % [m.name for m in self.members])
+
+if __name__ == '__main__':
+    ev = Evidence(pmid='asdf', text="""
+Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.""")
+    print ev

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -37,8 +37,7 @@ def test_pysb_assembler_complex3():
 def test_pysb_assembler_phos1():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine',
-                           '222', '', '', '', '')
+    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -49,8 +48,7 @@ def test_pysb_assembler_phos2():
     hras = Agent('HRAS')
     enz = Agent('BRAF', bound_conditions=[BoundCondition(hras, True)])
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222',
-                           '', '', '', '')
+    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -62,8 +60,7 @@ def test_pysb_assembler_phos3():
     erk1 = Agent('ERK1')
     enz = Agent('BRAF', bound_conditions=[BoundCondition(hras, True)])
     sub = Agent('MEK1', bound_conditions=[BoundCondition(erk1, True)])
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222',
-                           '', '', '', '')
+    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -75,8 +72,7 @@ def test_pysb_assembler_phos4():
     erk1 = Agent('ERK1')
     enz = Agent('BRAF', bound_conditions=[BoundCondition(hras, True)])
     sub = Agent('MEK1', bound_conditions=[BoundCondition(erk1, False)])
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222',
-                           '', '', '', '')
+    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -85,8 +81,7 @@ def test_pysb_assembler_phos4():
 
 def test_pysb_assembler_autophos1():
     enz = Agent('MEK1')
-    stmt = Autophosphorylation(enz, 'PhosphorylationSerine', '222',
-                               '', '', '', '')
+    stmt = Autophosphorylation(enz, 'PhosphorylationSerine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -96,8 +91,7 @@ def test_pysb_assembler_autophos1():
 def test_pysb_assembler_autophos2():
     raf1 = Agent('RAF1')
     enz = Agent('MEK1', bound_conditions=[BoundCondition(raf1, True)])
-    stmt = Autophosphorylation(enz, 'PhosphorylationSerine', '222',
-                               '', '', '', '')
+    stmt = Autophosphorylation(enz, 'PhosphorylationSerine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -108,8 +102,7 @@ def test_pysb_assembler_autophos2():
 def test_pysb_assembler_autophos3():
     egfr = Agent('EGFR')
     enz = Agent('EGFR', bound_conditions=[BoundCondition(egfr, True)])
-    stmt = Autophosphorylation(enz, 'PhosphorylationTyrosine', None,
-                               '', '', '', '')
+    stmt = Autophosphorylation(enz, 'PhosphorylationTyrosine', None)
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -120,8 +113,7 @@ def test_pysb_assembler_autophos3():
 def test_pysb_assembler_transphos1():
     egfr = Agent('EGFR')
     enz = Agent('EGFR', bound_conditions=[BoundCondition(egfr, True)])
-    stmt = Transphosphorylation(enz, 'PhosphorylationTyrosine', None,
-                                '', '', '', '')
+    stmt = Transphosphorylation(enz, 'PhosphorylationTyrosine', None)
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -133,8 +125,7 @@ def test_pysb_assembler_actact1():
     egfr = Agent('EGFR')
     subj = Agent('GRB2', bound_conditions=[BoundCondition(egfr, True)])
     obj = Agent('SOS1')
-    stmt = ActivityActivity(subj, 'act', 'increase', obj, 'act',
-                            '', '', '', '')
+    stmt = ActivityActivity(subj, 'act', 'increase', obj, 'act')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -145,8 +136,7 @@ def test_pysb_assembler_actact1():
 def test_pysb_assembler_dephos1():
     phos = Agent('PP2A')
     sub = Agent('MEK1')
-    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222',
-                             '', '', '', '')
+    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -158,8 +148,7 @@ def test_pysb_assembler_dephos2():
     phos = Agent('PP2A')
     raf1 = Agent('RAF1')
     sub = Agent('MEK1', bound_conditions=[BoundCondition(raf1, True)])
-    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222',
-                             '', '', '', '')
+    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -170,7 +159,7 @@ def test_pysb_assembler_dephos2():
 def test_pysb_assembler_rasgef1():
     gef = Agent('SOS1')
     ras = Agent('HRAS')
-    stmt = RasGef(gef, 'catalytic', ras, '', '', '', '')
+    stmt = RasGef(gef, 'catalytic', ras)
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -181,7 +170,7 @@ def test_pysb_assembler_rasgef1():
 def test_pysb_assembler_rasgap1():
     gap = Agent('NF1')
     ras = Agent('HRAS')
-    stmt = RasGap(gap, 'catalytic', ras, '', '', '', '')
+    stmt = RasGap(gap, 'catalytic', ras)
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -195,11 +184,9 @@ def test_pysb_assembler_actmod1():
     stmts = []
     stmts.append(ActivityModification(mek, ['PhosphorylationSerine', 
                                       'PhosphorylationSerine'], [218,222],
-                                      'increases', 'act', '', '', '', ''))
-    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationThreonine', '185',
-                                 '', '', '', ''))
-    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationTyrosine', '187',
-                                 '', '', '', ''))
+                                      'increases', 'act'))
+    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationThreonine', '185'))
+    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationTyrosine', '187'))
     pa = PysbAssembler()
     pa.add_statements(stmts)
     model = pa.make_model()
@@ -212,13 +199,11 @@ def test_pysb_assembler_actmod2():
     erk = Agent('ERK')
     stmts = []
     stmts.append(ActivityModification(mek, ['PhosphorylationSerine'], 
-        [218], 'increases', 'act', '', '', '', ''))
+        [218], 'increases', 'act'))
     stmts.append(ActivityModification(mek, ['PhosphorylationSerine'], 
-        [222], 'increases', 'act', '', '', '', ''))
-    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationThreonine', '185',
-                                 '', '', '', ''))
-    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationTyrosine', '187',
-                                 '', '', '', ''))
+        [222], 'increases', 'act'))
+    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationThreonine', '185'))
+    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationTyrosine', '187'))
     pa = PysbAssembler()
     pa.add_statements(stmts)
     model = pa.make_model()
@@ -229,8 +214,7 @@ def test_pysb_assembler_actmod2():
 def test_pysb_assembler_phos_twostep1():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222',
-                           '', '', '', '')
+    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
     pa = PysbAssembler(policies='two_step')
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -241,8 +225,7 @@ def test_pysb_assembler_phos_twostep1():
 def test_pysb_assembler_dephos_twostep1():
     phos = Agent('PP2A')
     sub = Agent('MEK1')
-    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222',
-                             '', '', '', '')
+    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222')
     pa = PysbAssembler(policies='two_step')
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -254,8 +237,7 @@ def test_statement_specific_policies():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
     phos = Agent('PP2A')
-    stmt1 = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222',
-                            '', '', '', '')
+    stmt1 = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
     stmt2 = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222')
     policies = {'Phosphorylation': 'two_step',
                 'Dephosphorylation': 'interactions_only'}
@@ -270,8 +252,7 @@ def test_unspecified_statement_policies():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
     phos = Agent('PP2A')
-    stmt1 = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222',
-                            '', '', '', '')
+    stmt1 = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
     stmt2 = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222')
     policies = {'Phosphorylation': 'two_step',
                 'other': 'interactions_only'}

--- a/indra/trips/processor.py
+++ b/indra/trips/processor.py
@@ -53,12 +53,10 @@ class TripsProcessor(object):
             affected_name = self._get_name_by_id(affected_id)
             affected_agent = Agent(affected_name)
 
-            citation = ''
-            evidence = sentence
-            annotations = ''
+            ev = Evidence(source_api='trips', text=sentence)
             self.statements.append(ActivityActivity(agent_agent, 'act',
                                     'increases', affected_agent, 'act',
-                                    sentence, citation, evidence, annotations))
+                                    evidence=ev))
 
     def get_activating_mods(self):
         act_events = self.tree.findall("EVENT/[type='ONT::ACTIVATE']")
@@ -83,12 +81,11 @@ class TripsProcessor(object):
             precond_id = precond_event_ref.find('event').attrib['id']
             precond_event = self.tree.find("EVENT[@id='%s']" % precond_id)
             mod, mod_pos = self._get_mod_site(precond_event)
-            citation = ''
-            evidence = sentence
-            annotations = ''
+
+            ev = Evidence(source_api='trips', text=sentence)
             self.statements.append(ActivityModification(affected_agent, mod,
                                     mod_pos, 'increases', 'Active',
-                                    sentence, citation, evidence, annotations))
+                                    evidence=ev))
 
     def get_complexes(self):
         bind_events = self.tree.findall("EVENT/[type='ONT::BIND']")
@@ -171,9 +168,7 @@ class TripsProcessor(object):
                                                    event.attrib['id'])
             mod, mod_pos = self._get_mod_site(event)
             # TODO: extract more information about text to use as evidence
-            citation = ''
-            evidence = sentence
-            annotations = ''
+            ev = Evidence(source_api='trips', text=sentence)
             # Assuming that multiple modifications can only happen in
             # distinct steps, we add a statement for each modification
             # independently
@@ -186,26 +181,22 @@ class TripsProcessor(object):
                                            [BoundCondition(agent_bound, True)]
                 for m, p in zip(mod, mod_pos):
                     self.statements.append(Transphosphorylation(agent_agent,
-                                        m, p, sentence,
-                                        citation, evidence, annotations))
+                                        m, p, evidence=ev))
             # Dephosphorylation
             elif 'ONT::MANNER-UNDO' in [mt.text for mt in mod_types]:
                 for m, p in zip(mod, mod_pos):
                     self.statements.append(Dephosphorylation(agent_agent,
-                                        affected_agent, m, p, sentence,
-                                        citation, evidence, annotations))
+                                        affected_agent, m, p, evidence=ev))
             # Autophosphorylation
             elif agent.attrib['id'] == affected.attrib['id']:
                 for m, p in zip(mod, mod_pos):
                     self.statements.append(Autophosphorylation(agent_agent,
-                                        m, p, sentence,
-                                        citation, evidence, annotations))
+                                        m, p, evidence=ev))
             # Regular phosphorylation
             else:
                 for m, p in zip(mod, mod_pos):
                     self.statements.append(Phosphorylation(agent_agent,
-                                            affected_agent, m, p, sentence,
-                                            citation, evidence, annotations))
+                                            affected_agent, m, p, evidence=ev))
 
     def _get_agent_by_id(self, entity_id, event_id):
         term = self.tree.find("TERM/[@id='%s']" % entity_id)


### PR DESCRIPTION
This pull request refactors the approach to evidence for statements from its original instantiation leftover from the BelPy days. The new approach uses a class, Evidence, that has fields for publication, text, source API, epistemic metadata, etc. The PR also updates the various processors to set the evidence with an instance of Evidence when creating Statements.