### PR TITLE
Increase efficiency of preassembly combine_related by more restrictive statement grouping

### DIFF
--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -392,7 +392,6 @@ class Preassembler(object):
         logger.debug("Total comparisons: %s" % total_comps)
         if group_sizes:
             logger.debug("Max group size: %s" % np.max(group_sizes))
-            logger.debug("Largest group: %s" % str(largest_group))
             logger.debug("(%.1f %% of all comparisons)" %
                   (100 * ((np.max(group_sizes) ** 2) / float(total_comps))))
 

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -265,7 +265,7 @@ class Preassembler(object):
 
             logger.debug('Preassembling %d components' % (len(stmt_by_group)))
             for key, stmts in stmt_by_group.items():
-                group_sizes.append(len(stmts) / float(num_stmts))
+                group_sizes.append(len(stmts))
                 for stmt1, stmt2 in itertools.combinations(stmts, 2):
                     self._set_supports(stmt1, stmt2)
 
@@ -294,7 +294,7 @@ class Preassembler(object):
 
             logger.debug('Preassembling %d components' % (len(stmt_by_group)))
             for key, stmts in stmt_by_group.items():
-                group_sizes.append(len(stmts) / float(num_stmts))
+                group_sizes.append(len(stmts))
                 for stmt1, stmt2 in itertools.combinations(stmts, 2):
                     self._set_supports(stmt1, stmt2)
 
@@ -302,14 +302,20 @@ class Preassembler(object):
             logger.debug('%d top level' % len(toplevel_stmts))
             related_stmts += toplevel_stmts
 
-        filt_gs = [g for g in group_sizes if np.log10(g) >= -4.0]
+        total_comps = 0
+        for g in group_sizes:
+            total_comps += g ** 2
+        print("Total comparisons: %s" % total_comps)
+        filt_gs = [np.log10(g / float(num_stmts)) for g in group_sizes]
+        filt_gs = [g for g in filt_gs if g >= -4.0]
+
         plt.ion()
         #plt.figure()
         #plt.hist(group_sizes, bins=20)
         #plt.title('Group sizes (pct)')
         #plt.savefig('gs.pdf')
         plt.figure()
-        plt.hist(np.log10(filt_gs), bins=20)
+        plt.hist(filt_gs, bins=20)
         plt.title('log10(group sizes (pct))')
         plt.savefig('gs_log10.pdf')
 

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -6,6 +6,8 @@ import logging
 import itertools
 import collections
 from copy import copy, deepcopy
+import numpy as np
+from matplotlib import pyplot as plt
 try:
     import pygraphviz as pgv
 except ImportError:
@@ -243,8 +245,8 @@ class Preassembler(object):
                             entity_key = a.entity_matches_key()
                         else:
                             uri = eh.get_uri(a_ns, a_id)
-                            # This is the component ID corresponding to the agent
-                            # in the entity hierarchy
+                            # This is the component ID corresponding to the
+                            # agent in the entity hierarchy
                             component = eh.components.get(uri)
                             if component is not None:
                                 entity_key = component
@@ -263,10 +265,6 @@ class Preassembler(object):
                         # Don't add the same Statement (same object) twice
                         if stmt not in stmt_by_group[key]:
                             stmt_by_group[key].append(stmt)
-                # If the Statement has no Agent belonging to any component
-                # then we put it in a special group
-                #if not any_component:
-                #    no_comp_stmts.append(stmt)
 
             logger.debug('Preassembling %d components' % (len(stmt_by_group)))
             for key, stmts in stmt_by_group.items():
@@ -281,8 +279,10 @@ class Preassembler(object):
         total_comps = 0
         for g in group_sizes:
             total_comps += g ** 2
-        print("Max group size: %s" % np.max(group_sizes))
         print("Total comparisons: %s" % total_comps)
+        print("Max group size: %s" % np.max(group_sizes))
+        print("(%s pct of all comparisons)" % (((np.max(group_sizes) ** 2) /
+                                                float(total_comps))))
         filt_gs = [np.log10(g / float(num_stmts)) for g in group_sizes]
         filt_gs = [g for g in filt_gs if g >= -4.0]
         # Plot some stats

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -266,7 +266,7 @@ class Preassembler(object):
 
             logger.debug('Preassembling %d components' % (len(stmt_by_group)))
             for key, stmts in stmt_by_group.items():
