### PR TITLE
Amino acids standardization

### DIFF
--- a/data/amino_acids.tsv
+++ b/data/amino_acids.tsv
@@ -1,0 +1,21 @@
+full_name	short_name	letter_name	indra_name
+alanine	ala	A	alanine
+arginine	arg	R	arginine
+asparagine	asn	N	asparagine
+aspartic acid	asp	D	aspartic_acid
+cysteine	cys	C	cysteine
+glutamine	gln	Q	glutamine
+glutamic acid	glu	E	glutamic_acid
+glycine	gly	G	glycine
+histidine	his	H	histidine
+isoleucine	ile	I	isoleucine
+leucine	leu	L	leucine
+lysine	lys	K	lysine
+methionine	met	M	methionine
+phenylalanine	phe	F	phenylalanine
+proline	pro	P	proline
+serine	ser	S	serine
+threonine	thr	T	threonine
+tryptophan	trp	W	tryptophan
+tyrosine	tyr	Y	tyrosine
+valine	val	V	valine

--- a/indra/bel/processor.py
+++ b/indra/bel/processor.py
@@ -16,13 +16,6 @@ prefixes = """
     PREFIX belns: <http://www.openbel.org/bel/namespace/>
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>"""
 
-phospho_mods = [
-    'PhosphorylationSerine',
-    'PhosphorylationThreonine',
-    'PhosphorylationTyrosine',
-    'Phosphorylation',
-]
-
 class InvalidNameError(ValueError):
     def __init__(self, name):
         ValueError.__init__(self, "Not a valid name: %s" % name)

--- a/indra/benchmarks/test_trips.py
+++ b/indra/benchmarks/test_trips.py
@@ -74,7 +74,7 @@ def test_bound_mod():
     assert(has_hgnc_ref(st.members[1]))
     assert(st.members[1].mods)
     assert(st.members[1].mods[0].mod_type == 'phosphorylation')
-    assert(st.members[1].mods[0].residue == 'tyrosine')
+    assert(st.members[1].mods[0].residue == 'Y')
     os.remove(fname)
 
 def test_not_bound_to():
@@ -198,7 +198,7 @@ def test_transphosphorylate2():
     assert(st.enz is not None)
     assert(st.enz.name == 'EGFR')
     assert(has_hgnc_ref(st.enz))
-    assert(st.residue == 'tyrosine')
+    assert(st.residue == 'Y')
     assert(len(st.enz.bound_conditions) == 1)
     assert(st.enz.bound_conditions[0].agent.name == 'EGFR')
     os.remove(fname)
@@ -214,7 +214,7 @@ def test_act_mod():
     assert(st.monomer.name == 'MAP2K1')
     residues = [m.residue for m in st.mod]
     positions = [m.position for m in st.mod]
-    assert(residues == ['serine', 'serine'])
+    assert(residues == ['S', 'S'])
     assert(positions == ['218', '222'])
     assert(st.relationship == 'increases')
     os.remove(fname)
@@ -260,7 +260,7 @@ def test_act_phosphorylate():
     assert(st.enz.name == 'MAP2K1')
     assert(st.sub is not None)
     assert(st.sub.name == 'MAPK1')
-    assert(st.residue == 'tyrosine')
+    assert(st.residue == 'Y')
     assert(st.position == '187')
     os.remove(fname)
 
@@ -275,7 +275,7 @@ def test_dephosphorylate():
     assert(st.enz.name == 'DUSP6')
     assert(st.sub is not None)
     assert(st.sub.name == 'MAPK1')
-    assert(st.residue == 'tyrosine')
+    assert(st.residue == 'Y')
     assert(st.position == '187')
     os.remove(fname)
 

--- a/indra/biopax/processor.py
+++ b/indra/biopax/processor.py
@@ -576,10 +576,10 @@ class BiopaxProcessor(object):
 
     _mftype_dict = {
         'phosphorylated residue': ('phosphorylation', None),
-        'O-phospho-L-serine': ('phosphorylation', 'serine'),
-        'O-phospho-L-threonine': ('phosphorylation', 'threonine'),
-        'O-phospho-L-tyrosine': ('phosphorylation', 'tyrosine'),
-        'O4\'-phospho-L-tyrosine': ('phosphorylation', 'tyrosine'),
+        'O-phospho-L-serine': ('phosphorylation', 'S'),
+        'O-phospho-L-threonine': ('phosphorylation', 'T'),
+        'O-phospho-L-tyrosine': ('phosphorylation', 'Y'),
+        'O4\'-phospho-L-tyrosine': ('phosphorylation', 'Y'),
         'residue modification, active': ('active', None),
         'residue modification, inactive': ('inactive', None)
         }

