### PR TITLE
Reimplementation of the Preassembler

### DIFF
--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -142,15 +142,16 @@ class Preassembler(object):
         The procedure for combining statements in this way involves a series
         of steps:
 
-        1. The statements are grouped by whether they are of the same type
-           (e.g., Phosphorylation) and involve the same entities (e.g.,
-           BRAF and MAP2K1).
-        2. The groups of statements are then further compared to see if one
-           group involves superfamily entities of another group. If so, the
-           statements involving the superfamily are added into the group of
-           statements involving the more concrete entities to create an
-           "extended group."
-        3. The statements within each extended group are then compared; if one
+        1. The statements are grouped by type (e.g., Phosphorylation) and
+           each type is iterated over independently.
+        2. Statements of the same type are then grouped according to their
+           Agents' entity hierarchy component identifiers. For instance,
+           ERK, MAPK1 and MAPK3 are all in the same connected component in the
+           entity hierarchy and therefore all Statements of the same type
+           referencing these entities will be grouped. This grouping assures
+           that relations are only possible within Statement groups and
+           not among groups.
+        3. The statements within each group are then compared; if one
            statement represents a refinement of the other (as defined by the
            `refinement_of()` method implemented for the Statement), then the
            more refined statement is added to the `supports` field of the more

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -215,16 +215,24 @@ class Preassembler(object):
                           if type(stmt) == stmt_type]
             stmt_by_comp = {}
             for stmt in stmts_this_type:
+                any_component = False
                 for a in stmt.agent_list():
                     if a is not None:
-                        uri = eh.get_uri(*a.get_grounding())
+                        a_ns, a_id = a.get_grounding()
+                        if a_ns is None:
+                            continue
+                        uri = eh.get_uri(a_ns, a_id)
                         print uri
                         component = eh.components.get(uri)
                         print component
-                    try:
-                        stmt_by_comp[component].append(stmt)
-                    except KeyError:
-                        stmt_by_comp[component] = [stmt]
+                        if component is not None:
+                            any_component = True
+                            try:
+                                stmt_by_comp[component].append(stmt)
+                            except KeyError:
+                                stmt_by_comp[component] = [stmt]
+                if not any_component:
+                    related_stmts.append(stmt)
 
             for comp, stmts in stmt_by_comp.iteritems():
                 print comp, stmts
@@ -237,9 +245,10 @@ class Preassembler(object):
 
             toplevel_stmts = [st for st in stmts_this_type if not st.supports]
             related_stmts += toplevel_stmts
+        print related_stmts
         self.related_stmts = related_stmts
 
-        return
+        return self.related_stmts
 
         unique_stmts.sort(key=lambda x: x.entities_match_key())
         groups = {grouper[0]: list(grouper[1])

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -191,7 +191,6 @@ class Preassembler(object):
         >>> st2 = Phosphorylation(braf, map2k1, residue='S')
         >>> pa = Preassembler(hierarchies, [st1, st2])
         >>> combined_stmts = pa.combine_related() # doctest:+ELLIPSIS
-        Combining ...
         >>> combined_stmts
         [Phosphorylation(BRAF(), MAP2K1(), S)]
         >>> combined_stmts[0].supported_by
@@ -310,7 +309,6 @@ def render_stmt_graph(statements, agent_style=None):
     >>> st2 = Phosphorylation(braf, map2k1, residue='S')
     >>> pa = Preassembler(hierarchies, [st1, st2])
     >>> pa.combine_related() # doctest:+ELLIPSIS
-    Combining ...
     [Phosphorylation(BRAF(), MAP2K1(), S)]
     >>> graph = render_stmt_graph(pa.related_stmts)
     >>> graph.write('example_graph.dot') # To make the DOT file
@@ -385,7 +383,6 @@ def flatten_stmts(stmts):
     >>> st2 = Phosphorylation(braf, map2k1, residue='S')
     >>> pa = Preassembler(hierarchies, [st1, st2])
     >>> pa.combine_related() # doctest:+ELLIPSIS
-    Combining ...
     [Phosphorylation(BRAF(), MAP2K1(), S)]
     >>> flattened = flatten_stmts(pa.related_stmts)
     >>> flattened.sort(key=lambda x: x.matches_key())
@@ -439,7 +436,6 @@ def flatten_evidence(stmts):
     ... evidence=[Evidence(text='baz'), Evidence(text='bak')])
     >>> pa = Preassembler(hierarchies, [st1, st2])
     >>> pa.combine_related() # doctest:+ELLIPSIS