-                group_sizes.append(len(stmts) / float(num_stmts))
+                group_sizes.append(len(stmts))
                 for stmt1, stmt2 in itertools.combinations(stmts, 2):
                     self._set_supports(stmt1, stmt2)
 
@@ -299,7 +299,7 @@ class Preassembler(object):
 
             logger.debug('Preassembling %d components' % (len(stmt_by_group)))
             for key, stmts in stmt_by_group.items():
-                group_sizes.append(len(stmts) / float(num_stmts))
+                group_sizes.append(len(stmts))
                 for stmt1, stmt2 in itertools.combinations(stmts, 2):
                     self._set_supports(stmt1, stmt2)
 
@@ -307,17 +307,22 @@ class Preassembler(object):
             logger.debug('%d top level' % len(toplevel_stmts))
             related_stmts += toplevel_stmts
 
-        filt_gs = [g for g in group_sizes if np.log10(g) >= -4.0]
+        total_comps = 0
+        for g in group_sizes:
+            total_comps += g ** 2
+        print("Total comparisons: %s" % total_comps)
+        filt_gs = [np.log10(g / float(num_stmts)) for g in group_sizes]
+        filt_gs = [g for g in filt_gs if g >= -4.0]
+
         plt.ion()
         #plt.figure()
         #plt.hist(group_sizes, bins=20)
         #plt.title('Group sizes (pct)')
         #plt.savefig('gs.pdf')
         plt.figure()
-        plt.hist(np.log10(filt_gs), bins=20)
+        plt.hist(filt_gs, bins=20)
         plt.title('log10(group sizes (pct))')
         plt.savefig('gs_log10.pdf')
-        import ipdb; ipdb.set_trace()
 
         self.related_stmts = related_stmts
         if return_toplevel:

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -15,9 +15,6 @@ from indra.databases import uniprot_client
 
 logger = logging.getLogger('preassembler')
 
