### PR TITLE
Sort keys when dumping JSON

### DIFF
--- a/indra/assemblers/cyjs_assembler.py
+++ b/indra/assemblers/cyjs_assembler.py
@@ -275,7 +275,7 @@ class CyJSAssembler(object):
         model_dict = {'exp_colorscale': self._exp_colorscale,
                       'mut_colorscale': self._mut_colorscale,
                       'model_elements': cyjs_dict}
-        cyjs_str = json.dumps(model_dict, indent=1)
+        cyjs_str = json.dumps(model_dict, indent=1, sort_keys=True)
         return cyjs_str
 
     def save_json(self, fname='model.json'):
@@ -291,7 +291,7 @@ class CyJSAssembler(object):
         model_dict = {'exp_colorscale': self._exp_colorscale,
                       'mut_colorscale': self._mut_colorscale,
                       'model_elements': cyjs_dict}
-        json_str = json.dumps(model_dict, indent=1)
+        json_str = json.dumps(model_dict, indent=1, sort_keys=True)
         with open(fname, 'wt') as fh:
             fh.write(json_str)
 


### PR DESCRIPTION
Previously some members of families would be expanded and end up not in
alphabetical order. This places all json output in alphabetical order, making
visualization in the cyjs canvas more intuitive, as pie slices are now also arranged alphabetically.