-    Combining ...
     [Phosphorylation(BRAF(), MAP2K1(), S)]
     >>> [e.text for e in pa.related_stmts[0].evidence]
     ['baz', 'bak']

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -204,14 +204,16 @@ class Preassembler(object):
         unique_stmts = deepcopy(self.unique_stmts)
         eh = self.hierarchies['entity']
         # Make a list of Statement types
-        type_groups = list(set([type(stmt) for stmt in unique_stmts]))
+        stmts_by_type = {}
+        for stmt in unique_stmts:
+            try:
+                stmts_by_type[type(stmt)].append(stmt)
+            except KeyError:
+                stmts_by_type[type(stmt)] = [stmt]
         no_comp_stmts = []
         related_stmts = []
         # Each Statement type can be preassembled independently
-        for stmt_type in type_groups:
-            # All Statements of this type
-            stmts_this_type = [stmt for stmt in unique_stmts
-                          if type(stmt) == stmt_type]
+        for stmt_type, stmts_this_type in stmts_by_type.iteritems():
             # Here we group Statements according to the hierarchy graph
             # components that their agents are part of
             stmt_by_comp = {}

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -211,10 +211,10 @@ class Preassembler(object):
                 stmts_by_type[type(stmt)].append(stmt)
             except KeyError:
                 stmts_by_type[type(stmt)] = [stmt]
-        no_comp_stmts = []
         related_stmts = []
         # Each Statement type can be preassembled independently
         for stmt_type, stmts_this_type in stmts_by_type.iteritems():
+            no_comp_stmts = []
             # Here we group Statements according to the hierarchy graph
             # components that their agents are part of
             stmt_by_comp = {}
@@ -242,12 +242,16 @@ class Preassembler(object):
 
             # This is the preassembly within each component ID group
             for comp, stmts in stmt_by_comp.iteritems():
-                comparisons = list(itertools.permutations(stmts, 2))
+                comparisons = list(itertools.combinations(stmts, 2))
                 for stmt1, stmt2 in comparisons:
                     if stmt1.refinement_of(stmt2, self.hierarchies):
                         if stmt2 not in stmt1.supported_by:
                             stmt1.supported_by.append(stmt2)
                             stmt2.supports.append(stmt1)
+                    elif stmt2.refinement_of(stmt1, self.hierarchies):
+                        if stmt1 not in stmt2.supported_by:
+                            stmt2.supported_by.append(stmt1)
+                            stmt1.supports.append(stmt2)
 
             # Next we deal with the Statements that have no associated
             # entity hierarchy component IDs.
@@ -265,12 +269,16 @@ class Preassembler(object):
             # This is the preassembly within each Statement group
             # keyed by the Agent entity_matches_key
             for _, stmts in no_comp_keys.iteritems():
-                comparisons = list(itertools.permutations(stmts, 2))
+                comparisons = list(itertools.combinations(stmts, 2))
                 for stmt1, stmt2 in comparisons:
                     if stmt1.refinement_of(stmt2, self.hierarchies):
                         if stmt2 not in stmt1.supported_by:
                             stmt1.supported_by.append(stmt2)
                             stmt2.supports.append(stmt1)
+                    elif stmt2.refinement_of(stmt1, self.hierarchies):
+                        if stmt1 not in stmt2.supported_by:
+                            stmt2.supported_by.append(stmt1)
+                            stmt1.supports.append(stmt2)
             toplevel_stmts = [st for st in stmts_this_type if not st.supports]
             related_stmts += toplevel_stmts
 

--- a/indra/preassembler/hierarchy_manager.py
+++ b/indra/preassembler/hierarchy_manager.py
@@ -38,6 +38,7 @@ class HierarchyManager(object):
         self.graph.parse(rdf_file)
         self.isa_closure = {}
         self.partof_closure = {}
+        self.components = {}
 
     def build_transitive_closures(self):
         """Build the transitive closures of the hierarchy.
@@ -46,6 +47,7 @@ class HierarchyManager(object):
         hierarchy as keys and either all the "isa+" or "partof+" related terms
         as values.
         """