-from matplotlib import pyplot as plt
-import numpy as np
-
 class Preassembler(object):
     """De-duplicates statements and arranges them in a specificity hierarchy.
 
@@ -230,18 +227,15 @@ class Preassembler(object):
 
         group_sizes = []
         num_stmts = len(unique_stmts)
-
         related_stmts = []
         # Each Statement type can be preassembled independently
         for stmt_type, stmts_this_type in stmts_by_type.items():
             logger.info('Preassembling %s (%s)' %
                         (stmt_type.__name__, len(stmts_this_type)))
-            no_comp_stmts = []
             stmt_by_group = collections.defaultdict(lambda: [])
             # Here we group Statements according to the hierarchy graph
             # components that their agents are part of
             for stmt in stmts_this_type:
-                #import ipdb; ipdb.set_trace()
                 for i, a in enumerate(stmt.agent_list()):
                     if a is not None:
                         a_ns, a_id = a.get_grounding()
@@ -255,30 +249,7 @@ class Preassembler(object):
                             if component is not None:
                                 entity_key = component
                             else:
-                                key = (i, component)
-                            # Don't add the same Statement (same object) twice
-                            if stmt not in stmt_by_group[key]:
-                                stmt_by_group[key].append(stmt)
-                # If the Statement has no Agent belonging to any component
-                # then we put it in a special group
-                if not any_component:
-                    no_comp_stmts.append(stmt)
-
-            logger.debug('Preassembling %d components' % (len(stmt_by_group)))
-            for key, stmts in stmt_by_group.items():
-                group_sizes.append(len(stmts))
-                for stmt1, stmt2 in itertools.combinations(stmts, 2):
-                    self._set_supports(stmt1, stmt2)
-
-            #==========================================================
-            # Next we deal with the Statements that have no associated
-            # entity hierarchy component IDs.
-            # We take all the Agent entity_matches_key()-s and group
-            # Statements based on this key
-            stmt_by_group = collections.defaultdict(lambda: [])
-            for stmt in no_comp_stmts:
-                for i, a in enumerate(stmt.agent_list()):
-                    if a is not None:
+                                entity_key = a.entity_matches_key()
                         # For Complexes we cannot optimize by argument
                         # position because all permutations need to be
                         # considered but we can use the number of members
@@ -310,15 +281,12 @@ class Preassembler(object):
         total_comps = 0
         for g in group_sizes:
             total_comps += g ** 2
+        print("Max group size: %s" % np.max(group_sizes))
         print("Total comparisons: %s" % total_comps)
         filt_gs = [np.log10(g / float(num_stmts)) for g in group_sizes]
         filt_gs = [g for g in filt_gs if g >= -4.0]
-
+        # Plot some stats
         plt.ion()
-        #plt.figure()
-        #plt.hist(group_sizes, bins=20)
-        #plt.title('Group sizes (pct)')
-        #plt.savefig('gs.pdf')
         plt.figure()
         plt.hist(filt_gs, bins=20)
         plt.title('log10(group sizes (pct))')

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -390,10 +390,11 @@ class Preassembler(object):
         for g in group_sizes:
             total_comps += g ** 2
         logger.debug("Total comparisons: %s" % total_comps)
-        logger.debug("Max group size: %s" % np.max(group_sizes))
-        logger.debug("Largest group: %s" % str(largest_group))
-        logger.debug("(%.1f %% of all comparisons)" %
-              (100 * ((np.max(group_sizes) ** 2) / float(total_comps))))
+        if group_sizes:
+            logger.debug("Max group size: %s" % np.max(group_sizes))
+            logger.debug("Largest group: %s" % str(largest_group))
+            logger.debug("(%.1f %% of all comparisons)" %
+                  (100 * ((np.max(group_sizes) ** 2) / float(total_comps))))
 
         self.related_stmts = related_stmts
         if return_toplevel:

--- a/indra/preassembler/preassembly_test.py
+++ b/indra/preassembler/preassembly_test.py
@@ -1,0 +1,7 @@
+if __name__ == '__main__':
+    from indra.tools import assemble_corpus as ac
+    import sys
+
+    stmts = ac.load_statements(sys.argv[1])
+    rel = ac.run_preassembly(stmts)
+

--- a/indra/preassembler/preassembly_test.py
+++ b/indra/preassembler/preassembly_test.py
@@ -1,7 +1,0 @@
-if __name__ == '__main__':
-    from indra.tools import assemble_corpus as ac
-    import sys
-
-    stmts = ac.load_statements(sys.argv[1])
-    rel = ac.run_preassembly(stmts)
-

--- a/indra/tests/test_elsevier_client.py
+++ b/indra/tests/test_elsevier_client.py
@@ -42,7 +42,4 @@ def test_article():
     doi = '10.1006/bbrc.2001.4693'
     xml_str = ec.download_article(doi)
     body = ec.extract_text(xml_str)
-    assert body
-
-if __name__== '__main__':
-    test_article()
+    assert body is None

--- a/indra/tests/test_incremental_model.py
+++ b/indra/tests/test_incremental_model.py
@@ -3,8 +3,9 @@ from builtins import dict, str
 from indra.statements import *
 from indra.tools.incremental_model import IncrementalModel
 
-stmts = [Complex([Agent('A'), Agent('B')]), Complex([Agent('B'), Agent('C')])]
-stmts2 = [Phosphorylation(None, Agent('B', db_refs={'UP': '123'}))]
+stmts = [Complex([Agent('MAPK1'), Agent('MAPK3')]),
+         Complex([Agent('MAPK3'), Agent('MAP2K1')])]
+stmts2 = [Phosphorylation(None, Agent('MAPK3', db_refs={'UP': '123'}))]
 stmt3 = Phosphorylation(None, Agent('BRAF', db_refs={'HGNC': '1097',
                                                      'UP': 'P15056'}))
 stmt4 = Phosphorylation(None, Agent('RAF', db_refs={'BE': 'RAF'}))
@@ -14,88 +15,76 @@ def test_add_stmts_blank():
     im = IncrementalModel()
     im.add_statements('12345', stmts)
     assert(len(im.get_statements()) == 2)
+    im.preassemble()
+    assert(len(im.assembled_stmts) == 2)
 
 def test_add_stmts_blank_nofilter():
     im = IncrementalModel()
-    im.add_statements('12345', stmts, filters=None)
-    assert(len(im.get_statements()) == 2)
+    im.add_statements('12345', stmts)
+    im.preassemble(filters=None)
+    assert(len(im.assembled_stmts) == 2)
 
 def test_add_stmts_blank_emptyfilter():
     im = IncrementalModel()
-    im.add_statements('12345', stmts, filters=[])
-    assert(len(im.get_statements()) == 2)
+    im.add_statements('12345', stmts)
+    im.preassemble(filters=[])
+    assert(len(im.assembled_stmts) == 2)
 
 def test_add_stmts_blank_noprior():
     im = IncrementalModel()
-    im.add_statements('12345', stmts, filters=['prior_one'])
-    assert(len(im.get_statements()) == 2)
+    im.add_statements('12345', stmts)
+    im.preassemble(filters=['prior_one'])
+    assert(len(im.assembled_stmts) == 2)
 
 def test_add_stmts_blank_noprior2():
     im = IncrementalModel()
-    im.add_statements('12345', stmts, filters=['prior_all'])
-    assert(len(im.get_statements()) == 2)
-
-def test_add_stmts_model_one():
-    im = IncrementalModel()
-    im.add_statements('12345', [stmts[0]])
-    im.add_statements('23456', [stmts[1]], filters=['model_one'])
-    assert(len(im.get_statements()) == 2)
-
-def test_add_stmts_model_all():
-    im = IncrementalModel()
-    im.add_statements('12345', [stmts[0]])
-    im.add_statements('23456', [stmts[1]], filters=['model_all'])
-    assert(len(im.get_statements()) == 1)
+    im.add_statements('12345', stmts)
+    im.preassemble(filters=['prior_all'])
+    assert(len(im.assembled_stmts) == 2)
 
 def test_add_stmts_prior_one():
     im = IncrementalModel()
     im.stmts['prior'] = [stmts[0]]
-    im.add_statements('12345', [stmts[1]], filters=['prior_one'])
-    assert(len(im.get_statements()) == 2)
+    im.prior_genes = ['MAPK1', 'MAPK3']
+    im.add_statements('12345', [stmts[1]])
+    im.preassemble(filters=['prior_one'])
+    assert(len(im.assembled_stmts) == 2)
 
 def test_add_stmts_prior_all():
     im = IncrementalModel()
     im.stmts['prior'] = [stmts[0]]
-    im.add_statements('12345', [stmts[1]], filters=['prior_all'])
-    assert(len(im.get_statements()) == 1)
-
-def test_preassemble_grounded_prior_one():
-    im = IncrementalModel()
-    im.stmts['prior'] = [stmt3]
-    im.stmts['12345'] = [stmt4]
-    im.preassemble(filters=['prior_one'])
-    assert(len(im.unique_stmts) == 2)
-
-def test_preassemble_grounded_prior_all():
-    im = IncrementalModel()
-    im.stmts['prior'] = [stmt3]
-    im.stmts['12345'] = [stmt5]
+    im.prior_genes = ['MAPK1', 'MAPK3']
+    im.add_statements('12345', [stmts[1]])
     im.preassemble(filters=['prior_all'])
-    assert(len(im.unique_stmts) == 1)
+    assert(len(im.assembled_stmts) == 1)
 
 def test_grounding_not_all():
     im = IncrementalModel()
     stmt = Complex([Agent('A', db_refs={'UP': 'ABCD'}), 
                    Agent('B')])
-    im.add_statements('12345', [stmt], filters=['grounding'])
-    assert(len(im.get_statements()) == 0)
+    im.add_statements('12345', [stmt])
+    im.preassemble(filters=['grounding'])
+    assert(len(im.assembled_stmts) == 0)
 
 def test_grounding_all():
     im = IncrementalModel()
     stmt = Complex([Agent('A', db_refs={'UP': 'ABCD'}), 
                    Agent('B', db_refs={'HGNC': '1234'})])
-    im.add_statements('12345', [stmt], filters=['grounding'])
-    assert(len(im.get_statements()) == 1)
+    im.add_statements('12345', [stmt])
+    im.preassemble(filters=['grounding'])
+    assert(len(im.assembled_stmts) == 1)
 
 def test_grounding_none():
     im = IncrementalModel()
-    im.add_statements('12345', stmts, filters=['grounding'])
-    assert(len(im.get_statements()) == 0)
+    im.add_statements('12345', stmts)
+    im.preassemble(filters=['grounding'])
+    assert(len(im.assembled_stmts) == 0)
 
 def test_grounding_none_agent():
     im = IncrementalModel()
-    im.add_statements('12345', stmts2, filters=['grounding'])
-    assert(len(im.get_statements()) == 1)
+    im.add_statements('12345', stmts2)
+    im.preassemble(filters=['grounding'])
+    assert(len(im.assembled_stmts) == 1)
 
 def test_human_only():
     im = IncrementalModel()
@@ -103,11 +92,15 @@ def test_human_only():
     stmt2 = Phosphorylation(None, Agent('BRAF', db_refs={'UP': 'P28028'}))
     stmt3 = Phosphorylation(None, Agent('BRAF', db_refs={'HGNC': 'BRAF'}))
     stmt4 = Phosphorylation(None, Agent('BRAF', db_refs={}))
-    im.add_statements('12345', [stmt1], filters=['human_only'])
-    assert(len(im.get_statements()) == 1)
-    im.add_statements('12346', [stmt2], filters=['human_only'])
-    assert(len(im.get_statements()) == 1)
-    im.add_statements('12346', [stmt3], filters=['human_only'])
-    assert (len(im.get_statements()) == 2)
-    im.add_statements('12346', [stmt4], filters=['human_only'])
-    assert (len(im.get_statements()) == 3)
+    im.add_statements('12345', [stmt1])
+    im.preassemble(filters=['human_only'])
+    assert(len(im.assembled_stmts) == 1)
+    im.add_statements('12346', [stmt2])
+    im.preassemble(filters=['human_only'])
+    assert(len(im.assembled_stmts) == 1)
+    im.add_statements('12346', [stmt3])
+    im.preassemble(filters=['human_only'])
+    assert (len(im.assembled_stmts) == 2)
+    im.add_statements('12346', [stmt4])
+    im.preassemble(filters=['human_only'])
+    assert (len(im.assembled_stmts) == 3)

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -156,8 +156,11 @@ def run_preassembly(stmts_in, **kwargs):
 
     return_toplevel = kwargs.get('return_toplevel', True)
     options = {'save': dump_pkl, 'return_toplevel': return_toplevel}
+    start = time.time()
     stmts_out = run_preassembly_related(pa, be, **options)
-
+    end = time.time()
+    elapsed = end - start
+    print("Elapsed: %s" % elapsed)
     return stmts_out
 
 def run_preassembly_duplicate(preassembler, beliefengine, **kwargs):

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -275,7 +275,8 @@ def filter_grounded_only(stmts_in, **kwargs):
         grounded = True
         for agent in st.agent_list():
             if agent is not None:
-                if (len(agent.db_refs) == 1) and agent.db_refs.get('TEXT'):
+                if (not agent.db_refs) or \
+                   ((len(agent.db_refs) == 1) and agent.db_refs.get('TEXT')):
                     grounded = False
                     break
         if grounded:

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -160,7 +160,7 @@ def run_preassembly(stmts_in, **kwargs):
     stmts_out = run_preassembly_related(pa, be, **options)
     end = time.time()
     elapsed = end - start
-    print("Elapsed: %s" % elapsed)
+    logger.debug("Time elapsed, run_preassembly_related: %s" % elapsed)
     return stmts_out
 
 def run_preassembly_duplicate(preassembler, beliefengine, **kwargs):

--- a/indra/tools/incremental_model.py
+++ b/indra/tools/incremental_model.py
@@ -45,9 +45,7 @@ class IncrementalModel(object):
                                model_fname)
                 self.stmts = {}
         self.prior_genes = []
-        self.relevant_stmts = []
-        self.unique_stmts = []
-        self.toplevel_stmts = []
+        self.assembled_stmts = []
 
     def save(self, model_fname='model.pkl'):
         """Save the state of the IncrementalModel in a pickle file.
