### PR TITLE
Modifications refactoring

### DIFF
--- a/indra/bel/processor.py
+++ b/indra/bel/processor.py
@@ -168,20 +168,25 @@ class BelProcessor(object):
 
             if act_type == 'Kinase' and mod.startswith('Phosphorylation'):
                 self.statements.append(
-                        Phosphorylation(enz, sub, mc, evidence))
+                        Phosphorylation(enz, sub, mc.residue, mc.position,
+                                        evidence))
             elif act_type == 'Catalytic':
                 if mod == 'Hydroxylation':
                     self.statements.append(
-                            Hydroxylation(enz, sub, mc, evidence))
+                            Hydroxylation(enz, sub, mc.residue, mc.position,
+                                          evidence))
                 elif mod == 'Sumoylation':
                     self.statements.append(
-                            Sumoylation(enz, sub, mc, evidence))
+                            Sumoylation(enz, sub, mc.residue, mc.position,
+                                        evidence))
                 elif mod == 'Acetylation':
                     self.statements.append(
-                            Acetylation(enz, sub, mc, evidence))
+                            Acetylation(enz, sub, mc.residue, mc.position,
+                                        evidence))
                 elif mod == 'Ubiquitination':
                     self.statements.append(
-                            Ubiquitination(enz, sub, mc, evidence))
+                            Ubiquitination(enz, sub, mc.residue, mc.position,
+                                           evidence))
                 else:
                     print "Warning: Unknown modification type!"
                     print("Activity: %s, Mod: %s, Mod_Pos: %s" %

--- a/indra/bel/processor.py
+++ b/indra/bel/processor.py
@@ -160,32 +160,32 @@ class BelProcessor(object):
             sub_name = gene_name_from_uri(stmt[2])
             sub = Agent(sub_name)
             mod = term_from_uri(stmt[3])
+            residue = self._get_residue(mod)
             mod_pos = term_from_uri(stmt[4])
-            mc = self._get_mod_condition(mod, mod_pos)
             stmt_str = strip_statement(stmt[5])
             # Mark this as a converted statement
             self.converted_stmts.append(stmt_str)
 
             if act_type == 'Kinase' and mod.startswith('Phosphorylation'):
                 self.statements.append(
-                        Phosphorylation(enz, sub, mc.residue, mc.position,
+                        Phosphorylation(enz, sub, residue, mod_pos,
                                         evidence))
             elif act_type == 'Catalytic':
                 if mod == 'Hydroxylation':
                     self.statements.append(
-                            Hydroxylation(enz, sub, mc.residue, mc.position,
+                            Hydroxylation(enz, sub, residue, mod_pos,
                                           evidence))
                 elif mod == 'Sumoylation':
                     self.statements.append(
-                            Sumoylation(enz, sub, mc.residue, mc.position,
+                            Sumoylation(enz, sub, residue, mod_pos,
                                         evidence))
                 elif mod == 'Acetylation':
                     self.statements.append(
-                            Acetylation(enz, sub, mc.residue, mc.position,
+                            Acetylation(enz, sub, residue, mod_pos,
                                         evidence))
                 elif mod == 'Ubiquitination':
                     self.statements.append(
-                            Ubiquitination(enz, sub, mc.residue, mc.position,
+                            Ubiquitination(enz, sub, residue, mod_pos,
                                            evidence))
                 else:
                     print "Warning: Unknown modification type!"
@@ -197,17 +197,24 @@ class BelProcessor(object):
                       (act_type, mod, mod_pos))
 
     @staticmethod
+    def _get_residue(mod):
+        if mod.startswith('Phosphorylation'):
+            if mod == 'Phosphorylation':
+                residue = None
+            else:
+                residue = mod[15:].lower()
+        else:
+            residue = None
+        return residue
+
+    @staticmethod
     def _get_mod_condition(mod, mod_pos):
         if mod.startswith('Phosphorylation'):
             mc = ModCondition('phosphorylation')
-            if mod == 'Phosphorylation':
-                mc.residue = None
-            else:
-                mc.residue = mod[15:].lower()
-            mc.position = mod_pos
         else:
             mc = ModCondition(mod)
-            mc.position = mod_pos
+        mc.residue = BelProcessor._get_residue(mod)
+        mc.position = mod_pos
         return mc
 
     def get_dephosphorylations(self):

--- a/indra/bel/processor.py
+++ b/indra/bel/processor.py
@@ -159,29 +159,29 @@ class BelProcessor(object):
             act_type = name_from_uri(stmt[1])
             sub_name = gene_name_from_uri(stmt[2])
             sub = Agent(sub_name)
-            print stmt[3]
             mod = term_from_uri(stmt[3])
             mod_pos = term_from_uri(stmt[4])
+            mc = self._get_mod_condition(mod, mod_pos)
             stmt_str = strip_statement(stmt[5])
             # Mark this as a converted statement
             self.converted_stmts.append(stmt_str)
 
-            if act_type == 'Kinase' and mod in phospho_mods:
+            if act_type == 'Kinase' and mod.startswith('Phosphorylation'):
                 self.statements.append(
-                        Phosphorylation(enz, sub, mod, mod_pos, evidence))
+                        Phosphorylation(enz, sub, mc, evidence))
             elif act_type == 'Catalytic':
                 if mod == 'Hydroxylation':
                     self.statements.append(
-                            Hydroxylation(enz, sub, mod, mod_pos, evidence))
+                            Hydroxylation(enz, sub, mc, evidence))
                 elif mod == 'Sumoylation':
                     self.statements.append(
-                            Sumoylation(enz, sub, mod, mod_pos, evidence))
+                            Sumoylation(enz, sub, mc, evidence))
                 elif mod == 'Acetylation':
                     self.statements.append(
-                            Acetylation(enz, sub, mod, mod_pos, evidence))
+                            Acetylation(enz, sub, mc, evidence))
                 elif mod == 'Ubiquitination':
                     self.statements.append(
-                            Ubiquitination(enz, sub, mod, mod_pos, evidence))
+                            Ubiquitination(enz, sub, mc, evidence))
                 else:
                     print "Warning: Unknown modification type!"
                     print("Activity: %s, Mod: %s, Mod_Pos: %s" %
@@ -190,6 +190,20 @@ class BelProcessor(object):
                 print "Warning: Unknown modification type!"
                 print("Activity: %s, Mod: %s, Mod_Pos: %s" %
                       (act_type, mod, mod_pos))
+
+    @staticmethod
+    def _get_mod_condition(mod, mod_pos):
+        if mod.startswith('Phosphorylation'):
+            mc = ModCondition('phosphorylation')
+            if mod == 'Phosphorylation':
+                mc.residue = None
+            else:
+                mc.residue = mod[15:].lower()
+            mc.position = mod_pos
+        else:
+            mc = ModCondition(mod)
+            mc.position = mod_pos
+        return mc
 
     def get_dephosphorylations(self):
         q_phospho = prefixes + """
@@ -272,8 +286,10 @@ class BelProcessor(object):
             act_type = term_from_uri(stmt[1])
             mod1 = term_from_uri(stmt[2])
             mod_pos1 = term_from_uri(stmt[3])
+            mc1 = self._get_mod_condition(mod1, mod_pos1)
             mod2 = term_from_uri(stmt[4])
             mod_pos2 = term_from_uri(stmt[5])
+            mc2 = self._get_mod_condition(mod2, mod_pos2)
             rel = term_from_uri(stmt[6])
             if rel == 'DirectlyDecreases':
                 rel = 'decreases'
@@ -283,8 +299,7 @@ class BelProcessor(object):
             # Mark this as a converted statement
             self.converted_stmts.append(stmt_str)
             self.statements.append(
-                    ActivityModification(species, (mod1, mod2),
-                                         (mod_pos1, mod_pos2),
+                    ActivityModification(species, [mc1, mc2],
                                          rel, act_type, evidence))
 
     def get_activating_mods(self):
@@ -319,6 +334,7 @@ class BelProcessor(object):
             act_type = term_from_uri(stmt[1])
             mod = term_from_uri(stmt[2])
             mod_pos = term_from_uri(stmt[3])
+            mc = self._get_mod_condition(mod, mod_pos)
             rel = term_from_uri(stmt[4])
             if rel == 'DirectlyDecreases':
                 rel = 'decreases'
@@ -328,8 +344,8 @@ class BelProcessor(object):
             # Mark this as a converted statement
             self.converted_stmts.append(stmt_str)
             self.statements.append(
-                    ActivityModification(species, (mod,), (mod_pos,), rel,
-                                         act_type, evidence))
+                    ActivityModification(species, mc, rel, act_type,
+                                         evidence))
 
     def get_complexes(self):
         # Find all complexes described in the corpus
@@ -414,7 +430,7 @@ class BelProcessor(object):
                 print("Warning: Could not parse substitution expression %s" %
                       sub_expr)
                 continue
-            
+
             rel = strip_statement(stmt[3])
             if rel == 'DirectlyDecreases':
                 rel = 'decreases'

--- a/indra/benchmarks/test_trips.py
+++ b/indra/benchmarks/test_trips.py
@@ -73,7 +73,8 @@ def test_bound_mod():
     assert(has_hgnc_ref(st.members[0]))
     assert(has_hgnc_ref(st.members[1]))
     assert(st.members[1].mods)
-    assert('PhosphorylationTyrosine' in st.members[1].mods)
+    assert(st.members[1].mods[0].mod_type == 'phosphorylation')
+    assert(st.members[1].mods[0].residue == 'tyrosine')
     os.remove(fname)
 
 def test_not_bound_to():
@@ -182,7 +183,7 @@ def test_transphosphorylate():
     assert(st.enz is not None)
     assert(st.enz.name == 'EGFR')
     assert(has_hgnc_ref(st.enz))
-    assert(st.mod == 'Phosphorylation')
+    assert(st.residue == None)
     assert(len(st.enz.bound_conditions) == 1)
     assert(st.enz.bound_conditions[0].agent.name == 'EGFR')
     os.remove(fname)
@@ -197,7 +198,7 @@ def test_transphosphorylate2():
     assert(st.enz is not None)
     assert(st.enz.name == 'EGFR')
     assert(has_hgnc_ref(st.enz))
-    assert(st.mod == 'PhosphorylationTyrosine')
+    assert(st.residue == 'tyrosine')
     assert(len(st.enz.bound_conditions) == 1)
     assert(st.enz.bound_conditions[0].agent.name == 'EGFR')
     os.remove(fname)
@@ -211,8 +212,10 @@ def test_act_mod():
     assert(is_actmod(st))
     assert(st.monomer is not None)
     assert(st.monomer.name == 'MAP2K1')
-    assert(st.monomer.mod == ['PhosphorylationSerine', 'PhosphorylationSerine'])
-    assert(st.monomer.mod_pos == ['218', '222'])
+    residues = [m.residue for m in st.mod]
+    positions = [m.position for m in st.mod]
+    assert(residues == ['serine', 'serine'])
+    assert(positions == ['218', '222'])
     assert(st.relationship == 'increases')
     os.remove(fname)
 
@@ -227,7 +230,7 @@ def test_bound_phosphorylate():
     assert(st.enz.name == 'RAF')
     assert(st.sub is not None)
     assert(st.sub.name == 'MAP2K1')
-    assert(st.mod == 'Phosphorylation')
+    assert(st.residue == None)
     os.remove(fname)
 
 '''
@@ -257,8 +260,8 @@ def test_act_phosphorylate():
     assert(st.enz.name == 'MAP2K1')
     assert(st.sub is not None)
     assert(st.sub.name == 'MAPK1')
-    assert(st.mod == 'PhosphorylationTyrosine')
-    assert(st.mod_pos == '187')
+    assert(st.residue == 'tyrosine')
+    assert(st.position == '187')
     os.remove(fname)
 
 def test_dephosphorylate():
@@ -272,8 +275,8 @@ def test_dephosphorylate():
     assert(st.enz.name == 'DUSP6')
     assert(st.sub is not None)
     assert(st.sub.name == 'MAPK1')
-    assert(st.mod == 'PhosphorylationTyrosine')
-    assert(st.mod_pos == '187')
+    assert(st.residue == 'tyrosine')
+    assert(st.position == '187')
     os.remove(fname)
 
 def is_complex(statement):
@@ -284,10 +287,10 @@ def is_phosphorylation(statement):
 
 def is_transphosphorylation(statement):
     return isinstance(statement, indra.statements.Transphosphorylation)
-   
+
 def is_actmod(statement):
     return isinstance(statement, indra.statements.ActivityModification)
-    
+
 def is_dephosphorylation(statement):
     return isinstance(statement, indra.statements.Dephosphorylation)
 

--- a/indra/biopax/processor.py
+++ b/indra/biopax/processor.py
@@ -296,7 +296,7 @@ class BiopaxProcessor(object):
                     if m.mod_type  in ['active', 'inactive']:
                         # Skip activity as a modification state
                         continue
-                    stmt = (enz, sub, m, ev)
+                    stmt = (enz, sub, m.residue, m.position, ev)
                     stmts.append(stmt)
         return stmts
 

--- a/indra/english_assembler.py
+++ b/indra/english_assembler.py
@@ -91,11 +91,11 @@ def assemble_phosphorylation(stmt):
     else:
         stmt_str = sub_str + ' is phosphorylated'
 
-    if stmt.mod.residue is not None:
-        if stmt.mod.position is None:
-            mod_str = 'on ' + stmt.mod.residue
+    if stmt.residue is not None:
+        if stmt.position is None:
+            mod_str = 'on ' + stmt.residue
         else:
-            mod_str = 'on ' + abbrev_letter[stmt.mod.residue] + stmt.mod.position
+            mod_str = 'on ' + abbrev_letter[stmt.residue] + stmt.position
     else:
         mod_str = ''
     stmt_str += ' ' + mod_str
@@ -109,11 +109,11 @@ def assemble_dephosphorylation(stmt):
     else:
         stmt_str = sub_str + ' is dephosphorylated'
 
-    if stmt.mod.residue is not None:
-        if stmt.mod.position is None:
-            mod_str = 'on ' + stmt.mod.residue
+    if stmt.residue is not None:
+        if stmt.position is None:
+            mod_str = 'on ' + stmt.residue
         else:
-            mod_str = 'on ' + abbrev_letter[stmt.mod.residue] + stmt.mod.position
+            mod_str = 'on ' + abbrev_letter[stmt.residue] + stmt.position
     else:
         mod_str = 'on an unknown residue '
     stmt_str += ' ' + mod_str

--- a/indra/graph_assembler.py
+++ b/indra/graph_assembler.py
@@ -8,7 +8,7 @@ class GraphAssembler():
         self.existing_edges = []
         self.graph = pygraphviz.AGraph(directed=True, rankdir='LR',
                                        splines='spline')
-    
+
     def add_statements(self, stmts):
         for stmt in stmts:
             self.statements.append(stmt)
@@ -27,7 +27,7 @@ class GraphAssembler():
                 self.add_node(stmt.enz)
                 self.add_node(stmt.sub)
                 self.add_dephosphorylation(stmt.enz, stmt.sub)
-     
+
     def add_edge(self, source, target, color, arrowhead):
         style = 'solid'
         self.graph.add_edge(source, target,
@@ -54,20 +54,20 @@ class GraphAssembler():
         arrowhead = 'normal'
         self.add_edge(source, target, color, arrowhead)
 
-    def add_node(self, agent):    
+    def add_node(self, agent):
         node_name = agent.name
         if node_name in self.existing_nodes:
             return
         self.existing_nodes.append(node_name)
         node_label = agent.name
-        color = "#ffeeee" 
+        color = "#ffeeee"
         self.graph.add_node(node_name,
                         label=node_label,
                         shape='Mrecord',
                         fillcolor=color, style="filled", color="transparent",
                         fontsize="12",
                         margin="0.06,0")
-    
+
     def get_string(self):
         graph_string = self.graph.string()
         graph_string = graph_string.replace('\\N', '\\n')
@@ -77,6 +77,6 @@ class GraphAssembler():
         s = self.get_string()
         with open(fname, 'wt') as fh:
             fh.write(s)
-    
+
     def save_pdf(self, fname='graph.pdf'):
         self.graph.draw(fname, prog='circo')

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -297,12 +297,14 @@ def check_sequence(stmt):
     elif isinstance(stmt, Modification):
         failures += check_agent_mod(stmt.sub)
         failures += check_agent_mod(stmt.enz)
-        if stmt.mod.position is not None:
-            failures += check_agent_mod(stmt.sub, [stmt.mod])
+        if stmt.position is not None:
+            mc = ModCondition('phosphorylation', stmt.residue, stmt.position)
+            failures += check_agent_mod(stmt.sub, [mc])
     elif isinstance(stmt, SelfModification):
         failures += check_agent_mod(stmt.sub)
-        if stmt.mod.position is not None:
-            failures += check_agent_mod(stmt.enz, [stmt.mod])
+        if stmt.position is not None:
+            mc = ModCondition('phosphorylation', stmt.residue, stmt.position)
+            failures += check_agent_mod(stmt.enz, [mc])
     elif isinstance(stmt, ActivityModification):
         failures += check_agent_mod(stmt.monomer)
         failures += check_agent_mod(stmt.monomer, stmt.mod)

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -297,18 +297,18 @@ def check_sequence(stmt):
     elif isinstance(stmt, Modification):
         failures += check_agent_mod(stmt.sub)
         failures += check_agent_mod(stmt.enz)
-        if stmt.mod_pos is not None:
-            failures += check_agent_mod(stmt.sub, [stmt.mod], [stmt.mod_pos])
+        if stmt.mod.position is not None:
+            failures += check_agent_mod(stmt.sub, [stmt.mod])
     elif isinstance(stmt, SelfModification):
         failures += check_agent_mod(stmt.sub)
-        if stmt.mod_pos is not None:
-            failures += check_agent_mod(stmt.enz, [stmt.mod], [stmt.mod_pos])
+        if stmt.mod.position is not None:
+            failures += check_agent_mod(stmt.enz, [stmt.mod])
     elif isinstance(stmt, ActivityModification):
         failures += check_agent_mod(stmt.monomer)
-        failures += check_agent_mod(stmt.monomer, stmt.mod, stmt.mod_pos)
+        failures += check_agent_mod(stmt.monomer, stmt.mod)
     return failures
 
-def check_agent_mod(agent, mods=None, mod_sites=None):
+def check_agent_mod(agent, mods=None):
     failures = []
     # If no UniProt ID is found, we don't report a failure
     up_id = agent.db_refs.get('UP')
@@ -319,35 +319,32 @@ def check_agent_mod(agent, mods=None, mod_sites=None):
     if not isinstance(up_id, basestring):
         up_id = up_id[0]
     agent_entry = uniprot_client.query_protein(up_id)
-    
-    if mod_sites is not None:
+
+    if mods is not None:
         check_mods = mods
-        check_mod_sites = mod_sites
     else:
         check_mods = agent.mods
-        check_mod_sites = agent.mod_sites
 
-    for m, mp in zip(check_mods, check_mod_sites):
-        if mp is None:
+    for m in check_mods:
+        if m.position is None:
             continue
-        residue = get_residue(m)
+        residue = get_residue(m.residue)
         if residue is None:
             continue
-        ver = uniprot_client.verify_location(agent_entry, residue, mp)
+        ver = uniprot_client.verify_location(agent_entry, residue, m.position)
         if not ver:
             print '-> Sequence check failed; position %s on %s is not %s.' %\
-                  (mp, agent.name, residue)
-            failures.append((agent.name, residue, mp))
+                  (m.position, agent.name, residue)
+            failures.append((agent.name, residue, m.position))
     return failures
 
-def get_residue(mod):
+def get_residue(residue):
     """Return the amino acid letter from a  modification string"""
-    if mod == 'PhosphorylationSerine':
-        residue = 'S'
-    elif mod == 'PhosphorylationThreonine':
-        residue = 'T'
-    elif mod == 'PhosphorylationTyrosine':
-        residue = 'Y'
+    if residue == 'serine':
+        return 'S'
+    elif residue == 'threonine':
+        return 'T'
+    elif residue == 'tyrosine':
+        return 'Y'
     else:
         return None
-    return residue 

--- a/indra/preassembler/make_modification_hierarchy.py
+++ b/indra/preassembler/make_modification_hierarchy.py
@@ -7,33 +7,22 @@ if __name__ == '__main__':
     rn = Namespace(indra_ns + 'relations/')
     en = Namespace(indra_ns + 'entitiess/')
     g = Graph()
-    
+
     isa = rn.term('isa')
     has_name = rn.term('hasName')
 
-    g.add((en.term('Modification'), has_name, Literal('Modification')))
-    g.add((en.term('Phosphorylation'), has_name, Literal('Phosphorylation')))
-    g.add((en.term('Ubiquitination'), has_name, Literal('Ubiquitination')))
-    g.add((en.term('Sumoylation'), has_name, Literal('Sumoylation')))
-    g.add((en.term('Acetylation'), has_name, Literal('Acetylation')))
-    g.add((en.term('Hydroxylation'), has_name, Literal('Hydroxylation')))
-    g.add((en.term('PhosphorylationSerine'), has_name, 
-            Literal('PhosphorylationSerine')))
-    g.add((en.term('PhosphorylationTyrosine'), has_name, 
-            Literal('PhosphorylationTyrosine')))
-    g.add((en.term('PhosphorylationThreonine'), has_name, 
-            Literal('PhosphorylationThreonine')))
-    
+    g.add((en.term('Modification'), has_name, Literal('modification')))
+    g.add((en.term('Phosphorylation'), has_name, Literal('phosphorylation')))
+    g.add((en.term('Ubiquitination'), has_name, Literal('ubiquitination')))
+    g.add((en.term('Sumoylation'), has_name, Literal('sumoylation')))
+    g.add((en.term('Acetylation'), has_name, Literal('acetylation')))
+    g.add((en.term('Hydroxylation'), has_name, Literal('hydroxylation')))
+
     g.add((en.term('Phosphorylation'), isa, en.term('Modification')))
     g.add((en.term('Ubiquitination'), isa, en.term('Modification')))
+    g.add((en.term('Sumoylation'), isa, en.term('Modification')))
     g.add((en.term('Acetylation'), isa, en.term('Modification')))
     g.add((en.term('Hydroxylation'), isa, en.term('Modification')))
-    g.add((en.term('Sumoylation'), isa, en.term('Modification')))
-    g.add((en.term('Phosphorylation'), isa, en.term('Modification')))
-    g.add((en.term('PhosphorylationSerine'), isa, en.term('Phosphorylation')))
-    g.add((en.term('PhosphorylationTyrosine'), isa, en.term('Phosphorylation')))
-    g.add((en.term('PhosphorylationThreonine'), isa, en.term('Phosphorylation')))
 
     with open('modification_hierarchy.rdf', 'wt') as out_file:
         out_file.write(g.serialize(format='xml'))
-    

--- a/indra/preassembler/modification_hierarchy.rdf
+++ b/indra/preassembler/modification_hierarchy.rdf
@@ -4,38 +4,26 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 >
   <rdf:Description rdf:about="http://sorger.med.harvard.edu/indra/entitiess/Modification">
-    <ns1:hasName>Modification</ns1:hasName>
+    <ns1:hasName>modification</ns1:hasName>
   </rdf:Description>
   <rdf:Description rdf:about="http://sorger.med.harvard.edu/indra/entitiess/Ubiquitination">
-    <ns1:hasName>Ubiquitination</ns1:hasName>
+    <ns1:hasName>ubiquitination</ns1:hasName>
     <ns1:isa rdf:resource="http://sorger.med.harvard.edu/indra/entitiess/Modification"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://sorger.med.harvard.edu/indra/entitiess/Acetylation">
     <ns1:isa rdf:resource="http://sorger.med.harvard.edu/indra/entitiess/Modification"/>
-    <ns1:hasName>Acetylation</ns1:hasName>
+    <ns1:hasName>acetylation</ns1:hasName>
   </rdf:Description>
   <rdf:Description rdf:about="http://sorger.med.harvard.edu/indra/entitiess/Sumoylation">
-    <ns1:hasName>Sumoylation</ns1:hasName>
+    <ns1:hasName>sumoylation</ns1:hasName>
     <ns1:isa rdf:resource="http://sorger.med.harvard.edu/indra/entitiess/Modification"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://sorger.med.harvard.edu/indra/entitiess/PhosphorylationThreonine">
-    <ns1:hasName>PhosphorylationThreonine</ns1:hasName>
-    <ns1:isa rdf:resource="http://sorger.med.harvard.edu/indra/entitiess/Phosphorylation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://sorger.med.harvard.edu/indra/entitiess/PhosphorylationSerine">
-    <ns1:isa rdf:resource="http://sorger.med.harvard.edu/indra/entitiess/Phosphorylation"/>
-    <ns1:hasName>PhosphorylationSerine</ns1:hasName>
   </rdf:Description>
   <rdf:Description rdf:about="http://sorger.med.harvard.edu/indra/entitiess/Phosphorylation">
     <ns1:isa rdf:resource="http://sorger.med.harvard.edu/indra/entitiess/Modification"/>
-    <ns1:hasName>Phosphorylation</ns1:hasName>
+    <ns1:hasName>phosphorylation</ns1:hasName>
   </rdf:Description>
   <rdf:Description rdf:about="http://sorger.med.harvard.edu/indra/entitiess/Hydroxylation">
     <ns1:isa rdf:resource="http://sorger.med.harvard.edu/indra/entitiess/Modification"/>
-    <ns1:hasName>Hydroxylation</ns1:hasName>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://sorger.med.harvard.edu/indra/entitiess/PhosphorylationTyrosine">
-    <ns1:isa rdf:resource="http://sorger.med.harvard.edu/indra/entitiess/Phosphorylation"/>
-    <ns1:hasName>PhosphorylationTyrosine</ns1:hasName>
+    <ns1:hasName>hydroxylation</ns1:hasName>
   </rdf:Description>
 </rdf:RDF>

--- a/indra/reach/processor.py
+++ b/indra/reach/processor.py
@@ -6,15 +6,15 @@ from indra.statements import *
 import indra.databases.uniprot_client as up_client
 
 residue_names = {
-    'S': 'Serine',
-    'T': 'Threonine',
-    'Y': 'Tyrosine',
-    'SER': 'Serine',
-    'THR': 'Threonine',
-    'TYR': 'Tyrosine',
-    'SERINE': 'Serine',
-    'THREONINE': 'Threonine',
-    'TYROSINE': 'Tyrosine'
+    'S': 'serine',
+    'T': 'threonine',
+    'Y': 'tyrosine',
+    'SER': 'serine',
+    'THR': 'threonine',
+    'TYR': 'tyrosine',
+    'SERINE': 'serine',
+    'THREONINE': 'threonine',
+    'TYROSINE': 'tyrosine'
     }
 
 

--- a/indra/reach/processor.py
+++ b/indra/reach/processor.py
@@ -84,19 +84,17 @@ class ReachProcessor(object):
             #continue
 
             theme_agent = self._get_agent_from_entity(theme)
-            mod = 'Phosphorylation'
             if site is not None:
                 residue, pos = self._parse_site_text(site)
             else:
-                residue = ''
+                residue = None
                 pos = None
-            mod = mod + residue
             sentence = r['verbose-text']
             ev = Evidence(source_api='reach', text=sentence,
                           annotations=context, pmid=self.citation,
                           epistemics=epistemics)
             self.statements.append(Phosphorylation(controller_agent,
-                                   theme_agent, mod, pos, ev))
+                                   theme_agent, residue, pos, ev))
 
     def get_complexes(self):
         qstr = "$.events.frames[@.type is 'complex-assembly']"
@@ -192,7 +190,6 @@ class ReachProcessor(object):
 
         mod_terms = entity_term.get('modifications')
         mods = []
-        mod_sites = []
         if mod_terms is not None:
             for m in mod_terms:
                 if m['type'] == 'mutation':
@@ -206,20 +203,16 @@ class ReachProcessor(object):
                     site = m.get('site')
                     if site is not None:
                         mod_res, mod_pos = self._parse_site_text(site)
-                        mod = 'Phosphorylation' + mod_res
+                        mod = ModCondition('phosphorylation', mod_res, mod_pos)
                         mods.append(mod)
-                        mod_sites.append(mod_pos)
                     else:
-                        mods.append('Phosphorylation')
-                        mod_sites.append(None)
+                        mods.append(ModCondition('phosphorylation'))
                 elif m['type'] == 'Ubiquitination':
-                    mods.append('Ubiquitination')
-                    mod_sites.append(None)
+                    mods.append(ModCondition('ubiquitination'))
                 else:
                     print 'Unhandled entity modification type: %s' % m['type']
 
-        agent = Agent(agent_name, db_refs=db_refs, mods=mods,
-                      mod_sites=mod_sites)
+        agent = Agent(agent_name, db_refs=db_refs, mods=mods)
         return agent
 
     @staticmethod

--- a/indra/reach/reach_api.py
+++ b/indra/reach/reach_api.py
@@ -46,7 +46,12 @@ def process_text(text, citation=None, offline=False):
         json_str = result_map.get('resultJson')
     else:
         data = {'text': text.encode('utf-8')}
-        res = requests.post(reach_text_url, data)
+        try:
+            res = requests.post(reach_text_url, data)
+        except requests.exceptions.RequestException as e:
+            print 'Could not connect to REACH service:'
+            print e
+            return None
         # TODO: we could use res.json() here to get a dict 
         # directly
         json_str = res.text
@@ -71,9 +76,14 @@ def process_nxml_str(nxml_str, citation=None, offline=False):
         json_str = result_map.get('resultJson')
     else:
         data = {'nxml': nxml_str}
-        res = requests.post(reach_nxml_url, data)
+        try:
+            res = requests.post(reach_nxml_url, data)
+        except requests.exceptions.RequestException as e:
+            print 'Could not connect to REACH service:'
+            print e
+            return None
         if res.status_code != 200:
-            print 'Could not process NXML.'
+            print 'Could not process NXML via REACH service.'
             return None
         json_str = res.text
     with open('reach_output.json', 'wt') as fh:

--- a/indra/sbgn_assembler.py
+++ b/indra/sbgn_assembler.py
@@ -9,35 +9,31 @@ from indra import statements as ist
 
 
 abbrevs = {
-    'PhosphorylationSerine': 'S',
-    'PhosphorylationThreonine': 'T',
-    'PhosphorylationTyrosine': 'Y',
-    'Phosphorylation': 'phospho',
-    'Ubiquitination': 'ub',
-    'Farnesylation': 'farnesyl',
-    'Hydroxylation': 'hydroxyl',
-    'Acetylation': 'acetyl',
-    'Sumoylation': 'sumo',
-    'Glycosylation': 'glycosyl',
-    'Methylation': 'methyl',
-    'Modification': 'mod',
+    'phosphorylation': 'phospho',
+    'ubiquitination': 'ub',
+    'farnesylation': 'farnesyl',
+    'hydroxylation': 'hydroxyl',
+    'acetylation': 'acetyl',
+    'sumoylation': 'sumo',
+    'glycosylation': 'glycosyl',
+    'methylation': 'methyl',
+    'modification': 'mod',
+    'serine': 'S',
+    'threonine': 'T',
+    'tyrosine': 'Y'
 }
 
 states = {
-    'PhosphorylationSerine': ['u', 'p'],
-    'PhosphorylationThreonine': ['u', 'p'],
-    'PhosphorylationTyrosine': ['u', 'p'],
-    'Phosphorylation': ['u', 'p'],
-    'Ubiquitination': ['n', 'y'],
-    'Farnesylation': ['n', 'y'],
-    'Hydroxylation': ['n', 'y'],
-    'Acetylation': ['n', 'y'],
-    'Sumoylation': ['n', 'y'],
-    'Glycosylation': ['n', 'y'],
-    'Methylation': ['n', 'y'],
-    'Modification': ['n', 'y'],
+    'phosphorylation': ['u', 'p'],
+    'ubiquitination': ['n', 'y'],
+    'farnesylation': ['n', 'y'],
+    'hydroxylation': ['n', 'y'],
+    'acetylation': ['n', 'y'],
+    'sumoylation': ['n', 'y'],
+    'glycosylation': ['n', 'y'],
+    'methylation': ['n', 'y'],
+    'modification': ['n', 'y'],
 }
-
 
 class SBGNAssembler(object):
 
@@ -156,11 +152,14 @@ SBGNState = collections.namedtuple('SBGNState', 'variable value')
 
 def sbgn_states_for_agent(agent):
     agent_states = []
-    for m, mp in zip(agent.mods, agent.mod_sites):
-        mod = abbrevs[m]
-        mod_pos = mp if mp is not None else ''
+    for m in agent.mods:
+        if m.residue is not None:
+            mod = abbrevs[m.residue]
+        else:
+            mod = abbrevs[m.mod_type]
+        mod_pos = m.position if m.position is not None else ''
         variable = '%s%s' % (mod, mod_pos)
-        value = states[m][1].upper()
+        value = states[m.mod_type][1].upper()
         agent_states.append(SBGNState(variable, value))
     return agent_states
 
@@ -173,10 +172,10 @@ def transformed_agents(statements):
     return [a for a in agents if a is not None]
 
 def statement_product(stmt):
-    if isinstance(stmt, ist.Modification):
+    if isinstance(stmt, ist.Phosphorylation):
         product = copy.deepcopy(stmt.sub)
-        product.mods.append(stmt.mod)
-        product.mod_sites.append(stmt.mod_pos)
+        mc = ist.ModCondition('phosphorylation', stmt.residue, stmt.position)
+        product.mods.append(mc)
     elif isinstance(stmt, ist.Complex):
         product = copy.deepcopy(stmt.members[0])
         for member in stmt.members[1:]:

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -337,7 +337,7 @@ class SelfModification(Statement):
         self.position = position
 
     def __str__(self):
-        s = ("%s(%s, %s, %s, %s)" %
+        s = ("%s(%s, %s, %s)" %
              (type(self).__name__, self.enz.name,
               self.residue, self.position))
         return s

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -73,7 +73,7 @@ class Agent(object):
 
     def matches_key(self):
         key = (self.name,
-               set(self.mods),
+               set([m.matches_key() for m in self.mods]),
                self.active,
                len(self.bound_conditions),
                tuple((bc.agent.matches_key(), bc.is_bound)

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -152,6 +152,7 @@ class Agent(object):
         if self.mods:
             mod_str = 'mods: '
             mod_str += ', '.join(['%s' % m for m in self.mods])
+            attr_strs.append(mod_str)
         if self.active:
             attr_strs.append('active: %s' % self.active)
         if self.bound_conditions:

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -2,22 +2,18 @@ from collections import namedtuple
 import textwrap
 
 BoundCondition = namedtuple('BoundCondition', ['agent', 'is_bound'])
+ModCondition = namedtuple('ModCondition', ['type', 'residue', 'position'])
 
 class Agent(object):
 
-    def __init__(self, name, mods=None, mod_sites=None, active=None,
+    def __init__(self, name, mod_conditions=None, active=None,
                  bound_conditions=None, db_refs=None):
         self.name = name
 
-        if mods is None:
-            self.mods = []
-        else:
-            self.mods = mods
-
-        if mod_sites is None:
-            self.mod_sites = []
-        else:
-            self.mod_sites = mod_sites
+        if mod_conditions is None:
+            self.mod_conditions = []
+        else:    
+            self.mod_conditions = mod_conditions
 
         if bound_conditions is None:
             self.bound_conditions = []
@@ -36,8 +32,7 @@ class Agent(object):
 
     def matches_key(self):
         key = (self.name,
-               set(self.mods),
-               set(self.mod_sites),
+               set(self.mod_conditions),
                self.active,
                len(self.bound_conditions),
                tuple((bc.agent.matches_key(), bc.is_bound)
@@ -95,23 +90,13 @@ class Agent(object):
         # MODIFICATIONS
         # Similar to the above, we check that self has all of the modifications
         # of other.
-        assert len(self.mods) == len(self.mod_sites), \
-               "Mods and mod_sites must match."
-        assert len(other.mods) == len(other.mod_sites), \
-               "Mods and mod_sites must match."
         # Make sure they have the same modifications
-        for other_mod_ix in range(len(other.mods)):
+        for other_mod_ix in range(len(other.mod_conditions)):
             mod_found = False
-            other_mod = other.mods[other_mod_ix]
-            other_mod_site = other.mod_sites[other_mod_ix]
-            for self_mod_ix in range(len(self.mods)):
-                self_mod = self.mods[self_mod_ix]
-                self_mod_site = self.mod_sites[self_mod_ix]
-                # Or has an isa relationship...
-                if (self_mod == other_mod or \
-                        mod_hierarchy.isa(self_mod, other_mod)) and \
-                   (self_mod_site == other_mod_site or \
-                        (self_mod_site is not None and other_mod_site is None)):
+            other_mod = other.mod_conditions[other_mod_ix]
+            for self_mod_ix in range(len(self.mod_conditions)):
+                self_mod = self.mod_conditions[self_mod_ix]
+                if mod_matches(self_mod, other_mod, mod_hierarchy):
                     mod_found = True
             # If we didn't find an exact match for this mod in other, then
             # no refinement
@@ -123,10 +108,10 @@ class Agent(object):
 
     def __str__(self):
         attr_strs = []
-        if self.mods:
-            attr_strs.append('mods: %s' % self.mods)
-        if self.mod_sites:
-            attr_strs.append('mod_sites: %s' % self.mod_sites)
+        if self.mod_conditions:
+            attr_strs += [append('mods: [%s, %s, %s]' %\
+                            (m.type, m.residue, m.pos))
+                            for m in self.mod_conditions]
         if self.active:
             attr_strs.append('active: %s' % self.active)
         if self.bound_conditions:
@@ -243,20 +228,18 @@ class Statement(object):
 class Modification(Statement):
     """Generic statement representing the modification of a protein"""
 
-    def __init__(self, enz, sub, mod, mod_pos, evidence=None):
+    def __init__(self, enz, sub, mod, evidence=None):
         super(Modification, self).__init__(evidence)
         self.enz = enz
         self.sub = sub
         self.mod = mod
-        self.mod_pos = mod_pos
 
     def matches_key(self):
         if self.enz is None:
             enz_key = None
         else:
             enz_key = self.enz.matches_key()
-        key = (type(self), enz_key, self.sub.matches_key(),
-                self.mod, self.mod_pos)
+        key = (type(self), enz_key, self.sub.matches_key(), self.mod)
         return str(key)
 
     def agent_list(self):
@@ -283,37 +266,32 @@ class Modification(Statement):
         # have to match or have this one be a subtype of the other; in
         # addition, the sites have to match, or this one has to have site
         # information and the other one not.
-        if (self.mod == other.mod or \
-                mod_hierarchy.isa(self.mod, other.mod)) and \
-           (self.mod_pos == other.mod_pos or \
-                (self.mod_pos is not None and other.mod_pos is None)):
+        if mod_matches(self.mod, other.mod, mod_hierarchy):    
             return True
         else:
             return False
 
     def __str__(self):
         s = ("%s(%s, %s, %s, %s)" %
-                  (type(self).__name__, self.enz, self.sub, self.mod,
-                   self.mod_pos))
+                  (type(self).__name__, self.enz, self.sub, self.mod))
         return s
 
 
 class SelfModification(Statement):
     """Generic statement representing the self modification of a protein"""
 
-    def __init__(self, enz, mod, mod_pos, evidence=None):
+    def __init__(self, enz, mod, evidence=None):
         super(SelfModification, self).__init__(evidence)
         self.enz = enz
         self.mod = mod
-        self.mod_pos = mod_pos
 
     def __str__(self):
         s = ("%s(%s, %s, %s)" %
-             (type(self).__name__, self.enz.name, self.mod, self.mod_pos))
+             (type(self).__name__, self.enz.name, self.mod))
         return s
 
     def matches_key(self):
-        key = (type(self), self.enz.matches_key(), self.mod, self.mod_pos)
+        key = (type(self), self.enz.matches_key(), self.mod)
         return str(key)
 
     def agent_list(self):
@@ -332,10 +310,7 @@ class SelfModification(Statement):
         # have to match or have this one be a subtype of the other; in
         # addition, the sites have to match, or this one has to have site
         # information and the other one not.
-        if (self.mod == other.mod or \
-                mod_hierarchy.isa(self.mod, other.mod)) and \
-           (self.mod_pos == other.mod_pos or \
-                (self.mod_pos is not None and other.mod_pos is None)):
+        if mod_matches(self.mod, other.mod, mod_hierarchy):
             return True
         else:
             return False
@@ -437,44 +412,16 @@ class ActivityModification(Statement):
     """Statement representing the activation of a protein as a result
     of a residue modification"""
 
-    def __init__(self, monomer, mod, mod_pos, relationship, activity,
+    def __init__(self, monomer, mod, relationship, activity,
                  evidence=None):
         super(ActivityModification, self).__init__(evidence)
         self.monomer = monomer
-        # This means that one of mod and mod_pos are a list, but not both,
-        # which should raise a ValueError
-        if isinstance(mod, list) and len(mod) > 1 and mod_pos is None:
-            raise ValueError('If more than one modification is specified then '
-                             'mod_pos must also be specified and cannot be '
-                             'None.')
-        elif isinstance(mod, list) != isinstance(mod_pos, list):
-            raise ValueError('If mod or mod_pos are provided as lists they '
-                             'must be matched.')
-        elif isinstance(mod, list) and isinstance(mod_pos, list) and \
-                len(mod) != len(mod_pos):
-            raise ValueError('If mod and mod_pos are lists, then they must be '
-                             'the same length.')
-        elif isinstance(mod, list) and isinstance(mod_pos, list) and \
-                len(mod) == len(mod_pos):
-            # Set the fields to be the lists, but make sure to stringify
-            # any entries in the mod_pos list that might be ints
-            self.mod = mod
-            self.mod_pos = [str(mp) for mp in mod_pos]
-        elif isinstance(mod, basestring) and \
-                (isinstance(mod_pos, int) or isinstance(mod_pos, basestring)):
-            self.mod = [mod]
-            self.mod_pos = [str(mod_pos)]
-        elif isinstance(mod, basestring) and mod_pos is None:
-            self.mod = [mod]
-            self.mod_pos = [None]
-        else:
-            raise ValueError('Invalid values for mod and/or mod_pos')
-
+        self.mod = mod
         self.relationship = relationship
         self.activity = activity
 
     def matches_key(self):
-        key = (type(self), self.monomer.matches_key(), self.mod, self.mod_pos,
+        key = (type(self), self.monomer.matches_key(), self.mod,
                 self.relationship, self.activity)
         return str(key)
 
@@ -491,12 +438,6 @@ class ActivityModification(Statement):
                                           mod_hierarchy):
             return False
 
-        # Mod and mod_pos should always be lists of the same length; mod_pos
-        # can also be None
-        assert isinstance(self.mod, list)
-        assert isinstance(self.mod_pos, list) or mod_pos is None
-        assert isinstance(other.mod, list)
-        assert isinstance(other.mod_pos, list) or mod_pos is None
         # Make sure that every instance of a modification in other is also
         # found (or refined) in self. To facilitate comparisons, we first zip
         # the two lists together in a list of tuples that can be sorted to
@@ -506,15 +447,9 @@ class ActivityModification(Statement):
         for other_mod_ix in range(len(other.mod)):
             mod_found = False
             other_mod = other.mod[other_mod_ix]
-            other_mod_pos = other.mod_pos[other_mod_ix]
             for self_mod_ix in range(len(self.mod)):
                 self_mod = self.mod[self_mod_ix]
-                self_mod_pos = self.mod_pos[self_mod_ix]
-                # Or has an isa relationship...
-                if (self_mod == other_mod or \
-                        mod_hierarchy.isa(self_mod, other_mod)) and \
-                   (self_mod_pos == other_mod_pos or \
-                        (self_mod_pos is not None and other_mod_pos is None)):
+                if mod_matches(self_mod, other_mod, mod_hierarchy):    
                     mod_found = True
             # If we didn't find an exact match for this mod in other, then
             # no refinement
@@ -531,8 +466,8 @@ class ActivityModification(Statement):
 
     def __str__(self):
         s = ("ActivityModification(%s, %s, %s, %s, %s)" %
-                (self.monomer, self.mod, self.mod_pos, self.relationship,
-                #(str(self.monomer), self.mod, self.mod_pos, self.relationship,
+                (self.monomer, self.mod, self.relationship,
+                #(str(self.monomer), self.mod, self.mod, self.relationship,
                  self.activity))
         return s
 
@@ -699,3 +634,11 @@ class Complex(Statement):
         else:
             return True
 
+def mod_matches(ref, other, mod_hierarchy):
+    type_match = (ref.type == other.type or \
+            mod_hierarchy.isa(ref.type, other.type))
+    residue_match = (ref.residue == other.residue or \
+            (ref.residue is not None and other.residue is None))
+    pos_match = (ref.pos == other.pos or \
+            (ref.pos is not None and other.pos is None))
+    return (type_match and residue_match and pos_match)

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -25,6 +25,17 @@ class ModCondition(object):
             (self.position is not None and other.position is None))
         return (type_match and residue_match and pos_match)
 
+    def __str__(self):
+        ms = '%s' % self.mod_type
+        if self.residue is not None:
+            ms += ', %s' % self.residue
+        if self.position is not None:
+            ms += ', %s' % self.position
+        if not self.is_modified:
+            ms += ', FALSE'
+        ms = '(' + ms + ')'
+        return ms
+
 class Agent(object):
 
     def __init__(self, name, mods=None, active=None,
@@ -136,9 +147,8 @@ class Agent(object):
     def __str__(self):
         attr_strs = []
         if self.mods:
-            attr_strs += [append('mods: [%s, %s, %s]' %\
-                            (m.type, m.residue, m.pos))
-                            for m in self.mods]
+            mod_str = 'mods: '
+            mod_str += ', '.join(['%s' % m for m in self.mods])
         if self.active:
             attr_strs.append('active: %s' % self.active)
         if self.bound_conditions:
@@ -293,13 +303,13 @@ class Modification(Statement):
         # have to match or have this one be a subtype of the other; in
         # addition, the sites have to match, or this one has to have site
         # information and the other one not.
-        if self.mod.matches(other.mod, mod_hierarchy):    
+        if self.mod.matches(other.mod, mod_hierarchy):
             return True
         else:
             return False
 
     def __str__(self):
-        s = ("%s(%s, %s, %s, %s)" %
+        s = ("%s(%s, %s, %s)" %
                   (type(self).__name__, self.enz, self.sub, self.mod))
         return s
 
@@ -496,10 +506,9 @@ class ActivityModification(Statement):
             return False
 
     def __str__(self):
-        s = ("ActivityModification(%s, %s, %s, %s, %s)" %
-                (self.monomer, self.mod, self.relationship,
-                #(str(self.monomer), self.mod, self.mod, self.relationship,
-                 self.activity))
+        mods = '[' + ', '.join(['%s' % m for m in self.mod]) + ']'
+        s = ("ActivityModification(%s, %s, %s, %s)" %
+                (self.monomer, mods, self.relationship, self.activity))
         return s
 
 

--- a/indra/tests/test_biopax.py
+++ b/indra/tests/test_biopax.py
@@ -47,7 +47,7 @@ def test_has_members_er():
                      'ProteinReference_971cec47bcd850e2b7d602f0416edacf')
     bpe = cast(bpc.bp('ProteinReference'), bpe)
     assert(bpc.has_members(bpe))
-    
+
     bpe = bp.model.getByID('http://identifiers.org/uniprot/P56159')
     bpe = cast(bpc.bp('ProteinReference'), bpe)
     assert(not bpc.has_members(bpe))
@@ -66,7 +66,7 @@ def test_is_pe():
     bpe = bp.model.getByID('http://identifiers.org/reactome/REACT_117345.2')
     bpe = cast(bpc.bp('Protein'), bpe)
     assert(bpc.is_entity(bpe))
-    
+
 def test_is_pe2():
     bpe = bp.model.getByID(uri_prefix +\
                      'ProteinReference_971cec47bcd850e2b7d602f0416edacf')
@@ -77,7 +77,7 @@ def test_is_er():
     bpe = bp.model.getByID('http://identifiers.org/reactome/REACT_117345.2')
     bpe = cast(bpc.bp('Protein'), bpe)
     assert(not bpc.is_reference(bpe))
-    
+
 def test_is_er2():
     bpe = bp.model.getByID(uri_prefix +\
                      'ProteinReference_971cec47bcd850e2b7d602f0416edacf')
@@ -127,3 +127,25 @@ def test_get_hgnc_id():
 def test_get_hgnc_name():
     hgnc_name = bp._get_hgnc_name(3432)
     assert(hgnc_name == 'ERBB4')
+
+def test_get_mod_feature():
+    bpe = bp.model.getByID(uri_prefix +\
+            'ModificationFeature_bd27a53570fb9a5094bb5929bd973217')
+    mf = cast(bpc.bp('ModificationFeature'), bpe)
+    mc = bpc.BiopaxProcessor._extract_mod_from_feature(mf)
+    assert(mc.mod_type == 'phosphorylation')
+    assert(mc.residue == 'threonine')
+    assert(mc.position == '274')
+
+def test_get_entity_mods():
+    bpe = bp.model.getByID(uri_prefix +\
+            'Protein_7aeb1631f64e49491b7a0303aaaec536')
+    protein = cast(bpc.bp('Protein'), bpe)
+    mods = bpc.BiopaxProcessor._get_entity_mods(protein)
+    assert(len(mods) == 5)
+    mod_types = set([m.mod_type for m in mods])
+    assert(mod_types == set(['phosphorylation']))
+    residues = set([m.residue for m in mods])
+    assert(residues == set(['tyrosine']))
+    mod_pos = set([m.position for m in mods])
+    assert(mod_pos == set(['1035', '1056', '1128', '1188', '1242']))

--- a/indra/tests/test_english_assembler.py
+++ b/indra/tests/test_english_assembler.py
@@ -7,43 +7,49 @@ def test_agent_basic():
     assert (s == 'EGFR')
 
 def test_agent_mod():
-    a = Agent('EGFR', mods=['Phosphorylation'], mod_sites=[None])
+    mc = ModCondition('phosphorylation')
+    a = Agent('EGFR', mods=mc)
     s = ea.assemble_agent_str(a)
     print s
     assert (s == 'phosphorylated EGFR')
 
 def test_agent_mod2():
-    a = Agent('EGFR', mods=['PhosphorylationTyrosine'], mod_sites=[None])
+    mc = ModCondition('phosphorylation', 'tyrosine')
+    a = Agent('EGFR', mods=mc)
     s = ea.assemble_agent_str(a)
     print s
     assert (s == 'tyrosine-phosphorylated EGFR')
 
 def test_agent_mod3():
-    a = Agent('EGFR', mods=['PhosphorylationTyrosine'], mod_sites=[1111])
+    mc = ModCondition('phosphorylation', 'tyrosine', '1111')
+    a = Agent('EGFR', mods=mc)
     s = ea.assemble_agent_str(a)
     print s
     assert (s == 'EGFR phosphorylated on Y1111')
 
 def test_agent_mods():
-    a = Agent('EGFR', mods=['PhosphorylationTyrosine', 
-              'PhosphorylationTyrosine'], mod_sites=[1111, 1234])
+    mc1 = ModCondition('phosphorylation', 'tyrosine', '1111')
+    mc2 = ModCondition('phosphorylation', 'tyrosine', '1234')
+    a = Agent('EGFR', mods=[mc1, mc2])
     s = ea.assemble_agent_str(a)
     print s
     assert (s == 'EGFR phosphorylated on Y1111 and Y1234')
 
 def test_agent_mods2():
-    a = Agent('EGFR', mods=['PhosphorylationTyrosine', 
-              'PhosphorylationTyrosine'], mod_sites=[1111, None])
+    mc1 = ModCondition('phosphorylation', 'tyrosine', '1111')
+    mc2 = ModCondition('phosphorylation', 'tyrosine')
+    a = Agent('EGFR', mods=[mc1, mc2])
     s = ea.assemble_agent_str(a)
     print s
-    assert (s == 'EGFR phosphorylated on Y1111 and a tyrosine residue')
+    assert (s == 'EGFR phosphorylated on Y1111 and tyrosine')
 
 def test_agent_mods3():
-    a = Agent('EGFR', mods=['PhosphorylationTyrosine', 
-              'Phosphorylation'], mod_sites=[1111, None])
+    mc1 = ModCondition('phosphorylation', 'tyrosine', '1111')
+    mc2 = ModCondition('phosphorylation')
+    a = Agent('EGFR', mods=[mc1, mc2])
     s = ea.assemble_agent_str(a)
     print s
-    assert (s == 'EGFR phosphorylated on Y1111 and an unknown site')
+    assert (s == 'EGFR phosphorylated on Y1111 and an unknown residue')
 
 def test_agent_bound():
     bc = BoundCondition(Agent('EGF'), True)
@@ -86,21 +92,22 @@ def test_agent_bound_mixed():
 
 def test_phos_noenz():
     a = Agent('MAP2K1')
-    st = Phosphorylation(None, a, 'Phosphorylation', None)
+    st = Phosphorylation(None, a, ModCondition('phosphorylation'))
     s = ea.assemble_phosphorylation(st)
     print s
     assert(s == 'MAP2K1 is phosphorylated.')
 
 def test_phos_noenz2():
     a = Agent('MAP2K1')
-    st = Phosphorylation(None, a, 'PhosphorylationSerine', None)
+    st = Phosphorylation(None, a, ModCondition('phosphorylation', 'serine'))
     s = ea.assemble_phosphorylation(st)
     print s
-    assert(s == 'MAP2K1 is phosphorylated on a serine residue.')
+    assert(s == 'MAP2K1 is phosphorylated on serine.')
 
 def test_phos_noenz3():
     a = Agent('MAP2K1')
-    st = Phosphorylation(None, a, 'PhosphorylationSerine', 222)
+    st = Phosphorylation(None, a,
+                         ModCondition('phosphorylation', 'serine', '222'))
     s = ea.assemble_phosphorylation(st)
     print s
     assert(s == 'MAP2K1 is phosphorylated on S222.')
@@ -108,7 +115,8 @@ def test_phos_noenz3():
 def test_phos_enz():
     a = Agent('MAP2K1')
     b = Agent('BRAF')
-    st = Phosphorylation(b, a, 'PhosphorylationSerine', 222)
+    st = Phosphorylation(b, a,
+                         ModCondition('phosphorylation', 'serine', '222'))
     s = ea.assemble_phosphorylation(st)
     print s
     assert(s == 'BRAF phosphorylates MAP2K1 on S222.')
@@ -116,7 +124,8 @@ def test_phos_enz():
 def test_phos_enz():
     a = Agent('MAP2K1')
     b = Agent('PP2A')
-    st = Dephosphorylation(b, a, 'PhosphorylationSerine', 222)
+    st = Dephosphorylation(b, a,
+                           ModCondition('phosphorylation', 'serine', '222'))
     s = ea.assemble_dephosphorylation(st)
     print s
     assert(s == 'PP2A dephosphorylates MAP2K1 on S222.')
@@ -141,7 +150,8 @@ def test_complex_more():
 def test_assemble_one():
     a = Agent('MAP2K1')
     b = Agent('PP2A')
-    st = Dephosphorylation(b, a, 'PhosphorylationSerine', 222)
+    st = Dephosphorylation(b, a,
+                           ModCondition('phosphorylation', 'serine', 222))
     e = ea.EnglishAssembler()
     e.add_statements([st])
     s = e.make_model()
@@ -151,7 +161,8 @@ def test_assemble_one():
 def test_assemble_more():
     a = Agent('MAP2K1')
     b = Agent('PP2A')
-    st1 = Dephosphorylation(b, a, 'PhosphorylationSerine', 222)
+    st1 = Dephosphorylation(b, a,
+                            ModCondition('phosphorylation', 'serine', 222))
     b = Agent('BRAF')
     c = Agent('RAF1')
     st2 = Complex([a, b, c])

--- a/indra/tests/test_english_assembler.py
+++ b/indra/tests/test_english_assembler.py
@@ -92,22 +92,21 @@ def test_agent_bound_mixed():
 
 def test_phos_noenz():
     a = Agent('MAP2K1')
-    st = Phosphorylation(None, a, ModCondition('phosphorylation'))
+    st = Phosphorylation(None, a)
     s = ea.assemble_phosphorylation(st)
     print s
     assert(s == 'MAP2K1 is phosphorylated.')
 
 def test_phos_noenz2():
     a = Agent('MAP2K1')
-    st = Phosphorylation(None, a, ModCondition('phosphorylation', 'serine'))
+    st = Phosphorylation(None, a, 'serine')
     s = ea.assemble_phosphorylation(st)
     print s
     assert(s == 'MAP2K1 is phosphorylated on serine.')
 
 def test_phos_noenz3():
     a = Agent('MAP2K1')
-    st = Phosphorylation(None, a,
-                         ModCondition('phosphorylation', 'serine', '222'))
+    st = Phosphorylation(None, a, 'serine', '222')
     s = ea.assemble_phosphorylation(st)
     print s
     assert(s == 'MAP2K1 is phosphorylated on S222.')
@@ -115,8 +114,7 @@ def test_phos_noenz3():
 def test_phos_enz():
     a = Agent('MAP2K1')
     b = Agent('BRAF')
-    st = Phosphorylation(b, a,
-                         ModCondition('phosphorylation', 'serine', '222'))
+    st = Phosphorylation(b, a, 'serine', '222')
     s = ea.assemble_phosphorylation(st)
     print s
     assert(s == 'BRAF phosphorylates MAP2K1 on S222.')
@@ -124,8 +122,7 @@ def test_phos_enz():
 def test_phos_enz():
     a = Agent('MAP2K1')
     b = Agent('PP2A')
-    st = Dephosphorylation(b, a,
-                           ModCondition('phosphorylation', 'serine', '222'))
+    st = Dephosphorylation(b, a, 'serine', '222')
     s = ea.assemble_dephosphorylation(st)
     print s
     assert(s == 'PP2A dephosphorylates MAP2K1 on S222.')
@@ -150,8 +147,7 @@ def test_complex_more():
 def test_assemble_one():
     a = Agent('MAP2K1')
     b = Agent('PP2A')
-    st = Dephosphorylation(b, a,
-                           ModCondition('phosphorylation', 'serine', 222))
+    st = Dephosphorylation(b, a, 'serine', 222)
     e = ea.EnglishAssembler()
     e.add_statements([st])
     s = e.make_model()
@@ -161,8 +157,7 @@ def test_assemble_one():
 def test_assemble_more():
     a = Agent('MAP2K1')
     b = Agent('PP2A')
-    st1 = Dephosphorylation(b, a,
-                            ModCondition('phosphorylation', 'serine', 222))
+    st1 = Dephosphorylation(b, a, 'serine', 222)
     b = Agent('BRAF')
     c = Agent('RAF1')
     st2 = Complex([a, b, c])

--- a/indra/tests/test_hierarchy_manager.py
+++ b/indra/tests/test_hierarchy_manager.py
@@ -25,15 +25,11 @@ def test_find_entity4():
 
 def test_find_mod():
     hm = HierarchyManager(mod_file)
-    assert(hm.find_entity('Phosphorylation'))
+    assert(hm.find_entity('phosphorylation'))
 
 def test_find_mod2():
     hm = HierarchyManager(mod_file)
-    assert(hm.find_entity('Sumoylation'))
-
-def test_find_mod3():
-    hm = HierarchyManager(mod_file)
-    assert(hm.find_entity('PhosphorylationSerine'))
+    assert(hm.find_entity('sumoylation'))
 
 def test_isa():
     hm = HierarchyManager(entity_file)
@@ -53,16 +49,8 @@ def test_isa4():
 
 def test_isa_mod():
     hm = HierarchyManager(mod_file)
-    assert(hm.isa('Phosphorylation', 'Modification'))
+    assert(hm.isa('phosphorylation', 'modification'))
 
-def test_isa_mod2():
+def test_isa_mod_not():
     hm = HierarchyManager(mod_file)
-    assert(hm.isa('PhosphorylationSerine', 'Phosphorylation'))
-
-def test_isa_mod3():
-    hm = HierarchyManager(mod_file)
-    assert(hm.isa('PhosphorylationSerine', 'Modification'))
-
-def test_isa_mod4():
-    hm = HierarchyManager(mod_file)
-    assert(not hm.isa('Phosphorylation', 'Ubiquitination'))
+    assert(not hm.isa('phosphorylation', 'ubiquitination'))

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -26,8 +26,8 @@ def test_from_text():
 def test_duplicates():
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     ras = Agent('RAS', db_refs = {'FA': '03663'})
-    st1 = Phosphorylation(src, ras, ModCondition('phosphorylation'))
-    st2 = Phosphorylation(src, ras, ModCondition('phosphorylation'))
+    st1 = Phosphorylation(src, ras)
+    st2 = Phosphorylation(src, ras)
     pa = Preassembler(eh, mh, [st1, st2])
     pa.combine_duplicates()
     assert(len(pa.unique_stmts) == 1)
@@ -42,12 +42,9 @@ def test_duplicates_sorting():
     mapk3 = Agent('MAPK3')
     #ras = Agent('MAPK3', db_refs = {'FA': '03663'})
     #nras = Agent('NRAS', db_refs = {'FA': '03663'})
-    st1 = Phosphorylation(map2k1_1, mapk3,
-                          ModCondition('phosphorylation', position='218'))
-    st2 = Phosphorylation(map2k1_2, mapk3,
-                          ModCondition('phosphorylation'))
-    st3 = Phosphorylation(map2k1_1, mapk3,
-                          ModCondition('phosphorylation', position='218'))
+    st1 = Phosphorylation(map2k1_1, mapk3, position='218')
+    st2 = Phosphorylation(map2k1_2, mapk3)
+    st3 = Phosphorylation(map2k1_1, mapk3, position='218')
     stmts = [st1, st2, st3]
     pa = Preassembler(eh, mh, stmts)
     pa.combine_duplicates()
@@ -57,24 +54,23 @@ def test_combine_duplicates():
     raf = Agent('RAF1')
     mek = Agent('MEK1')
     erk = Agent('ERK2')
-    mcphos = ModCondition('phosphorylation')
-    p1 = Phosphorylation(raf, mek, mcphos,
+    p1 = Phosphorylation(raf, mek,
             evidence=Evidence(text='foo'))
-    p2 = Phosphorylation(raf, mek, mcphos,
+    p2 = Phosphorylation(raf, mek,
             evidence=Evidence(text='bar'))
-    p3 = Phosphorylation(raf, mek, mcphos,
+    p3 = Phosphorylation(raf, mek,
             evidence=Evidence(text='baz'))
-    p4 = Phosphorylation(raf, mek, mcphos,
+    p4 = Phosphorylation(raf, mek,
             evidence=Evidence(text='beep'))
-    p5 = Phosphorylation(mek, erk, mcphos,
+    p5 = Phosphorylation(mek, erk,
             evidence=Evidence(text='foo'))
-    p6 = Dephosphorylation(mek, erk, mcphos,
+    p6 = Dephosphorylation(mek, erk,
             evidence=Evidence(text='bar'))
-    p7 = Dephosphorylation(mek, erk, mcphos,
+    p7 = Dephosphorylation(mek, erk,
             evidence=Evidence(text='baz'))
-    p8 = Dephosphorylation(mek, erk, mcphos,
+    p8 = Dephosphorylation(mek, erk,
             evidence=Evidence(text='beep'))
-    p9 = Dephosphorylation(Agent('SRC'), Agent('KRAS'), mcphos,
+    p9 = Dephosphorylation(Agent('SRC'), Agent('KRAS'),
                            evidence=Evidence(text='beep'))
     stmts = [p1, p2, p3, p4, p5, p6, p7, p8, p9]
     pa = Preassembler(eh, mh, stmts)
@@ -96,9 +92,8 @@ def test_superfamily_refinement():
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     ras = Agent('RAS', db_refs = {'FA': '03663'})
     nras = Agent('NRAS', db_refs = {'HGNC': '7989'})
-    mcphostyr = ModCondition('phosphorylation', 'tyrosine', '32')
-    st1 = Phosphorylation(src, ras, mcphostyr)
-    st2 = Phosphorylation(src, nras, mcphostyr)
+    st1 = Phosphorylation(src, ras, 'tyrosine', '32')
+    st2 = Phosphorylation(src, nras, 'tyrosine', '32')
     pa = Preassembler(eh, mh, [st1, st2])
     stmts = pa.combine_related()
     # The top-level list should contain only one statement, the gene-level
@@ -112,10 +107,8 @@ def test_modification_refinement():
     generic modification statement."""
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     nras = Agent('NRAS', db_refs = {'HGNC': '7989'})
-    mcphos = ModCondition('phosphorylation')
-    mcphostyr = ModCondition('phosphorylation', 'tyrosine', '32')
-    st1 = Phosphorylation(src, nras, mcphostyr)
-    st2 = Phosphorylation(src, nras, mcphos)
+    st1 = Phosphorylation(src, nras, 'tyrosine', '32')
+    st2 = Phosphorylation(src, nras)
     pa = Preassembler(eh, mh, [st1, st2])
     stmts = pa.combine_related()
     # The top-level list should contain only one statement, the more specific
@@ -129,9 +122,8 @@ def test_modification_refinement_noenz():
     generic modification statement."""
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     nras = Agent('NRAS', db_refs = {'HGNC': '7989'})
-    mcphostyr = ModCondition('phosphorylation', 'tyrosine', '32')
-    st1 = Phosphorylation(src, nras, mcphostyr)
-    st2 = Phosphorylation(None, nras, mcphostyr)
+    st1 = Phosphorylation(src, nras, 'tyrosine', '32')
+    st2 = Phosphorylation(None, nras, 'tyrosine', '32')
     pa = Preassembler(eh, mh, [st1, st2])
     stmts = pa.combine_related()
     # The top-level list should contain only one statement, the more specific
@@ -145,10 +137,8 @@ def test_modification_norefinement_noenz():
     generic modification statement."""
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     nras = Agent('NRAS', db_refs = {'HGNC': '7989'})
-    mcphos = ModCondition('phosphorylation')
-    mcphostyr = ModCondition('phosphorylation', 'tyrosine', '32')
-    st1 = Phosphorylation(src, nras, mcphos)
-    st2 = Phosphorylation(None, nras, mcphostyr)
+    st1 = Phosphorylation(src, nras)
+    st2 = Phosphorylation(None, nras, 'tyrosine', '32')
     pa = Preassembler(eh, mh, [st1, st2])
     #import ipdb; ipdb.set_trace()
     stmts = pa.combine_related()
@@ -165,9 +155,8 @@ def test_bound_condition_refinement():
     nras = Agent('NRAS', db_refs = {'HGNC': '7989'})
     nrasgtp = Agent('NRAS', db_refs = {'HGNC': '7989'},
         bound_conditions=[BoundCondition(gtp, True)])
-    mcphostyr = ModCondition('phosphorylation', 'tyrosine', '32')
-    st1 = Phosphorylation(src, nras, mcphostyr)
-    st2 = Phosphorylation(src, nrasgtp, mcphostyr)
+    st1 = Phosphorylation(src, nras, 'tyrosine', '32')
+    st2 = Phosphorylation(src, nrasgtp, 'tyrosine', '32')
     # The top-level list should contain only one statement, the more specific
     # modification, supported by the less-specific modification.
     pa = Preassembler(eh, mh, [st1, st2])
@@ -184,10 +173,8 @@ def test_bound_condition_norefinement():
     nras = Agent('NRAS', db_refs = {'HGNC': '7989'})
     nrasgtp = Agent('NRAS', db_refs = {'HGNC': '7989'},
         bound_conditions=[BoundCondition(gtp, True)])
-    mcphos = ModCondition('phosphorylation')
-    mcphostyr = ModCondition('phosphorylation', 'tyrosine', '32')
-    st1 = Phosphorylation(src, nras, mcphostyr)
-    st2 = Phosphorylation(src, nrasgtp, mcphos)
+    st1 = Phosphorylation(src, nras, 'tyrosine', '32')
+    st2 = Phosphorylation(src, nrasgtp)
     pa = Preassembler(eh, mh, [st1, st2])
     stmts = pa.combine_related()
     # The bound condition is more specific in st2 but the modification is less
@@ -212,18 +199,13 @@ def test_render_stmt_graph():
     mek1 = Agent('MAP2K1')
     mek = Agent('MEK')
     # Statements
-    p0 = Phosphorylation(braf, mek, ModCondition('phosphorylation'))
-    p1 = Phosphorylation(braf, mek1, ModCondition('phosphorylation'))
-    p2 = Phosphorylation(braf, mek1,
-                         ModCondition('phosphorylation', position='218'))
-    p3 = Phosphorylation(braf, mek1,
-                         ModCondition('phosphorylation', position='222'))
-    p4 = Phosphorylation(braf, mek1,
-                         ModCondition('phosphorylation', 'serine'))
-    p5 = Phosphorylation(braf, mek1,
-                         ModCondition('phosphorylation', 'serine', '218'))
-    p6 = Phosphorylation(braf, mek1,
-                         ModCondition('phosphorylation', 'serine', '222'))
+    p0 = Phosphorylation(braf, mek)
+    p1 = Phosphorylation(braf, mek1)
+    p2 = Phosphorylation(braf, mek1, position='218')
+    p3 = Phosphorylation(braf, mek1, position='222')
+    p4 = Phosphorylation(braf, mek1, 'serine')
+    p5 = Phosphorylation(braf, mek1, 'serine', '218')
+    p6 = Phosphorylation(braf, mek1, 'serine', '222')
     stmts = [p0, p1, p2, p3, p4, p5, p6]
     pa = Preassembler(eh, mh, stmts)
     pa.combine_related()

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -2,7 +2,7 @@ import os
 from indra.preassembler import Preassembler, render_stmt_graph
 from indra.trips import trips_api
 from indra.statements import Agent, Phosphorylation, BoundCondition, \
-                             Dephosphorylation, Evidence
+                             Dephosphorylation, Evidence, ModCondition
 from indra.preassembler.hierarchy_manager import HierarchyManager
 
 entity_file_path = os.path.join(os.path.dirname(__file__),
@@ -26,22 +26,28 @@ def test_from_text():
 def test_duplicates():
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     ras = Agent('RAS', db_refs = {'FA': '03663'})
-    st1 = Phosphorylation(src, ras, 'Phosphorylation', None)
-    st2 = Phosphorylation(src, ras, 'Phosphorylation', None)
+    st1 = Phosphorylation(src, ras, ModCondition('phosphorylation'))
+    st2 = Phosphorylation(src, ras, ModCondition('phosphorylation'))
     pa = Preassembler(eh, mh, [st1, st2])
     pa.combine_duplicates()
     assert(len(pa.unique_stmts) == 1)
 
 def test_duplicates_sorting():
-    map2k1_1 = Agent('MAP2K1', mods=['Phosphorylation'], mod_sites=[None])
-    map2k1_2 = Agent('MAP2K1', mods=['PhosphorylationSerine'],
-                               mod_sites=['218', '222', '298'])
+    mc = ModCondition('phosphorylation')
+    map2k1_1 = Agent('MAP2K1', mods=[mc])
+    mc1 = ModCondition('phosphorylation', 'serine', '218')
+    mc2 = ModCondition('phosphorylation', 'serine', '222')
+    mc3 = ModCondition('phosphorylation', 'serine', '298')
+    map2k1_2 = Agent('MAP2K1', mods=[mc1, mc2, mc3])
     mapk3 = Agent('MAPK3')
     #ras = Agent('MAPK3', db_refs = {'FA': '03663'})
     #nras = Agent('NRAS', db_refs = {'FA': '03663'})
-    st1 = Phosphorylation(map2k1_1, mapk3, 'Phosphorylation', '218')
-    st2 = Phosphorylation(map2k1_2, mapk3, 'Phosphorylation', None)
-    st3 = Phosphorylation(map2k1_1, mapk3, 'Phosphorylation', '218')
+    st1 = Phosphorylation(map2k1_1, mapk3,
+                          ModCondition('phosphorylation', position='218'))
+    st2 = Phosphorylation(map2k1_2, mapk3,
+                          ModCondition('phosphorylation'))
+    st3 = Phosphorylation(map2k1_1, mapk3,
+                          ModCondition('phosphorylation', position='218'))
     stmts = [st1, st2, st3]
     pa = Preassembler(eh, mh, stmts)
     pa.combine_duplicates()
@@ -51,24 +57,25 @@ def test_combine_duplicates():
     raf = Agent('RAF1')
     mek = Agent('MEK1')
     erk = Agent('ERK2')
-    p1 = Phosphorylation(raf, mek, 'Phosphorylation', None,
+    mcphos = ModCondition('phosphorylation')
+    p1 = Phosphorylation(raf, mek, mcphos,
             evidence=Evidence(text='foo'))
-    p2 = Phosphorylation(raf, mek, 'Phosphorylation', None,
+    p2 = Phosphorylation(raf, mek, mcphos,
             evidence=Evidence(text='bar'))
-    p3 = Phosphorylation(raf, mek, 'Phosphorylation', None,
+    p3 = Phosphorylation(raf, mek, mcphos,
             evidence=Evidence(text='baz'))
-    p4 = Phosphorylation(raf, mek, 'Phosphorylation', None,
+    p4 = Phosphorylation(raf, mek, mcphos,
             evidence=Evidence(text='beep'))
-    p5 = Phosphorylation(mek, erk, 'Phosphorylation', None,
+    p5 = Phosphorylation(mek, erk, mcphos,
             evidence=Evidence(text='foo'))
-    p6 = Dephosphorylation(mek, erk, 'Phosphorylation', None,
+    p6 = Dephosphorylation(mek, erk, mcphos,
             evidence=Evidence(text='bar'))
-    p7 = Dephosphorylation(mek, erk, 'Phosphorylation', None,
+    p7 = Dephosphorylation(mek, erk, mcphos,
             evidence=Evidence(text='baz'))
-    p8 = Dephosphorylation(mek, erk, 'Phosphorylation', None,
+    p8 = Dephosphorylation(mek, erk, mcphos,
             evidence=Evidence(text='beep'))
-    p9 = Dephosphorylation(Agent('SRC'), Agent('KRAS'),
-                         'Phosphorylation', None, evidence=Evidence(text='beep'))
+    p9 = Dephosphorylation(Agent('SRC'), Agent('KRAS'), mcphos,
+                           evidence=Evidence(text='beep'))
     stmts = [p1, p2, p3, p4, p5, p6, p7, p8, p9]
     pa = Preassembler(eh, mh, stmts)
     pa.combine_duplicates()
@@ -89,8 +96,9 @@ def test_superfamily_refinement():
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     ras = Agent('RAS', db_refs = {'FA': '03663'})
     nras = Agent('NRAS', db_refs = {'HGNC': '7989'})
-    st1 = Phosphorylation(src, ras, 'PhosphorylationTyrosine', '32')
-    st2 = Phosphorylation(src, nras, 'PhosphorylationTyrosine', '32')
+    mcphostyr = ModCondition('phosphorylation', 'tyrosine', '32')
+    st1 = Phosphorylation(src, ras, mcphostyr)
+    st2 = Phosphorylation(src, nras, mcphostyr)
     pa = Preassembler(eh, mh, [st1, st2])
     stmts = pa.combine_related()
     # The top-level list should contain only one statement, the gene-level
@@ -104,8 +112,10 @@ def test_modification_refinement():
     generic modification statement."""
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     nras = Agent('NRAS', db_refs = {'HGNC': '7989'})
-    st1 = Phosphorylation(src, nras, 'PhosphorylationTyrosine', '32')
-    st2 = Phosphorylation(src, nras, 'Phosphorylation', None)
+    mcphos = ModCondition('phosphorylation')
+    mcphostyr = ModCondition('phosphorylation', 'tyrosine', '32')
+    st1 = Phosphorylation(src, nras, mcphostyr)
+    st2 = Phosphorylation(src, nras, mcphos)
     pa = Preassembler(eh, mh, [st1, st2])
     stmts = pa.combine_related()
     # The top-level list should contain only one statement, the more specific
@@ -119,8 +129,9 @@ def test_modification_refinement_noenz():
     generic modification statement."""
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     nras = Agent('NRAS', db_refs = {'HGNC': '7989'})
-    st1 = Phosphorylation(src, nras, 'PhosphorylationTyrosine', '32')
-    st2 = Phosphorylation(None, nras, 'PhosphorylationTyrosine', '32')
+    mcphostyr = ModCondition('phosphorylation', 'tyrosine', '32')
+    st1 = Phosphorylation(src, nras, mcphostyr)
+    st2 = Phosphorylation(None, nras, mcphostyr)
     pa = Preassembler(eh, mh, [st1, st2])
     stmts = pa.combine_related()
     # The top-level list should contain only one statement, the more specific
@@ -134,8 +145,10 @@ def test_modification_norefinement_noenz():
     generic modification statement."""
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     nras = Agent('NRAS', db_refs = {'HGNC': '7989'})
-    st1 = Phosphorylation(src, nras, 'Phosphorylation', None)
-    st2 = Phosphorylation(None, nras, 'PhosphorylationTyrosine', '32')
+    mcphos = ModCondition('phosphorylation')
+    mcphostyr = ModCondition('phosphorylation', 'tyrosine', '32')
+    st1 = Phosphorylation(src, nras, mcphos)
+    st2 = Phosphorylation(None, nras, mcphostyr)
     pa = Preassembler(eh, mh, [st1, st2])
     #import ipdb; ipdb.set_trace()
     stmts = pa.combine_related()
@@ -152,8 +165,9 @@ def test_bound_condition_refinement():
     nras = Agent('NRAS', db_refs = {'HGNC': '7989'})
     nrasgtp = Agent('NRAS', db_refs = {'HGNC': '7989'},
         bound_conditions=[BoundCondition(gtp, True)])
-    st1 = Phosphorylation(src, nras, 'PhosphorylationTyrosine', '32')
-    st2 = Phosphorylation(src, nrasgtp, 'PhosphorylationTyrosine', '32')
+    mcphostyr = ModCondition('phosphorylation', 'tyrosine', '32')
+    st1 = Phosphorylation(src, nras, mcphostyr)
+    st2 = Phosphorylation(src, nrasgtp, mcphostyr)
     # The top-level list should contain only one statement, the more specific
     # modification, supported by the less-specific modification.
     pa = Preassembler(eh, mh, [st1, st2])
@@ -170,8 +184,10 @@ def test_bound_condition_norefinement():
     nras = Agent('NRAS', db_refs = {'HGNC': '7989'})
     nrasgtp = Agent('NRAS', db_refs = {'HGNC': '7989'},
         bound_conditions=[BoundCondition(gtp, True)])
-    st1 = Phosphorylation(src, nras, 'PhosphorylationTyrosine', '32')
-    st2 = Phosphorylation(src, nrasgtp, 'Phosphorylation', None)
+    mcphos = ModCondition('phosphorylation')
+    mcphostyr = ModCondition('phosphorylation', 'tyrosine', '32')
+    st1 = Phosphorylation(src, nras, mcphostyr)
+    st2 = Phosphorylation(src, nrasgtp, mcphos)
     pa = Preassembler(eh, mh, [st1, st2])
     stmts = pa.combine_related()
     # The bound condition is more specific in st2 but the modification is less
@@ -196,13 +212,18 @@ def test_render_stmt_graph():
     mek1 = Agent('MAP2K1')
     mek = Agent('MEK')
     # Statements
-    p0 = Phosphorylation(braf, mek, 'Phosphorylation', None)
-    p1 = Phosphorylation(braf, mek1, 'Phosphorylation', None)
-    p2 = Phosphorylation(braf, mek1, 'Phosphorylation', '218')
-    p3 = Phosphorylation(braf, mek1, 'Phosphorylation', '222')
-    p4 = Phosphorylation(braf, mek1, 'PhosphorylationSerine', None)
-    p5 = Phosphorylation(braf, mek1, 'PhosphorylationSerine', '218')
-    p6 = Phosphorylation(braf, mek1, 'PhosphorylationSerine', '222')
+    p0 = Phosphorylation(braf, mek, ModCondition('phosphorylation'))
+    p1 = Phosphorylation(braf, mek1, ModCondition('phosphorylation'))
+    p2 = Phosphorylation(braf, mek1,
+                         ModCondition('phosphorylation', position='218'))
+    p3 = Phosphorylation(braf, mek1,
+                         ModCondition('phosphorylation', position='222'))
+    p4 = Phosphorylation(braf, mek1,
+                         ModCondition('phosphorylation', 'serine'))
+    p5 = Phosphorylation(braf, mek1,
+                         ModCondition('phosphorylation', 'serine', '218'))
+    p6 = Phosphorylation(braf, mek1,
+                         ModCondition('phosphorylation', 'serine', '222'))
     stmts = [p0, p1, p2, p3, p4, p5, p6]
     pa = Preassembler(eh, mh, stmts)
     pa.combine_related()

--- a/indra/tests/test_preassembler_checks.py
+++ b/indra/tests/test_preassembler_checks.py
@@ -1,78 +1,90 @@
 from indra.preassembler import check_statements, check_sequence
 from indra.preassembler import check_agent_mod
-from indra.statements import Phosphorylation, Agent
+from indra.statements import Phosphorylation, Agent, ModCondition
 
 def test_check_agent_mod_args():
     a = Agent('MAPK1', db_refs = {'UP': 'P28482'})
-    failures = check_agent_mod(a, ['PhosphorylationThreonine'], [185])
+    mc = ModCondition('phosphorylation', 'threonine', '185')
+    failures = check_agent_mod(a, [mc])
     assert(not failures)
 
 def test_check_agent_mod_multiple():
-    a = Agent('MAPK1', mods=['PhosphorylationThreonine', 'PhosphorylationTyrosine'],
-              mod_sites=[185, 187], db_refs = {'UP': 'P28482'})
+    mc1 = ModCondition('phosphorylation', 'threonine', '185')
+    mc2 = ModCondition('phosphorylation', 'tyrosine', '187')
+    a = Agent('MAPK1', mods=[mc1, mc2], db_refs = {'UP': 'P28482'})
     failures = check_agent_mod(a)
     assert(not failures)
 
 def test_check_agent_mod_wrong():
-    a = Agent('MAPK1', mods=['PhosphorylationThreonine'],
-              mod_sites=[186], db_refs = {'UP': 'P28482'})
+    mc = ModCondition('phosphorylation', 'threonine', '186')
+    a = Agent('MAPK1', mods=[mc], db_refs = {'UP': 'P28482'})
     failures = check_agent_mod(a)
     assert(failures)
 
 def test_check_agent_mod_wrong_multiple():
-    a = Agent('MAPK1', mods=['PhosphorylationThreonine', 'PhosphorylationTyrosine'],
-              mod_sites=[184, 186], db_refs = {'UP': 'P28482'})
+    mc1 = ModCondition('phosphorylation', 'threonine', '184')
+    mc2 = ModCondition('phosphorylation', 'tyrosine', '186')
+    a = Agent('MAPK1', mods=[mc1, mc2], db_refs = {'UP': 'P28482'})
     failures = check_agent_mod(a)
     assert(failures)
 
 def test_check_agent_mod_wrong_multiple2():
-    a = Agent('MAPK1', mods=['PhosphorylationThreonine', 'PhosphorylationTyrosine'],
-              mod_sites=[185, 186], db_refs = {'UP': 'P28482'})
+    mc1 = ModCondition('phosphorylation', 'threonine', '185')
+    mc2 = ModCondition('phosphorylation', 'tyrosine', '186')
+    a = Agent('MAPK1', mods=[mc1, mc2], db_refs = {'UP': 'P28482'})
     failures = check_agent_mod(a)
     assert(failures)
 
 def test_check_sequence_phos():
     s = Agent('MAPK1', db_refs = {'UP': 'P28482'})
     e = Agent('MAP2K1')
-    stmt = Phosphorylation(e, s, 'PhosphorylationThreonine', 185)
+    mc1 = ModCondition('phosphorylation', 'threonine', '185')
+    stmt = Phosphorylation(e, s, mc1)
     failures = check_sequence(stmt)
     assert(not failures)
 
 def test_check_sequence_phos_wrong():
     s = Agent('MAPK1', db_refs = {'UP': 'P28482'})
     e = Agent('MAP2K1')
-    stmt = Phosphorylation(e, s, 'PhosphorylationThreonine', 186)
+    mc1 = ModCondition('phosphorylation', 'threonine', '186')
+    stmt = Phosphorylation(e, s, mc1)
     failures = check_sequence(stmt)
     assert(failures)
 
 def test_check_sequence_phos_enz():
     s = Agent('MAPK1', db_refs = {'UP': 'P28482'})
-    e = Agent('MAP2K1', mods=['PhosphorylationSerine'], mod_sites=[222], 
-              db_refs = {'UP': 'Q02750'})
-    stmt = Phosphorylation(e, s, 'PhosphorylationThreonine', 185)
+    mc1 = ModCondition('phosphorylation', 'serine', '222')
+    mc2 = ModCondition('phosphorylation', 'threoninine', '185')
+    e = Agent('MAP2K1', mc1, db_refs = {'UP': 'Q02750'})
+    stmt = Phosphorylation(e, s, mc2)
     failures = check_sequence(stmt)
     assert(not failures)
 
 def test_check_sequence_phos_enz_wrong():
     s = Agent('MAPK1', db_refs = {'UP': 'P28482'})
-    e = Agent('MAP2K1', mods=['PhosphorylationSerine'], mod_sites=[221],
+    mc1 = ModCondition('phosphorylation', 'serine', '221')
+    mc2 = ModCondition('phosphorylation', 'threoninine', '185')
+    e = Agent('MAP2K1', mods=[mc1],
               db_refs = {'UP': 'Q02750'})
-    stmt = Phosphorylation(e, s, 'PhosphorylationThreonine', 185)
+    stmt = Phosphorylation(e, s, mc2)
     failures = check_sequence(stmt)
     assert(failures)
 
 def test_check_statements():
     stmts = []
     s = Agent('MAPK1', db_refs = {'UP': 'P28482'})
-    e = Agent('MAP2K1', mods=['PhosphorylationSerine'], mod_sites=[222], 
+    mc1 = ModCondition('phosphorylation', 'serine', '222')
+    mc2 = ModCondition('phosphorylation', 'threoninine', '185')
+    e = Agent('MAP2K1', mods=[mc1],
               db_refs = {'UP': 'Q02750'})
-    stmt = Phosphorylation(e, s, 'PhosphorylationThreonine', 185)
+    stmt = Phosphorylation(e, s, mc2)
     stmts.append(stmt)
-    
+
+    mc1 = ModCondition('phosphorylation', 'serine', '221')
+    mc2 = ModCondition('phosphorylation', 'threoninine', '185')
     s = Agent('MAPK1', db_refs = {'UP': 'P28482'})
-    e = Agent('MAP2K1', mods=['PhosphorylationSerine'], mod_sites=[221],
-              db_refs = {'UP': 'Q02750'})
-    stmt = Phosphorylation(e, s, 'PhosphorylationThreonine', 185)
+    e = Agent('MAP2K1', mods=[mc1], db_refs = {'UP': 'Q02750'})
+    stmt = Phosphorylation(e, s, mc2)
     stmts.append(stmt)
 
     p, f = check_statements(stmts)

--- a/indra/tests/test_preassembler_checks.py
+++ b/indra/tests/test_preassembler_checks.py
@@ -38,35 +38,31 @@ def test_check_agent_mod_wrong_multiple2():
 def test_check_sequence_phos():
     s = Agent('MAPK1', db_refs = {'UP': 'P28482'})
     e = Agent('MAP2K1')
-    mc1 = ModCondition('phosphorylation', 'threonine', '185')
-    stmt = Phosphorylation(e, s, mc1)
+    stmt = Phosphorylation(e, s, 'threonine', '185')
     failures = check_sequence(stmt)
     assert(not failures)
 
 def test_check_sequence_phos_wrong():
     s = Agent('MAPK1', db_refs = {'UP': 'P28482'})
     e = Agent('MAP2K1')
-    mc1 = ModCondition('phosphorylation', 'threonine', '186')
-    stmt = Phosphorylation(e, s, mc1)
+    stmt = Phosphorylation(e, s, 'threonine', '186')
     failures = check_sequence(stmt)
     assert(failures)
 
 def test_check_sequence_phos_enz():
     s = Agent('MAPK1', db_refs = {'UP': 'P28482'})
     mc1 = ModCondition('phosphorylation', 'serine', '222')
-    mc2 = ModCondition('phosphorylation', 'threoninine', '185')
     e = Agent('MAP2K1', mc1, db_refs = {'UP': 'Q02750'})
-    stmt = Phosphorylation(e, s, mc2)
+    stmt = Phosphorylation(e, s, 'threonine', '185')
     failures = check_sequence(stmt)
     assert(not failures)
 
 def test_check_sequence_phos_enz_wrong():
     s = Agent('MAPK1', db_refs = {'UP': 'P28482'})
     mc1 = ModCondition('phosphorylation', 'serine', '221')
-    mc2 = ModCondition('phosphorylation', 'threoninine', '185')
     e = Agent('MAP2K1', mods=[mc1],
               db_refs = {'UP': 'Q02750'})
-    stmt = Phosphorylation(e, s, mc2)
+    stmt = Phosphorylation(e, s, 'threonine', '185')
     failures = check_sequence(stmt)
     assert(failures)
 
@@ -74,17 +70,15 @@ def test_check_statements():
     stmts = []
     s = Agent('MAPK1', db_refs = {'UP': 'P28482'})
     mc1 = ModCondition('phosphorylation', 'serine', '222')
-    mc2 = ModCondition('phosphorylation', 'threoninine', '185')
     e = Agent('MAP2K1', mods=[mc1],
               db_refs = {'UP': 'Q02750'})
-    stmt = Phosphorylation(e, s, mc2)
+    stmt = Phosphorylation(e, s, 'threonine', '185')
     stmts.append(stmt)
 
     mc1 = ModCondition('phosphorylation', 'serine', '221')
-    mc2 = ModCondition('phosphorylation', 'threoninine', '185')
     s = Agent('MAPK1', db_refs = {'UP': 'P28482'})
     e = Agent('MAP2K1', mods=[mc1], db_refs = {'UP': 'Q02750'})
-    stmt = Phosphorylation(e, s, mc2)
+    stmt = Phosphorylation(e, s, 'threonine', '185')
     stmts.append(stmt)
 
     p, f = check_statements(stmts)

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -37,7 +37,8 @@ def test_pysb_assembler_complex3():
 def test_pysb_assembler_phos_noenz():
     enz = None
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
+    stmt = Phosphorylation(enz, sub,
+                           ModCondition('phosphorylation', 'serine', '222'))
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -47,7 +48,8 @@ def test_pysb_assembler_phos_noenz():
 def test_pysb_assembler_dephos_noenz():
     enz = None
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
+    stmt = Phosphorylation(enz, sub,
+                           ModCondition('phosphorylation', 'serine', '222'))
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -57,7 +59,8 @@ def test_pysb_assembler_dephos_noenz():
 def test_pysb_assembler_phos1():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
+    stmt = Phosphorylation(enz, sub,
+                           ModCondition('phosphorylation', 'serine', '222'))
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -68,7 +71,8 @@ def test_pysb_assembler_phos2():
     hras = Agent('HRAS')
     enz = Agent('BRAF', bound_conditions=[BoundCondition(hras, True)])
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
+    stmt = Phosphorylation(enz, sub,
+                           ModCondition('phosphorylation', 'serine', '222'))
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -80,7 +84,8 @@ def test_pysb_assembler_phos3():
     erk1 = Agent('ERK1')
     enz = Agent('BRAF', bound_conditions=[BoundCondition(hras, True)])
     sub = Agent('MEK1', bound_conditions=[BoundCondition(erk1, True)])
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
+    stmt = Phosphorylation(enz, sub,
+                           ModCondition('phosphorylation', 'serine', '222'))
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -92,7 +97,8 @@ def test_pysb_assembler_phos4():
     erk1 = Agent('ERK1')
     enz = Agent('BRAF', bound_conditions=[BoundCondition(hras, True)])
     sub = Agent('MEK1', bound_conditions=[BoundCondition(erk1, False)])
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
+    stmt = Phosphorylation(enz, sub,
+                           ModCondition('phosphorylation', 'serine', '222'))
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -101,7 +107,8 @@ def test_pysb_assembler_phos4():
 
 def test_pysb_assembler_autophos1():
     enz = Agent('MEK1')
-    stmt = Autophosphorylation(enz, 'PhosphorylationSerine', '222')
+    stmt = Autophosphorylation(enz,
+                        ModCondition('phosphorylation', 'serine', '222'))
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -111,7 +118,8 @@ def test_pysb_assembler_autophos1():
 def test_pysb_assembler_autophos2():
     raf1 = Agent('RAF1')
     enz = Agent('MEK1', bound_conditions=[BoundCondition(raf1, True)])
-    stmt = Autophosphorylation(enz, 'PhosphorylationSerine', '222')
+    stmt = Autophosphorylation(enz,
+                        ModCondition('phosphorylation', 'serine', '222'))
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -122,7 +130,8 @@ def test_pysb_assembler_autophos2():
 def test_pysb_assembler_autophos3():
     egfr = Agent('EGFR')
     enz = Agent('EGFR', bound_conditions=[BoundCondition(egfr, True)])
-    stmt = Autophosphorylation(enz, 'PhosphorylationTyrosine', None)
+    stmt = Autophosphorylation(enz,
+                           ModCondition('phosphorylation', 'tyrosine'))
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -133,7 +142,8 @@ def test_pysb_assembler_autophos3():
 def test_pysb_assembler_transphos1():
     egfr = Agent('EGFR')
     enz = Agent('EGFR', bound_conditions=[BoundCondition(egfr, True)])
-    stmt = Transphosphorylation(enz, 'PhosphorylationTyrosine', None)
+    stmt = Transphosphorylation(enz,
+                           ModCondition('phosphorylation', 'tyrosine'))
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -156,7 +166,8 @@ def test_pysb_assembler_actact1():
 def test_pysb_assembler_dephos1():
     phos = Agent('PP2A')
     sub = Agent('MEK1')
-    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222')
+    stmt = Dephosphorylation(phos, sub,
+                             ModCondition('phosphorylation', 'serine', '222'))
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -168,7 +179,8 @@ def test_pysb_assembler_dephos2():
     phos = Agent('PP2A')
     raf1 = Agent('RAF1')
     sub = Agent('MEK1', bound_conditions=[BoundCondition(raf1, True)])
-    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222')
+    stmt = Dephosphorylation(phos, sub,
+                             ModCondition('phosphorylation', 'serine', '222'))
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -202,11 +214,13 @@ def test_pysb_assembler_actmod1():
     mek = Agent('MEK')
     erk = Agent('ERK')
     stmts = []
-    stmts.append(ActivityModification(mek, ['PhosphorylationSerine', 
-                                      'PhosphorylationSerine'], [218,222],
-                                      'increases', 'act'))
-    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationThreonine', '185'))
-    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationTyrosine', '187'))
+    mc1 = ModCondition('phosphorylation', 'serine', '218')
+    mc2 = ModCondition('phosphorylation', 'serine', '222')
+    stmts.append(ActivityModification(mek, [mc1, mc2], 'increases', 'act'))
+    mc = ModCondition('phosphorylation', 'threonine', '185')
+    stmts.append(Phosphorylation(mek, erk, mc))
+    mc = ModCondition('phosphorylation', 'tyrosine', '187')
+    stmts.append(Phosphorylation(mek, erk, mc))
     pa = PysbAssembler()
     pa.add_statements(stmts)
     model = pa.make_model()
@@ -218,12 +232,16 @@ def test_pysb_assembler_actmod2():
     mek = Agent('MEK')
     erk = Agent('ERK')
     stmts = []
-    stmts.append(ActivityModification(mek, ['PhosphorylationSerine'], 
-        [218], 'increases', 'act'))
-    stmts.append(ActivityModification(mek, ['PhosphorylationSerine'], 
-        [222], 'increases', 'act'))
-    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationThreonine', '185'))
-    stmts.append(Phosphorylation(mek, erk, 'PhosphorylationTyrosine', '187'))
+    stmts.append(ActivityModification(mek,
+                    [ModCondition('phosphorylation', 'serine', '218')],
+                    'increases', 'act'))
+    stmts.append(ActivityModification(mek,
+                    [ModCondition('phosphorylation', 'serine', '222')],
+                    'increases', 'act'))
+    stmts.append(Phosphorylation(mek, erk,
+                ModCondition('phosphorylation', 'threonine', '185')))
+    stmts.append(Phosphorylation(mek, erk,
+                ModCondition('phosphorylation', 'tyrosine', '187')))
     pa = PysbAssembler()
     pa.add_statements(stmts)
     model = pa.make_model()
@@ -234,7 +252,8 @@ def test_pysb_assembler_actmod2():
 def test_pysb_assembler_phos_twostep1():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
+    stmt = Phosphorylation(enz, sub,
+                           ModCondition('phosphorylation', 'serine', '222'))
     pa = PysbAssembler(policies='two_step')
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -245,7 +264,8 @@ def test_pysb_assembler_phos_twostep1():
 def test_pysb_assembler_dephos_twostep1():
     phos = Agent('PP2A')
     sub = Agent('MEK1')
-    stmt = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222')
+    stmt = Dephosphorylation(phos, sub,
+                             ModCondition('phosphorylation', 'serine', '222'))
     pa = PysbAssembler(policies='two_step')
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -257,8 +277,10 @@ def test_statement_specific_policies():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
     phos = Agent('PP2A')
-    stmt1 = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
-    stmt2 = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222')
+    stmt1 = Phosphorylation(enz, sub,
+                            ModCondition('phosphorylation', 'serine', '222'))
+    stmt2 = Dephosphorylation(phos, sub,
+                              ModCondition('phosphorylation', 'serine', '222'))
     policies = {'Phosphorylation': 'two_step',
                 'Dephosphorylation': 'interactions_only'}
     pa = PysbAssembler(policies=policies)
@@ -272,8 +294,10 @@ def test_unspecified_statement_policies():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
     phos = Agent('PP2A')
-    stmt1 = Phosphorylation(enz, sub, 'PhosphorylationSerine', '222')
-    stmt2 = Dephosphorylation(phos, sub, 'PhosphorylationSerine', '222')
+    stmt1 = Phosphorylation(enz, sub,
+                            ModCondition('phosphorylation', 'serine', '222'))
+    stmt2 = Dephosphorylation(phos, sub,
+                              ModCondition('phosphorylation', 'serine', '222'))
     policies = {'Phosphorylation': 'two_step',
                 'other': 'interactions_only'}
     pa = PysbAssembler(policies=policies)
@@ -346,13 +370,13 @@ def test_rule_name_str_3():
     assert(s == 'GRB2_nEGFR')
 
 def test_rule_name_str_4():
-    a = Agent('BRAF', mods=['PhosphorylationSerine'], mod_sites=[None])
+    a = Agent('BRAF', mods=[ModCondition('phosphorylation', 'serine')])
     s = get_agent_rule_str(a)
     print s
-    assert(s == 'BRAF_S')
+    assert(s == 'BRAF_phosphoS')
 
 def test_rule_name_str_5():
-    a = Agent('BRAF', mods=['PhosphorylationSerine'], mod_sites=[123])
+    a = Agent('BRAF', mods=[ModCondition('phosphorylation', 'serine', '123')])
     s = get_agent_rule_str(a)
     print s
-    assert(s == 'BRAF_S123')
+    assert(s == 'BRAF_phosphoS123')

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -37,8 +37,7 @@ def test_pysb_assembler_complex3():
 def test_pysb_assembler_phos_noenz():
     enz = None
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub,
-                           ModCondition('phosphorylation', 'serine', '222'))
+    stmt = Phosphorylation(enz, sub, 'serine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -48,8 +47,7 @@ def test_pysb_assembler_phos_noenz():
 def test_pysb_assembler_dephos_noenz():
     enz = None
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub,
-                           ModCondition('phosphorylation', 'serine', '222'))
+    stmt = Phosphorylation(enz, sub, 'serine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -59,8 +57,7 @@ def test_pysb_assembler_dephos_noenz():
 def test_pysb_assembler_phos1():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub,
-                           ModCondition('phosphorylation', 'serine', '222'))
+    stmt = Phosphorylation(enz, sub, 'serine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -71,8 +68,7 @@ def test_pysb_assembler_phos2():
     hras = Agent('HRAS')
     enz = Agent('BRAF', bound_conditions=[BoundCondition(hras, True)])
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub,
-                           ModCondition('phosphorylation', 'serine', '222'))
+    stmt = Phosphorylation(enz, sub, 'serine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -84,8 +80,7 @@ def test_pysb_assembler_phos3():
     erk1 = Agent('ERK1')
     enz = Agent('BRAF', bound_conditions=[BoundCondition(hras, True)])
     sub = Agent('MEK1', bound_conditions=[BoundCondition(erk1, True)])
-    stmt = Phosphorylation(enz, sub,
-                           ModCondition('phosphorylation', 'serine', '222'))
+    stmt = Phosphorylation(enz, sub, 'serine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -97,8 +92,7 @@ def test_pysb_assembler_phos4():
     erk1 = Agent('ERK1')
     enz = Agent('BRAF', bound_conditions=[BoundCondition(hras, True)])
     sub = Agent('MEK1', bound_conditions=[BoundCondition(erk1, False)])
-    stmt = Phosphorylation(enz, sub,
-                           ModCondition('phosphorylation', 'serine', '222'))
+    stmt = Phosphorylation(enz, sub, 'serine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -107,8 +101,7 @@ def test_pysb_assembler_phos4():
 
 def test_pysb_assembler_autophos1():
     enz = Agent('MEK1')
-    stmt = Autophosphorylation(enz,
-                        ModCondition('phosphorylation', 'serine', '222'))
+    stmt = Autophosphorylation(enz, 'serine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -118,8 +111,7 @@ def test_pysb_assembler_autophos1():
 def test_pysb_assembler_autophos2():
     raf1 = Agent('RAF1')
     enz = Agent('MEK1', bound_conditions=[BoundCondition(raf1, True)])
-    stmt = Autophosphorylation(enz,
-                        ModCondition('phosphorylation', 'serine', '222'))
+    stmt = Autophosphorylation(enz, 'serine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -130,8 +122,7 @@ def test_pysb_assembler_autophos2():
 def test_pysb_assembler_autophos3():
     egfr = Agent('EGFR')
     enz = Agent('EGFR', bound_conditions=[BoundCondition(egfr, True)])
-    stmt = Autophosphorylation(enz,
-                           ModCondition('phosphorylation', 'tyrosine'))
+    stmt = Autophosphorylation(enz, 'tyrosine')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -142,8 +133,7 @@ def test_pysb_assembler_autophos3():
 def test_pysb_assembler_transphos1():
     egfr = Agent('EGFR')
     enz = Agent('EGFR', bound_conditions=[BoundCondition(egfr, True)])
-    stmt = Transphosphorylation(enz,
-                           ModCondition('phosphorylation', 'tyrosine'))
+    stmt = Transphosphorylation(enz, 'tyrosine')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -166,8 +156,7 @@ def test_pysb_assembler_actact1():
 def test_pysb_assembler_dephos1():
     phos = Agent('PP2A')
     sub = Agent('MEK1')
-    stmt = Dephosphorylation(phos, sub,
-                             ModCondition('phosphorylation', 'serine', '222'))
+    stmt = Dephosphorylation(phos, sub, 'serine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -179,8 +168,7 @@ def test_pysb_assembler_dephos2():
     phos = Agent('PP2A')
     raf1 = Agent('RAF1')
     sub = Agent('MEK1', bound_conditions=[BoundCondition(raf1, True)])
-    stmt = Dephosphorylation(phos, sub,
-                             ModCondition('phosphorylation', 'serine', '222'))
+    stmt = Dephosphorylation(phos, sub, 'serine', '222')
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -217,10 +205,8 @@ def test_pysb_assembler_actmod1():
     mc1 = ModCondition('phosphorylation', 'serine', '218')
     mc2 = ModCondition('phosphorylation', 'serine', '222')
     stmts.append(ActivityModification(mek, [mc1, mc2], 'increases', 'act'))
-    mc = ModCondition('phosphorylation', 'threonine', '185')
-    stmts.append(Phosphorylation(mek, erk, mc))
-    mc = ModCondition('phosphorylation', 'tyrosine', '187')
-    stmts.append(Phosphorylation(mek, erk, mc))
+    stmts.append(Phosphorylation(mek, erk, 'threonine', '185'))
+    stmts.append(Phosphorylation(mek, erk, 'tyrosine', '187'))
     pa = PysbAssembler()
     pa.add_statements(stmts)
     model = pa.make_model()
@@ -238,10 +224,8 @@ def test_pysb_assembler_actmod2():
     stmts.append(ActivityModification(mek,
                     [ModCondition('phosphorylation', 'serine', '222')],
                     'increases', 'act'))
-    stmts.append(Phosphorylation(mek, erk,
-                ModCondition('phosphorylation', 'threonine', '185')))
-    stmts.append(Phosphorylation(mek, erk,
-                ModCondition('phosphorylation', 'tyrosine', '187')))
+    stmts.append(Phosphorylation(mek, erk, 'threonine', '185'))
+    stmts.append(Phosphorylation(mek, erk, 'tyrosine', '187'))
     pa = PysbAssembler()
     pa.add_statements(stmts)
     model = pa.make_model()
@@ -252,8 +236,7 @@ def test_pysb_assembler_actmod2():
 def test_pysb_assembler_phos_twostep1():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
-    stmt = Phosphorylation(enz, sub,
-                           ModCondition('phosphorylation', 'serine', '222'))
+    stmt = Phosphorylation(enz, sub, 'serine', '222')
     pa = PysbAssembler(policies='two_step')
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -264,8 +247,7 @@ def test_pysb_assembler_phos_twostep1():
 def test_pysb_assembler_dephos_twostep1():
     phos = Agent('PP2A')
     sub = Agent('MEK1')
-    stmt = Dephosphorylation(phos, sub,
-                             ModCondition('phosphorylation', 'serine', '222'))
+    stmt = Dephosphorylation(phos, sub, 'serine', '222')
     pa = PysbAssembler(policies='two_step')
     pa.add_statements([stmt])
     model = pa.make_model()
@@ -277,10 +259,8 @@ def test_statement_specific_policies():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
     phos = Agent('PP2A')
-    stmt1 = Phosphorylation(enz, sub,
-                            ModCondition('phosphorylation', 'serine', '222'))
-    stmt2 = Dephosphorylation(phos, sub,
-                              ModCondition('phosphorylation', 'serine', '222'))
+    stmt1 = Phosphorylation(enz, sub, 'serine', '222')
+    stmt2 = Dephosphorylation(phos, sub, 'serine', '222')
     policies = {'Phosphorylation': 'two_step',
                 'Dephosphorylation': 'interactions_only'}
     pa = PysbAssembler(policies=policies)
@@ -294,10 +274,8 @@ def test_unspecified_statement_policies():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
     phos = Agent('PP2A')
-    stmt1 = Phosphorylation(enz, sub,
-                            ModCondition('phosphorylation', 'serine', '222'))
-    stmt2 = Dephosphorylation(phos, sub,
-                              ModCondition('phosphorylation', 'serine', '222'))
+    stmt1 = Phosphorylation(enz, sub, 'serine', '222')
+    stmt2 = Dephosphorylation(phos, sub, 'serine', '222')
     policies = {'Phosphorylation': 'two_step',
                 'other': 'interactions_only'}
     pa = PysbAssembler(policies=policies)

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -6,14 +6,14 @@ def test_parse_site_text():
             'threonine residue 185', 'T185']
     for t in text:
         residue, site = ReachProcessor._parse_site_text(t)
-        assert(residue == 'Threonine')
+        assert(residue == 'threonine')
         assert(site == '185')
 
 def test_parse_site_residue_only():
     text = ['serine residue', 'serine', 'a serine site']
     for t in text:
         residue, site = ReachProcessor._parse_site_text(t)
-        assert(residue == 'Serine')
+        assert(residue == 'serine')
         assert(site is None)
 
 def test_valid_name():

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -27,14 +27,14 @@ def test_activitymod_sitelist_of_ints():
 def testactivitymod_string_string():
     """Check that string mod position is preserved"""
     st = ActivityModification(Agent('MAP2K1'),
-                              [ModCondition('phosphorylation' 'serine', '218')],
+                              [ModCondition('phosphorylation', 'serine', '218')],
                               'increases', 'KinaseActivity')
     assert isinstance(st.mod[0].position, basestring)
 
 def testactivitymod_string_none():
     """Check that None mod position is preserved"""
     st = ActivityModification(Agent('MAP2K1'),
-                              [ModCondition('phosphorylation' 'serine', None)],
+                              [ModCondition('phosphorylation', 'serine', None)],
                               'increases', 'KinaseActivity')
     assert (st.mod[0].position is None)
 
@@ -65,35 +65,29 @@ def test_matches_key():
 def test_matches2():
     raf = Agent('Raf')
     mek = Agent('Mek')
-    mc = ModCondition('phosphorylation')
-    st1 = Phosphorylation(raf, mek, mc)
-    st2 = Phosphorylation(raf, mek, mc)
+    st1 = Phosphorylation(raf, mek)
+    st2 = Phosphorylation(raf, mek)
     assert(st1.matches(st2))
 
 def test_matches_key2():
     raf = Agent('Raf')
     mek = Agent('Mek')
-    mc = ModCondition('phosphorylation')
-    st1 = Phosphorylation(raf, mek, mc)
-    st2 = Phosphorylation(raf, mek, mc)
+    st1 = Phosphorylation(raf, mek)
+    st2 = Phosphorylation(raf, mek)
     assert(st1.matches_key() == st2.matches_key())
 
 def test_not_matches():
     raf = Agent('Raf')
     mek = Agent('Mek')
-    mc1 = ModCondition('phosphorylation')
-    mc2 = ModCondition('phosphorylation', residue='tyrosine')
-    st1 = Phosphorylation(raf, mek, mc1)
-    st2 = Phosphorylation(raf, mek, mc2)
+    st1 = Phosphorylation(raf, mek)
+    st2 = Phosphorylation(raf, mek, 'tyrosine')
     assert(not st1.matches(st2))
 
 def test_not_matches_key():
     raf = Agent('Raf')
     mek = Agent('Mek')
-    mc1 = ModCondition('phosphorylation')
-    mc2 = ModCondition('phosphorylation', residue='tyrosine')
-    st1 = Phosphorylation(raf, mek, mc1)
-    st2 = Phosphorylation(raf, mek, mc2)
+    st1 = Phosphorylation(raf, mek)
+    st2 = Phosphorylation(raf, mek, 'tyrosine')
     assert(st1.matches_key() != st2.matches_key())
 
 def test_matches_dbrefs():
@@ -181,14 +175,11 @@ def test_matches_selfmod():
     """Test matching of entities only, entities match only on name."""
     nras1 = Agent('NRAS', db_refs = {'HGNC': '7989'})
     nras2 = Agent('NRAS', db_refs = {'HGNC': 'dummy'})
-    st1 = Autophosphorylation(nras1, ModCondition('phosphorylation',
-                                                  'tyrosine', '32'),
+    st1 = Autophosphorylation(nras1, 'tyrosine', '32',
                               evidence=Evidence(text='foo'))
-    st2 = Autophosphorylation(nras1, ModCondition('phosphorylation',
-                                                  'tyrosine', '32'),
+    st2 = Autophosphorylation(nras1, 'tyrosine', '32',
                               evidence=Evidence(text='bar'))
-    st3 = Autophosphorylation(nras2, ModCondition('phosphorylation'),
-                              evidence=Evidence(text='bar'))
+    st3 = Autophosphorylation(nras2, evidence=Evidence(text='bar'))
     assert(st1.matches(st2))
     assert(not st1.matches(st3))
 
@@ -293,8 +284,7 @@ def test_entities_match_mod():
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     nras1 = Agent('NRAS', db_refs = {'HGNC': '7989'})
     nras2 = Agent('NRAS', db_refs = {'HGNC': 'dummy'})
-    st1 = Phosphorylation(src, nras1, ModCondition('phosphorylation',
-                                                   'tyrosine', '32'),
+    st1 = Phosphorylation(src, nras1, 'tyrosine', '32',
                           evidence=Evidence(text='foo'))
     st2 = Phosphorylation(src, nras2, ModCondition('phosphorylation'),
                           evidence=Evidence(text='bar'))
@@ -304,11 +294,9 @@ def test_entities_match_selfmod():
     """Test matching of entities only, entities match only on name."""
     nras1 = Agent('NRAS', db_refs = {'HGNC': '7989'})
     nras2 = Agent('NRAS', db_refs = {'HGNC': 'dummy'})
-    st1 = Autophosphorylation(nras1,
-                          ModCondition('phosphorylation', 'tyrosine', '32'),
+    st1 = Autophosphorylation(nras1, 'tyrosine', '32',
                           evidence=Evidence(text='foo'))
     st2 = Autophosphorylation(nras2,
-                          ModCondition('phosphorylation'),
                           evidence=Evidence(text='bar'))
     assert(st1.entities_match(st2))
 
@@ -525,18 +513,12 @@ def test_agent_modification_refinement():
 def test_phosphorylation_modification_refinement():
     braf = Agent('BRAF', db_refs = {'HGNC': 'braf'})
     mek1 = Agent('MAP2K1', db_refs = {'HGNC': 'map2k1'})
-    p1 = Phosphorylation(braf, mek1,
-                         ModCondition('phosphorylation'))
-    p2 = Phosphorylation(braf, mek1,
-                         ModCondition('phosphorylation', position='218'))
-    p3 = Phosphorylation(braf, mek1,
-                         ModCondition('phosphorylation', position='222'))
-    p4 = Phosphorylation(braf, mek1,
-                         ModCondition('phosphorylation', 'serine'))
-    p5 = Phosphorylation(braf, mek1,
-                         ModCondition('phosphorylation', 'serine', '218'))
-    p6 = Phosphorylation(braf, mek1,
-                         ModCondition('phosphorylation', 'serine', '222'))
+    p1 = Phosphorylation(braf, mek1)
+    p2 = Phosphorylation(braf, mek1, position='218')
+    p3 = Phosphorylation(braf, mek1, position='222')
+    p4 = Phosphorylation(braf, mek1, 'serine')
+    p5 = Phosphorylation(braf, mek1, 'serine', '218')
+    p6 = Phosphorylation(braf, mek1, 'serine', '222')
 
     # p1
     assert p2.refinement_of(p1, eh, mh)
@@ -577,18 +559,12 @@ def test_phosphorylation_modification_refinement():
 
 def test_autophosphorylation_modification_refinement():
     braf = Agent('BRAF', db_refs = {'HGNC': 'braf'})
-    p1 = Autophosphorylation(braf,
-                             ModCondition('phosphorylation'))
-    p2 = Autophosphorylation(braf,
-                             ModCondition('phosphorylation', position='218'))
-    p3 = Autophosphorylation(braf,
-                             ModCondition('phosphorylation', position='222'))
-    p4 = Autophosphorylation(braf,
-                             ModCondition('phosphorylation', 'serine'))
-    p5 = Autophosphorylation(braf,
-                             ModCondition('phosphorylation', 'serine', '218'))
-    p6 = Autophosphorylation(braf,
-                             ModCondition('phosphorylation', 'serine', '222'))
+    p1 = Autophosphorylation(braf,)
+    p2 = Autophosphorylation(braf, position='218')
+    p3 = Autophosphorylation(braf, position='222')
+    p4 = Autophosphorylation(braf, 'serine')
+    p5 = Autophosphorylation(braf, 'serine', '218')
+    p6 = Autophosphorylation(braf, 'serine', '222')
 
     # p1
     assert p2.refinement_of(p1, eh, mh)

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -15,74 +15,36 @@ mh = HierarchyManager(mod_file)
 
 # Argument checking for ActivityModifications ----------------------------
 
-@raises(ValueError)
-def test_activitymod_list_and_string():
-    st = ActivityModification(Agent('MAP2K1'),
-                        ['PhosphorylationSerine', 'PhosphorylationSerine'],
-                        '218', 'increases', 'KinaseActivity')
-
-@raises(ValueError)
-def test_activitymod_list_and_int():
-    st = ActivityModification(Agent('MAP2K1'),
-                        ['PhosphorylationSerine', 'PhosphorylationSerine'],
-                        218, 'increases', 'KinaseActivity')
-
-@raises(ValueError)
-def test_activitymod_list_and_none():
-    st = ActivityModification(Agent('MAP2K1'),
-                        ['PhosphorylationSerine', 'PhosphorylationSerine'],
-                        None, 'increases', 'KinaseActivity')
-
-@raises(ValueError)
-def test_activitymod_mismatched_lists():
-    st = ActivityModification(Agent('MAP2K1'),
-                        ['PhosphorylationSerine', 'PhosphorylationSerine'],
-                        ['218'], 'increases', 'KinaseActivity')
-
 def test_activitymod_sitelist_of_ints():
     """Check that mod positions specified as ints get promoted to strings."""
     st = ActivityModification(Agent('MAP2K1'),
-                        ['PhosphorylationSerine', 'PhosphorylationSerine'],
-                        [218, 222], 'increases', 'KinaseActivity')
-    assert isinstance(st.mod, list)
-    assert isinstance(st.mod_pos, list)
-    assert len(st.mod_pos) == 2
-    assert isinstance(st.mod_pos[0], basestring)
-    assert isinstance(st.mod_pos[1], basestring)
+                              [ModCondition('phosphorylation', 'serine', 218),
+                               ModCondition('phosphorylation', 'serine', 222)],
+                              'increases', 'KinaseActivity')
+    assert isinstance(st.mod[0].position, basestring)
+    assert isinstance(st.mod[1].position, basestring)
 
 def testactivitymod_string_string():
-    """Check that string mod and mod_pos get promoted to lists"""
-    st = ActivityModification(Agent('MAP2K1'), 'PhosphorylationSerine', '218',
+    """Check that string mod position is preserved"""
+    st = ActivityModification(Agent('MAP2K1'),
+                              [ModCondition('phosphorylation' 'serine', '218')],
                               'increases', 'KinaseActivity')
-    assert isinstance(st.mod, list)
-    assert isinstance(st.mod_pos, list)
-    assert len(st.mod) == 1
-    assert len(st.mod_pos) == 1
-    assert isinstance(st.mod_pos[0], basestring)
-
-def testactivitymod_string_int():
-    """Check that string mod and int mod_pos get promoted to lists of strings"""
-    st = ActivityModification(Agent('MAP2K1'), 'PhosphorylationSerine', 218,
-                              'increases', 'KinaseActivity')
-    assert isinstance(st.mod, list)
-    assert isinstance(st.mod_pos, list)
-    assert len(st.mod) == 1
-    assert len(st.mod_pos) == 1
-    assert isinstance(st.mod_pos[0], basestring)
-
-@raises(ValueError)
-def testactivitymod_none_int():
-    """Check that None for mod triggers ValueError"""
-    st = ActivityModification(Agent('MAP2K1'), None, 218,
-                              'increases', 'KinaseActivity')
+    assert isinstance(st.mod[0].position, basestring)
 
 def testactivitymod_string_none():
-    """Make sure None for mod_pos is permissible (doesn't error)"""
-    st = ActivityModification(Agent('MAP2K1'), 'Phosphorylation', None,
+    """Check that None mod position is preserved"""
+    st = ActivityModification(Agent('MAP2K1'),
+                              [ModCondition('phosphorylation' 'serine', None)],
+                              'increases', 'KinaseActivity')
+    assert (st.mod[0].position is None)
+
+def testactivitymod_nolist():
+    """Make sure mod is correctly turned into a list if it's 
+    a single ModCondition"""
+    mc = ModCondition('phosphorylation')
+    st = ActivityModification(Agent('MAP2K1'), mc,
                               'increases', 'KinaseActivity')
     assert isinstance(st.mod, list)
-    assert isinstance(st.mod_pos, list)
-    assert st.mod_pos[0] is None
 
 # Checking for exact matching (except Evidence) between Agents/stmts ---------
 
@@ -103,29 +65,35 @@ def test_matches_key():
 def test_matches2():
     raf = Agent('Raf')
     mek = Agent('Mek')
-    st1 = Phosphorylation(raf, mek, 'Phosphorylation', None)
-    st2 = Phosphorylation(raf, mek, 'Phosphorylation', None)
+    mc = ModCondition('phosphorylation')
+    st1 = Phosphorylation(raf, mek, mc)
+    st2 = Phosphorylation(raf, mek, mc)
     assert(st1.matches(st2))
 
 def test_matches_key2():
     raf = Agent('Raf')
     mek = Agent('Mek')
-    st1 = Phosphorylation(raf, mek, 'Phosphorylation', None)
-    st2 = Phosphorylation(raf, mek, 'Phosphorylation', None)
+    mc = ModCondition('phosphorylation')
+    st1 = Phosphorylation(raf, mek, mc)
+    st2 = Phosphorylation(raf, mek, mc)
     assert(st1.matches_key() == st2.matches_key())
 
 def test_not_matches():
     raf = Agent('Raf')
     mek = Agent('Mek')
-    st1 = Phosphorylation(raf, mek, 'Phosphorylation', None)
-    st2 = Phosphorylation(raf, mek, 'PhosphorylationTyrosine', None)
+    mc1 = ModCondition('phosphorylation')
+    mc2 = ModCondition('phosphorylation', residue='tyrosine')
+    st1 = Phosphorylation(raf, mek, mc1)
+    st2 = Phosphorylation(raf, mek, mc2)
     assert(not st1.matches(st2))
 
 def test_not_matches_key():
     raf = Agent('Raf')
     mek = Agent('Mek')
-    st1 = Phosphorylation(raf, mek, 'Phosphorylation', None)
-    st2 = Phosphorylation(raf, mek, 'PhosphorylationTyrosine', None)
+    mc1 = ModCondition('phosphorylation')
+    mc2 = ModCondition('phosphorylation', residue='tyrosine')
+    st1 = Phosphorylation(raf, mek, mc1)
+    st2 = Phosphorylation(raf, mek, mc2)
     assert(st1.matches_key() != st2.matches_key())
 
 def test_matches_dbrefs():
@@ -213,12 +181,14 @@ def test_matches_selfmod():
     """Test matching of entities only, entities match only on name."""
     nras1 = Agent('NRAS', db_refs = {'HGNC': '7989'})
     nras2 = Agent('NRAS', db_refs = {'HGNC': 'dummy'})
-    st1 = Autophosphorylation(nras1, 'PhosphorylationTyrosine', '32',
-                          evidence=Evidence(text='foo'))
-    st2 = Autophosphorylation(nras1, 'PhosphorylationTyrosine', '32',
-                          evidence=Evidence(text='bar'))
-    st3 = Autophosphorylation(nras2, 'Phosphorylation', None,
-                          evidence=Evidence(text='bar'))
+    st1 = Autophosphorylation(nras1, ModCondition('phosphorylation',
+                                                  'tyrosine', '32'),
+                              evidence=Evidence(text='foo'))
+    st2 = Autophosphorylation(nras1, ModCondition('phosphorylation',
+                                                  'tyrosine', '32'),
+                              evidence=Evidence(text='bar'))
+    st3 = Autophosphorylation(nras2, ModCondition('phosphorylation'),
+                              evidence=Evidence(text='bar'))
     assert(st1.matches(st2))
     assert(not st1.matches(st3))
 
@@ -243,13 +213,15 @@ def test_matches_activitymod():
     """Test matching of entities only, entities match only on name."""
     nras1 = Agent('NRAS', db_refs = {'HGNC': '7989'})
     nras2 = Agent('NRAS', db_refs = {'HGNC': 'dummy'})
-    st1 = ActivityModification(nras1, 'PhosphorylationTyrosine', '32',
+    st1 = ActivityModification(nras1, ModCondition('phosphorylation',
+                                                   'tyrosine', '32'),
                                'increases1', 'GtpBoundActivity1',
                                evidence=Evidence(text='foo'))
-    st2 = ActivityModification(nras1, 'PhosphorylationTyrosine', '32',
+    st2 = ActivityModification(nras1, ModCondition('phosphorylation',
+                                                   'tyrosine', '32'),
                                'increases1', 'GtpBoundActivity1',
                                evidence=Evidence(text='bar'))
-    st3 = ActivityModification(nras2, 'Phosphorylation', None,
+    st3 = ActivityModification(nras2, ModCondition('phosphorylation'),
                                'increases2', 'GtpBoundActivity2',
                                evidence=Evidence(text='bar'))
     assert(st1.matches(st2))
@@ -321,9 +293,10 @@ def test_entities_match_mod():
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     nras1 = Agent('NRAS', db_refs = {'HGNC': '7989'})
     nras2 = Agent('NRAS', db_refs = {'HGNC': 'dummy'})
-    st1 = Phosphorylation(src, nras1, 'PhosphorylationTyrosine', '32',
+    st1 = Phosphorylation(src, nras1, ModCondition('phosphorylation',
+                                                   'tyrosine', '32'),
                           evidence=Evidence(text='foo'))
-    st2 = Phosphorylation(src, nras2, 'Phosphorylation', None,
+    st2 = Phosphorylation(src, nras2, ModCondition('phosphorylation'),
                           evidence=Evidence(text='bar'))
     assert(st1.entities_match(st2))
 
@@ -331,9 +304,11 @@ def test_entities_match_selfmod():
     """Test matching of entities only, entities match only on name."""
     nras1 = Agent('NRAS', db_refs = {'HGNC': '7989'})
     nras2 = Agent('NRAS', db_refs = {'HGNC': 'dummy'})
-    st1 = Autophosphorylation(nras1, 'PhosphorylationTyrosine', '32',
+    st1 = Autophosphorylation(nras1,
+                          ModCondition('phosphorylation', 'tyrosine', '32'),
                           evidence=Evidence(text='foo'))
-    st2 = Autophosphorylation(nras2, 'Phosphorylation', None,
+    st2 = Autophosphorylation(nras2,
+                          ModCondition('phosphorylation'),
                           evidence=Evidence(text='bar'))
     assert(st1.entities_match(st2))
 
@@ -354,10 +329,11 @@ def test_entities_match_activitymod():
     """Test matching of entities only, entities match only on name."""
     nras1 = Agent('NRAS', db_refs = {'HGNC': '7989'})
     nras2 = Agent('NRAS', db_refs = {'HGNC': 'dummy'})
-    st1 = ActivityModification(nras1, 'PhosphorylationTyrosine', '32',
+    st1 = ActivityModification(nras1, ModCondition('phosphorylation',
+                                                   'tyrosine', '32'),
                                'increases1', 'GtpBoundActivity1',
                                evidence=Evidence(text='foo'))
-    st2 = ActivityModification(nras2, 'Phosphorylation', None,
+    st2 = ActivityModification(nras2, ModCondition('phosphorylation'),
                                'increases2', 'GtpBoundActivity2',
                                evidence=Evidence(text='bar'))
     assert(st1.entities_match(st2))
@@ -463,23 +439,23 @@ def test_agent_modification_refinement():
     """A gene-level statement should be supported by a family-level
     statement."""
     mek1 = Agent('MAP2K1', db_refs = {'HGNC': 'asdf'},
-                mods=['Phosphorylation'], mod_sites=[None])
+                mods=ModCondition('phosphorylation'))
     mek2 = Agent('MAP2K1', db_refs = {'HGNC': 'asdf'},
-                mods=['Phosphorylation'], mod_sites=['218'])
+                mods=ModCondition('phosphorylation', position='218'))
     mek3 = Agent('MAP2K1', db_refs = {'HGNC': 'asdf'},
-                mods=['Phosphorylation'], mod_sites=['222'])
+                mods=ModCondition('phosphorylation', position='222'))
     mek4 = Agent('MAP2K1', db_refs = {'HGNC': 'asdf'},
-                mods=['Phosphorylation', 'Phosphorylation'],
-                mod_sites=['218', '222'])
+                mods=[ModCondition('phosphorylation', position='218'),
+                      ModCondition('phosphorylation', position='222')])
     mek5 = Agent('MAP2K1', db_refs = {'HGNC': 'asdf'},
-                mods=['PhosphorylationSerine'], mod_sites=[None])
+                mods=ModCondition('phosphorylation', 'serine', None))
     mek6 = Agent('MAP2K1', db_refs = {'HGNC': 'asdf'},
-                mods=['PhosphorylationSerine'], mod_sites=['218'])
+                mods=ModCondition('phosphorylation', 'serine', '218'))
     mek7 = Agent('MAP2K1', db_refs = {'HGNC': 'asdf'},
-                mods=['PhosphorylationSerine'], mod_sites=['222'])
+                mods=ModCondition('phosphorylation', 'serine', '222'))
     mek8 = Agent('MAP2K1', db_refs = {'HGNC': 'asdf'},
-                mods=['PhosphorylationSerine', 'PhosphorylationSerine'],
-                mod_sites=['218', '222'])
+                mods=[ModCondition('phosphorylation', 'serine', '218'),
+                      ModCondition('phosphorylation', 'serine', '222')])
 
     # mek1 agent is refined by all others
     assert mek2.refinement_of(mek1, eh, mh)
@@ -549,12 +525,18 @@ def test_agent_modification_refinement():
 def test_phosphorylation_modification_refinement():
     braf = Agent('BRAF', db_refs = {'HGNC': 'braf'})
     mek1 = Agent('MAP2K1', db_refs = {'HGNC': 'map2k1'})
-    p1 = Phosphorylation(braf, mek1, 'Phosphorylation', None)
-    p2 = Phosphorylation(braf, mek1, 'Phosphorylation', '218')
-    p3 = Phosphorylation(braf, mek1, 'Phosphorylation', '222')
-    p4 = Phosphorylation(braf, mek1, 'PhosphorylationSerine', None)
-    p5 = Phosphorylation(braf, mek1, 'PhosphorylationSerine', '218')
-    p6 = Phosphorylation(braf, mek1, 'PhosphorylationSerine', '222')
+    p1 = Phosphorylation(braf, mek1,
+                         ModCondition('phosphorylation'))
+    p2 = Phosphorylation(braf, mek1,
+                         ModCondition('phosphorylation', position='218'))
+    p3 = Phosphorylation(braf, mek1,
+                         ModCondition('phosphorylation', position='222'))
+    p4 = Phosphorylation(braf, mek1,
+                         ModCondition('phosphorylation', 'serine'))
+    p5 = Phosphorylation(braf, mek1,
+                         ModCondition('phosphorylation', 'serine', '218'))
+    p6 = Phosphorylation(braf, mek1,
+                         ModCondition('phosphorylation', 'serine', '222'))
 
     # p1
     assert p2.refinement_of(p1, eh, mh)
@@ -595,12 +577,18 @@ def test_phosphorylation_modification_refinement():
 
 def test_autophosphorylation_modification_refinement():
     braf = Agent('BRAF', db_refs = {'HGNC': 'braf'})
-    p1 = Autophosphorylation(braf, 'Phosphorylation', None)
-    p2 = Autophosphorylation(braf, 'Phosphorylation', '218')
-    p3 = Autophosphorylation(braf, 'Phosphorylation', '222')
-    p4 = Autophosphorylation(braf, 'PhosphorylationSerine', None)
-    p5 = Autophosphorylation(braf, 'PhosphorylationSerine', '218')
-    p6 = Autophosphorylation(braf, 'PhosphorylationSerine', '222')
+    p1 = Autophosphorylation(braf,
+                             ModCondition('phosphorylation'))
+    p2 = Autophosphorylation(braf,
+                             ModCondition('phosphorylation', position='218'))
+    p3 = Autophosphorylation(braf,
+                             ModCondition('phosphorylation', position='222'))
+    p4 = Autophosphorylation(braf,
+                             ModCondition('phosphorylation', 'serine'))
+    p5 = Autophosphorylation(braf,
+                             ModCondition('phosphorylation', 'serine', '218'))
+    p6 = Autophosphorylation(braf,
+                             ModCondition('phosphorylation', 'serine', '222'))
 
     # p1
     assert p2.refinement_of(p1, eh, mh)
@@ -684,21 +672,25 @@ def test_activityactivity_modification_refinement():
 def test_activitymod_refinement():
     mek_fam = Agent('MEK')
     mek1 = Agent('MAP2K1')
-    p1 = ActivityModification(mek_fam, 'Phosphorylation', None, 'increases',
-                              'KinaseActivity')
-    p2 = ActivityModification(mek_fam, 'PhosphorylationSerine', '218',
+    p1 = ActivityModification(mek_fam, ModCondition('phosphorylation'),
                               'increases', 'KinaseActivity')
-    p3 = ActivityModification(mek1, 'Phosphorylation', None, 'increases',
-                              'KinaseActivity')
-    p4 = ActivityModification(mek1, 'PhosphorylationSerine', None, 'increases',
-                              'KinaseActivity')
-    p5 = ActivityModification(mek1, 'PhosphorylationSerine', '218', 'increases',
-                              'KinaseActivity')
-    p6 = ActivityModification(mek1, 'PhosphorylationSerine', '222', 'increases',
-                              'KinaseActivity')
+    p2 = ActivityModification(mek_fam, ModCondition('phosphorylation',
+                                                    'serine', '218'),
+                              'increases', 'KinaseActivity')
+    p3 = ActivityModification(mek1, ModCondition('phosphorylation'),
+                              'increases', 'KinaseActivity')
+    p4 = ActivityModification(mek1, ModCondition('phosphorylation', 'serine'),
+                              'increases', 'KinaseActivity')
+    p5 = ActivityModification(mek1, ModCondition('phosphorylation',
+                                                 'serine', '218'),
+                              'increases', 'KinaseActivity')
+    p6 = ActivityModification(mek1, ModCondition('phosphorylation',
+                                                 'serine', '222'),
+                              'increases', 'KinaseActivity')
     p7 = ActivityModification(mek1,
-                            ['PhosphorylationSerine', 'PhosphorylationSerine'],
-                            ['218', '222'], 'increases', 'KinaseActivity')
+                            [ModCondition('phosphorylation', 'serine', '218'),
+                             ModCondition('phosphorylation', 'serine', '222')],
+                            'increases', 'KinaseActivity')
     # p1
     assert p2.refinement_of(p1, eh, mh)
     assert p3.refinement_of(p1, eh, mh)

--- a/indra/tests/test_trips.py
+++ b/indra/tests/test_trips.py
@@ -12,30 +12,24 @@ def test_phosphorylation():
     assert(len(tp.statements) == 1)
     st = tp.statements[0]
     assert(isinstance(st, ist.Phosphorylation))
-    assert(isinstance(st.mod, ist.ModCondition))
-    assert(st.mod.mod_type == 'phosphorylation')
-    assert(st.mod.residue == 'serine')
-    assert(st.mod.position == '222')
+    assert(st.residue == 'serine')
+    assert(st.position == '222')
 
 def test_phosphorylation_noresidue():
     tp = trips_api.process_text('BRAF phosphorylates MEK1.')
     assert(len(tp.statements) == 1)
     st = tp.statements[0]
     assert(isinstance(st, ist.Phosphorylation))
-    assert(isinstance(st.mod, ist.ModCondition))
-    assert(st.mod.mod_type == 'phosphorylation')
-    assert(st.mod.residue is None)
-    assert(st.mod.position is None)
+    assert(st.residue is None)
+    assert(st.position is None)
 
 def test_phosphorylation_nosite():
     tp = trips_api.process_text('BRAF phosphorylates MEK1 at Serine.')
     assert(len(tp.statements) == 1)
     st = tp.statements[0]
     assert(isinstance(st, ist.Phosphorylation))
-    assert(isinstance(st.mod, ist.ModCondition))
-    assert(st.mod.mod_type == 'phosphorylation')
-    assert(st.mod.residue == 'serine')
-    assert(st.mod.position is None)
+    assert(st.residue == 'serine')
+    assert(st.position is None)
 
 def test_actmod():
     tp = trips_api.process_text('MEK1 phosphorylated at Ser222 is activated.')

--- a/indra/tests/test_trips.py
+++ b/indra/tests/test_trips.py
@@ -1,24 +1,79 @@
 from indra.pysb_assembler import PysbAssembler
 from indra.trips import trips_api
 from os.path import dirname, join
-import indra.statements
+import indra.statements as ist
 import sys
 import os
 
 test_small_file = join(dirname(__file__), 'test_small.xml')
 
+def test_phosphorylation():
+    tp = trips_api.process_text('BRAF phosphorylates MEK1 at Ser222.')
+    assert(len(tp.statements) == 1)
+    st = tp.statements[0]
+    assert(isinstance(st, ist.Phosphorylation))
+    assert(isinstance(st.mod, ist.ModCondition))
+    assert(st.mod.mod_type == 'phosphorylation')
+    assert(st.mod.residue == 'serine')
+    assert(st.mod.position == '222')
+
+def test_phosphorylation_noresidue():
+    tp = trips_api.process_text('BRAF phosphorylates MEK1.')
+    assert(len(tp.statements) == 1)
+    st = tp.statements[0]
+    assert(isinstance(st, ist.Phosphorylation))
+    assert(isinstance(st.mod, ist.ModCondition))
+    assert(st.mod.mod_type == 'phosphorylation')
+    assert(st.mod.residue is None)
+    assert(st.mod.position is None)
+
+def test_phosphorylation_nosite():
+    tp = trips_api.process_text('BRAF phosphorylates MEK1 at Serine.')
+    assert(len(tp.statements) == 1)
+    st = tp.statements[0]
+    assert(isinstance(st, ist.Phosphorylation))
+    assert(isinstance(st.mod, ist.ModCondition))
+    assert(st.mod.mod_type == 'phosphorylation')
+    assert(st.mod.residue == 'serine')
+    assert(st.mod.position is None)
+
+def test_actmod():
+    tp = trips_api.process_text('MEK1 phosphorylated at Ser222 is activated.')
+    assert(len(tp.statements) == 1)
+    st = tp.statements[0]
+    assert(isinstance(st, ist.ActivityModification))
+    assert(isinstance(st.mod[0], ist.ModCondition))
+    assert(st.mod[0].mod_type == 'phosphorylation')
+    assert(st.mod[0].residue == 'serine')
+    assert(st.mod[0].position == '222')
+
+def test_actmods():
+    tp = trips_api.process_text('MEK1 phosphorylated at Ser 218 and Ser222 is activated.')
+    assert(len(tp.statements) == 1)
+    st = tp.statements[0]
+    assert(isinstance(st, ist.ActivityModification))
+    assert(isinstance(st.mod[0], ist.ModCondition))
+    assert(isinstance(st.mod[1], ist.ModCondition))
+    assert(st.mod[0].mod_type == 'phosphorylation')
+    assert(st.mod[0].residue == 'serine')
+    assert(st.mod[0].position == '218')
+
+def test_actmods():
+    tp = trips_api.process_text('BRAF phosphorylated at Ser536 binds MEK1.')
+    assert(len(tp.statements) == 1)
+    st = tp.statements[0]
+    assert(isinstance(st, ist.Complex))
+    braf = st.members[0]
+    assert(braf.mods[0].mod_type == 'phosphorylation')
+    assert(braf.mods[0].residue == 'serine')
+    assert(braf.mods[0].position == '536')
+
 def test_trips_processor_online():
     """Smoke test to see if imports and executes without error. Doesn't
     check for correctness of parse or of assembled model."""
-    pa = PysbAssembler()
     tp = trips_api.process_text('BRAF phosphorylates MEK1 at Ser222.')
-    pa.add_statements(tp.statements)
 
 def test_trips_processor_offline():
     """Smoke test to see if imports and executes without error. Doesn't
     check for correctness of parse or of assembled model."""
-    pa = PysbAssembler()
     tp = trips_api.process_xml(open(test_small_file).read())
-    pa.add_statements(tp.statements)
-    model = pa.make_model()
-

--- a/indra/trips/processor.py
+++ b/indra/trips/processor.py
@@ -276,25 +276,31 @@ class TripsProcessor(object):
                                            [BoundCondition(agent_bound, True)]
                 for m in mods:
                     self.statements.append(Transphosphorylation(enzyme_agent,
-                                           m, evidence=ev))
+                                            m.residue, m.position,
+                                            evidence=ev))
             # Dephosphorylation
             elif 'ONT::MANNER-UNDO' in [mt.text for mt in mod_types]:
                 for m in mods:
                     self.statements.append(Dephosphorylation(enzyme_agent,
-                                           affected_agent, m, evidence=ev))
+                                            affected_agent,
+                                            m.residue, m.position,
+                                            evidence=ev))
             # Autophosphorylation
             elif enzyme_agent is not None and\
                 (enzyme.attrib['id'] == affected.attrib['id']):
                 for m in mods:
                     self.statements.append(Autophosphorylation(enzyme_agent,
-                                           m, evidence=ev))
+                                            m.residue, m.position,
+                                            evidence=ev))
             # Regular phosphorylation
             else:
                 if mods is None:
                     continue
                 for m in mods:
                     self.statements.append(Phosphorylation(enzyme_agent,
-                                            affected_agent, m, evidence=ev))
+                                            affected_agent,
+                                            m.residue, m.position,
+                                            evidence=ev))
             self.extracted_events['ONT::PHOSPHORYLATION'].append(
                                                             event.attrib['id'])
 


### PR DESCRIPTION
This pull request changes the way modifications are represented in INDRA. The modifications in ActivityModification statements and the modification conditions of Agents are now a list of ModCondition objects. A ModCondition object has a mod_type (e.g. 'phosphorylation'), a residue (e.g. 'serine'), a position (e.g. '222') and an is_modified flag (True/False) to be able to represent the lack of a modification. 

Modification and SelfModification statements have also been refactored. They now have a residue (e.g. 'serine') and a position (e.g. '222') associated with them. This replaces the old 'PhosphorylationSerine' and similar modification strings. 

All processors and assemblers as well as the Statements and Preassembler of INDRA are affected.