### PR TITLE
Model checker and updates to PySB assembler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: python
 python:
   - "2.7"
   - "3.5"
+addons:
+    apt:
+        packages:
+            - ocaml-nox
+            - opam
 before_install:
   - sudo add-apt-repository --yes ppa:webupd8team/java
   - sudo apt-get update
@@ -29,6 +34,17 @@ install:
   - tar xzf BioNetGen-2.2.6-stable.tar.gz
   - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
   - pip install git+https://github.com/pysb/pysb.git
+  # Kappa
+  # First install ocamlfind via opam (needed to build KaSim/KaSa)
+  - opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
+  - opam install ocamlfind --yes
+  # Install KaSim/KaSa
+  - git clone https://github.com/Kappa-Dev/KaSim.git
+  - cd KaSim
+  - git checkout f87eada
+  - make all
+  - export KAPPAPATH=`pwd`
+  - cd ../
   # Biopax/Paxtools dependencies
   - pip install jnius-indra
   # Download a number of useful resource files for testing purposes

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "3.5"
 addons:
     apt:
+        sources:
+            - avsm
         packages:
             - ocaml-nox
             - opam

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -406,8 +406,7 @@ def grounded_monomer_patterns(model, agent):
         # If there are any sites left after we subject them to residue
         # and position constraints, then return the relevant monomer patterns!
         for site_name in viable_sites:
-            pattern = {}
-            pattern[site_name] = mod_sites[site_name]
+            pattern = {site_name: (mod_sites[site_name], WILD)}
             yield monomer(**pattern)
 
 def get_monomer_pattern(model, agent, extra_fields=None):

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -6,7 +6,7 @@ import itertools
 
 from pysb import (Model, Monomer, Parameter, Rule, Annotation,
         ComponentDuplicateNameError, ComplexPattern, ReactionPattern, ANY,
-        InvalidInitialConditionError)
+        WILD, InvalidInitialConditionError)
 from pysb.core import SelfExporter
 import pysb.export
 
@@ -360,9 +360,9 @@ def get_site_pattern(agent):
         mod_site = ('%s%s' % (mod_site_str, mod_pos_str))
         site_states = states[mod.mod_type]
         if mod.is_modified:
-            pattern[mod_site] = site_states[1]
+            pattern[mod_site] = (site_states[1], WILD)
         else:
-            pattern[mod_site] = site_states[0]
+            pattern[mod_site] = (site_states[0], WILD)
 
     # Handle mutations
     for mc in agent.mutations:

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -137,6 +137,7 @@ class _BaseAgent(object):
             self.add_site_states(site, states)
 
     def create_mod_site(self, mc):
+        """Create modification site for the BaseAgent from a ModCondition."""
         site_name = get_mod_site_name('phosphorylation',
                                       mc.residue, mc.position)
         self.create_site(site_name, ('u', 'p'))
@@ -332,6 +333,8 @@ def get_uncond_agent(agent):
     return agent_uncond
 
 def grounded_monomer_patterns(model, agent):
+    """Get monomer patterns for the agent accounting for grounding information.
+    """
     # Iterate over all model annotations
     monomer = None
     for ann in model.annotations:
@@ -549,6 +552,7 @@ def get_annotation(component, db_name, db_ref):
     return Annotation(subj, obj, pred)
 
 def parse_identifiers_url(url):
+    """Parse an identifiers.org URL into (namespace, ID) tuple."""
     url_pattern = 'http://identifiers.org/([A-Za-z]+)/([A-Za-z0-9:]+)'
     match = re.match(url_pattern, url)
     if match is not None:
@@ -1003,7 +1007,7 @@ def phosphorylation_monomers_interactions_only(stmt, agent_set):
     sub = agent_set.get_create_base_agent(stmt.sub)
     # See NOTE in monomers_one_step, below
     sub.create_mod_site(ist.ModCondition('phosphorylation',
-                                     stmt.residue, stmt.position))
+                                         stmt.residue, stmt.position))
 
 
 def phosphorylation_monomers_one_step(stmt, agent_set):
@@ -1039,7 +1043,7 @@ def phosphorylation_monomers_atp_dependent(stmt, agent_set):
     enz = agent_set.get_create_base_agent(stmt.enz)
     sub = agent_set.get_create_base_agent(stmt.sub)
     sub.create_mod_site(ist.ModCondition('phosphorylation',
-                                     stmt.residue, stmt.position))
+                                         stmt.residue, stmt.position))
     # Create site for binding the substrate
     enz.create_site(get_binding_site_name(sub.name))
     sub.create_site(get_binding_site_name(enz.name))
@@ -1479,10 +1483,6 @@ def dephosphorylation_monomers_interactions_only(stmt, agent_set):
     phos = agent_set.get_create_base_agent(stmt.enz)
     sub = agent_set.get_create_base_agent(stmt.sub)
     phos.create_site(active_site_names['phosphatase'])
-    #dephos_site = get_mod_site_name('phosphorylation',
-    #                              stmt.residue, stmt.position)
-    #sub = agent_set.get_create_base_agent(stmt.sub)
-    #sub.create_site(dephos_site, ('u', 'p'))
     sub.create_mod_site(ist.ModCondition('phosphorylation',
                                      stmt.residue, stmt.position))
 
@@ -1492,10 +1492,6 @@ def dephosphorylation_monomers_one_step(stmt, agent_set):
         return
     phos = agent_set.get_create_base_agent(stmt.enz)
     sub = agent_set.get_create_base_agent(stmt.sub)
-    #dephos_site = get_mod_site_name('phosphorylation',
-    #                              stmt.residue, stmt.position)
-    #sub = agent_set.get_create_base_agent(stmt.sub)
-    #sub.create_site(dephos_site, ('u', 'p'))
     sub.create_mod_site(ist.ModCondition('phosphorylation',
                                      stmt.residue, stmt.position))
 

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -350,7 +350,8 @@ def grounded_monomer_patterns(model, agent):
     # We looked at all the annotations in the model and didn't find a
     # match
     if monomer is None:
-        return None
+        logger.info('No monomer found corresponding to agent %s' % agent)
+        return iter(())
 
     # Now that we have a monomer for the agent, look for site/state
     # combinations corresponding to the state of the agent.

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -880,7 +880,7 @@ def phosphorylation_monomers_interactions_only(stmt, agent_set):
     if stmt.enz is None:
         return
     enz = agent_set.get_create_base_agent(stmt.enz)
-    enz.create_site(active_site_names['Kinase'])
+    enz.create_site(active_site_names['kinase'])
     sub = agent_set.get_create_base_agent(stmt.sub)
     # See NOTE in monomers_one_step, below
     site_name = get_mod_site_name('phosphorylation',
@@ -955,8 +955,8 @@ def phosphorylation_assemble_interactions_only(stmt, model, agent_set):
     rule_enz_str = get_agent_rule_str(stmt.enz)
     rule_sub_str = get_agent_rule_str(stmt.sub)
 
-    rule_name = '%s_phospho_%s_%s' % (rule_enz_str, rule_sub_str, site)
-    active_site = active_site_names['Kinase']
+    rule_name = '%s_phospho_%s_%s' % (rule_enz_str, rule_sub_str, phos_site)
+    active_site = active_site_names['kinase']
     # Create a rule specifying that the substrate binds to the kinase at
     # its active site
     lhs = enz(**{active_site: None}) + sub(**{phos_site: None})

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -359,8 +359,7 @@ def grounded_monomer_patterns(model, agent):
     # match
     if monomer is None:
         logger.info('No monomer found corresponding to agent %s' % agent)
-        return iter(())
-
+        return
     # Now that we have a monomer for the agent, look for site/state
     # combinations corresponding to the state of the agent.
     # For every one of the modifications specified in the agent
@@ -402,7 +401,7 @@ def grounded_monomer_patterns(model, agent):
             viable_sites = viable_sites.intersection(pos_sites)
         # If there are no viable sites, return None
         if not viable_sites:
-            return iter(())
+            return
         # If there are any sites left after we subject them to residue
         # and position constraints, then return the relevant monomer patterns!
         for site_name in viable_sites:

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -1769,11 +1769,11 @@ def activeform_assemble_one_step(stmt, model, agent_set):
 activeform_assemble_default = activeform_assemble_one_step
 
 # RASGTPACTIVITIACTIVITY ######################################
-def rasgtpactivation_monomers_default(stmt, agent_set):
-    pass
 
-def rasgtpactivation_assemble_default(stmt, model, agent_set):
-    pass
+rasgtpactivation_monomers_default = activation_monomers_default
+
+rasgtpactivation_assemble_default = activation_assemble_default
+
 
 # TRANSLOCATION ###############################################
 def translocation_monomers_default(stmt, agent_set):

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -447,11 +447,34 @@ def get_annotation(component, db_name, db_ref):
         obj = url + 'interpro/%s' % db_ref
         pred = 'is'
     elif db_name == 'CHEBI':
-        obj = url + 'chebi/CHEBI:%s' % db_ref
+        obj = url + 'chebi/%s' % db_ref
         pred = 'is'
     else:
         return None
     return Annotation(subj, obj, pred)
+
+def parse_identifiers_url(url):
+    url_pattern = 'http://identifiers.org/([A-Za-z]+)/([A-Za-z0-9:]+)'
+    match = re.match(url_pattern, url)
+    if match is not None:
+        g = match.groups()
+        if not len(g) == 2:
+            return (None, None)
+        ns_map = {'hgnc': 'HGNC', 'uniprot': 'UP', 'chebi':'CHEBI',
+                  'interpro':'IP', 'pfam':'XFAM'}
+        ns = g[0]
+        id = g[1]
+        if not ns in ns_map.keys():
+            return (None, None)
+        if ns == 'hgnc':
+            if id.startswith('HGNC:'):
+                id = id[5:]
+            else:
+                logger.warning('HGNC URL missing "HGNC:" prefix: %s' % url)
+                return (None, None)
+        indra_ns = ns_map[ns]
+        return (indra_ns, id)
+    return (None, None)
 
 # PysbAssembler #######################################################
 

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -343,9 +343,13 @@ def get_monomer_pattern(model, agent, extra_fields=None, use_grounding=False):
             # we check to see if there is a matching identifier in the db_refs
             # for this agent
             for db_ns, db_id in agent.db_refs.items():
-                # We've found a match! Return the monomer
+                # We've found a match! Return first match.
+                # FIXME Could also update this to check for alternative
+                # FIXME matches, or make sure that all grounding IDs match,
+                # FIXME etc.
                 if db_ns == ns and db_id == id:
                     monomer = ann.subject
+                    return monomer
         # We looked at all the annotations in the model and didn't find a
         # match
         return None

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -369,7 +369,12 @@ def get_monomer_pattern(model, agent, extra_fields=None):
             pattern[k] = v
     # If a model is given, return the Monomer with the generated pattern,
     # otherwise just return the pattern
-    monomer_pattern = monomer(**pattern)
+    try:
+        monomer_pattern = monomer(**pattern)
+    except Exception as e:
+        logger.info("Invalid site pattern %s for monomer %s" %
+                      (pattern, monomer))
+        return None
     return monomer_pattern
 
 def get_site_pattern(agent):

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -141,11 +141,12 @@ class _BaseAgent(object):
                                       mc.residue, mc.position)
         (unmod_site_state, mod_site_state) = states[mc.mod_type]
         self.create_site(site_name, (unmod_site_state, mod_site_state))
-        site_anns = [
-            Annotation((site_name, mod_site_state), mc.mod_type,
-                       'is_modification'),
-            Annotation(site_name, mc.residue, 'is_residue'),
-            Annotation(site_name, mc.position, 'is_position')]
+        site_anns = [Annotation((site_name, mod_site_state), mc.mod_type,
+                                'is_modification')]
+        if mc.residue:
+            site_anns.append(Annotation(site_name, mc.residue, 'is_residue'))
+        if mc.position:
+            site_anns.append(Annotation(site_name, mc.position, 'is_position'))
         self.site_annotations += site_anns
 
     def add_site_states(self, site, states):
@@ -407,7 +408,6 @@ def grounded_monomer_patterns(model, agent):
     # FIXME
     if not agent.mods:
         yield monomer()
-
     for mod in agent.mods:
         # Find all site/state combinations that have the appropriate
         # modification type

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -1478,21 +1478,27 @@ def dephosphorylation_monomers_interactions_only(stmt, agent_set):
     if stmt.enz is None:
         return
     phos = agent_set.get_create_base_agent(stmt.enz)
-    phos.create_site(active_site_names['phosphatase'])
-    dephos_site = get_mod_site_name('phosphorylation',
-                                  stmt.residue, stmt.position)
     sub = agent_set.get_create_base_agent(stmt.sub)
-    sub.create_site(dephos_site, ('u', 'p'))
+    phos.create_site(active_site_names['phosphatase'])
+    #dephos_site = get_mod_site_name('phosphorylation',
+    #                              stmt.residue, stmt.position)
+    #sub = agent_set.get_create_base_agent(stmt.sub)
+    #sub.create_site(dephos_site, ('u', 'p'))
+    sub.create_mod_site(ist.ModCondition('phosphorylation',
+                                     stmt.residue, stmt.position))
 
 
 def dephosphorylation_monomers_one_step(stmt, agent_set):
     if stmt.enz is None:
         return
     phos = agent_set.get_create_base_agent(stmt.enz)
-    dephos_site = get_mod_site_name('phosphorylation',
-                                  stmt.residue, stmt.position)
     sub = agent_set.get_create_base_agent(stmt.sub)
-    sub.create_site(dephos_site, ('u', 'p'))
+    #dephos_site = get_mod_site_name('phosphorylation',
+    #                              stmt.residue, stmt.position)
+    #sub = agent_set.get_create_base_agent(stmt.sub)
+    #sub.create_site(dephos_site, ('u', 'p'))
+    sub.create_mod_site(ist.ModCondition('phosphorylation',
+                                     stmt.residue, stmt.position))
 
 
 def dephosphorylation_monomers_two_step(stmt, agent_set):
@@ -1500,10 +1506,11 @@ def dephosphorylation_monomers_two_step(stmt, agent_set):
         return
     phos = agent_set.get_create_base_agent(stmt.enz)
     sub = agent_set.get_create_base_agent(stmt.sub)
-    dephos_site = get_mod_site_name('phosphorylation',
-                                  stmt.residue, stmt.position)
-    sub.create_site(dephos_site, ('u', 'p'))
-
+    #dephos_site = get_mod_site_name('phosphorylation',
+    #                              stmt.residue, stmt.position)
+    #sub.create_site(dephos_site, ('u', 'p'))
+    sub.create_mod_site(ist.ModCondition('phosphorylation',
+                                     stmt.residue, stmt.position))
     # Create site for binding the substrate
     phos.create_site(get_binding_site_name(sub.name))
     sub.create_site(get_binding_site_name(phos.name))

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -71,10 +71,7 @@ class _BaseAgentSet(object):
 
         # Handle modification conditions
         for mc in agent.mods:
-            mod_site_name =\
-                get_mod_site_name(mc.mod_type, mc.residue, mc.position)
-            site_states = states[mc.mod_type]
-            base_agent.create_site(mod_site_name, site_states)
+            base_agent.create_mod_site(mc)
 
         # Handle mutation conditions
         for mc in agent.mutations:

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -663,7 +663,7 @@ class PysbAssembler(object):
         # the global policies of the PySB assembler
         if policies is not None:
             global_policies = self.policies
-            if isinstance(policies, str):
+            if isinstance(policies, basestring):
                 local_policies = {'other': policies}
             else:
                 local_policies = {'other': 'default'}

--- a/indra/assemblers/sif_assembler.py
+++ b/indra/assemblers/sif_assembler.py
@@ -31,7 +31,21 @@ class SifAssembler(object):
 
     def make_model(self, use_name_as_key=False, include_mods=False,
                    include_complexes=False):
-        """Assemble the graph from the assembler's list of INDRA Statements."""
+        """Assemble the graph from the assembler's list of INDRA Statements.
+
+        Parameters
+        ----------
+        use_name_as_key : boolean
+            If True, uses the name of the agent as the key to the nodes in
+            the network. If False (default) uses the matches_key() of the
+            agent.
+        include_mods : boolean
+            If True, adds Modification statements into the graph as directed
+            edges. Default is False.
+        include_complexes : boolean
+            If True, creates two edges (in both directions) between all pairs
+            of nodes in Complex statements. Default is False.
+        """
         def add_node_edge(s, t, polarity):
             if s is not None:
                 s = self._add_node(s, use_name_as_key=use_name_as_key)

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -929,9 +929,11 @@ class Deglycosylation(Modification):
     """Deglycosylation modification."""
     pass
 
+
 class Ribosylation(Modification):
     """Ribosylation modification."""
     pass
+
 
 class Deribosylation(Modification):
     """Deribosylation modification."""
@@ -952,9 +954,41 @@ class Farnesylation(Modification):
     """Farnesylation modification."""
     pass
 
+
 class Defarnesylation(Modification):
     """Defarnesylation modification."""
     pass