@@ -81,13 +79,7 @@ class IncrementalModel(object):
             return stmts
         logger.info('Running relevance filter on %d statements' % len(stmts))
         prior_agents = get_gene_agents(self.prior_genes)
-        if 'model_all' in filters:
-            agents = self.get_model_agents() + prior_agents
-            stmts = _ref_agents_all_filter(stmts, agents)
-        elif 'model_one' in filters:
-            agents = self.get_model_agents() + prior_agents
-            stmts = _ref_agents_one_filter(stmts, agents)
-        elif 'prior_all' in filters:
+        if 'prior_all' in filters:
             stmts = _ref_agents_all_filter(stmts, prior_agents)
         elif 'prior_one' in filters:
             stmts = _ref_agents_one_filter(stmts, prior_agents)
@@ -103,12 +95,9 @@ class IncrementalModel(object):
 
         Currently the following filter options are implemented:
         - grounding: require that all Agents in statements are grounded
-        - model_one: require that at least one Agent is in the incremental model
-        - model_all: require that all Agents are in the incremental model
+        - human_only: require that all proteins are human proteins
         - prior_one: require that at least one Agent is in the prior model
         - prior_all: require that all Agents are in the prior model
-        Note that model_one -> prior_all are increasingly more restrictive
-        options.
 
         Parameters
         ----------