+        component_counter = 0
         for rel, tc_dict in (('isa', self.isa_closure),
                              ('partof', self.partof_closure)):
             qstr = self.prefixes + """
@@ -61,6 +63,39 @@ class HierarchyManager(object):
                     tc_dict[xs].append(ys)
                 except KeyError:
                     tc_dict[xs] = [ys]
+                xcomp = self.components.get(xs)
+                ycomp = self.components.get(ys)
+                if xcomp is None:
+                    if ycomp is None:
+                        # Neither x nor y are in a component so we start a
+                        # new component and assign x and y to the same
+                        # component
+                        self.components[xs] = component_counter
+                        self.components[ys] = component_counter
+                        component_counter += 1
+                    else:
+                        # Because y is already part of an existing component
+                        # we assign its component to x
+                        self.components[xs] = ycomp
+                else:
+                    if ycomp is None:
+                        # Because x is already part of an existing component
+                        # we assign its component to y
+                        self.components[ys] = xcomp
+                    else:
+                        # This is a special case in which both x and y are
+                        # parts of components
+                        # If they are in the same component then there's
+                        # nothing further to do
+                        if xcomp == ycomp:
+                            continue
+                        else:
+                            remove_component = max(xcomp, ycomp)
+                            joint_component = min(xcomp, ycomp)
+                            for k, v in self.components.iteritems():
+                                if v == remove_component:
+                                    self.components[k] = joint_component
+
 
     @functools32.lru_cache(maxsize=100000)
     def find_entity(self, x):

--- a/indra/preassembler/hierarchy_manager.py
+++ b/indra/preassembler/hierarchy_manager.py
@@ -2,16 +2,6 @@ import os
 import rdflib
 import functools32
 
-def get_uri(ns, id):
-    if ns == 'HGNC':
-        return 'http://identifiers.org/hgnc.symbol/' + id
-    elif ns == 'UP':
-        return 'http://identifiers.org/uniprot/' + id
-    elif ns == 'BE' or ns == 'INDRA':
-        return 'http://sorger.med.harvard.edu/indra/entities/' + id
-    else:
-        raise ValueError('Unknown namespace %s' % ns)
-
 class HierarchyManager(object):
     """Store hierarchical relationships between different types of entities.
 
@@ -149,8 +139,8 @@ class HierarchyManager(object):
             return False
 
         if self.isa_closure:
-            term1 = get_uri(ns1, id1)
-            term2 = get_uri(ns2, id2)
+            term1 = self.get_uri(ns1, id1)
+            term2 = self.get_uri(ns2, id2)
             ec = self.isa_closure.get(term1)
             if ec is not None and term2 in ec:
                 return True
@@ -187,8 +177,8 @@ class HierarchyManager(object):
             return False
 
         if self.partof_closure:
-            term1 = get_uri(ns1, id1)
-            term2 = get_uri(ns2, id2)
+            term1 = self.get_uri(ns1, id1)
+            term2 = self.get_uri(ns2, id2)
             ec = self.partof_closure.get(term1)
             if ec is not None and term2 in ec:
                 return True
@@ -212,6 +202,18 @@ class HierarchyManager(object):
             return True
         else:
             return False
+
+    @staticmethod
+    def get_uri(ns, id):
+        if ns == 'HGNC':
+            return 'http://identifiers.org/hgnc.symbol/' + id
+        elif ns == 'UP':
+            return 'http://identifiers.org/uniprot/' + id
+        elif ns == 'BE' or ns == 'INDRA':
+            return 'http://sorger.med.harvard.edu/indra/entities/' + id
+        else:
+            raise ValueError('Unknown namespace %s' % ns)
+
 
 # Load the default entity and modification hierarchies
 entity_file_path = os.path.join(os.path.dirname(__file__),

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -172,7 +172,7 @@ def test_modification_norefinement_subsfamily():
     generic modification statement."""
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     nras = Agent('NRAS', db_refs = {'HGNC': '7989'})
-    ras = Agent('RAS')
+    ras = Agent('RAS', db_refs = {'BE': 'RAS'})
     st1 = Phosphorylation(src, nras)
     st2 = Phosphorylation(src, ras, 'Y', '32',
                           evidence=[Evidence(text='foo')])


### PR DESCRIPTION
This is a complete, conceptual reimplementation of building the Statement hierarchy (combine_related) in the Preassembler.

Some results on RAS Machine subsets: 
**10k Statements** from the RAS Machine now preassemble in **10 seconds**. 
**20k Statements** from the RAS Machine now preassemble in **1 minute**. 
**45k Statements** from the RAS Machine now preassemble in **3 minutes**. 
And no memory issues either :)

First, we start with an extension of the HierarchyManager. Namely, this pull request extends the transitive closure construction with a connected-component labeling algorithm. This allows one to look up an entity such as "ERK" (namespace not shown here) and in O(1) time get the ID of the connected component that it is in within the entity hierarchy, for instance, 123. Logically, "MAPK1" and "MAPK" would be in the same connected component and would therefore also be associated with the same component ID: 123. 

The Preassembler first groups Statements by their type. Then for each type of Statement it constructs groups of Statements that are potentially related based on their Agents' component IDs.   The trick of course is that this grouping is done in O(n) time since we just need to do O(1) lookups for each Statement. Within each compatible component ID group, it does pairwise comparisons to find the supports-supported_by relationships.

All relevant tests are passing but we should inspect real use cases carefully to make sure everything still works.