+
+
+class Geranylgeranylation(Modification):
+    """Geranylgeranylation modification."""
+    pass
+
+
+class Degeranylgeranylation(Modification):
+    """Degeranylgeranylation modification."""
+    pass
+
+
+class Palmitoylation(Modification):
+    """Palmitoylation modification."""
+    pass
+
+
+class Depalmitoylation(Modification):
+    """Depalmitoylation modification."""
+    pass
+
+
+class Myristoylation(Modification):
+    """Myristoylation modification."""
+    pass
+
+
+class Demyristoylation(Modification):
+    """Demyristoylation modification."""
+    pass
+
 
 @python_2_unicode_compatible
 class Activation(Statement):

--- a/indra/tests/im_polarity.dot
+++ b/indra/tests/im_polarity.dot
@@ -1,0 +1,16 @@
+digraph G {
+	node [fillcolor=palegreen3,
+		shape=ellipse,
+		style=filled
+	];
+	edge [arrowhead=tee,
+		color=red
+	];
+	BRAF_phospho_MAPK1_T185_1	 [fillcolor=lightskyblue, shape=box];
+	BRAF_phospho_MAPK1_T185_3	 [fillcolor=lightskyblue, shape=box];
+	BRAF_phospho_MAPK1_T185_1 -> BRAF_phospho_MAPK1_T185_3	 [label="[1->1]"];
+	MAPK1_phospho_DUSP6_S159_1	 [fillcolor=lightskyblue, shape=box];
+	BRAF_phospho_MAPK1_T185_1 -> MAPK1_phospho_DUSP6_S159_1	 [arrowhead=normal, color=green, label="[1->0]"];
+	BRAF_phospho_MAPK1_T185_3 -> BRAF_phospho_MAPK1_T185_1	 [label="[1->1]"];
+	BRAF_phospho_MAPK1_T185_3 -> MAPK1_phospho_DUSP6_S159_1	 [arrowhead=normal, color=green, label="[1->0]"];
+}

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -1,0 +1,28 @@
+from indra.statements import *
+from pysb import *
+
+def test_simple_phosphorylation():
+    # Create the statement
+    a = Agent('A')
+    b = Agent('B')
+    st = Phosphorylation(a, b, 'T', '185')
+    # Now create the PySB model
+    Model('test_simple_phosphorylation')
+    Monomer('A')
+    Monomer('B', ['T185'], {'T185':['u', 'p']})
+    Rule('A_phos_B', A() + B(T185='u') >> A() + B(T185='p'),
+         Parameter('k', 1))
+    Observable('B_phosphoT185', B(T185='p'))
+    Initial(A(), Parameter('A_0', 100))
+    Initial(B(T185='u'), Parameter('B_0', 100))
+    # Now check the model
+    mc = ModelChecker(model, [st])
+    results = mc.check_model()
+    assert len(results) == 1
+    assert isinstance(results[0], tuple)
+    assert results[0][0] == st
+    assert results[0][1] == True
+
+if __name__ == '__main__':
+    test_simple_phosphorylation()
+

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -568,6 +568,20 @@ def test_grounded_modified_enzyme():
     assert results[0][0] == stmt_to_check
     assert results[0][1] == True
 
+def test_check_ubiquitination():
+    xiap = Agent('XIAP', db_refs={'HGNC': '592'})
+    casp3 = Agent('CASP3', db_refs={'HGNC': '1504'})
+    stmt = Ubiquitination(xiap, casp3)
+    pysba = PysbAssembler()
+    pysba.add_statements([stmt])
+    pysba.make_model(policies='one_step')
+    mc = ModelChecker(pysba.model, [stmt])
+    checks = mc.check_model()
+    assert len(checks) == 1
+    assert isinstance(checks[0], tuple)
+    assert checks[0][0] == stmt
+    assert checks[0][1] == True
+
 """
 def test_activation_subtype():
     sos1 = Agent('SOS1', db_refs={'HGNC':'11187'})
@@ -616,21 +630,6 @@ def test_check_transphosphorylation():
     assert results[1][1] == True
 """
 
-"""
-def test_ubiquitination():
-    xiap = Agent('XIAP')
-    casp3 = Agent('CASP3')
-    stmt = Ubiquitination(xiap, casp3)
-    pysba = PysbAssembler()
-    pysba.add_statements([stmt])
-    pysba.make_model(policies='one_step')
-    mc = ModelChecker(pysba.model, [stmt])
-    checks = mc.check_model()
-    assert len(checks) == 1
-    assert isinstance(checks[0], tuple)
-    assert checks[0][0] == stmt
-    assert checks[0][1] == True
-"""
 
 
 # TODO Add tests for autophosphorylation
@@ -725,7 +724,8 @@ def test_ubiquitination():
 # When Ras machine finds a new finding, it can be checked to see if it's
 # satisfied by the model.
 if __name__ == '__main__':
-    test_grounded_modified_enzyme()
+    test_check_ubiquitination()
+    #test_grounded_modified_enzyme()
     #test_activation_subtype()
     #test_check_transphosphorylation()
     #test_check_autophosphorylation()
@@ -742,4 +742,3 @@ if __name__ == '__main__':
     #test_path_polarity()
     #test_consumption_rule()
     #test_dephosphorylation()
-    #test_check_ubiquitination()

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -317,7 +317,7 @@ def test_invalid_modification():
 
 def _path_polarity_stmt_list():
     a = Agent('A')
-    b = Agent('B1')
+    b = Agent('B')
     c = Agent('C')
     st1 = Phosphorylation(a, c, 'T', '185')
     st2 = Dephosphorylation(a, c, 'T', '185')
@@ -440,7 +440,27 @@ def test_ubiquitination():
     assert checks[0][1] == True
 """
 
-# 
+"""
+@with_model
+def test_check_activation():
+    a = Agent('A')
+    b = Agent('B')
+    c = Agent('C')
+    st1 = Activation(a, 'activity', b, 'activity', True)
+    st2 = Activation(b, 'activity', c, 'activity', False)
+    stmts = [st1, st2]
+    # Create the model
+    pa = PysbAssembler()
+    pa.add_statements(stmts)
+    # Try two step
+    pa.make_model(policies='one_step')
+    mc = ModelChecker(pa.model, stmts)
+    results = mc.check_model()
+    assert len(results) ==  len(stmts)
+    assert isinstance(results[0], tuple)
+    assert results[0][1] == True
+    assert results[1][1] == True
+"""
 
 # Issues--if a rule activity isn't contingent on a particular mod,
 # then were will be no causal connection between any upstream modifying
@@ -527,4 +547,5 @@ if __name__ == '__main__':
     #test_path_polarity()
     #test_consumption_rule()
     #test_dephosphorylation()
-
+    #test_check_ubiquitination()
+    test_check_activation()

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -287,6 +287,34 @@ def test_dephosphorylation():
     assert checks[0][0] == stmt
     assert checks[0][1] == True
 
+
+@with_model
+def test_invalid_modification():
+     # Override the shutoff of self export in psyb_assembler
+     # Create the statement
+     a = Agent('A')
+     b = Agent('B')
+     st = Phosphorylation(a, b, 'T', '185')
+     # Now create the PySB model
+     Monomer('A')
+     Monomer('B', ['Y187'], {'Y187':['u', 'p']})
+     Rule('A_phos_B', A() + B(Y187='u') >> A() + B(Y187='p'),
+          Parameter('k', 1))
+     #Initial(A(), Parameter('A_0', 100))
+     #Initial(B(T187='u'), Parameter('B_0', 100))
+     #with open('model_rxn.dot', 'w') as f:
+     #    f.write(render_reactions.run(model))
+     #with open('species_1step.dot', 'w') as f:
+     #    f.write(species_graph.run(model))
+     # Now check the model
+     mc = ModelChecker(model, [st])
+     results = mc.check_model()
+     #assert len(results) == 1
+     #assert isinstance(results[0], tuple)
+     #assert results[0][0] == st
+     #assert results[0][1] == True
+
+
 """
 def test_ubiquitination():
     xiap = Agent('XIAP')
@@ -340,7 +368,8 @@ def test_ubiquitination():
 # When Ras machine finds a new finding, it can be checked to see if it's
 # satisfied by the model.
 if __name__ == '__main__':
-    test_ras_220_network()
+    test_invalid_modification()
+    #test_ras_220_network()
     #test_path_polarity()
     #test_consumption_rule()
     #test_dephosphorylation()

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -188,13 +188,44 @@ def test_ras_220_network():
     pa.add_statements(ras220_stmts)
     pa.make_model(policies='one_step')
     # Now create an indirect statement to check the model against
+    egfr = Agent('EGFR')
     braf = Agent('BRAF')
     dusp6 = Agent('DUSP6')
-    stmt = Phosphorylation(braf, dusp6, 'S', '159')
+    stmt1 = Phosphorylation(braf, dusp6, 'S', '159')
+    stmt2 = Phosphorylation(egfr, dusp6, 'S', '159')
     # Check model
-    mc = ModelChecker(pa.model, [stmt])
+    mc = ModelChecker(pa.model, [stmt1, stmt2])
+    checks = mc.check_model()
+    assert len(checks) == 2
+    assert isinstance(checks[0], tuple)
+    assert checks[0][0] == stmt1
+    assert checks[0][1] == True
+    assert checks[1][0] == stmt2
+    assert checks[1][1] == False
+    # Now try again, with a two_step policy
+    """
+    # Skip this, building the influence map takes a very long time
+    pa.make_model(policies='two_step')
+    mc = ModelChecker(pa.model, [stmt1, stmt2])
     checks = mc.check_model()
     print checks
+    assert len(checks) == 2
+    assert isinstance(checks[0], tuple)
+    assert checks[0][0] == stmt1
+    assert checks[0][1] == True
+    assert checks[1][0] == stmt2
+    assert checks[1][1] == False
+    """
+    # Now with an interactions_only policy
+    pa.make_model(policies='interactions_only')
+    mc = ModelChecker(pa.model, [stmt1, stmt2])
+    checks = mc.check_model()
+    assert len(checks) == 2
+    assert isinstance(checks[0], tuple)
+    assert checks[0][0] == stmt1
+    assert checks[0][1] == False
+    assert checks[1][0] == stmt2
+    assert checks[1][1] == False
 
 def test_path_polarity():
     im = pgv.AGraph('im_polarity.dot')
@@ -206,4 +237,4 @@ def test_path_polarity():
 
 if __name__ == '__main__':
     test_path_polarity()
-
+    test_ras_220_network()

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -2,7 +2,8 @@ from indra.statements import *
 from pysb import *
 from pysb.core import SelfExporter
 from pysb.tools import render_reactions
-from indra.tools.model_checker import ModelChecker, mp_embeds_into
+from indra.tools.model_checker import ModelChecker, mp_embeds_into, \
+                                      cp_embeds_into
 from pysb.tools import species_graph
 from pysb.bng import generate_equations
 from pysb import kappa
@@ -23,6 +24,47 @@ def test_mp_embedding():
     assert not mp_embeds_into(mp1, mp3)
 
 @with_model
+def test_cp_embedding():
+    Monomer('A', ['b', 'other'], {'other':['u','p']})
+    Monomer('B', ['b'])
+    cp1 = A(b=1, other='p') % B(b=1)
+    cp2 = A()
+    cp3 = A(b=1, other='u') % B(b=1)
+    cp4 = A(other='p')
+    cp5 = A(b=1) % B(b=1)
+    # Some tests not performed because ComplexPatterns for second term are not
+    # yet supported
+    assert cp_embeds_into(cp1, cp2)
+    #assert not cp_embeds_into(cp1, cp3)
+    assert cp_embeds_into(cp1, cp4)
+    #assert not cp_embeds_into(cp1, cp5)
+    #assert not cp_embeds_into(cp2, cp1)
+    #assert not cp_embeds_into(cp2, cp3)
+    assert not cp_embeds_into(cp2, cp4)
+    #assert not cp_embeds_into(cp2, cp5)
+    #assert not cp_embeds_into(cp3, cp1)
+    assert cp_embeds_into(cp3, cp2)
+    assert not cp_embeds_into(cp3, cp4)
+    #assert cp_embeds_into(cp3, cp5)
+    #assert not cp_embeds_into(cp4, cp1)
+    assert cp_embeds_into(cp4, cp2)
+    #assert not cp_embeds_into(cp4, cp3)
+    #assert not cp_embeds_into(cp4, cp5)
+    #assert not cp_embeds_into(cp5, cp1)
+    assert cp_embeds_into(cp5, cp2)
+    #assert not cp_embeds_into(cp5, cp3)
+    assert not cp_embeds_into(cp5, cp4)
+
+"""
+@with_model
+def test_match_rules():
+    Monomer('A')
+    Monomer('B', ['T185'], {'T185':['u', 'p']})
+    rule = Rule('A_phos_B', A() + B(T185='u') >> A() + B(T185='p'),
+                Parameter('k', 1))
+"""
+
+@with_model
 def test_one_step_phosphorylation():
     # Override the shutoff of self export in psyb_assembler
     # Create the statement
@@ -36,11 +78,10 @@ def test_one_step_phosphorylation():
          Parameter('k', 1))
     Initial(A(), Parameter('A_0', 100))
     Initial(B(T185='u'), Parameter('B_0', 100))
-    with open('model_rxn.dot', 'w') as f:
-        f.write(render_reactions.run(model))
-    with open('species_1step.dot', 'w') as f:
-        f.write(species_graph.run(model))
-    import ipdb; ipdb.set_trace()
+    #with open('model_rxn.dot', 'w') as f:
+    #    f.write(render_reactions.run(model))
+    #with open('species_1step.dot', 'w') as f:
+    #    f.write(species_graph.run(model))
     # Now check the model
     mc = ModelChecker(model, [st])
     results = mc.check_model()
@@ -49,6 +90,7 @@ def test_one_step_phosphorylation():
     assert results[0][0] == st
     assert results[0][1] == True
 
+@with_model
 def test_two_step_phosphorylation():
     # Create the statement
     a = Agent('A')
@@ -66,13 +108,13 @@ def test_two_step_phosphorylation():
     Initial(A(b=None, other='p'), Parameter('Ap_0', 100))
     Initial(A(b=None, other='u'), Parameter('Au_0', 100))
     Initial(B(b=None, T185='u'), Parameter('B_0', 100))
-    with open('model_rxn.dot', 'w') as f:
-        f.write(render_reactions.run(model))
-    with open('species_2step.dot', 'w') as f:
-        f.write(species_graph.run(model))
-    im = kappa.influence_map(model)
-    im.draw('im_2step.pdf', prog='dot')
-    generate_equations(model)
+    #with open('model_rxn.dot', 'w') as f:
+    #    f.write(render_reactions.run(model))
+    #with open('species_2step.dot', 'w') as f:
+    #    f.write(species_graph.run(model))
+    #im = kappa.influence_map(model)
+    #im.draw('im_2step.pdf', prog='dot')
+    #generate_equations(model)
     # Now check the model
     mc = ModelChecker(model, [st])
     results = mc.check_model()
@@ -84,4 +126,5 @@ def test_two_step_phosphorylation():
 
 if __name__ == '__main__':
     test_mp_embedding()
+    test_cp_embedding()
 

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -1,5 +1,6 @@
 from indra.statements import *
 from pysb import *
+from indra.tools.model_checker import ModelChecker
 
 def test_simple_phosphorylation():
     # Create the statement
@@ -7,7 +8,7 @@ def test_simple_phosphorylation():
     b = Agent('B')
     st = Phosphorylation(a, b, 'T', '185')
     # Now create the PySB model