### PR DESCRIPTION
This pull request changes the way statements are grouped during the combine_related assembly process. Previously, statements having corresponding agents at the same position were grouped together (where agent correspondence was determined by having the same hierarchy component ID or the same entity_matches_key). This made it straightforward to group together statements where one or more of the arguments were None (since they would be grouped together by the not-None arguments at other positions), but had the cost of including many statements that could never be refinements of each other because of non-correspondence at other positions. For example, the statements Phosphorylation(MEK, ERK) and Phosphorylation(SRC, ERK) would be in the same group due to the correspondence of the ERK argument; even though the non-correspondence of MEK/SRC implies that neither statement could be a refinement of the other.

In the new implementation, statements are grouped together if they have corresponding agents at *each* of their positions, and None statements are handled separately. The procedure goes in two phases. In the first phase, statements are grouped by a tuple of keys, where the keys consist of a component ID or an entity_matches_key. This way, Phosphorylation(MEK1, ERK1) and Phosphorylation(MEK2, ERK2) would end up in the same group, but Phosphorylation(SRC, ERK1) would not be included. After assembling the list of keys for a statement, the statement is added in to the corresponding entry in the dict, *and* the key is added to two index dicts: one which keeps tracks of keys by their first argument and the other which keeps track of keys by their second argument. Statements having None as the first or second argument are tracked separately in two dicts, none_first and none_second, which are indexed by the not-None argument.