--- a/indra/english_assembler.py
+++ b/indra/english_assembler.py
@@ -51,22 +51,25 @@ def assemble_agent_str(agent):
         if len(agent.mods) == 1 and agent.mods[0].position is None:
             prefix = abbrev_prefix[agent.mods[0].mod_type]
             if agent.mods[0].residue is not None:
-                prefix = agent.mods[0].residue + '-' + prefix
+                residue_str =\
+                    ist.amino_acids[agent.mods[0].residue]['full_name']
+                prefix = residue_str + '-' + prefix
             agent_str =  prefix + ' ' + agent_str
         else:
             if agent.bound_conditions:
                 agent_str += ' and'
-            # TODO: handle multiple different mod types
             agent_str += ' %s on ' % abbrev_prefix[agent.mods[0].mod_type]
             mod_lst = []
             for m in agent.mods:
                 if m.position is None:
                     if m.residue is not None:
-                        mod_lst.append(m.residue)
+                        residue_str =\
+                            ist.amino_acids[m.residue]['full_name']
+                        mod_lst.append(residue_str)
                     else:
                         mod_lst.append('an unknown residue')
                 else:
-                    mod_lst.append(abbrev_letter[m.residue] + m.position)
+                    mod_lst.append(m.residue + m.position)
             agent_str += join_list(mod_lst)
 
     return agent_str
@@ -93,9 +96,9 @@ def assemble_phosphorylation(stmt):
 
     if stmt.residue is not None:
         if stmt.position is None:
-            mod_str = 'on ' + stmt.residue
+            mod_str = 'on ' + ist.amino_acids[stmt.residue]['full_name']
         else:
-            mod_str = 'on ' + abbrev_letter[stmt.residue] + stmt.position
+            mod_str = 'on ' + stmt.residue + stmt.position
     else:
         mod_str = ''
     stmt_str += ' ' + mod_str
@@ -111,9 +114,9 @@ def assemble_dephosphorylation(stmt):
 
     if stmt.residue is not None:
         if stmt.position is None:
-            mod_str = 'on ' + stmt.residue
+            mod_str = 'on ' + ist.amino_acids[stmt.residue]['full_name']
         else:
-            mod_str = 'on ' + abbrev_letter[stmt.residue] + stmt.position
+            mod_str = 'on ' + stmt.residue + stmt.position
     else:
         mod_str = 'on an unknown residue '
     stmt_str += ' ' + mod_str
@@ -129,12 +132,6 @@ def make_sentence(txt):
     txt = txt.strip(' ')
     txt = txt[0].upper() + txt[1:] + '.'
     return txt