-    Model('test_simple_phosphorylation')
+    Model()
     Monomer('A')
     Monomer('B', ['T185'], {'T185':['u', 'p']})
     Rule('A_phos_B', A() + B(T185='u') >> A() + B(T185='p'),
@@ -25,4 +26,5 @@ def test_simple_phosphorylation():
 
 if __name__ == '__main__':
     test_simple_phosphorylation()
+
 

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -232,8 +232,8 @@ def test_path_polarity():
     path1 = ['BRAF_phospho_MAPK1_T185_1', 'MAPK1_phospho_DUSP6_S159_1']
     path2 = ['BRAF_phospho_MAPK1_T185_1', 'BRAF_phospho_MAPK1_T185_3',
              'MAPK1_phospho_DUSP6_S159_1']
-    assert positive_path(im, path1)
-    assert not positive_path(im, path2)
+    assert positive_path(im, path1, 1)
+    assert not positive_path(im, path2, 1)
 
 @with_model
 def test_consumption_rule():
@@ -271,10 +271,54 @@ def test_consumption_rule():
     assert isinstance(checks[0], tuple)
     assert checks[0][0] == stmt
     assert checks[0][1] == True
-    im = kappa.influence_map(model)
-    im.draw('dusp.pdf', prog='dot')
+
+def test_dephosphorylation():
+    dusp = Agent('DUSP6')
+    mapk1 = Agent('MAPK1')
+    stmt = Dephosphorylation(dusp, mapk1, 'T', '185')
+    pysba = PysbAssembler()
+    pysba.add_statements([stmt])
+    pysba.make_model(policies='one_step')
+    mc = ModelChecker(pysba.model, [stmt])
+    checks = mc.check_model()
+    assert len(checks) == 1
+    assert isinstance(checks[0], tuple)
+    assert checks[0][0] == stmt
+    assert checks[0][1] == True
+
+"""
+def test_ubiquitination():
+    xiap = Agent('XIAP')
+    casp3 = Agent('CASP3')
+    stmt = Ubiquitination(xiap, casp3)
+    pysba = PysbAssembler()
+    pysba.add_statements([stmt])
+    pysba.make_model(policies='one_step')
+    mc = ModelChecker(pysba.model, [stmt])
+    checks = mc.check_model()
+    assert len(checks) == 1
+    assert isinstance(checks[0], tuple)
+    assert checks[0][0] == stmt
+    assert checks[0][1] == True
+"""
+
+
 
 # TODO
+# Need to handle complex statements. Would show that one_step approach
+# would not satisfy constraint, but two-step approach could, where the
+# Complex information was specified.
+# Can probably handle all modifications in a generic function.
+# Then need to handle: Complex, Dephosphorylation.
+# Then RasGef/RasGap?
+# Then Activation/ActiveForm.
+# Get the stuff from databases involving the canonical proteins,
+# and show that a simple model satisfies it.
+# Try to build the model using natural language?
+#
+# By tying molecules to biological processes, we can even check that
+# these types of high-level observations are satisfied.
+#
 # Need to handle case where Phosphorylation site is not specified by
 # statement, but is actually handled in the model (i.e., need to know
 # that a particular site name and state corresponds to a phosphorylation.
@@ -285,8 +329,17 @@ def test_consumption_rule():
 # modification state and bonds
 #
 # Need to handle reversible rules!
-
+#
+# Should probably build in some way of returning the paths found
+#
+# Save all the paths that a particular rule is on--then if you're wondering
+# why it's in the model, you look at all of the statements for which that
+# rule provides a path.
+#
+# When Ras machine finds a new finding, it can be checked to see if it's
+# satisfied by the model.
 if __name__ == '__main__':
-    test_ras_220_network()
+    #test_ras_220_network()
     #test_path_polarity()
     #test_consumption_rule()
+    test_dephosphorylation()

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -89,8 +89,8 @@ def test_match_rhs():
 @with_model
 def test_one_step_phosphorylation():
     # Create the statement
-    a = Agent('A')
-    b = Agent('B')
+    a = Agent('A', db_refs={'HGNC':'1'})
+    b = Agent('B', db_refs={'HGNC':'2'})
     st = Phosphorylation(a, b, 'T', '185')
     # Now create the PySB model
     Monomer('A')
@@ -99,6 +99,14 @@ def test_one_step_phosphorylation():
          Parameter('k', 1))
     Initial(A(), Parameter('A_0', 100))
     Initial(B(T185='u'), Parameter('B_0', 100))
+    # Add annotations
+    Annotation(A, 'http://identifiers.org/hgnc/HGNC:1')
+    Annotation(B, 'http://identifiers.org/hgnc/HGNC:2')
+    B.site_annotations = [
+        Annotation(('T185', 'p'), 'phosphorylation', 'is_modification'),
+        Annotation('T185', 'T', 'is_residue'),
+        Annotation('T185', '185', 'is_position'),
+    ]
     mc = ModelChecker(model, [st])
     results = mc.check_model()
     assert len(results) == 1
@@ -109,8 +117,8 @@ def test_one_step_phosphorylation():
 @with_model
 def test_two_step_phosphorylation():
     # Create the statement
-    a = Agent('A')
-    b = Agent('B')
+    a = Agent('A', db_refs={'HGNC':'1'})
+    b = Agent('B', db_refs={'HGNC':'2'})
     st = Phosphorylation(a, b, 'T', '185')
     # Now create the PySB model
     Monomer('A', ['b', 'other'], {'other':['u','p']})
@@ -125,6 +133,14 @@ def test_two_step_phosphorylation():
     Initial(A(b=None, other='p'), Parameter('Ap_0', 100))
     Initial(A(b=None, other='u'), Parameter('Au_0', 100))
     Initial(B(b=None, T185='u'), Parameter('B_0', 100))
+    # Add annotations
+    Annotation(A, 'http://identifiers.org/hgnc/HGNC:1')
+    Annotation(B, 'http://identifiers.org/hgnc/HGNC:2')
+    B.site_annotations = [
+        Annotation(('T185', 'p'), 'phosphorylation', 'is_modification'),
+        Annotation('T185', 'T', 'is_residue'),
+        Annotation('T185', '185', 'is_position'),
+    ]
     #with open('model_rxn.dot', 'w') as f:
     #    f.write(render_reactions.run(model))
     #with open('species_2step.dot', 'w') as f:
@@ -141,8 +157,8 @@ def test_two_step_phosphorylation():
     assert results[0][1] == True
 
 def test_pysb_assembler_phospho_policies():
-    a = Agent('A')
-    b = Agent('B')
+    a = Agent('A', db_refs={'HGNC': '1'})
+    b = Agent('B', db_refs={'HGNC': '2'})
     st = Phosphorylation(a, b, 'T', '185')
     pa = PysbAssembler()
     pa.add_statements([st])
@@ -171,6 +187,7 @@ def test_pysb_assembler_phospho_policies():
     assert results[0][0] == st
     assert results[0][1] == False
 
+"""
 def test_ras_220_network():
     ras_220_results_path = os.path.join('../../models/ras_220_genes'
                                         '/ras_220_gn_related2_stmts.pkl')
@@ -203,21 +220,18 @@ def test_ras_220_network():
     assert checks[1][0] == stmt2
     assert checks[1][1] == False
     # Now try again, with a two_step policy
-    """
     # Skip this, building the influence map takes a very long time
-    pa.make_model(policies='two_step')
-    mc = ModelChecker(pa.model, [stmt1, stmt2])
-    checks = mc.check_model()
-    print checks
-    assert len(checks) == 2
-    assert isinstance(checks[0], tuple)
-    assert checks[0][0] == stmt1
-    assert checks[0][1] == True
-    assert checks[1][0] == stmt2
-    assert checks[1][1] == False
-    """
+    #pa.make_model(policies='two_step')
+    #mc = ModelChecker(pa.model, [stmt1, stmt2])
+    #checks = mc.check_model()
+    #print checks
+    #assert len(checks) == 2
+    #assert isinstance(checks[0], tuple)
+    #assert checks[0][0] == stmt1
+    #assert checks[0][1] == True
+    #assert checks[1][0] == stmt2
+    #assert checks[1][1] == False
     # Now with an interactions_only policy
-    """
     pa.make_model(policies='interactions_only')
     mc = ModelChecker(pa.model, [stmt1, stmt2])
     checks = mc.check_model()
@@ -227,7 +241,7 @@ def test_ras_220_network():
     assert checks[0][1] == False
     assert checks[1][0] == stmt2
     assert checks[1][1] == False
-    """
+"""
 
 def test_path_polarity():
     im = pgv.AGraph('im_polarity.dot')
@@ -239,8 +253,8 @@ def test_path_polarity():
 
 @with_model
 def test_consumption_rule():
-    pvd = Agent('Pervanadate')
-    erk = Agent('MAPK1')
+    pvd = Agent('Pervanadate', db_refs={'HGNC': '1'})
+    erk = Agent('MAPK1', db_refs={'HGNC': '2'})
     stmt = Phosphorylation(pvd, erk, 'T', '185')
     # Now make the model
     Monomer('Pervanadate', ['b'])
@@ -266,6 +280,13 @@ def test_consumption_rule():
          DUSP(b=1) % MAPK1(b=1, T185='p') >>
          DUSP(b=None) % MAPK1(b=None, T185='u'),
          Parameter('k5', 1))
+    Annotation(Pervanadate, 'http://identifiers.org/hgnc/HGNC:1')
+    Annotation(MAPK1, 'http://identifiers.org/hgnc/HGNC:2')
+    MAPK1.site_annotations = [
+            Annotation(('T185', 'p'), 'phosphorylation', 'is_modification'),
+            Annotation('T185', 'T', 'is_residue'),
+            Annotation('T185', '185', 'is_position'),
+        ]
     # Now check the model against the statement
     mc = ModelChecker(model, [stmt])
     checks = mc.check_model()
@@ -315,13 +336,14 @@ def test_invalid_modification():
      #assert results[0][1] == True
 
 def _path_polarity_stmt_list():
-    a = Agent('A')
-    b = Agent('B')
-    c = Agent('C')
+    a = Agent('A', db_refs={'HGNC': '1'})
+    b = Agent('B', db_refs={'HGNC': '2'})
+    c = Agent('C', db_refs={'HGNC': '3'})
     st1 = Phosphorylation(a, c, 'T', '185')
     st2 = Dephosphorylation(a, c, 'T', '185')
     st3 = Phosphorylation(None, c, 'T', '185')
     st4 = Dephosphorylation(None, c, 'T', '185')
+
     return [st1, st2, st3, st4]
 
 @with_model
@@ -337,6 +359,14 @@ def test_distinguish_path_polarity1():
     Initial(A(), k)
     Initial(B(act='y'), k)
     Initial(C(T185='p'), k)
+    Annotation(A, 'http://identifiers.org/hgnc/HGNC:1')
+    Annotation(B, 'http://identifiers.org/hgnc/HGNC:2')
+    Annotation(C, 'http://identifiers.org/hgnc/HGNC:3')
+    C.site_annotations = [
+            Annotation(('T185', 'p'), 'phosphorylation', 'is_modification'),
+            Annotation('T185', 'T', 'is_residue'),
+            Annotation('T185', '185', 'is_position'),
+        ]
     # Create the model checker
     stmts = _path_polarity_stmt_list()
     mc = ModelChecker(model, stmts)
@@ -480,10 +510,10 @@ def test_ubiquitination():
 
 # Goal: Be able to check generic phosphorylations against specific rules
 # and vice versa.
-# 0. Need to make model checker work with multiple downstream observables and
-#    multiple input rules
 # 1. Need PySB assembler to generate appropriate annotations for
 #    sites/states
+# 1b. Add test making sure modifications can be checked from pysb_assembled
+#     model
 # 2. Need to be able to annotate specific site/state combinations as
 #    active forms
 # 3. Need to make grounded_mp generation work with MutConditions and
@@ -563,13 +593,13 @@ def test_ubiquitination():
 # When Ras machine finds a new finding, it can be checked to see if it's
 # satisfied by the model.
 if __name__ == '__main__':
-    test_phosphorylation_annotations()
+    #test_phosphorylation_annotations()
     #test_check_activation()
     #test_none_phosphorylation_stmt()
     #test_distinguish_path_polarity1()
     #test_distinguish_path_polarity2()
     #test_distinguish_path_polarity_none_stmt()
-    #test_pysb_assembler_phospho_policies()
+    test_pysb_assembler_phospho_policies()
     #test_invalid_modification()
     #test_ras_220_network()
     #test_path_polarity()

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -440,14 +440,13 @@ def test_ubiquitination():
     assert checks[0][1] == True
 """
 
-"""
 @with_model
 def test_check_activation():
     a = Agent('A')
     b = Agent('B')
     c = Agent('C')
     st1 = Activation(a, 'activity', b, 'activity', True)
-    st2 = Activation(b, 'activity', c, 'activity', False)
+    st2 = Activation(b, 'activity', c, 'kinase', False)
     stmts = [st1, st2]
     # Create the model
     pa = PysbAssembler()
@@ -460,7 +459,6 @@ def test_check_activation():
     assert isinstance(results[0], tuple)
     assert results[0][1] == True
     assert results[1][1] == True
-"""
 
 # Issues--if a rule activity isn't contingent on a particular mod,
 # then were will be no causal connection between any upstream modifying
@@ -535,7 +533,7 @@ def test_check_activation():
 # When Ras machine finds a new finding, it can be checked to see if it's
 # satisfied by the model.
 if __name__ == '__main__':
-    pass
+    test_check_activation()
     #test_none_phosphorylation_stmt()
     #test_distinguish_path_polarity1()
     #test_distinguish_path_polarity2()
@@ -548,4 +546,3 @@ if __name__ == '__main__':
     #test_consumption_rule()
     #test_dephosphorylation()
     #test_check_ubiquitination()
-    test_check_activation()

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -332,8 +332,21 @@ def test_ubiquitination():
 """
 
 
+# DIfferent combinations of input/target rules will produce different paths
+# So the paths don't come out in the shortest order this way
+# Using an observable will be a big advantage on the target rule side
 
 # TODO
+
+# Another issue--doesn't know that RAF1(phospho='p') should be satisfied
+# by RAF1(S259='p'). A big problem, even after pre-assembly--because longer
+# paths where a 'phospho' is the observable will never be satisfied.
+
+# Does this mean that we need a PySB ComplexPattern -> Agent mapping, that
+# we can subsequently use for refinements?
+
+# Why is
+
 # Need to handle complex statements. Would show that one_step approach
 # would not satisfy constraint, but two-step approach could, where the
 # Complex information was specified.

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -155,6 +155,7 @@ def test_pysb_assembler_phospho_policies():
     # Try two step
     pa.make_model(policies='two_step')
     mc = ModelChecker(pa.model, [st])
+    import ipdb; ipdb.set_trace()
     results = mc.check_model()
     assert len(results) == 1
     assert isinstance(results[0], tuple)
@@ -177,6 +178,7 @@ def test_pysb_assembler_phospho_policies():
     assert results[0][0] == st
     assert results[0][1] == False
 
+"""
 def test_ras_220_network():
     file_path = os.path.dirname(os.path.abspath(__file__))
     ras_220_results_path = os.path.join('../../models/ras_220_genes'
@@ -204,7 +206,8 @@ def test_ras_220_network():
     assert checks[1][0] == stmt2
     assert checks[1][1] == False
     # Now try again, with a two_step policy
-    """
+"""
+"""
     # Skip this, building the influence map takes a very long time
     pa.make_model(policies='two_step')
     mc = ModelChecker(pa.model, [stmt1, stmt2])
@@ -216,7 +219,8 @@ def test_ras_220_network():
     assert checks[0][1] == True
     assert checks[1][0] == stmt2
     assert checks[1][1] == False
-    """
+"""
+"""
     # Now with an interactions_only policy
     pa.make_model(policies='interactions_only')
     mc = ModelChecker(pa.model, [stmt1, stmt2])
@@ -227,14 +231,15 @@ def test_ras_220_network():
     assert checks[0][1] == False
     assert checks[1][0] == stmt2
     assert checks[1][1] == False
+"""
 
 def test_path_polarity():
     im = pgv.AGraph('im_polarity.dot')
     path1 = ['BRAF_phospho_MAPK1_T185_1', 'MAPK1_phospho_DUSP6_S159_1']
     path2 = ['BRAF_phospho_MAPK1_T185_1', 'BRAF_phospho_MAPK1_T185_3',
              'MAPK1_phospho_DUSP6_S159_1']
-    assert positive_path(im, path1, 1)
-    assert not positive_path(im, path2, 1)
+    assert positive_path(im, path1)
+    assert not positive_path(im, path2)
 
 @with_model
 def test_consumption_rule():
@@ -381,7 +386,8 @@ def test_ubiquitination():
 # When Ras machine finds a new finding, it can be checked to see if it's
 # satisfied by the model.
 if __name__ == '__main__':
-    test_invalid_modification()
+    test_pysb_assembler_phospho_policies()
+    #test_invalid_modification()
     #test_ras_220_network()
     #test_path_polarity()
     #test_consumption_rule()

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -1,21 +1,46 @@
 from indra.statements import *
 from pysb import *
-from indra.tools.model_checker import ModelChecker
+from pysb.core import SelfExporter
+from pysb.tools import render_reactions
+from indra.tools.model_checker import ModelChecker, mp_embeds_into
+from pysb.tools import species_graph
+from pysb.bng import generate_equations
+from pysb import kappa
+from pysb.testing import with_model
 
-def test_simple_phosphorylation():
+@with_model
+def test_mp_embedding():
+    # Create a PySB model
+    Monomer('A', ['b', 'other'], {'other':['u','p']})
+    mp1 = A(other='u')
+    mp2 = A()
+    mp3 = A(other='p')
+    assert mp_embeds_into(mp1, mp2)
+    assert not mp_embeds_into(mp2, mp1)
+    assert mp_embeds_into(mp3, mp2)
+    assert not mp_embeds_into(mp2, mp3)
+    assert not mp_embeds_into(mp3, mp1)
+    assert not mp_embeds_into(mp1, mp3)
+
+@with_model
+def test_one_step_phosphorylation():
+    # Override the shutoff of self export in psyb_assembler
     # Create the statement
     a = Agent('A')
     b = Agent('B')
     st = Phosphorylation(a, b, 'T', '185')
     # Now create the PySB model
-    Model()
     Monomer('A')
     Monomer('B', ['T185'], {'T185':['u', 'p']})
     Rule('A_phos_B', A() + B(T185='u') >> A() + B(T185='p'),
          Parameter('k', 1))
-    Observable('B_phosphoT185', B(T185='p'))
     Initial(A(), Parameter('A_0', 100))
     Initial(B(T185='u'), Parameter('B_0', 100))
+    with open('model_rxn.dot', 'w') as f:
+        f.write(render_reactions.run(model))
+    with open('species_1step.dot', 'w') as f:
+        f.write(species_graph.run(model))
+    import ipdb; ipdb.set_trace()
     # Now check the model
     mc = ModelChecker(model, [st])
     results = mc.check_model()
@@ -24,7 +49,39 @@ def test_simple_phosphorylation():
     assert results[0][0] == st
     assert results[0][1] == True
 