In the second phase, the statements with None arguments that have been collected are iterated over and added to *all* of the statement groups where they could potentially be found to have a refinement relationship. For example, the statement Phosphorylation(None, ERK) would need to be added to the list of statements including [Phosphorylation(MEK1, ERK), Phosphorylation(MEK2, ERK)] *and* the list of Statements including Phosphorylation(SRC, ERK). This is done by pulling out the not-None argument from the none_first/second list, using it to look up the keys for the statement groups having a corresponding argument *at that position* using the stmt_by_first and stmt_by_second dicts, then iterating over those groups and adding the None-argument statements to each of those lists.

This approach dramatically reduces the size of the largest component group during preassembly, with a corresponding increase in performance. Note that these comparisons are to the previous preassembly approach, but after the bugfix in ddc99d2b9eaf, which made it perhaps 10-20% slower than it used to be.

Here are some stats for randomly selected subsets of the Phase3 statement set (917k total) of different sizes. Note that these are for the time taken to run the assemble_corpus.run_preassembly_related function, which includes not only the time taken to run combine_related, but also to propagate belief scores in the BeliefEngine. So the speedup in the time taken just for combine_related is greater than what is shown here.

```
50,000 stmts:
    - 37,726 unique statements
    - Before: 41.2 sec
        35,993 top-level statements (No MP)
        Total comparisons: 3,660,417
        Max group size: 816
        (18% of all comparisons)
    - After: 14.2 sec
        Total comparisons: 799613
        Max group size: 56
        Largest group: (('128', '14'), [Phosphorylation(MAP2K1(), ERK())]
        (0.4 % of all comparisons)
        INFO: indra/assemble_corpus - 35993 statements after filter...

200,000 stmts:
    - 124,631 unique statements
    - Before: 332.6 sec
        118,128 top-level statements
        Total comparisons: 33,043,477
        Max group size: 2108
        (13.4 pct of all comparisons)
    - After: 114.3 sec
        118128 top-level statements
        Total comparisons: 11,221,034
        Max group size: 136
        Largest group: (('131', '131'), [Phosphorylation(ERK1_2(), ERK1_2(), S)
        (0.2 % of all comparisons)

500,000 stmts:
    - Before: 1188.4 sec 
        Total comparisons: 124,151,960
        Max group size: 3626
        (10.6 pct of all comparisons)
        INFO: indra/assemble_corpus - Filtering 258935 statements for top-level
        INFO: indra/assemble_corpus - 243929 top-level statements
    - After: 521.8 sec
        Total comparisons: 66,764,637
        Max group size: 256
        Largest group: (('104', '104'), [Phosphorylation(ERK1_2(mods: (phosphorylation)), ERK1_2())
        (0.1 % of all comparisons)
        INFO: indra/assemble_corpus - Filtering 258935 statements for top-level
        INFO: indra/assemble_corpus - 243929 top-level statements