-
-abbrev_letter = {
-    'serine': 'S',
-    'threonine': 'T',
-    'tyrosine': 'Y',
-}
 
 abbrev_prefix = {
     'phosphorylation': 'phosphorylated',

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -330,7 +330,7 @@ def check_agent_mod(agent, mods=None):
     for m in check_mods:
         if m.position is None:
             continue
-        residue = get_residue(m.residue)
+        residue = m.residue
         if residue is None:
             continue
         ver = uniprot_client.verify_location(agent_entry, residue, m.position)
@@ -339,14 +339,3 @@ def check_agent_mod(agent, mods=None):
                   (m.position, agent.name, residue)
             failures.append((agent.name, residue, m.position))
     return failures
-
-def get_residue(residue):
-    """Return the amino acid letter from a  modification string"""
-    if residue == 'serine':
-        return 'S'
-    elif residue == 'threonine':
-        return 'T'
-    elif residue == 'tyrosine':
-        return 'Y'
-    else:
-        return None

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -119,16 +119,16 @@ class Preassembler(object):
                     entity_hierarchy as eh, modification_hierarchy as mh
             >>> braf = Agent('BRAF')
             >>> map2k1 = Agent('MAP2K1')
-            >>> st1 = Phosphorylation(braf, map2k1, 'Phosphorylation', None)
-            >>> st2 = Phosphorylation(braf, map2k1, 'Phosphorylation', '218')
+            >>> st1 = Phosphorylation(braf, map2k1)
+            >>> st2 = Phosphorylation(braf, map2k1, position='218')
             >>> pa = Preassembler(eh, mh, [st1, st2])
             >>> combined_stmts = pa.combine_related()
             >>> combined_stmts
-            [Phosphorylation(BRAF(), MAP2K1(), Phosphorylation, 218)]
+            [Phosphorylation(BRAF(), MAP2K1(), None, 218)]
             >>> combined_stmts[0].supported_by
-            [Phosphorylation(BRAF(), MAP2K1(), Phosphorylation, None)]
+            [Phosphorylation(BRAF(), MAP2K1(), None, None)]
             >>> combined_stmts[0].supported_by[0].supports
-            [Phosphorylation(BRAF(), MAP2K1(), Phosphorylation, 218)]
+            [Phosphorylation(BRAF(), MAP2K1(), None, 218)]
         """
 
         # If unique_stmts is not initialized, call combine_duplicates.

--- a/indra/pysb_assembler.py
+++ b/indra/pysb_assembler.py
@@ -101,9 +101,6 @@ abbrevs = {
     'glycosylation': 'glycosyl',
     'methylation': 'methyl',
     'modification': 'mod',
-    'serine': 'S',
-    'threonine': 'T',
-    'tyrosine': 'Y'
 }
 
 active_site_names = {
@@ -153,7 +150,7 @@ def get_mod_site_name(mod_type, residue, position):
     if residue is None:
         mod_str = abbrevs[mod_type]
     else:
-        mod_str = abbrevs[residue]
+        mod_str = residue
     mod_pos = position if position is not None else ''
     name = ('%s%s' % (mod_str, mod_pos))
     return name
@@ -171,7 +168,7 @@ def get_agent_rule_str(agent):
     for mod in agent.mods:
         mstr = abbrevs[mod.mod_type]
         if mod.residue is not None:
-            mstr += abbrevs[mod.residue]
+            mstr += mod.residue
         if mod.position is not None:
             mstr += mod.position
         rule_str_list.append('%s' % mstr)
@@ -243,7 +240,7 @@ def get_complex_pattern(model, agent, agent_set, extra_fields=None):
     for mod in agent.mods:
         mod_site_str = abbrevs[mod.mod_type]
         if mod.residue is not None:
-            mod_site_str = abbrevs[mod.residue]
+            mod_site_str = mod.residue
         mod_pos_str = mod.position if mod.position is not None else ''
         mod_site = ('%s%s' % (mod_site_str, mod_pos_str))
         site_states = states[mod.mod_type]
@@ -411,7 +408,7 @@ def complex_monomers_one_step(stmt, agent_set):
             if mod.residue is None:
                 mod_str = abbrevs[mod.mod_type]
             else:
-                mod_str = abbrevs[mod.residue]
+                mod_str = mod.residue
             mod_pos = mod.position if mod.position is not None else ''
             mod_site = ('%s%s' % (mod_str, mod_pos))
             gene_mono.create_site(mod_site, states[mod.mod_type])
@@ -535,7 +532,7 @@ def complex_assemble_multi_way(stmt, model, agent_set):
             if mod.residue is None:
                 mod_str = abbrevs[mod.mod_type]
             else:
-                mod_str = abbrevs[mod.residue]
+                mod_str = mod.residue
             mod_pos = mod.position if mod.position is not None else ''
             mod_site = ('%s%s' % (mod_str, mod_pos))
             left_site_dict[mod_site] = states[mod.mod_type][1]

--- a/indra/reach/processor.py
+++ b/indra/reach/processor.py
@@ -5,18 +5,6 @@ import warnings
 from indra.statements import *
 import indra.databases.uniprot_client as up_client
 
-residue_names = {
-    'S': 'serine',
-    'T': 'threonine',
-    'Y': 'tyrosine',
-    'SER': 'serine',
-    'THR': 'threonine',
-    'TYR': 'tyrosine',
-    'SERINE': 'serine',
-    'THREONINE': 'threonine',
-    'TYROSINE': 'tyrosine'
-    }
-
 
 class ReachProcessor(object):
     def __init__(self, json_dict, pmid=None):
@@ -255,25 +243,25 @@ class ReachProcessor(object):
     def _parse_site_text(s):
         m = re.match(r'([TYS])[-]?([0-9]+)', s)
         if m is not None:
-            residue = residue_names[m.groups()[0]]
+            residue = get_valid_residue(m.groups()[0])
             site = m.groups()[1]
             return residue, site
 
         m = re.match(r'(THR|TYR|SER)[- ]?([0-9]+)', s.upper())    
         if m is not None:
-            residue = residue_names[m.groups()[0]]
+            residue = get_valid_residue(m.groups()[0])
             site = m.groups()[1]
             return residue, site
 
         m = re.match(r'(THREONINE|TYROSINE|SERINE)[^0-9]*([0-9]+)', s.upper())
         if m is not None:
-            residue = residue_names[m.groups()[0]]
+            residue = get_valid_residue(m.groups()[0])
             site = m.groups()[1]
             return residue, site
 
         m = re.match(r'.*(THREONINE|TYROSINE|SERINE).*', s.upper())
         if m is not None:
-            residue = residue_names[m.groups()[0]]
+            residue = get_valid_residue(m.groups()[0])
             site = None
             return residue, site
 

--- a/indra/sbgn_assembler.py
+++ b/indra/sbgn_assembler.py
@@ -18,9 +18,6 @@ abbrevs = {
     'glycosylation': 'glycosyl',
     'methylation': 'methyl',
     'modification': 'mod',
-    'serine': 'S',
-    'threonine': 'T',
-    'tyrosine': 'Y'
 }
 
 states = {
@@ -154,7 +151,7 @@ def sbgn_states_for_agent(agent):
     agent_states = []
     for m in agent.mods:
         if m.residue is not None:
-            mod = abbrevs[m.residue]
+            mod = m.residue
         else:
             mod = abbrevs[m.mod_type]
         mod_pos = m.position if m.position is not None else ''

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -24,6 +24,8 @@ BoundCondition = namedtuple('BoundCondition', ['agent', 'is_bound'])
 class ModCondition(object):
     def __init__(self, mod_type, residue=None, position=None, is_modified=True):
         self.mod_type = mod_type
+        if residue is not None and amino_acids.get(residue) is None:
+            raise InvalidResidueError(residue)
         self.residue = residue
         if not isinstance(position, basestring):
             if position is None:
@@ -62,7 +64,6 @@ class ModCondition(object):
         return ms
 
 class Agent(object):
-
     def __init__(self, name, mods=None, active=None,
                  bound_conditions=None, db_refs=None):
         self.name = name
@@ -296,6 +297,8 @@ class Modification(Statement):
         super(Modification, self).__init__(evidence)
         self.enz = enz
         self.sub = sub
+        if residue is not None and amino_acids.get(residue) is None:
+            raise InvalidResidueError(residue)
         self.residue = residue
         if position is not None:
             if not isinstance(position, basestring):
@@ -354,6 +357,8 @@ class SelfModification(Statement):
     def __init__(self, enz, residue=None, position=None, evidence=None):
         super(SelfModification, self).__init__(evidence)
         self.enz = enz
+        if residue is not None and amino_acids.get(residue) is None:
+            raise InvalidResidueError(residue)
         self.residue = residue
         if position is not None:
             if not isinstance(position, basestring):
@@ -713,3 +718,8 @@ class Complex(Statement):
             return False
         else:
             return True
+
+class InvalidResidueError(ValueError):
+    """Invalid residue (amino acid) name."""
+    def __init__(self, name):
+        ValueError.__init__(self, "Invalid residue name: '%s'" % name)

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -6,27 +6,28 @@ def read_amino_acids():
     this_dir = os.path.dirname(os.path.abspath(__file__))
     aa_file = this_dir + '/../data/amino_acids.tsv'
     amino_acids = {}
+    amino_acids_reverse = {}
     with open(aa_file, 'rt') as fh:
         lines = fh.readlines()
-        for lin in lines[1:]:
-            terms = lin.strip().split('\t')
-            key = terms[2]
-            val = {'full_name': terms[0],
-                   'short_name': terms[1],
-                   'indra_name': terms[3]}
-            amino_acids[key] = val
-    return amino_acids
+    for lin in lines[1:]:
+        terms = lin.strip().split('\t')
+        key = terms[2]
+        val = {'full_name': terms[0],
+               'short_name': terms[1],
+               'indra_name': terms[3]}
+        amino_acids[key] = val
+        for v in val.values():
+            amino_acids_reverse[v] = key
+    return amino_acids, amino_acids_reverse
 
-amino_acids = read_amino_acids()
+amino_acids, amino_acids_reverse = read_amino_acids()
 
 BoundCondition = namedtuple('BoundCondition', ['agent', 'is_bound'])
 
 class ModCondition(object):
     def __init__(self, mod_type, residue=None, position=None, is_modified=True):
         self.mod_type = mod_type
-        if residue is not None and amino_acids.get(residue) is None:
-            raise InvalidResidueError(residue)
-        self.residue = residue
+        self.residue = get_valid_residue(residue)
         if not isinstance(position, basestring):
             if position is None:
                 self.position = None
@@ -297,9 +298,7 @@ class Modification(Statement):
         super(Modification, self).__init__(evidence)
         self.enz = enz
         self.sub = sub
-        if residue is not None and amino_acids.get(residue) is None:
-            raise InvalidResidueError(residue)
-        self.residue = residue
+        self.residue = get_valid_residue(residue)
         if position is not None:
             if not isinstance(position, basestring):
                 position = str(position)
@@ -357,9 +356,7 @@ class SelfModification(Statement):
     def __init__(self, enz, residue=None, position=None, evidence=None):
         super(SelfModification, self).__init__(evidence)
         self.enz = enz
-        if residue is not None and amino_acids.get(residue) is None:
-            raise InvalidResidueError(residue)
-        self.residue = residue
+        self.residue = get_valid_residue(residue)
         if position is not None:
             if not isinstance(position, basestring):
                 position = str(position)
@@ -718,6 +715,15 @@ class Complex(Statement):
             return False
         else:
             return True
+
+def get_valid_residue(residue):
+    if residue is not None and amino_acids.get(residue) is None:
+        res = amino_acids_reverse.get(residue.lower())
+        if res is None:
+            raise InvalidResidueError(residue)
+        else:
+            return res
+    return residue
 
 class InvalidResidueError(ValueError):
     """Invalid residue (amino acid) name."""

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1,5 +1,23 @@
+import os
 from collections import namedtuple
 import textwrap
+
+def read_amino_acids():
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    aa_file = this_dir + '/../data/amino_acids.tsv'
+    amino_acids = {}
+    with open(aa_file, 'rt') as fh:
+        lines = fh.readlines()
+        for lin in lines[1:]:
+            terms = lin.strip().split('\t')
+            key = terms[2]
+            val = {'full_name': terms[0],
+                   'short_name': terms[1],
+                   'indra_name': terms[3]}
+            amino_acids[key] = val
+    return amino_acids
+
+amino_acids = read_amino_acids()
 
 BoundCondition = namedtuple('BoundCondition', ['agent', 'is_bound'])
 
@@ -695,4 +713,3 @@ class Complex(Statement):
             return False
         else:
             return True
-

--- a/indra/tests/test_biopax.py
+++ b/indra/tests/test_biopax.py
@@ -138,7 +138,7 @@ def test_get_mod_feature():
     mf = cast(bpc.bp('ModificationFeature'), bpe)
     mc = bpc.BiopaxProcessor._extract_mod_from_feature(mf)
     assert(mc.mod_type == 'phosphorylation')
-    assert(mc.residue == 'threonine')
+    assert(mc.residue == 'T')
     assert(mc.position == '274')
 
 def test_get_entity_mods():
@@ -150,6 +150,6 @@ def test_get_entity_mods():
     mod_types = set([m.mod_type for m in mods])
     assert(mod_types == set(['phosphorylation']))
     residues = set([m.residue for m in mods])
-    assert(residues == set(['tyrosine']))
+    assert(residues == set(['Y']))
     mod_pos = set([m.position for m in mods])
     assert(mod_pos == set(['1035', '1056', '1128', '1188', '1242']))

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -6,14 +6,14 @@ def test_parse_site_text():
             'threonine residue 185', 'T185']
     for t in text:
         residue, site = ReachProcessor._parse_site_text(t)
-        assert(residue == 'threonine')
+        assert(residue == 'T')
         assert(site == '185')
 
 def test_parse_site_residue_only():
     text = ['serine residue', 'serine', 'a serine site']
     for t in text:
         residue, site = ReachProcessor._parse_site_text(t)
-        assert(residue == 'serine')
+        assert(residue == 'S')
         assert(site is None)
 
 def test_valid_name():

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -286,7 +286,7 @@ def test_entities_match_mod():
     nras2 = Agent('NRAS', db_refs = {'HGNC': 'dummy'})
     st1 = Phosphorylation(src, nras1, 'tyrosine', '32',
                           evidence=Evidence(text='foo'))
-    st2 = Phosphorylation(src, nras2, ModCondition('phosphorylation'),
+    st2 = Phosphorylation(src, nras2,
                           evidence=Evidence(text='bar'))
     assert(st1.entities_match(st2))
 
@@ -854,6 +854,28 @@ def test_complex_family_refinement():
     assert not st2.refinement_of(st5, eh, mh)
     assert not st3.refinement_of(st5, eh, mh)
     assert not st4.refinement_of(st5, eh, mh)
+
+@raises(InvalidResidueError)
+def test_residue_mod_condition():
+    mc = ModCondition('phosphorylation', 'xyz')
+
+@raises(InvalidResidueError)
+def test_residue_mod():
+    Phosphorylation(Agent('a'), Agent('b'), 'xyz')
+
+@raises(InvalidResidueError)
+def test_residue_selfmod():
+    Autophosphorylation(Agent('a'), 'xyz')
+
+def test_valid_mod_residue():
+    mc = ModCondition('phosphorylation', 'serine')
+    assert(mc.residue == 'S')
+
+def test_valid_residue():
+    assert(get_valid_residue('serine') == 'S')
+    assert(get_valid_residue('ser') == 'S')
+    assert(get_valid_residue('Serine') == 'S')
+    assert(get_valid_residue('SERINE') == 'S')
 
 # TODO expand tests to also check for things that should NOT match (different
 # agent names)

--- a/indra/tests/test_trips.py
+++ b/indra/tests/test_trips.py
@@ -12,7 +12,7 @@ def test_phosphorylation():
     assert(len(tp.statements) == 1)
     st = tp.statements[0]
     assert(isinstance(st, ist.Phosphorylation))
-    assert(st.residue == 'serine')
+    assert(st.residue == 'S')
     assert(st.position == '222')
 
 def test_phosphorylation_noresidue():
@@ -28,7 +28,7 @@ def test_phosphorylation_nosite():
     assert(len(tp.statements) == 1)
     st = tp.statements[0]
     assert(isinstance(st, ist.Phosphorylation))
-    assert(st.residue == 'serine')
+    assert(st.residue == 'S')
     assert(st.position is None)
 
 def test_actmod():
@@ -38,7 +38,7 @@ def test_actmod():
     assert(isinstance(st, ist.ActivityModification))
     assert(isinstance(st.mod[0], ist.ModCondition))
     assert(st.mod[0].mod_type == 'phosphorylation')
-    assert(st.mod[0].residue == 'serine')
+    assert(st.mod[0].residue == 'S')
     assert(st.mod[0].position == '222')
 
 def test_actmods():
@@ -49,7 +49,7 @@ def test_actmods():
     assert(isinstance(st.mod[0], ist.ModCondition))
     assert(isinstance(st.mod[1], ist.ModCondition))
     assert(st.mod[0].mod_type == 'phosphorylation')
-    assert(st.mod[0].residue == 'serine')
+    assert(st.mod[0].residue == 'S')
     assert(st.mod[0].position == '218')
 
 def test_actmods():
@@ -59,7 +59,7 @@ def test_actmods():
     assert(isinstance(st, ist.Complex))
     braf = st.members[0]
     assert(braf.mods[0].mod_type == 'phosphorylation')
-    assert(braf.mods[0].residue == 'serine')
+    assert(braf.mods[0].residue == 'S')
     assert(braf.mods[0].position == '536')
 
 def test_trips_processor_online():

--- a/indra/trips/processor.py
+++ b/indra/trips/processor.py
@@ -10,19 +10,6 @@ import indra.databases.hgnc_client as hgnc_client
 import indra.databases.uniprot_client as up_client
 
 
-residue_names = {
-    'S': 'serine',
-    'T': 'threonine',
-    'Y': 'tyrosine',
-    'SER': 'serine',
-    'THR': 'threonine',
-    'TYR': 'tyrosine',
-    'SERINE': 'serine',
-    'THREONINE': 'threonine',
-    'TYROSINE': 'tyrosine'
-    }
-
-
 mod_names = {
     'PHOSPHORYLATION': 'phosphorylation'
     }
@@ -582,7 +569,7 @@ class TripsProcessor(object):
         # Collect mods in a list
         mods = []
         for r, p in zip(residues, mod_pos):
-            residue_name = residue_names.get(r)
+            residue_name = get_valid_residue(r)
             if residue_name is None:
                 warnings.warn('Residue name %s unknown. ' % r)
                 residue_name = None


### PR DESCRIPTION
This pull request standardizes the naming of amino acids in INDRA Statements (the standard is a single capitalized letter like "S" or "V") and adds some lookup tables in statements.py for processors and assemblers to get different forms of amino acid names (1-letter, 3-letter, full) as needed. This simplifies processors and assemblers and gets rid of some duplicated string lookups. When constructing a Statement we can now also check if the passed residue name is valid (1-letter, 3-letter and full names are all accepted and standardized) and if it is invalid, it raises an InvalidResidueError. 