-if __name__ == '__main__':
-    test_simple_phosphorylation()
+def test_two_step_phosphorylation():
+    # Create the statement
+    a = Agent('A')
+    b = Agent('B')
+    st = Phosphorylation(a, b, 'T', '185')
+    # Now create the PySB model
+    Monomer('A', ['b', 'other'], {'other':['u','p']})
+    Monomer('B', ['b', 'T185'], {'T185':['u', 'p']})
+    Rule('A_bind_B', A(b=None) + B(b=None, T185='u') <>
+                     A(b=1) % B(b=1, T185='u'),
+                 Parameter('kf', 1), Parameter('kr', 1))
+    Rule('A_phos_B', A(b=1) % B(b=1, T185='u') >>
+                     A(b=None) + B(b=None, T185='p'),
+                 Parameter('kcat', 1))
+    Initial(A(b=None, other='p'), Parameter('Ap_0', 100))
+    Initial(A(b=None, other='u'), Parameter('Au_0', 100))
+    Initial(B(b=None, T185='u'), Parameter('B_0', 100))
+    with open('model_rxn.dot', 'w') as f:
+        f.write(render_reactions.run(model))
+    with open('species_2step.dot', 'w') as f:
+        f.write(species_graph.run(model))
+    im = kappa.influence_map(model)
+    im.draw('im_2step.pdf', prog='dot')
+    generate_equations(model)
+    # Now check the model
+    mc = ModelChecker(model, [st])
+    results = mc.check_model()
+    assert len(results) == 1
+    assert isinstance(results[0], tuple)
+    assert results[0][0] == st
+    assert results[0][1] == True
 
+
+if __name__ == '__main__':
+    test_mp_embedding()
 

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -382,10 +382,12 @@ def test_none_phosphorylation_stmt():
     Initial(B(T185='u', Y187='p'), Parameter('B_0', 100))
     mc = ModelChecker(model, stmts)
     results = mc.check_model()
-    assert len(results) == 1
+    assert len(results) == 2
     assert isinstance(results[0], tuple)
-    assert results[0][0] == st
+    assert results[0][0] == st1
     assert results[0][1] == True
+    assert results[1][0] == st2
+    assert results[1][1] == False
 
 """
 def test_ubiquitination():

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -460,6 +460,7 @@ def test_check_activation():
     assert results[0][1] == True
     assert results[1][1] == True
 
+
 # Issues--if a rule activity isn't contingent on a particular mod,
 # then were will be no causal connection between any upstream modifying
 # rules and the downstream rule.

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -4,6 +4,7 @@ from pysb.core import SelfExporter
 from pysb.tools import render_reactions
 from indra.tools.model_checker import ModelChecker, mp_embeds_into, \
                                       cp_embeds_into, match_lhs, match_rhs
+from indra.assemblers.pysb_assembler import PysbAssembler
 from pysb.tools import species_graph
 from pysb.bng import generate_equations
 from pysb import kappa
@@ -141,7 +142,38 @@ def test_two_step_phosphorylation():
     assert results[0][0] == st
     assert results[0][1] == True
 
+def test_pysb_assembler_phospho_policies():
+    a = Agent('A')
+    b = Agent('B')
+    st = Phosphorylation(a, b, 'T', '185')
+    pa = PysbAssembler()
+    pa.add_statements([st])
+    # Try two step
+    pa.make_model(policies='two_step')
+    mc = ModelChecker(pa.model, [st])
+    results = mc.check_model()
+    assert len(results) == 1
+    assert isinstance(results[0], tuple)
+    assert results[0][0] == st
+    assert results[0][1] == True
+    # Try one step
+    pa.make_model(policies='one_step')
+    mc = ModelChecker(pa.model, [st])
+    results = mc.check_model()
+    assert len(results) == 1
+    assert isinstance(results[0], tuple)
+    assert results[0][0] == st
+    assert results[0][1] == True
+    # Try interactions_only
+    pa.make_model(policies='interactions_only')
+    mc = ModelChecker(pa.model, [st])
+    results = mc.check_model()
+    assert len(results) == 1
+    assert isinstance(results[0], tuple)
+    assert results[0][0] == st
+    assert results[0][1] == False
+
 
 if __name__ == '__main__':
-    test_match_rhs()
+    test_pysb_assembler_phospho_policies()
 

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -548,6 +548,7 @@ def test_multitype_path():
     assert results[0][1] == True
     assert results[1][1] == True
 
+"""
 def test_activation_subtype():
     sos1 = Agent('SOS1', db_refs={'HGNC':'11187'})
     kras = Agent('KRAS', db_refs={'HGNC':'6407'})
@@ -593,6 +594,7 @@ def test_check_transphosphorylation():
     assert isinstance(results[0], tuple)
     assert results[0][1] == True
     assert results[1][1] == True
+"""
 
 """
 def test_ubiquitination():

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -399,6 +399,14 @@ def test_distinguish_path_polarity2():
     Initial(A(), k)
     Initial(B(act='y'), k)
     Initial(C(T185='p'), k)
+    Annotation(A, 'http://identifiers.org/hgnc/HGNC:1')
+    Annotation(B, 'http://identifiers.org/hgnc/HGNC:2')
+    Annotation(C, 'http://identifiers.org/hgnc/HGNC:3')
+    C.site_annotations = [
+            Annotation(('T185', 'p'), 'phosphorylation', 'is_modification'),
+            Annotation('T185', 'T', 'is_residue'),
+            Annotation('T185', '185', 'is_position'),
+        ]
     # Create the model checker
     stmts = _path_polarity_stmt_list()
     mc = ModelChecker(model, stmts)
@@ -434,7 +442,7 @@ def test_check_activation():
 @with_model
 def test_none_phosphorylation_stmt():
     # Create the statement
-    b = Agent('B')
+    b = Agent('B', db_refs={'HGNC':'2'})
     st1 = Phosphorylation(None, b, 'T', '185')
     st2 = Phosphorylation(None, b, 'Y', '187')
     stmts = [st1, st2]
@@ -445,6 +453,16 @@ def test_none_phosphorylation_stmt():
          Parameter('k', 1))
     Initial(A(), Parameter('A_0', 100))
     Initial(B(T185='u', Y187='p'), Parameter('B_0', 100))
+    Annotation(A, 'http://identifiers.org/hgnc/HGNC:1')
+    Annotation(B, 'http://identifiers.org/hgnc/HGNC:2')
+    B.site_annotations = [
+        Annotation(('T185', 'p'), 'phosphorylation', 'is_modification'),
+        Annotation('T185', 'T', 'is_residue'),
+        Annotation('T185', '185', 'is_position'),
+        Annotation(('Y187', 'p'), 'phosphorylation', 'is_modification'),
+        Annotation('Y187', 'Y', 'is_residue'),
+        Annotation('Y187', '187', 'is_position'),
+    ]
     mc = ModelChecker(model, stmts)
     results = mc.check_model()
     assert len(results) == 2

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -245,13 +245,21 @@ def test_consumption_rule():
     Monomer('DUSP', ['b'])
     Monomer('MAPK1', ['b', 'T185'], {'T185': ['u', 'p']})
     Rule('Pvd_binds_DUSP',
-         Pervanadate(b=None) + DUSP(b=None) <>
+         Pervanadate(b=None) + DUSP(b=None) >>
          Pervanadate(b=1) % DUSP(b=1),
-         Parameter('k1', 1), Parameter('k2', 1))
+         Parameter('k1', 1))
+    Rule('Pvd_binds_DUSP_rev',
+         Pervanadate(b=1) % DUSP(b=1) >>
+         Pervanadate(b=None) + DUSP(b=None),
+         Parameter('k2', 1))
     Rule('DUSP_binds_MAPK1_phosT185',
-         DUSP(b=None) + MAPK1(b=None, T185='p') <>
+         DUSP(b=None) + MAPK1(b=None, T185='p') >>
          DUSP(b=1) % MAPK1(b=1, T185='p'),
-         Parameter('k3', 1), Parameter('k4', 1))
+         Parameter('k3', 1))
+    Rule('DUSP_binds_MAPK1_phosT185_rev',
+         DUSP(b=1) % MAPK1(b=1, T185='p') >>
+         DUSP(b=None) + MAPK1(b=None, T185='p'),
+         Parameter('k4', 1))
     Rule('DUSP_dephos_MAPK1_at_T185',
          DUSP(b=1) % MAPK1(b=1, T185='p') >>
          DUSP(b=None) % MAPK1(b=None, T185='u'),
@@ -262,7 +270,7 @@ def test_consumption_rule():
     assert len(checks) == 1
     assert isinstance(checks[0], tuple)
     assert checks[0][0] == stmt
-    assert checks[0][1] == False
+    assert checks[0][1] == True
     im = kappa.influence_map(model)
     im.draw('dusp.pdf', prog='dot')
 
@@ -275,8 +283,10 @@ def test_consumption_rule():
 #
 # Need to handle embeddings of complex patterns where sites can have both
 # modification state and bonds
+#
+# Need to handle reversible rules!
 
 if __name__ == '__main__':
+    test_ras_220_network()
     #test_path_polarity()
     #test_consumption_rule()
-    test_one_step_phosphorylation()

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -36,8 +36,8 @@ def test_cp_embedding():
     cp3 = A(b=1, other='u') % B(b=1)
     cp4 = A(other='p')
     cp5 = A(b=1) % B(b=1)
-    # Some tests not performed because ComplexPatterns for second term are not
-    # yet supported
+    # FIXME Some tests not performed because ComplexPatterns for second term
+    # FIXME are not yet supported
     assert cp_embeds_into(cp1, cp2)
     #assert not cp_embeds_into(cp1, cp3)
     assert cp_embeds_into(cp1, cp4)
@@ -288,7 +288,6 @@ def test_dephosphorylation():
     assert checks[0][0] == stmt
     assert checks[0][1] == True
 
-
 @with_model
 def test_invalid_modification():
      # Override the shutoff of self export in psyb_assembler
@@ -377,7 +376,6 @@ def test_distinguish_path_polarity2():
     assert results[2][1] == True
     assert results[3][1] == True
 
-
 @with_model
 def test_phosphorylation_annotations():
     # Override the shutoff of self export in psyb_assembler
@@ -451,7 +449,6 @@ def test_check_activation():
     # Create the model
     pa = PysbAssembler()
     pa.add_statements(stmts)
-    # Try two step
     pa.make_model(policies='one_step')
     mc = ModelChecker(pa.model, stmts)
     results = mc.check_model()

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -296,18 +296,24 @@ def test_consumption_rule():
     assert checks[0][1] == True
 
 def test_dephosphorylation():
-    dusp = Agent('DUSP6')
-    mapk1 = Agent('MAPK1')
+    dusp = Agent('DUSP6', db_refs={'HGNC':'1'})
+    mapk1 = Agent('MAPK1', db_refs={'HGNC':'2'})
     stmt = Dephosphorylation(dusp, mapk1, 'T', '185')
-    pysba = PysbAssembler()
-    pysba.add_statements([stmt])
-    pysba.make_model(policies='one_step')
-    mc = ModelChecker(pysba.model, [stmt])
-    checks = mc.check_model()
-    assert len(checks) == 1
-    assert isinstance(checks[0], tuple)
-    assert checks[0][0] == stmt
-    assert checks[0][1] == True
+    def check_policy(policy, result):
+        pysba = PysbAssembler()
+        pysba.add_statements([stmt])
+        pysba.make_model(policies=policy)
+        mc = ModelChecker(pysba.model, [stmt])
+        checks = mc.check_model()
+        #im = mc.get_im()
+        #im.draw('test_dephosphorylation.pdf', prog='dot')
+        assert len(checks) == 1
+        assert isinstance(checks[0], tuple)
+        assert checks[0][0] == stmt
+        assert checks[0][1] == result
+    check_policy('one_step', True)
+    check_policy('two_step', True)
+    check_policy('interactions_only', False)
 
 @with_model
 def test_invalid_modification():
@@ -508,6 +514,10 @@ def test_ubiquitination():
 """
 
 
+# TODO Add tests for autophosphorylation
+# TODO Add test for transphosphorylation
+# TODO Add test for dephosphorylation
+
 # Goal: Be able to check generic phosphorylations against specific rules
 # and vice versa.
 # 1. Need PySB assembler to generate appropriate annotations for
@@ -599,10 +609,10 @@ if __name__ == '__main__':
     #test_distinguish_path_polarity1()
     #test_distinguish_path_polarity2()
     #test_distinguish_path_polarity_none_stmt()
-    test_pysb_assembler_phospho_policies()
+    #test_pysb_assembler_phospho_policies()
     #test_invalid_modification()
     #test_ras_220_network()
     #test_path_polarity()
     #test_consumption_rule()
-    #test_dephosphorylation()
+    test_dephosphorylation()
     #test_check_ubiquitination()

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -3,7 +3,7 @@ from pysb import *
 from pysb.core import SelfExporter
 from pysb.tools import render_reactions
 from indra.tools.model_checker import ModelChecker, mp_embeds_into, \
-                                      cp_embeds_into
+                                      cp_embeds_into, match_lhs, match_rhs
 from pysb.tools import species_graph
 from pysb.bng import generate_equations
 from pysb import kappa
@@ -55,14 +55,32 @@ def test_cp_embedding():
     #assert not cp_embeds_into(cp5, cp3)
     assert not cp_embeds_into(cp5, cp4)
 
-"""
 @with_model
-def test_match_rules():
-    Monomer('A')
+def test_match_lhs():
+    Monomer('A', ['other'], {'other':['u', 'p']})
     Monomer('B', ['T185'], {'T185':['u', 'p']})
     rule = Rule('A_phos_B', A() + B(T185='u') >> A() + B(T185='p'),
                 Parameter('k', 1))
-"""
+    matching_rules = match_lhs(A(), model.rules)
+    assert len(matching_rules) == 1
+    assert matching_rules[0] == rule
+    matching_rules = match_lhs(A(other='u'), model.rules)
+    assert len(matching_rules) == 0
+
+@with_model
+def test_match_rhs():
+    Monomer('A', ['other'], {'other':['u', 'p']})
+    Monomer('B', ['T185'], {'T185':['u', 'p']})
+    rule = Rule('A_phos_B', A() + B(T185='u') >> A() + B(T185='p'),
+                Parameter('k', 1))
+    matching_rules = match_rhs(B(T185='p'), model.rules)
+    assert len(matching_rules) == 1
+    assert matching_rules[0] == rule
+    matching_rules = match_rhs(B(T185='u'), model.rules)
+    assert len(matching_rules) == 0
+    matching_rules = match_rhs(B(), model.rules)
+    assert len(matching_rules) == 1
+    assert matching_rules[0] == rule
 
 @with_model
 def test_one_step_phosphorylation():
@@ -125,6 +143,5 @@ def test_two_step_phosphorylation():
 
 
 if __name__ == '__main__':
-    test_mp_embedding()
-    test_cp_embedding()
+    test_match_rhs()
 

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -424,16 +424,18 @@ def test_phosphorylation_annotations():
     # Create the statement
     a = Agent('MEK1', db_refs={'HGNC': '6840'})
     b = Agent('ERK2', db_refs={'HGNC': '6871'})
-    st = Phosphorylation(a, b, 'T', '185')
+    st1 = Phosphorylation(a, b, 'T', '185')
+    st2 = Phosphorylation(a, b, None, None)
+    st3 = Phosphorylation(a, b, 'Y', '187')
     # Now create the PySB model
     Monomer('A_monomer')
-    Monomer('B_monomer', ['Thr185'], {'Thr185':['un', 'phos']})
-
+    Monomer('B_monomer', ['Thr185', 'Y187'],
+            {'Thr185':['un', 'phos'], 'Y187': ['u', 'p']})
     Rule('A_phos_B', A_monomer() + B_monomer(Thr185='un') >>
                      A_monomer() + B_monomer(Thr185='phos'),
          Parameter('k', 1))
     Initial(A_monomer(), Parameter('A_0', 100))
-    Initial(B_monomer(Thr185='un'), Parameter('B_0', 100))
+    Initial(B_monomer(Thr185='un', Y187='u'), Parameter('B_0', 100))
     # Add agent grounding
     Annotation(A_monomer, 'http://identifiers.org/hgnc/HGNC:6840')
     Annotation(B_monomer, 'http://identifiers.org/hgnc/HGNC:6871')
@@ -442,14 +444,21 @@ def test_phosphorylation_annotations():
         Annotation('Thr185', 'T', 'is_residue'),
         Annotation('Thr185', '185', 'is_position'),
         Annotation(('Thr185', 'phos'), 'phosphorylation', 'is_modification'),
+        Annotation('Y187', 'Y', 'is_residue'),
+        Annotation('Y187', '187', 'is_position'),
+        Annotation(('Y187', 'p'), 'phosphorylation', 'is_modification'),
     ]
     B_monomer.site_annotations = B_annot
-    mc = ModelChecker(model, [st])
+    mc = ModelChecker(model, [st1, st2, st3])
     results = mc.check_model()
-    assert len(results) == 1
+    assert len(results) == 3
     assert isinstance(results[0], tuple)
-    assert results[0][0] == st
+    assert results[0][0] == st1
     assert results[0][1] == True
+    assert results[1][0] == st2
+    assert results[1][1] == True
+    assert results[2][0] == st3
+    assert results[2][1] == False
 
 
 """

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -121,9 +121,10 @@ def test_two_step_phosphorylation():
     # Now create the PySB model
     Monomer('A', ['b', 'other'], {'other':['u','p']})
     Monomer('B', ['b', 'T185'], {'T185':['u', 'p']})
-    Rule('A_bind_B', A(b=None) + B(b=None, T185='u') <>
-                     A(b=1) % B(b=1, T185='u'),
-                 Parameter('kf', 1), Parameter('kr', 1))
+    Rule('A_bind_B', A(b=None) + B(b=None, T185='u') >>
+                     A(b=1) % B(b=1, T185='u'), Parameter('kf', 1))
+    Rule('A_bind_B_rev', A(b=1) % B(b=1, T185='u') >>
+                         A(b=None) + B(b=None, T185='u'), Parameter('kr', 1))
     Rule('A_phos_B', A(b=1) % B(b=1, T185='u') >>
                      A(b=None) + B(b=None, T185='p'),
                  Parameter('kcat', 1))
@@ -180,7 +181,7 @@ def test_ras_220_network():
     file_path = os.path.dirname(os.path.abspath(__file__))
     ras_220_results_path = os.path.join('../../models/ras_220_genes'
                                         '/ras_genes_results.pkl')
-    with open(ras_220_results_path) as f:
+    with open(ras_220_results_path, 'rb') as f:
         results = pickle.load(f)
     ras220_stmts = results['related2']
     # Build a PySB model from the Ras 220 statements
@@ -339,7 +340,7 @@ def test_ubiquitination():
 # When Ras machine finds a new finding, it can be checked to see if it's
 # satisfied by the model.
 if __name__ == '__main__':
-    #test_ras_220_network()
+    test_ras_220_network()
     #test_path_polarity()
     #test_consumption_rule()
-    test_dephosphorylation()
+    #test_dephosphorylation()

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -3,9 +3,9 @@ from indra.statements import *
 from pysb import *
 from pysb.core import SelfExporter
 from pysb.tools import render_reactions
-from indra.tools.model_checker import ModelChecker, mp_embeds_into, \
-                                      cp_embeds_into, match_lhs, match_rhs, \
-                                      positive_path
+from indra.tools.model_checker import ModelChecker, _mp_embeds_into, \
+                                      _cp_embeds_into, _match_lhs
+#from indra.tools.model_checker import _match_rhs, _positive_path
 from indra.assemblers.pysb_assembler import PysbAssembler
 from pysb.tools import species_graph
 from pysb.bng import generate_equations
@@ -20,12 +20,12 @@ def test_mp_embedding():
     mp1 = A(other='u')
     mp2 = A()
     mp3 = A(other='p')
-    assert mp_embeds_into(mp1, mp2)
-    assert not mp_embeds_into(mp2, mp1)
-    assert mp_embeds_into(mp3, mp2)
-    assert not mp_embeds_into(mp2, mp3)
-    assert not mp_embeds_into(mp3, mp1)
-    assert not mp_embeds_into(mp1, mp3)
+    assert _mp_embeds_into(mp1, mp2)
+    assert not _mp_embeds_into(mp2, mp1)
+    assert _mp_embeds_into(mp3, mp2)
+    assert not _mp_embeds_into(mp2, mp3)
+    assert not _mp_embeds_into(mp3, mp1)
+    assert not _mp_embeds_into(mp1, mp3)
 
 @with_model
 def test_cp_embedding():
@@ -38,53 +38,55 @@ def test_cp_embedding():
     cp5 = A(b=1) % B(b=1)
     # FIXME Some tests not performed because ComplexPatterns for second term
     # FIXME are not yet supported
-    assert cp_embeds_into(cp1, cp2)
-    #assert not cp_embeds_into(cp1, cp3)
-    assert cp_embeds_into(cp1, cp4)
-    #assert not cp_embeds_into(cp1, cp5)
-    #assert not cp_embeds_into(cp2, cp1)
-    #assert not cp_embeds_into(cp2, cp3)
-    assert not cp_embeds_into(cp2, cp4)
-    #assert not cp_embeds_into(cp2, cp5)
-    #assert not cp_embeds_into(cp3, cp1)
-    assert cp_embeds_into(cp3, cp2)
-    assert not cp_embeds_into(cp3, cp4)
-    #assert cp_embeds_into(cp3, cp5)
-    #assert not cp_embeds_into(cp4, cp1)
-    assert cp_embeds_into(cp4, cp2)
-    #assert not cp_embeds_into(cp4, cp3)
-    #assert not cp_embeds_into(cp4, cp5)
-    #assert not cp_embeds_into(cp5, cp1)
-    assert cp_embeds_into(cp5, cp2)
-    #assert not cp_embeds_into(cp5, cp3)
-    assert not cp_embeds_into(cp5, cp4)
+    assert _cp_embeds_into(cp1, cp2)
+    #assert not _cp_embeds_into(cp1, cp3)
+    assert _cp_embeds_into(cp1, cp4)
+    #assert not _cp_embeds_into(cp1, cp5)
+    #assert not _cp_embeds_into(cp2, cp1)
+    #assert not _cp_embeds_into(cp2, cp3)
+    assert not _cp_embeds_into(cp2, cp4)
+    #assert not _cp_embeds_into(cp2, cp5)
+    #assert not _cp_embeds_into(cp3, cp1)
+    assert _cp_embeds_into(cp3, cp2)
+    assert not _cp_embeds_into(cp3, cp4)
+    #assert _cp_embeds_into(cp3, cp5)
+    #assert not _cp_embeds_into(cp4, cp1)
+    assert _cp_embeds_into(cp4, cp2)
+    #assert not _cp_embeds_into(cp4, cp3)
+    #assert not _cp_embeds_into(cp4, cp5)
+    #assert not _cp_embeds_into(cp5, cp1)
+    assert _cp_embeds_into(cp5, cp2)
+    #assert not _cp_embeds_into(cp5, cp3)
+    assert not _cp_embeds_into(cp5, cp4)
 
 @with_model
-def test_match_lhs():
+def test__match_lhs():
     Monomer('A', ['other'], {'other':['u', 'p']})
     Monomer('B', ['T185'], {'T185':['u', 'p']})
     rule = Rule('A_phos_B', A() + B(T185='u') >> A() + B(T185='p'),
                 Parameter('k', 1))
-    matching_rules = match_lhs(A(), model.rules)
+    matching_rules = _match_lhs(A(), model.rules)
     assert len(matching_rules) == 1
     assert matching_rules[0] == rule
-    matching_rules = match_lhs(A(other='u'), model.rules)
+    matching_rules = _match_lhs(A(other='u'), model.rules)
     assert len(matching_rules) == 0
 
+"""
 @with_model
 def test_match_rhs():
     Monomer('A', ['other'], {'other':['u', 'p']})
     Monomer('B', ['T185'], {'T185':['u', 'p']})
     rule = Rule('A_phos_B', A() + B(T185='u') >> A() + B(T185='p'),
                 Parameter('k', 1))
-    matching_rules = match_rhs(B(T185='p'), model.rules)
+    matching_rules = _match_rhs(B(T185='p'), model.rules)
     assert len(matching_rules) == 1
     assert matching_rules[0] == rule
-    matching_rules = match_rhs(B(T185='u'), model.rules)
+    matching_rules = _match_rhs(B(T185='u'), model.rules)
     assert len(matching_rules) == 0
-    matching_rules = match_rhs(B(), model.rules)
+    matching_rules = _match_rhs(B(), model.rules)
     assert len(matching_rules) == 1
     assert matching_rules[0] == rule
+"""
 
 @with_model
 def test_one_step_phosphorylation():
@@ -243,13 +245,15 @@ def test_ras_220_network():
     assert checks[1][1] == False
 """
 
+"""
 def test_path_polarity():
     im = pgv.AGraph('im_polarity.dot')
     path1 = ['BRAF_phospho_MAPK1_T185_1', 'MAPK1_phospho_DUSP6_S159_1']
     path2 = ['BRAF_phospho_MAPK1_T185_1', 'BRAF_phospho_MAPK1_T185_3',
              'MAPK1_phospho_DUSP6_S159_1']
-    assert positive_path(im, path1)
-    assert not positive_path(im, path2)
+    assert _positive_path(im, path1)
+    assert not _positive_path(im, path2)
+"""
 
 @with_model
 def test_consumption_rule():
@@ -705,11 +709,12 @@ def test_ubiquitination():
 # When Ras machine finds a new finding, it can be checked to see if it's
 # satisfied by the model.
 if __name__ == '__main__':
+    pass
     #test_activation_subtype()
-    test_check_transphosphorylation()
-    test_check_autophosphorylation()
+    #test_check_transphosphorylation()
+    #test_check_autophosphorylation()
     #test_multitype_path()
-    #test_phosphorylation_annotations()
+    test_phosphorylation_annotations()
     #test_check_activation()
     #test_none_phosphorylation_stmt()
     #test_distinguish_path_polarity1()

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.assemblers import PysbAssembler
 from indra.assemblers.pysb_assembler import get_agent_rule_str, _n, \
-                                            parse_identifiers_url,
-                                            find_monomer_with_grounding
+                                            parse_identifiers_url
 from indra.statements import *
 from pysb import bng, WILD
 from pysb.testing import with_model
@@ -700,15 +699,17 @@ def test_parse_identifiers_url():
     assert ns == 'XFAM' and id == '12345'
 
 @with_model
-def test_find_monomer_with_grounding():
+def test_get_mp_with_grounding():
+    foo = Agent('Foo', db_refs={'HGNC': 'foo'})
+    a = Agent('A', db_refs={'HGNC': '6840'})
+    b = Agent('B', db_refs={'HGNC': '6871'})
     Monomer('A_monomer')
     Monomer('B_monomer')
     Annotation(A_monomer, 'http://identifiers.org/hgnc/HGNC:6840')
     Annotation(B_monomer, 'http://identifiers.org/hgnc/HGNC:6871')
-    mono = mc._find_monomer_with_grounding({'HGNC': 'foo'})
+    mono = pa.get_monomer_pattern(model, foo, use_grounding=True)
     assert mono is None
-    mono = mc._find_monomer_with_grounding({'HGNC': '6840'})
+    mono = pa.get_monomer_pattern(model, a, use_grounding=True)
     assert mono == A_monomer
-    mono = mc._find_monomer_with_grounding({'HGNC': '6871'})
+    mono = pa.get_monomer_pattern(model, b, use_grounding=True)
     assert mono == B_monomer
-

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.assemblers import PysbAssembler
-from indra.assemblers.pysb_assembler import get_agent_rule_str, _n, \
-                                            parse_identifiers_url
+from indra.assemblers import pysb_assembler as pa
 from indra.statements import *
-from pysb import bng, WILD
+from pysb import bng, WILD, Monomer, Annotation
 from pysb.testing import with_model
 
 def test_pysb_assembler_complex1():
@@ -380,29 +379,29 @@ def test_activity_activity3():
     assert(len(model.monomers)==2)
 
 def test_rule_name_str_1():
-    s = get_agent_rule_str(Agent('BRAF'))
+    s = pa.get_agent_rule_str(Agent('BRAF'))
     assert(s == 'BRAF')
 
 def test_rule_name_str_2():
     a = Agent('GRB2',
               bound_conditions=[BoundCondition(Agent('EGFR'), True)])
-    s = get_agent_rule_str(a)
+    s = pa.get_agent_rule_str(a)
     assert(s == 'GRB2_EGFR')
 
 def test_rule_name_str_3():
     a = Agent('GRB2',
               bound_conditions=[BoundCondition(Agent('EGFR'), False)])
-    s = get_agent_rule_str(a)
+    s = pa.get_agent_rule_str(a)
     assert(s == 'GRB2_nEGFR')
 
 def test_rule_name_str_4():
     a = Agent('BRAF', mods=[ModCondition('phosphorylation', 'serine')])
-    s = get_agent_rule_str(a)
+    s = pa.get_agent_rule_str(a)
     assert(s == 'BRAF_phosphoS')
 
 def test_rule_name_str_5():
     a = Agent('BRAF', mods=[ModCondition('phosphorylation', 'serine', '123')])
-    s = get_agent_rule_str(a)
+    s = pa.get_agent_rule_str(a)
     assert(s == 'BRAF_phosphoS123')
 
 def test_neg_act_mod():
@@ -536,13 +535,13 @@ def test_save_rst():
     pa.save_rst('/dev/null')
 
 def test_name_standardize():
-    n = _n('.*/- ^&#@$')
+    n = pa._n('.*/- ^&#@$')
     assert(isinstance(n, str))
     assert(n == '__________')
-    n = _n('14-3-3')
+    n = pa._n('14-3-3')
     assert(isinstance(n, str))
     assert(n == 'p14_3_3')
-    n = _n('\U0001F4A9bar')
+    n = pa._n('\U0001F4A9bar')
     assert(isinstance(n, str))
     assert(n == 'bar')
 
@@ -683,19 +682,19 @@ def test_parse_identifiers_url():
     url5 = 'http://identifiers.org/chebi/12345'
     url6 = 'http://identifiers.org/interpro/12345'
     url7 = 'http://identifiers.org/pfam/12345'
-    (ns, id) = parse_identifiers_url(url1)
+    (ns, id) = pa.parse_identifiers_url(url1)
     assert ns is None and id is None
-    (ns, id) = parse_identifiers_url(url2)
+    (ns, id) = pa.parse_identifiers_url(url2)
     assert ns is None and id is None
-    (ns, id) = parse_identifiers_url(url3)
+    (ns, id) = pa.parse_identifiers_url(url3)
     assert ns == 'HGNC' and id == '12345'
-    (ns, id) = parse_identifiers_url(url4)
+    (ns, id) = pa.parse_identifiers_url(url4)
     assert ns == 'UP' and id == '12345'
-    (ns, id) = parse_identifiers_url(url5)
+    (ns, id) = pa.parse_identifiers_url(url5)
     assert ns == 'CHEBI' and id == '12345'
-    (ns, id) = parse_identifiers_url(url6)
+    (ns, id) = pa.parse_identifiers_url(url6)
     assert ns == 'IP' and id == '12345'
-    (ns, id) = parse_identifiers_url(url7)
+    (ns, id) = pa.parse_identifiers_url(url7)
     assert ns == 'XFAM' and id == '12345'
 
 @with_model
@@ -713,3 +712,6 @@ def test_get_mp_with_grounding():
     assert mono == A_monomer
     mono = pa.get_monomer_pattern(model, b, use_grounding=True)
     assert mono == B_monomer
+
+if __name__ == '__main__':
+    test_get_mp_with_grounding()

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -2,9 +2,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.assemblers import PysbAssembler
 from indra.assemblers.pysb_assembler import get_agent_rule_str, _n, \
-                                            parse_identifiers_url
+                                            parse_identifiers_url,
+                                            find_monomer_with_grounding
 from indra.statements import *
 from pysb import bng, WILD
+from pysb.testing import with_model
 
 def test_pysb_assembler_complex1():
     member1 = Agent('BRAF')
@@ -696,3 +698,17 @@ def test_parse_identifiers_url():
     assert ns == 'IP' and id == '12345'
     (ns, id) = parse_identifiers_url(url7)
     assert ns == 'XFAM' and id == '12345'
+
+@with_model
+def test_find_monomer_with_grounding():
+    Monomer('A_monomer')
+    Monomer('B_monomer')
+    Annotation(A_monomer, 'http://identifiers.org/hgnc/HGNC:6840')
+    Annotation(B_monomer, 'http://identifiers.org/hgnc/HGNC:6871')
+    mono = mc._find_monomer_with_grounding({'HGNC': 'foo'})
+    assert mono is None
+    mono = mc._find_monomer_with_grounding({'HGNC': '6840'})
+    assert mono == A_monomer
+    mono = mc._find_monomer_with_grounding({'HGNC': '6871'})
+    assert mono == B_monomer
+

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -750,16 +750,26 @@ def test_assemble_model_with_grounding():
     b_phos = Agent('Foo', mods=[ModCondition('phosphorylation', None, None)],
                     db_refs={'HGNC': '6871'})
     st1 = Phosphorylation(a, b, 'T', '185')
-    #st2 = Phosphorylation(a, b, None, None)
-    pysb_asmb = pa.PysbAssembler(policies='one_step')
-    pysb_asmb.add_statements([st1])
-    model = pysb_asmb.make_model()
-    mps = list(pa.grounded_monomer_patterns(model, b_phos))
-    assert len(mps) == 1
-    assert mps[0].monomer.name == 'ERK2'
-    assert mps[0].site_conditions == {'T185':'p'}
+    # One step
+    def check_policy(policy):
+        pysb_asmb = pa.PysbAssembler(policies=policy)
+        pysb_asmb.add_statements([st1])
+        model = pysb_asmb.make_model()
+        mps = list(pa.grounded_monomer_patterns(model, b_phos))
+        assert len(mps) == 1
+        assert mps[0].monomer.name == 'ERK2'
+        assert mps[0].site_conditions == {'T185':'p'}
+    for policy in ('one_step', 'interactions_only', 'two_step',
+                   'atp_dependent'):
+        check_policy(policy)
 
 
+# TODO test grounded assembly where the modification is on the agent, not
+# part of the statement.
+# TODO Do the same for mutation condition
+# TODO Localization condition
+# TODO Bound condition
+# TODO Unphosphorylated/unmodified forms (try ubiquitinated/acetylated lysine)
 
 if __name__ == '__main__':
     test_assemble_model_with_grounding()

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -782,14 +782,37 @@ def test_phospho_mod_grounding():
     assert {'S218': ('p', WILD)} in sc
     assert {'S222': ('p', WILD)} in sc
 
+def _check_mod_assembly(mod_class):
+    subj = Agent('KRAS')
+    obj = Agent('BRAF')
+    st1 = mod_class(subj, obj)
+    pa = PysbAssembler(policies='one_step')
+    pa.add_statements([st1])
+    model = pa.make_model()
+    assert(len(model.rules)==1)
+    assert(len(model.monomers)==2)
+
+    pa = PysbAssembler(policies='interactions_only')
+    pa.add_statements([st1])
+    model = pa.make_model()
+    assert(len(model.rules)==1)
+    assert(len(model.monomers)==2)
+
+    pa = PysbAssembler(policies='two_step')
+    pa.add_statements([st1])
+    model = pa.make_model()
+    assert(len(model.rules)==3)
+    assert(len(model.monomers)==2)
+
+def test_modification_assembly():
+    for mod_class in Modification.__subclasses__():
+        if not mod_class.__name__.startswith('De'):
+            _check_mod_assembly(mod_class)
+
 # TODO Do the same for mutation condition
 # TODO Localization condition
 # TODO Bound condition
 # TODO Unphosphorylated/unmodified forms (try ubiquitinated/acetylated lysine)
 
 if __name__ == '__main__':
-    test_get_mp_with_grounding()
-    test_get_mp_with_grounding_2()
-    test_phospho_assemble_grounding()
-    test_phospho_mod_grounding()
-
+    test_modification_assembly()

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.assemblers import PysbAssembler
-from indra.assemblers.pysb_assembler import get_agent_rule_str, _n
+from indra.assemblers.pysb_assembler import get_agent_rule_str, _n, \
+                                            parse_identifiers_url
 from indra.statements import *
-from pysb import bng
+from pysb import bng, WILD
 
 def test_pysb_assembler_complex1():
     member1 = Agent('BRAF')
@@ -414,7 +415,7 @@ def test_neg_act_mod():
     r = pa.model.rules[0]
     braf = r.reactant_pattern.complex_patterns[0].monomer_patterns[0]
     assert(braf.monomer.name == 'BRAF')
-    assert(braf.site_conditions == {'S123': 'u'})
+    assert(braf.site_conditions == {'S123': ('u', WILD)})
 
 def test_pos_agent_mod():
     mc = ModCondition('phosphorylation', 'serine', '123', True)
@@ -426,7 +427,7 @@ def test_pos_agent_mod():
     r = pa.model.rules[0]
     braf = r.reactant_pattern.complex_patterns[0].monomer_patterns[0]
     assert(braf.monomer.name == 'BRAF')
-    assert(braf.site_conditions == {'S123': 'p'})
+    assert(braf.site_conditions == {'S123': ('p', WILD)})
 
 def test_neg_agent_mod():
     mc = ModCondition('phosphorylation', 'serine', '123', False)
@@ -438,7 +439,7 @@ def test_neg_agent_mod():
     r = pa.model.rules[0]
     braf = r.reactant_pattern.complex_patterns[0].monomer_patterns[0]
     assert(braf.monomer.name == 'BRAF')
-    assert(braf.site_conditions == {'S123': 'u'})
+    assert(braf.site_conditions == {'S123': ('u', WILD)})
 
 def test_mut():
     mut = MutCondition('600', 'V', 'E')
@@ -673,3 +674,25 @@ def test_translocation_loc_special_char():
     assert(f2.site_conditions == {'loc': 'cell_surface'})
     assert(r.rate_forward.name == 'kf_ksr1_cytoplasm_cell_surface_1')
 
+def test_parse_identifiers_url():
+    url1 = 'http://identifiers.org/foo/bar'
+    url2 = 'http://identifiers.org/hgnc/12345'
+    url3 = 'http://identifiers.org/hgnc/HGNC:12345'
+    url4 = 'http://identifiers.org/uniprot/12345'
+    url5 = 'http://identifiers.org/chebi/12345'
+    url6 = 'http://identifiers.org/interpro/12345'
+    url7 = 'http://identifiers.org/pfam/12345'
+    (ns, id) = parse_identifiers_url(url1)
+    assert ns is None and id is None
+    (ns, id) = parse_identifiers_url(url2)
+    assert ns is None and id is None
+    (ns, id) = parse_identifiers_url(url3)
+    assert ns == 'HGNC' and id == '12345'
+    (ns, id) = parse_identifiers_url(url4)
+    assert ns == 'UP' and id == '12345'
+    (ns, id) = parse_identifiers_url(url5)
+    assert ns == 'CHEBI' and id == '12345'
+    (ns, id) = parse_identifiers_url(url6)
+    assert ns == 'IP' and id == '12345'
+    (ns, id) = parse_identifiers_url(url7)
+    assert ns == 'XFAM' and id == '12345'

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -786,13 +786,14 @@ def _check_mod_assembly(mod_class):
     subj = Agent('KRAS')
     obj = Agent('BRAF')
     st1 = mod_class(subj, obj)
-    pa = PysbAssembler(policies='one_step')
+
+    pa = PysbAssembler(policies='interactions_only')
     pa.add_statements([st1])
     model = pa.make_model()
     assert(len(model.rules)==1)
     assert(len(model.monomers)==2)
 
-    pa = PysbAssembler(policies='interactions_only')
+    pa = PysbAssembler(policies='one_step')
     pa.add_statements([st1])
     model = pa.make_model()
     assert(len(model.rules)==1)
@@ -806,8 +807,8 @@ def _check_mod_assembly(mod_class):
 
 def test_modification_assembly():
     for mod_class in Modification.__subclasses__():
-        if not mod_class.__name__.startswith('De'):
-            _check_mod_assembly(mod_class)
+        _check_mod_assembly(mod_class)
+
 
 # TODO Do the same for mutation condition
 # TODO Localization condition

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -706,12 +706,12 @@ def test_get_mp_with_grounding():
     Monomer('B_monomer')
     Annotation(A_monomer, 'http://identifiers.org/hgnc/HGNC:6840')
     Annotation(B_monomer, 'http://identifiers.org/hgnc/HGNC:6871')
-    mono = pa.get_monomer_pattern(model, foo, use_grounding=True)
+    mono = pa.get_monomer_pattern(model, foo)
     assert mono is None
-    mono = pa.get_monomer_pattern(model, a, use_grounding=True)
-    assert mono == A_monomer
-    mono = pa.get_monomer_pattern(model, b, use_grounding=True)
-    assert mono == B_monomer
+    mono = pa.get_monomer_pattern(model, a)
+    assert mono.monomer == A_monomer
+    mono = pa.get_monomer_pattern(model, b)
+    assert mono.monomer == B_monomer
 
 if __name__ == '__main__':
     test_get_mp_with_grounding()

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -739,7 +739,7 @@ def test_get_mp_with_grounding_2():
     assert len(mps_2) == 1
     mp = mps_2[0]
     assert mp.monomer == A_monomer
-    assert mp.site_conditions == {'Y187': 'p'}
+    assert mp.site_conditions == {'Y187': ('p', WILD)}
     # TODO Add test for unmodified agent!
     # TODO Add test involving multiple (possibly degenerate) modifications!
     # TODO Add test for generic double phosphorylation
@@ -758,7 +758,7 @@ def test_phospho_assemble_grounding():
         mps = list(pa.grounded_monomer_patterns(model, b_phos))
         assert len(mps) == 1
         assert mps[0].monomer.name == 'ERK2'
-        assert mps[0].site_conditions == {'T185':'p'}
+        assert mps[0].site_conditions == {'T185': ('p', WILD)}
     for policy in ('one_step', 'interactions_only', 'two_step',
                    'atp_dependent'):
         check_policy(policy)
@@ -779,8 +779,8 @@ def test_phospho_mod_grounding():
     assert mps[0].monomer.name == 'MEK1'
     assert mps[1].monomer.name == 'MEK1'
     sc = [mp.site_conditions for mp in mps]
-    assert {'S218':'p'} in sc
-    assert {'S222':'p'} in sc
+    assert {'S218': ('p', WILD)} in sc
+    assert {'S222': ('p', WILD)} in sc
 
 # TODO Do the same for mutation condition
 # TODO Localization condition
@@ -788,4 +788,8 @@ def test_phospho_mod_grounding():
 # TODO Unphosphorylated/unmodified forms (try ubiquitinated/acetylated lysine)
 
 if __name__ == '__main__':
+    test_get_mp_with_grounding()
+    test_get_mp_with_grounding_2()
+    test_phospho_assemble_grounding()
     test_phospho_mod_grounding()
+

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -742,6 +742,7 @@ def test_get_mp_with_grounding_2():
     assert mp.site_conditions == {'Y187': 'p'}
     # TODO Add test for unmodified agent!
     # TODO Add test involving multiple (possibly degenerate) modifications!
+    # TODO Add test for generic double phosphorylation
 
 if __name__ == '__main__':
     test_get_mp_with_grounding()

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -744,6 +744,22 @@ def test_get_mp_with_grounding_2():
     # TODO Add test involving multiple (possibly degenerate) modifications!
     # TODO Add test for generic double phosphorylation
 
+def test_assemble_model_with_grounding():
+    a = Agent('MEK1', db_refs={'HGNC': '6840'})
+    b = Agent('ERK2', db_refs={'HGNC': '6871'})
+    b_phos = Agent('Foo', mods=[ModCondition('phosphorylation', None, None)],
+                    db_refs={'HGNC': '6871'})
+    st1 = Phosphorylation(a, b, 'T', '185')
+    #st2 = Phosphorylation(a, b, None, None)
+    pysb_asmb = pa.PysbAssembler(policies='one_step')
+    pysb_asmb.add_statements([st1])
+    model = pysb_asmb.make_model()
+    mps = list(pa.grounded_monomer_patterns(model, b_phos))
+    assert len(mps) == 1
+    assert mps[0].monomer.name == 'ERK2'
+    assert mps[0].site_conditions == {'T185':'p'}
+
+
+
 if __name__ == '__main__':
-    test_get_mp_with_grounding()
-    test_get_mp_with_grounding_2()
+    test_assemble_model_with_grounding()

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -1,0 +1,11 @@
+
+
+class ModelChecker(object):
+    """Check a PySB model against a set of INDRA statements."""
+
+    def __init__(self, model, statements):
+        self.model = model
+        self.statements = statements
+
+    def check_model(self):
+        return [(self.statements[0], True)]

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -1,4 +1,8 @@
-
+from pysb import kappa
+from pysb import Observable
+from indra.statements import *
+from indra.assemblers import pysb_assembler as pa
+from copy import deepcopy
 
 class ModelChecker(object):
     """Check a PySB model against a set of INDRA statements."""
@@ -8,4 +12,74 @@ class ModelChecker(object):
         self.statements = statements
 
     def check_model(self):
-        return [(self.statements[0], True)]
+        results = []
+        for stmt in self.statements:
+            result = self.check_statement(stmt)
+            results.append((stmt, result))
+        return results
+
+    def check_statement(self, stmt):
+        if isinstance(stmt, Phosphorylation):
+            return self.check_phosphorylation(stmt)
+        else:
+            return False
+
+    def check_phosphorylation(self, stmt):
+        # Identify the observable we're looking for in the model, which
+        # may not exist!
+        # The observable is the modified form of the substrate
+        enz_mp = pa.get_monomer_pattern(self.model, stmt.enz)
+        modified_sub = _add_modification_to_agent(stmt.sub, 'phosphorylation',
+                                                  stmt.residue, stmt.position)
+        sub_mp = pa.get_monomer_pattern(self.model, modified_sub)
+        # Make a copy of the model and add the observable for the modified
+        # substrate
+        new_model = deepcopy(self.model)
+        sub_obs = Observable('target', sub_mp, _export=False)
+        new_model.add_component(sub_obs)
+        return True
+
+def _add_modification_to_agent(agent, mod_type, residue, position):
+    new_mod = ModCondition(mod_type, residue, position)
+    # Check if this modification already exists
+    for old_mod in agent.mods:
+        if old_mod.equals(new_mod):
+            return agent
+    new_agent = deepcopy(agent)
+    new_agent.mods.append(new_mod)
+    return new_agent
+
+def match_lhs(cp, rules):
+    rule_matches = []
+    for rule in rules:
+        reactant_pattern = rule.rule_expression.reactant_pattern
+        for rule_cp in reactant_pattern.complex_patterns:
+            if embeds_into(rule_cp, cp):
+                rule_matches.append(rule)
+    return rule_matches
+
+def cp_embeds_into(cp1, cp2):
+    # Check that any state in cp2 is matched in cp2
+    # If the thing we're matching to is just a monomer pattern, that makes
+    # things easier--we just need to find the corresponding monomer pattern
+    # in cp1
+    if len(cp2.monomer_patterns) == 1:
+        mp2 = cp2.monomer_patterns[0]
+        # Iterate over the monomer patterns in cp1 and see if there is one
+        # that has the same name
+        for mp1 in cp1.monomer_patterns:
+            if mp_embeds_into(mp1, mp2):
+                return True
+    return False
+
+def mp_embeds_into(mp1, mp2):
+    sc_matches = []
+    if mp1.monomer.name != mp2.monomer.name:
+        return False
+    # Check that all conditions in mp2 are met in mp1
+    for site_name, site_state in mp2.site_conditions.items():
+        if site_name not in mp1.site_conditions or \
+           site_state != mp1.site_conditions[site_name]:
+            return False
+    return True
+

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -145,10 +145,13 @@ class ModelChecker(object):
         if not obj_mps:
             logger.info('Failed to create observable; returning False')
             return False
+        # Try to find paths between pairs of matching subj and object monomer
+        # patterns
         for enz_mp, obj_mp in itertools.product(enz_mps, obj_mps):
             obj_obs = Observable(obs_name, obj_mp, _export=False)
-            # If there's a path, return the first one
-            return self._find_im_paths(enz_mp, obj_obs, target_polarity)
+            # Return True for the first valid path we find
+            if self._find_im_paths(enz_mp, obj_obs, target_polarity):
+                return True
         # If we got here, then there was no path for any observable
         return False
 

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -135,6 +135,7 @@ class ModelChecker(object):
         else:
             return False
 
+
 def _add_modification_to_agent(agent, mod_type, residue, position):
     new_mod = ModCondition(mod_type, residue, position)
     # Check if this modification already exists

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -126,8 +126,7 @@ class ModelChecker(object):
         for enz_mp, obj_mp in itertools.product(enz_mps, obj_mps):
             obj_obs = Observable(obs_name, obj_mp, _export=False)
             # If there's a path, return the first one
-            for path in self._find_im_paths(enz_mp, obj_obs, target_polarity):
-                return True
+            return self._find_im_paths(enz_mp, obj_obs, target_polarity)
         # If we got here, then there was no path for any observable
         return False
 

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -1,3 +1,4 @@
+from pysb.core import as_complex_pattern
 from pysb import kappa
 from pysb import Observable
 from indra.statements import *
@@ -63,6 +64,8 @@ def cp_embeds_into(cp1, cp2):
     # If the thing we're matching to is just a monomer pattern, that makes
     # things easier--we just need to find the corresponding monomer pattern
     # in cp1
+    cp1 = as_complex_pattern(cp1)
+    cp2 = as_complex_pattern(cp2)
     if len(cp2.monomer_patterns) == 1:
         mp2 = cp2.monomer_patterns[0]
         # Iterate over the monomer patterns in cp1 and see if there is one

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -53,13 +53,13 @@ class ModelChecker(object):
         # Generate the influence map
         # Find rules in the model corresponding to the inputs and outputs
         input_rules = match_lhs(enz_mp, self.model.rules)
-        output_rules = match_rhs(sub_mp, self.model.rules)
+        target_prod_rules = find_production_rules(sub_mp, self.model.rules)
         input_rule_names = [r.name for r in input_rules]
-        output_rule_names = [r.name for r in output_rules]
-        if input_rule_names and output_rule_names:
+        target_prod_rule_names = [r.name for r in target_prod_rules]
+        if input_rule_names and target_prod_rule_names:
             # Generate the influence map
             for input_rule, output_rule in itertools.product(input_rule_names,
-                                                             output_rule_names):
+                                                      target_prod_rule_names):
                 try:
                     sp_gen = networkx.shortest_simple_paths(self.get_im(),
                                                        input_rule,
@@ -104,6 +104,16 @@ def match_rhs(cp, rules):
             if cp_embeds_into(rule_cp, cp):
                 rule_matches.append(rule)
     return rule_matches
+
+def find_production_rules(cp, rules):
+    # Find rules where the CP matches the left hand side
+    lhs_rule_set = set(match_lhs(cp, rules))
+    # Now find rules where the CP matches the right hand side
+    rhs_rule_set = set(match_rhs(cp, rules))
+    # Production rules are rules where there is a match on the right hand
+    # side but not on the left hand side
+    prod_rules = list(rhs_rule_set.difference(lhs_rule_set))
+    return prod_rules
 
 def cp_embeds_into(cp1, cp2):
     # Check that any state in cp2 is matched in cp2

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -142,6 +142,7 @@ class ModelChecker(object):
         #        paths.append(sp)
         #        break
 
+
 def _add_modification_to_agent(agent, mod_type, residue, position):
     new_mod = ModCondition(mod_type, residue, position)
     # Check if this modification already exists
@@ -152,6 +153,7 @@ def _add_modification_to_agent(agent, mod_type, residue, position):
     new_agent.mods.append(new_mod)
     return new_agent
 
+
 def match_lhs(cp, rules):
     rule_matches = []
     for rule in rules:
@@ -161,6 +163,7 @@ def match_lhs(cp, rules):
                 rule_matches.append(rule)
                 break
     return rule_matches
+
 
 def match_rhs(cp, rules):
     rule_matches = []
@@ -194,6 +197,7 @@ def find_consumption_rules(cp, rules):
     return cons_rules
 """
 
+
 def cp_embeds_into(cp1, cp2):
     # Check that any state in cp2 is matched in cp2
     # If the thing we're matching to is just a monomer pattern, that makes
@@ -210,6 +214,7 @@ def cp_embeds_into(cp1, cp2):
                 return True
     return False
 
+
 def mp_embeds_into(mp1, mp2):
     sc_matches = []
     if mp1.monomer.name != mp2.monomer.name:
@@ -221,6 +226,7 @@ def mp_embeds_into(mp1, mp2):
             return False
     return True
 
+
 def positive_path(im, path):
     # This doesn't address the effect of the rules themselves on the
     # observables of interest--just the effects of the rules on each other
@@ -229,17 +235,24 @@ def positive_path(im, path):
         from_rule = path[rule_ix]
         to_rule = path[rule_ix + 1]
         edge = im.get_edge(from_rule, to_rule)
-        if edge.attr.get('color') is None:
-            raise Exception('No color attribute for edge.')
-        elif edge.attr['color'] == 'green':
+        if _is_positive_edge(edge):
             edge_polarities.append(1)
-        elif edge.attr['color'] == 'red':
-            edge_polarities.append(-1)
         else:
-            raise Exception('Unexpected edge color: %s' % edge.attr['color'])
+            edge_polarities.append(-1)
     # Compute and return the overall path polarity
     path_polarity = np.prod(edge_polarities)
     assert path_polarity == 1 or path_polarity == -1
     return True if path_polarity == 1 else False
+
+
+def _is_positive_edge(edge):
+    if edge.attr.get('color') is None:
+        raise Exception('No color attribute for edge.')
+    elif edge.attr['color'] == 'green':
+        return True
+    elif edge.attr['color'] == 'red':
+        return False
+    else:
+        raise Exception('Unexpected edge color: %s' % edge.attr['color'])
 
 

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -56,29 +56,23 @@ class ModelChecker(object):
         output_rules = match_rhs(sub_mp, self.model.rules)
         input_rule_names = [r.name for r in input_rules]
         output_rule_names = [r.name for r in output_rules]
-        print input_rules
-        print output_rules
         if input_rule_names and output_rule_names:
             # Generate the influence map
             for input_rule, output_rule in itertools.product(input_rule_names,
                                                              output_rule_names):
                 try:
-                    logger.info('Looking for path between %s and %s' %
-                                (input_rule, output_rule))
                     sp_gen = networkx.shortest_simple_paths(self.get_im(),
                                                        input_rule,
                                                        output_rule)
-                    # Iterate over paths until we find one with the desired
+                    # Iterate over paths until we find one with positive
                     # polarity
                     for path_ix, sp in enumerate(sp_gen):
-                        logger.info('Found simple path %s: %s' %
-                                    (path_ix, str(sp)))
-                        pol = path_polarity(self.get_im(), sp)
-                        logger.info('Path %s has polarity %s' %
-                                    (str(sp), pol))
+                        if positive_path(self.get_im(), sp):
+                            logger.info('Found simple positive path %s: %s' %
+                                        (path_ix, str(sp)))
+                            return True
                 except networkx.NetworkXNoPath as nopath:
-                    logger.info('No path found between %s and %s' %
-                                (input_rule, output_rule))
+                    pass
             return False
         else:
             return False

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -135,6 +135,8 @@ class ModelChecker(object):
         self.model.observables = ComponentSet([])
         self.model.add_component(obj_obs)
         # Find rules in the model corresponding to the input
+        logger.info('Finding paths between %s and %s with polarity %s' %
+                    (subj_mp, obj_obs, target_polarity))
         if subj_mp is None:
             input_rule_set = None
         else:
@@ -143,8 +145,8 @@ class ModelChecker(object):
                                   #if r.name.startswith(stmt.enz.name)])
             logger.info('Found %s input rules matching %s' %
                         (len(input_rules), str(subj_mp)))
-            # If we have enzyme information but there are no input rules matching
-            # the enzyme, then there is no path
+            # If we have enzyme information but there are no input rules
+            # matching the enzyme, then there is no path
             if not input_rules:
                 return False
         # Generate the predecessors to our observable
@@ -255,11 +257,11 @@ def _find_sources(im, target, sources, polarity):
     # First, generate a list of visited nodes
     # Copied/adapted from networkx
     visited = set([(target, 1)])
-    # Generate list of predecessor nodes with a sign updated according to the sign
-    # of the target node
+    # Generate list of predecessor nodes with a sign updated according to the
+    # sign of the target node
     target_tuple = (target, 1)
-    # The queue holds tuples of "parents" (in this case downstream nodes) and their
-    # "children" (in this case their upstream influencers)
+    # The queue holds tuples of "parents" (in this case downstream nodes) and
+    # their "children" (in this case their upstream influencers)
     queue = deque([(target_tuple, _get_signed_predecessors(im, target, 1), 1)])
     while queue:
         parent, children, path_length = queue[0]
@@ -270,11 +272,11 @@ def _find_sources(im, target, sources, polarity):
             # the parent!
             # Could do this in the expansion step itself, or here;
             # If done during the expansion step, 
-            # Check this child against the visited list. If we haven't visited it,
-            # then we return the parent/child pair
+            # Check this child against the visited list. If we haven't visited
+            # it, then we return the parent/child pair
             if (sources is None or child in sources) and sign == polarity:
-                logger.info("Found path to %s from %s with desired sign %s with "
-                            "length %d" %
+                logger.info("Found path to %s from %s with desired sign %s "
+                            "with length %d" %
                             (target, child, polarity, path_length))
                 yield (child, sign, path_length)
             if (child, sign) not in visited:

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -1,17 +1,16 @@
 from __future__ import print_function, unicode_literals, absolute_import
 from builtins import dict, str
 import logging
-import numpy as np
 import networkx
 import itertools
 from copy import deepcopy
 from collections import deque
-from itertools import product
 from pysb import kappa
 from pysb import Observable, ComponentSet
 from pysb.core import as_complex_pattern
 from indra.statements import *
 from indra.assemblers import pysb_assembler as pa
+
 logger = logging.getLogger('model_checker')
 
 class ModelChecker(object):
@@ -25,7 +24,28 @@ class ModelChecker(object):
             self.statements = []
         self._im = None
 
+    def add_statements(self, stmts):
+        """Add to the list of statements to check against the model."""
+        self.statements += stmts
+
     def get_im(self, force_update=True):
+        """Get the influence map for the model, generating it if necessary.
+
+        Parameters
+        ----------
+        force_update : bool
+            Whether to generate the influence map when the function is called.
+            If False, returns the previously generated influence map if
+            available. Defaults to True.
+
+        Returns
+        -------
+        pygraphviz AGraph object containing the influence map.
+            The influence map can be rendered as a pdf using the dot layout
+            program as follows::
+
+                influence_map.draw('influence_map.pdf', prog='dot')
+        """
         if self._im and not force_update:
             return self._im
         if not self.model:
@@ -36,6 +56,14 @@ class ModelChecker(object):
             return self._im
 
     def check_model(self):
+        """Check all the statements added to the ModelChecker.
+
+        Returns
+        -------
+        list of (Statement, bool)
+            Each tuple contains the Statement checked against the model and
+            a boolean value indicating whether the model can satisfies it.
+        """
         results = []
         for stmt in self.statements:
             result = self.check_statement(stmt)
@@ -43,14 +71,27 @@ class ModelChecker(object):
         return results
 
     def check_statement(self, stmt):
+        """Check a single Statement against the model.
+
+        Parameters
+        ----------
+        indra.statements.Statement
+            The Statement to check.
+
+        Returns
+        -------
+        boolean
+            Whether the model satisfies the statement.
+        """
         if isinstance(stmt, Modification):
-            return self.check_modification(stmt)
+            return self._check_modification(stmt)
         elif isinstance(stmt, Activation):
-            return self.check_activation(stmt)
+            return self._check_activation(stmt)
         else:
             return False
 
-    def check_activation(self, stmt):
+    def _check_activation(self, stmt):
+        """Check an Activation statement."""
         logger.info('Checking stmt: %s' % stmt)
         # FIXME Currently this will match rules with the corresponding monomer
         # pattern from the Activation statement, which will nearly always have
@@ -76,18 +117,8 @@ class ModelChecker(object):
         obj_obs = Observable(obj_obs_name, obj_mp, _export=False)
         return self._find_im_paths(subj_mp, obj_obs, target_polarity)
 
-    # Need to be able to take an arbitrary set of agent modification/mut etc.
-    # conditions and generate an appropriate set of monomer patterns and/or
-    # observables. This has to apply to both input rules/agents as well as
-    # targets. Imagine the case of
-    # Phosphorylation(MAP2K1(mods:[phosphorylation, None, None]), MAPK1)
-    # Here, we need to match any rule where MEK (in any phosphorylated state)
-    # phosphoryaltes ERK on any site.
-    # If this can be done, then resolving activations becomes simply a matter of
-    # looking up which states are active, just like looking up phosphorylations.
-    # So we'll start by looking through the modification conditions of an agent.
-
-    def check_modification(self, stmt):
+    def _check_modification(self, stmt):
+        """Check a Modification statement."""
         # Identify the observable we're looking for in the model, which
         # may not exist!
         # The observable is the modified form of the substrate
@@ -109,15 +140,6 @@ class ModelChecker(object):
         # Add modification to substrate agent
         modified_sub = _add_modification_to_agent(stmt.sub, 'phosphorylation',
                                                   stmt.residue, stmt.position)
-        # Now look up the modified agent in the model
-        #obj_mp = pa.get_monomer_pattern(self.model, modified_sub)
-        #site_pattern = pa.get_site_pattern(modified_sub)
-        #monomer = self.model.monomers[modified_sub.name]
-        #try:
-        #    obj_mp = monomer(**site_pattern)
-        #except Exception as e:
-        #    logger.info("Invalid site: %s" % e)
-        #    return False
         obs_name = pa.get_agent_rule_str(modified_sub) + '_obs'
         obj_mps = list(pa.grounded_monomer_patterns(self.model, modified_sub))
         if not obj_mps:
@@ -131,6 +153,27 @@ class ModelChecker(object):
         return False
 
     def _find_im_paths(self, subj_mp, obj_obs, target_polarity):
+        """Check for a source/target path in the influence map.
+
+        Parameters
+        ----------
+        subj_mp : pysb.MonomerPattern
+            MonomerPattern corresponding to the subject of the Statement
+            being checked.
+        obj_obs : pysb.Observable
+            Observable corresponding to the object/target of the Statement
+            being checked.
+        target_polarity : 1 or -1
+            Whether the influence in the Statement is positive (1) or negative
+            (-1).
+
+        Returns
+        -------
+        boolean
+            Whether there is a path from a rule matching the subject
+            MonomerPattern to the object Observable with the appropriate
+            polarity.
+        """
         # Reset the observables list
         self.model.observables = ComponentSet([])
         self.model.add_component(obj_obs)
@@ -140,7 +183,7 @@ class ModelChecker(object):
         if subj_mp is None:
             input_rule_set = None
         else:
-            input_rules = match_lhs(subj_mp, self.model.rules)
+            input_rules = _match_lhs(subj_mp, self.model.rules)
             input_rule_set = set([r.name for r in input_rules])
                                   #if r.name.startswith(stmt.enz.name)])
             logger.info('Found %s input rules matching %s' %
@@ -161,101 +204,38 @@ class ModelChecker(object):
             return False
 
 
-def _add_modification_to_agent(agent, mod_type, residue, position):
-    new_mod = ModCondition(mod_type, residue, position)
-    # Check if this modification already exists
-    for old_mod in agent.mods:
-        if old_mod.equals(new_mod):
-            return agent
-    new_agent = deepcopy(agent)
-    new_agent.mods.append(new_mod)
-    return new_agent
-
-
-def match_lhs(cp, rules):
-    rule_matches = []
-    for rule in rules:
-        reactant_pattern = rule.rule_expression.reactant_pattern
-        for rule_cp in reactant_pattern.complex_patterns:
-            if cp_embeds_into(rule_cp, cp):
-                rule_matches.append(rule)
-                break
-    return rule_matches
-
-
-def match_rhs(cp, rules):
-    rule_matches = []
-    for rule in rules:
-        product_pattern = rule.rule_expression.product_pattern
-        for rule_cp in product_pattern.complex_patterns:
-            if cp_embeds_into(rule_cp, cp):
-                rule_matches.append(rule)
-                break
-    return rule_matches
-
-"""
-def find_production_rules(cp, rules):
-    # Find rules where the CP matches the left hand side
-    lhs_rule_set = set(match_lhs(cp, rules))
-    # Now find rules where the CP matches the right hand side
-    rhs_rule_set = set(match_rhs(cp, rules))
-    # Production rules are rules where there is a match on the right hand
-    # side but not on the left hand side
-    prod_rules = list(rhs_rule_set.difference(lhs_rule_set))
-    return prod_rules
-
-def find_consumption_rules(cp, rules):
-    # Find rules where the CP matches the left hand side
-    lhs_rule_set = set(match_lhs(cp, rules))
-    # Now find rules where the CP matches the right hand side
-    rhs_rule_set = set(match_rhs(cp, rules))
-    # Consumption rules are rules where there is a match on the left hand
-    # side but not on the right hand side
-    cons_rules = list(lhs_rule_set.difference(rhs_rule_set))
-    return cons_rules
-"""
-
-
-def cp_embeds_into(cp1, cp2):
-    # Check that any state in cp2 is matched in cp2
-    # If the thing we're matching to is just a monomer pattern, that makes
-    # things easier--we just need to find the corresponding monomer pattern
-    # in cp1
-    cp1 = as_complex_pattern(cp1)
-    cp2 = as_complex_pattern(cp2)
-    if len(cp2.monomer_patterns) == 1:
-        mp2 = cp2.monomer_patterns[0]
-        # Iterate over the monomer patterns in cp1 and see if there is one
-        # that has the same name
-        for mp1 in cp1.monomer_patterns:
-            if mp_embeds_into(mp1, mp2):
-                return True
-    return False
-
-
-def mp_embeds_into(mp1, mp2):
-    sc_matches = []
-    if mp1.monomer.name != mp2.monomer.name:
-        return False
-    # Check that all conditions in mp2 are met in mp1
-    for site_name, site_state in mp2.site_conditions.items():
-        if site_name not in mp1.site_conditions or \
-           site_state != mp1.site_conditions[site_name]:
-            return False
-    return True
-
-
-def _get_signed_predecessors(im, node, polarity):
-    signed_pred_list = []
-    predecessors = im.predecessors_iter
-    for pred in predecessors(node):
-        pred_edge = im.get_edge(pred, node)
-        yield (pred, _get_edge_sign(pred_edge) * polarity)
-
-
 def _find_sources(im, target, sources, polarity):
-    # First, generate a list of visited nodes
-    # Copied/adapted from networkx
+    """Get the subset of source nodes with paths to the target.
+
+    Given a target, a list of sources, and a path polarity, perform a
+    breadth-first search upstream from the target to determine whether any of
+    the queried sources have paths to the target with the appropriate polarity.
+    For efficiency, does not return the full path, but identifies the upstream
+    sources and the length of the path.
+
+    Parameters
+    ----------
+    im : pygraphviz.AGraph
+        Graph containing the influence map.
+    target : string
+        The node (rule name) in the influence map to start looking upstream for
+        marching sources.
+    sources : list of strings
+        The nodes (rules) corresponding to the subject or upstream influence
+        being checked.
+    polarity : int
+        Required polarity of the path between source and target.
+
+    Returns
+    -------
+    generator of (source, polarity, path_length)
+        Yields tuples of source node (string), polarity (int) and path length
+        (int). If there are no paths to any of the given source nodes, the
+        generator is empty.
+    """
+    # First, create a list of visited nodes
+    # Adapted from
+    # networkx.algorithms.traversal.breadth_first_search.bfs_edges
     visited = set([(target, 1)])
     # Generate list of predecessor nodes with a sign updated according to the
     # sign of the target node
@@ -268,24 +248,20 @@ def _find_sources(im, target, sources, polarity):
         try:
             # Get the next child in the list
             (child, sign) = next(children)
-            # The sign of the child should be updated according to the sign of
-            # the parent!
-            # Could do this in the expansion step itself, or here;
-            # If done during the expansion step, 
-            # Check this child against the visited list. If we haven't visited
-            # it, then we return the parent/child pair
+            # Is this child one of the source nodes we're looking for? If so,
+            # yield it along with path length
             if (sources is None or child in sources) and sign == polarity:
                 logger.info("Found path to %s from %s with desired sign %s "
                             "with length %d" %
                             (target, child, polarity, path_length))
                 yield (child, sign, path_length)
+            # Check this child against the visited list. If we haven't visited
+            # it already (accounting for the path to the node), then add it
+            # to the queue.
             if (child, sign) not in visited:
-                # TODO: Update this to include the path length, and perhaps to
-                # check for sources matching the list
                 visited.add((child, sign))
                 queue.append((child, _get_signed_predecessors(im, child, sign),
                               path_length + 1))
-                # Add in the new parent child pair after expanding out
         # Once we've finished iterating over the children of the current node,
         # pop the node off and go to the next one in the queue
         except StopIteration:
@@ -293,6 +269,141 @@ def _find_sources(im, target, sources, polarity):
             path_length += 1
     # There was no path; this will produce an empty generator
     return
+
+
+def _get_signed_predecessors(im, node, polarity):
+    """Get upstream nodes in the influence map
+
+    Return the upstream nodes along with the overall polarity of the path
+    to that node by account for the polarity of the path to the given node
+    and the polarity of the edge between the given node and its immediate
+    predecessors.
+
+    Parameters
+    ----------
+    im : pygraphviz.AGraph
+        Graph containing the influence map.
+    node : string
+        The node (rule name) in the influence map to get predecessors (upstream
+        nodes) for.
+    polarity : int
+        Polarity of the overall path to the given node.
+
+
+    Returns
+    -------
+    generator of tuples, (node, polarity)
+        Each tuple returned contains two elements, a node (string) and the
+        polarity of the overall path (int) to that node.
+    """
+    signed_pred_list = []
+    predecessors = im.predecessors_iter
+    for pred in predecessors(node):
+        pred_edge = im.get_edge(pred, node)
+        yield (pred, _get_edge_sign(pred_edge) * polarity)
+
+
+def _get_edge_sign(edge):
+    """Get the polarity of the influence by examining the edge color."""
+    if edge.attr.get('color') is None:
+        raise Exception('No color attribute for edge.')
+    elif edge.attr['color'] == 'green':
+        return 1
+    elif edge.attr['color'] == 'red':
+        return -1
+    else:
+        raise Exception('Unexpected edge color: %s' % edge.attr['color'])
+
+
+def _add_modification_to_agent(agent, mod_type, residue, position):
+    """Add a modification condition to an Agent."""
+    new_mod = ModCondition(mod_type, residue, position)
+    # Check if this modification already exists
+    for old_mod in agent.mods:
+        if old_mod.equals(new_mod):
+            return agent
+    new_agent = deepcopy(agent)
+    new_agent.mods.append(new_mod)
+    return new_agent
+
+
+def _match_lhs(cp, rules):
+    """Get rules with a left-hand side matching the given ComplexPattern."""
+    rule_matches = []
+    for rule in rules:
+        reactant_pattern = rule.rule_expression.reactant_pattern
+        for rule_cp in reactant_pattern.complex_patterns:
+            if _cp_embeds_into(rule_cp, cp):
+                rule_matches.append(rule)
+                break
+    return rule_matches
+
+
+def _cp_embeds_into(cp1, cp2):
+    """Check that any state in ComplexPattern2 is matched in ComplexPattern1.
+    """
+    # Check that any state in cp2 is matched in cp2
+    # If the thing we're matching to is just a monomer pattern, that makes
+    # things easier--we just need to find the corresponding monomer pattern
+    # in cp1
+    cp1 = as_complex_pattern(cp1)
+    cp2 = as_complex_pattern(cp2)
+    if len(cp2.monomer_patterns) == 1:
+        mp2 = cp2.monomer_patterns[0]
+        # Iterate over the monomer patterns in cp1 and see if there is one
+        # that has the same name
+        for mp1 in cp1.monomer_patterns:
+            if _mp_embeds_into(mp1, mp2):
+                return True
+    return False
+
+
+def _mp_embeds_into(mp1, mp2):
+    """Check that conditions in MonomerPattern2 are met in MonomerPattern1."""
+    sc_matches = []
+    if mp1.monomer.name != mp2.monomer.name:
+        return False
+    # Check that all conditions in mp2 are met in mp1
+    for site_name, site_state in mp2.site_conditions.items():
+        if site_name not in mp1.site_conditions or \
+           site_state != mp1.site_conditions[site_name]:
+            return False
+    return True
+
+
+"""
+# NOTE: This code is currently "deprecated" because it has been replaced by the
+# use of Observables for the Statement objects.
+
+def match_rhs(cp, rules):
+    rule_matches = []
+    for rule in rules:
+        product_pattern = rule.rule_expression.product_pattern
+        for rule_cp in product_pattern.complex_patterns:
+            if _cp_embeds_into(rule_cp, cp):
+                rule_matches.append(rule)
+                break
+    return rule_matches
+
+def find_production_rules(cp, rules):
+    # Find rules where the CP matches the left hand side
+    lhs_rule_set = set(_match_lhs(cp, rules))
+    # Now find rules where the CP matches the right hand side
+    rhs_rule_set = set(match_rhs(cp, rules))
+    # Production rules are rules where there is a match on the right hand
+    # side but not on the left hand side
+    prod_rules = list(rhs_rule_set.difference(lhs_rule_set))
+    return prod_rules
+
+def find_consumption_rules(cp, rules):
+    # Find rules where the CP matches the left hand side
+    lhs_rule_set = set(_match_lhs(cp, rules))
+    # Now find rules where the CP matches the right hand side
+    rhs_rule_set = set(match_rhs(cp, rules))
+    # Consumption rules are rules where there is a match on the left hand
+    # side but not on the right hand side
+    cons_rules = list(lhs_rule_set.difference(rhs_rule_set))
+    return cons_rules
 
 def positive_path(im, path):
     # This doesn't address the effect of the rules themselves on the
@@ -307,16 +418,6 @@ def positive_path(im, path):
     path_polarity = np.prod(edge_polarities)
     assert path_polarity == 1 or path_polarity == -1
     return True if path_polarity == 1 else False
-
-
-def _get_edge_sign(edge):
-    if edge.attr.get('color') is None:
-        raise Exception('No color attribute for edge.')
-    elif edge.attr['color'] == 'green':
-        return 1
-    elif edge.attr['color'] == 'red':
-        return -1
-    else:
-        raise Exception('Unexpected edge color: %s' % edge.attr['color'])
+"""
 
 

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -55,7 +55,16 @@ def match_lhs(cp, rules):
     for rule in rules:
         reactant_pattern = rule.rule_expression.reactant_pattern
         for rule_cp in reactant_pattern.complex_patterns:
-            if embeds_into(rule_cp, cp):
+            if cp_embeds_into(rule_cp, cp):
+                rule_matches.append(rule)
+    return rule_matches
+
+def match_rhs(cp, rules):
+    rule_matches = []
+    for rule in rules:
+        product_pattern = rule.rule_expression.product_pattern
+        for rule_cp in product_pattern.complex_patterns:
+            if cp_embeds_into(rule_cp, cp):
                 rule_matches.append(rule)
     return rule_matches
 

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -138,7 +138,12 @@ class ModelChecker(object):
                          Deubiquitination, Defarnesylation)
         target_polarity = -1 if type(stmt) in demodify_list else 1
         # Add modification to substrate agent
-        modified_sub = _add_modification_to_agent(stmt.sub, 'phosphorylation',
+        # TODO TODO TODO: Should be updated to get a valid mod condition name
+        mod_condition_name = stmt.__class__.__name__.lower()
+        if mod_condition_name.startswith('de'):
+            mod_condition_name = mod_condition_name[2:]
+        # TODO TODO TODO
+        modified_sub = _add_modification_to_agent(stmt.sub, mod_condition_name,
                                                   stmt.residue, stmt.position)
         obs_name = pa.get_agent_rule_str(modified_sub) + '_obs'
         obj_mps = list(pa.grounded_monomer_patterns(self.model, modified_sub))

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -91,6 +91,7 @@ class ModelChecker(object):
             # indicates that constraint is satisfied by a single rule
             for input_rule, target_rule_info in \
                             itertools.product(input_rules, target_rules):
+                # Break if we've found even a single path
                 if paths:
                     break
                 (target_rule, rule_polarity) = target_rule_info
@@ -100,12 +101,13 @@ class ModelChecker(object):
                                                        target_rule.name)
                     # Iterate over paths until we find one with positive
                     # polarity
-                    for path_ix, sp in enumerate(sp_gen):
-                        need_positive_path = False if unmodify_stmt else True
+                    need_positive_path = False if unmodify_stmt else True
+                    for sp in sp_gen:
                         if need_positive_path == \
                                 positive_path(self.get_im(), sp, rule_polarity):
-                            logger.info('Found non-repeating path %s: %s' %
-                                        (path_ix, str(sp)))
+                            logger.info('Found non-repeating path, '
+                                        'length %d: %s' %
+                                        (len(sp), str(sp)))
                             logger.info('Rule polarity of target: %s' %
                                         rule_polarity)
                             paths.append(sp)

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -1,13 +1,15 @@
-from pysb.core import as_complex_pattern
-from pysb import kappa
-from pysb import Observable
-from indra.statements import *
-from indra.assemblers import pysb_assembler as pa
-from copy import deepcopy
-import networkx
-import itertools
+from __future__ import print_function, unicode_literals, absolute_import
+from builtins import dict, str
 import logging
 import numpy as np
+import networkx
+import itertools
+from copy import deepcopy
+from pysb import kappa
+from pysb import Observable
+from pysb.core import as_complex_pattern
+from indra.statements import *
+from indra.assemblers import pysb_assembler as pa
 
 logger = logging.getLogger('model_checker')
 
@@ -65,8 +67,8 @@ class ModelChecker(object):
         target_cons_rules = find_consumption_rules(sub_mp, self.model.rules)
         # The final list contains a list of rules along with their "polarities"
         # (production = 1, consumption = -1)
-        target_rules = zip(target_prod_rules, [1]*len(target_prod_rules)) + \
-                       zip(target_cons_rules, [-1]*len(target_cons_rules))
+        target_rules = (list(zip(target_prod_rules, [1]*len(target_prod_rules)))
+                    + list(zip(target_cons_rules, [-1]*len(target_cons_rules))))
         logger.info('Found %s target rules matching %s' %
                     (len(target_rules), str(sub_mp)))
         if input_rules and target_rules:

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -125,7 +125,8 @@ class ModelChecker(object):
             return False
         for enz_mp, obj_mp in itertools.product(enz_mps, obj_mps):
             obj_obs = Observable(obs_name, obj_mp, _export=False)
-            if self._find_im_paths(enz_mp, obj_obs, target_polarity):
+            # If there's a path, return the first one
+            for path in self._find_im_paths(enz_mp, obj_obs, target_polarity):
                 return True
         # If we got here, then there was no path for any observable
         return False
@@ -149,10 +150,10 @@ class ModelChecker(object):
             # matching the enzyme, then there is no path
             if not input_rules:
                 return False
-        # Generate the predecessors to our observable
+        # Generate the predecessors to our observable and count the paths
+        # TODO: Make it optionally possible to return on the first path?
         num_paths = 0
-        for (source, polarity, path_length) in \
-                    _find_sources(self.get_im(), obj_obs.name, input_rule_set,
+        for path in _find_sources(self.get_im(), obj_obs.name, input_rule_set,
                                   target_polarity):
             num_paths += 1
         if num_paths > 0:
@@ -291,8 +292,8 @@ def _find_sources(im, target, sources, polarity):
         except StopIteration:
             queue.popleft()
             path_length += 1
-    return None
-
+    # There was no path; this will produce an empty generator
+    return
 
 def positive_path(im, path):
     # This doesn't address the effect of the rules themselves on the

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -100,7 +100,7 @@ class ModelChecker(object):
                              stmt.enz)
                 return False
         else:
-            enz_mps = []
+            enz_mps = [None]
         # Get target polarity
         demodify_list = (Dephosphorylation, Dehydroxylation, Desumoylation,
                          Deacetylation, Deglycosylation, Deribosylation,

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -138,7 +138,6 @@ class ModelChecker(object):
         if subj_mp is None:
             input_rule_set = None
         else:
-            import ipdb; ipdb.set_trace()
             input_rules = match_lhs(subj_mp, self.model.rules)
             input_rule_set = set([r.name for r in input_rules])
                                   #if r.name.startswith(stmt.enz.name)])

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -16,9 +16,12 @@ logger = logging.getLogger('model_checker')
 class ModelChecker(object):
     """Check a PySB model against a set of INDRA statements."""
 
-    def __init__(self, model, statements):
+    def __init__(self, model, stmts_to_check=None):
         self.model = model
-        self.statements = statements
+        if stmts_to_check:
+            self.statements = stmts_to_check
+        else:
+            self.statements = []
         self._im = None
 
     def get_im(self):
@@ -84,8 +87,12 @@ class ModelChecker(object):
         if input_rules and target_rules:
             # Generate the influence map
             paths = []
+            # Look for any rule that is both in the input and target set--
+            # indicates that constraint is satisfied by a single rule
             for input_rule, target_rule_info in \
                             itertools.product(input_rules, target_rules):
+                if paths:
+                    break
                 (target_rule, rule_polarity) = target_rule_info
                 try:
                     sp_gen = networkx.shortest_simple_paths(self.get_im(),

--- a/indra/tools/model_checker.py
+++ b/indra/tools/model_checker.py
@@ -56,7 +56,17 @@ class ModelChecker(object):
             unmodify_stmt = False
         modified_sub = _add_modification_to_agent(stmt.sub, 'phosphorylation',
                                                   stmt.residue, stmt.position)
-        sub_mp = pa.get_monomer_pattern(self.model, modified_sub)
+        # Check if the site and corresponding state exists in the
+        # model--if not, then it won't be observed. If we try to get a monomer
+        # pattern for a monomer that doesn't have the specified site, PySB
+        # throws a (generic) Exception; we catch this as an indication that
+        # the site doesn't exist, and hence the modification is not observed,
+        # and return False
+        try:
+            sub_mp = pa.get_monomer_pattern(self.model, modified_sub)
+        except Exception as e:
+            logger.info("Couldn't create monomer pattern: %s" % e)
+            return False
         # Generate the influence map
         # Find rules in the model corresponding to the inputs and outputs
         input_rules = match_lhs(enz_mp, self.model.rules)

--- a/models/ras_220_genes/build_ras_gene_network.py
+++ b/models/ras_220_genes/build_ras_gene_network.py
@@ -15,5 +15,5 @@ stmts = gn.get_statements(filter=True)
 grounded_stmts = grounding_filter(stmts)
 results = gn.run_preassembly(grounded_stmts)
 with open('ras_220_gn_stmts.pkl', 'wb') as f:
-    pickle.dump(results, f)
+    pickle.dump(results, f, protocol=2)
 

--- a/models/ras_220_genes/build_ras_gene_network.py
+++ b/models/ras_220_genes/build_ras_gene_network.py
@@ -1,5 +1,6 @@
 from indra.tools.gene_network import GeneNetwork, grounding_filter
 import csv
+import pickle
 
 # STEP 0: Get gene list
 gene_list = []
@@ -13,4 +14,6 @@ gn = GeneNetwork(gene_list, 'ras_genes')
 stmts = gn.get_statements(filter=True)
 grounded_stmts = grounding_filter(stmts)
 results = gn.run_preassembly(grounded_stmts)
+with open('ras_220_gn_stmts.pkl', 'wb') as f:
+    pickle.dump(results, f)
 


### PR DESCRIPTION
This pull request supports the ability to check statements about influences or mechanisms (in the form of INDRA statements) against executable models (in the form of PySB rule-based models). The functionality is implemented in a new tool, the ModelChecker (in indra/tools/model_checker.py) that uses the Kappa influence map to determine if there is a *possible* causal path linking a subject (e.g., an enzyme or perturbation) to a downstream object or target. Due to the non-transitivity of causality in the influence map (due to unmentioned context that doesn't carry over from the output of one rule to the input of another) the existence of a path does not guarantee that the model satisfies the statement. However, the failure of the model to satisfy the statement definitively indicates that the model cannot reproduce the statement if it were to be simulated. This therefore because a way to diagnose gaps and limitations in the scope of the model.

In the current implementation, the model checker returns only a boolean response indicating whether a statement is or is not satisfied; it doesn't return the path itself. For efficiency purposes, the breadth-first search algorithm (implemented in ModelChecker._find_sources) keeps track of path polarities and lengths but not the exact paths. This could be updated in the future.

Mapping the elements of the statement against the model requires that the model be annotated with grounding information. This is implemented via the "global" list of Annotations associated with the model, as well as Monomer-specific annotations added (monkeypatched) into the monomer field the site_annotations field, which consists of a list of Annotation objects. Site annotations currently used include the following:

* Site states representing modifications: ```Annotation(('T185', 'p'), 'phosphorylation', 'is_modification')```
* Residues: ```Annotation('T185', 'T', 'is_residue')```
* Residue positions: ```Annotation('T185', '185', 'is_position')```

The grounded_monomer_pattern method in the pysb_assembler is used to return a monomer pattern matching the elements of a statement while taking grounding and site annotations into account. Because there may be more than one monomer pattern associated with a "generic" state of an Agent, this function is a generator, returning matching monomer patterns with each call.

This pull request also adds support for all Modification types in the PySB assembler by creating generic modification assembly functions; and adds several new Modification types related to lipid modifications of proteins.