### PR TITLE
Orthology and isoform mapping for site mappering, paper 2 sitemapper figs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_install:
   - sudo add-apt-repository --yes ppa:webupd8team/java
   - sudo apt-get update
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh --nv;
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh -nv;
     else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh --nv;
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh -nv;
     fi
   - chmod +x miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
@@ -31,9 +31,9 @@ install:
   - export JAVA_HOME="/usr/lib/jvm/java-8-oracle/"
   - pip install pygraphviz jsonschema coverage python-coveralls boto3 pandas
   - pip install doctest-ignore-unicode
-  - wget http://sorger.med.harvard.edu/data/bachman/Phosphorylation_site_dataset.tsv --directory-prefix=indra/resources/ --nv
+  - wget http://sorger.med.harvard.edu/data/bachman/Phosphorylation_site_dataset.tsv --directory-prefix=indra/resources/ -nv
   # PySB and dependencies
-  - wget "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable_Linux.tar.gz" -O bionetgen.tar.gz --nv
+  - wget "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable_Linux.tar.gz" -O bionetgen.tar.gz -nv
   - tar xzf bionetgen.tar.gz
   - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
   - pip install git+https://github.com/pysb/pysb.git
@@ -57,10 +57,10 @@ install:
   - git submodule update --remote
   - pip install .
   - cd indra/benchmarks/assembly_eval/batch4
-  - wget http://sorger.med.harvard.edu/data/bachman/trips_reach_batch4.gz --nv
+  - wget http://sorger.med.harvard.edu/data/bachman/trips_reach_batch4.gz -nv
   - tar -xf trips_reach_batch4.gz
   - cd $TRAVIS_BUILD_DIR
-  - wget http://sorger.med.harvard.edu/data/bachman/reach-gordo-1.3.3-SNAPSHOT.jar --nv
+  - wget http://sorger.med.harvard.edu/data/bachman/reach-gordo-1.3.3-SNAPSHOT.jar -nv
 script:
   - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR
   - export CLASSPATH=$TRAVIS_BUILD_DIR/reach-gordo-1.3.3-SNAPSHOT.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_install:
   - sudo add-apt-repository --yes ppa:webupd8team/java
   - sudo apt-get update
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh --nv;
     else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh --nv;
     fi
   - chmod +x miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
@@ -31,9 +31,9 @@ install:
   - export JAVA_HOME="/usr/lib/jvm/java-8-oracle/"
   - pip install pygraphviz jsonschema coverage python-coveralls boto3 pandas
   - pip install doctest-ignore-unicode
-  - wget http://sorger.med.harvard.edu/data/bachman/Phosphorylation_site_dataset.tsv --directory-prefix=indra/resources/
+  - wget http://sorger.med.harvard.edu/data/bachman/Phosphorylation_site_dataset.tsv --directory-prefix=indra/resources/ --nv
   # PySB and dependencies
-  - wget "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable_Linux.tar.gz" -O bionetgen.tar.gz
+  - wget "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable_Linux.tar.gz" -O bionetgen.tar.gz --nv
   - tar xzf bionetgen.tar.gz
   - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
   - pip install git+https://github.com/pysb/pysb.git
@@ -57,10 +57,10 @@ install:
   - git submodule update --remote
   - pip install .
   - cd indra/benchmarks/assembly_eval/batch4
-  - wget http://sorger.med.harvard.edu/data/bachman/trips_reach_batch4.gz
+  - wget http://sorger.med.harvard.edu/data/bachman/trips_reach_batch4.gz --nv
   - tar -xf trips_reach_batch4.gz
   - cd $TRAVIS_BUILD_DIR
-  - wget http://sorger.med.harvard.edu/data/bachman/reach-gordo-1.3.3-SNAPSHOT.jar
+  - wget http://sorger.med.harvard.edu/data/bachman/reach-gordo-1.3.3-SNAPSHOT.jar --nv
 script:
   - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR
   - export CLASSPATH=$TRAVIS_BUILD_DIR/reach-gordo-1.3.3-SNAPSHOT.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
   - export JAVA_HOME="/usr/lib/jvm/java-8-oracle/"
   - pip install pygraphviz jsonschema coverage python-coveralls boto3 pandas
   - pip install doctest-ignore-unicode
+  - wget http://sorger.med.harvard.edu/data/bachman/Phosphorylation_site_dataset.tsv --directory-prefix=indra/resources/
   # PySB and dependencies
   - wget "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable_Linux.tar.gz" -O bionetgen.tar.gz
   - tar xzf bionetgen.tar.gz

--- a/indra/databases/phosphosite_client.py
+++ b/indra/databases/phosphosite_client.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import, print_function, unicode_literals
+from builtins import dict, str
+from os.path import dirname, abspath, join
+from collections import namedtuple, defaultdict
+from indra.util import read_unicode_csv
+
+PhosphoSite = namedtuple('PhosphoSite',
+                         ['GENE', 'PROTEIN', 'ACC_ID', 'HU_CHR_LOC', 'MOD_RSD',
+                          'SITE_GRP_ID', 'ORGANISM', 'MW_kD', 'DOMAIN',
+                          'SITE_7_AA', 'LT_LIT', 'MS_LIT', 'MS_CST', 'CST_CAT'])
+
+_data_by_up = None
+_data_by_site_grp = None
+
+def _read_phospho_site_dataset():
+    global _data_by_up
+    global _data_by_site_grp
+    if _data_by_up is None or _data_by_site_grp is None:
+        phosphosite_data_file = join(dirname(abspath(__file__)),
+                                 '../resources/Phosphorylation_site_dataset.tsv')
+        reader = read_unicode_csv(phosphosite_data_file, delimiter='\t',
+                                  skiprows=4)
+        # Build up a dict by protein
+        data_by_up = {}
+        data_by_site_grp = defaultdict(list)
+        for row in reader:
+            site = PhosphoSite(*row)
+            data_by_up[site.PROTEIN] = site
+            data_by_site_grp[site.SITE_GRP_ID].append(site)
+        _data_by_up = data_by_up
+        _data_by_site_grp = data_by_site_grp
+    return (_data_by_up, _data_by_site_grp)
+
+if __name__ == '__main__':
+    (data_by_up, data_by_site_grp) = _read_phospho_site_dataset()
+
+

--- a/indra/databases/phosphosite_client.py
+++ b/indra/databases/phosphosite_client.py
@@ -42,6 +42,8 @@ def map_to_human_site(up_id, mod_res, mod_pos):
     if sites_for_up is None:
         return None
     site_info = sites_for_up.get('%s%s' % (mod_res, mod_pos))
+    if not site_info:
+        return None
     # Lookup site group
     site_grp_list = data_by_site_grp.get(site_info.SITE_GRP_ID)
     # If an empty list, then return None (is unlikely to happen)
@@ -56,8 +58,9 @@ def map_to_human_site(up_id, mod_res, mod_pos):
                     (up_id, site_info.SITE_GRP_ID))
     human_site = human_sites[0].MOD_RSD.split('-')[0]
     human_res = human_site[0]
+    assert human_res == mod_res
     human_pos = human_site[1:]
-    return (human_res, human_pos)
+    return human_pos
 
 if __name__ == '__main__':
     (data_by_up, data_by_site_grp) = _read_phospho_site_dataset()

--- a/indra/databases/phosphosite_client.py
+++ b/indra/databases/phosphosite_client.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
+import logging
 from os.path import dirname, abspath, join
 from collections import namedtuple, defaultdict
 from indra.util import read_unicode_csv
+
+logger = logging.getLogger('phosphosite')
 
 PhosphoSite = namedtuple('PhosphoSite',
                          ['GENE', 'PROTEIN', 'ACC_ID', 'HU_CHR_LOC', 'MOD_RSD',
@@ -17,19 +20,44 @@ def _read_phospho_site_dataset():
     global _data_by_site_grp
     if _data_by_up is None or _data_by_site_grp is None:
         phosphosite_data_file = join(dirname(abspath(__file__)),
-                                 '../resources/Phosphorylation_site_dataset.tsv')
+                                '../resources/Phosphorylation_site_dataset.tsv')
         reader = read_unicode_csv(phosphosite_data_file, delimiter='\t',
                                   skiprows=4)
         # Build up a dict by protein
-        data_by_up = {}
+        data_by_up = defaultdict(dict)
         data_by_site_grp = defaultdict(list)
         for row in reader:
             site = PhosphoSite(*row)
-            data_by_up[site.PROTEIN] = site
+            res_pos = site.MOD_RSD.split('-')[0]
+            data_by_up[site.ACC_ID][res_pos] = site
             data_by_site_grp[site.SITE_GRP_ID].append(site)
         _data_by_up = data_by_up
         _data_by_site_grp = data_by_site_grp
     return (_data_by_up, _data_by_site_grp)
+
+def map_to_human_site(up_id, mod_res, mod_pos):
+    (data_by_up, data_by_site_grp) = _read_phospho_site_dataset()
+    sites_for_up = data_by_up.get(up_id)
+    # No info in Phosphosite for this Uniprot ID
+    if sites_for_up is None:
+        return None
+    site_info = sites_for_up.get('%s%s' % (mod_res, mod_pos))
+    # Lookup site group
+    site_grp_list = data_by_site_grp.get(site_info.SITE_GRP_ID)
+    # If an empty list, then return None (is unlikely to happen)
+    if not site_grp_list:
+        return None
+    # Check for a human protein in the list
+    human_sites = [s for s in site_grp_list if s.ORGANISM == 'human']
+    if not human_sites:
+        return None
+    if len(human_sites) > 1:
+        logger.info("More than one human site found for %s, site group %s" %
+                    (up_id, site_info.SITE_GRP_ID))
+    human_site = human_sites[0].MOD_RSD.split('-')[0]
+    human_res = human_site[0]
+    human_pos = human_site[1:]
+    return (human_res, human_pos)
 
 if __name__ == '__main__':
     (data_by_up, data_by_site_grp) = _read_phospho_site_dataset()

--- a/indra/databases/phosphosite_client.py
+++ b/indra/databases/phosphosite_client.py
@@ -30,7 +30,7 @@ def has_data():
     global _has_data
     if _has_data is None:
         try:
-            _read_phospho_site_dataset()
+            _get_phospho_site_dataset()
             # If we succeeded without exception, then we set _has_data to True
             _has_data = True
         except Exception as e:

--- a/indra/databases/phosphosite_client.py
+++ b/indra/databases/phosphosite_client.py
@@ -15,12 +15,23 @@ PhosphoSite = namedtuple('PhosphoSite',
 _data_by_up = None
 _data_by_site_grp = None
 
+phosphosite_data_file = join(dirname(abspath(__file__)),
+                             '../resources/Phosphorylation_site_dataset.tsv')
+
+
 def _read_phospho_site_dataset():
+    """Read phosphosite data into dicts keyed by Uniprot ID and by site group.
+
+    Returns
+    -------
+    tuple
+        The first element of the tuple contains the PhosphoSite data keyed
+        by Uniprot ID, the second element contains data keyed by site group.
+        Both dicts have instances of the PhosphoSite namedtuple as values.
+    """
     global _data_by_up
     global _data_by_site_grp
     if _data_by_up is None or _data_by_site_grp is None:
-        phosphosite_data_file = join(dirname(abspath(__file__)),
-                                '../resources/Phosphorylation_site_dataset.tsv')
         reader = read_unicode_csv(phosphosite_data_file, delimiter='\t',
                                   skiprows=4)
         # Build up a dict by protein
@@ -36,7 +47,25 @@ def _read_phospho_site_dataset():
         _data_by_site_grp = data_by_site_grp
     return (_data_by_up, _data_by_site_grp)
 
+
 def map_to_human_site(up_id, mod_res, mod_pos):
+    """Find site on human ref seq corresponding to (possibly non-human) site.
+
+    Parameters
+    ----------
+    up_id : str
+        Uniprot ID of the modified protein (generally human, rat, or mouse).
+    mod_res : str
+        Modified amino acid residue.
+    mod_pos : str
+        Amino acid sequence position.
+
+    Returns
+    -------
+    str
+        Returns amino acid position on the human reference sequence
+        corresponding to the site on the given protein.
+    """
     (data_by_up, data_by_site_grp) = _read_phospho_site_dataset()
     sites_for_up = data_by_up.get(up_id)
     # No info in Phosphosite for this Uniprot ID
@@ -73,7 +102,7 @@ def map_to_human_site(up_id, mod_res, mod_pos):
                          (site_info.ACC_ID, site_info.SITE_GRP_ID))
         else:
             site_info = ref_site_info
-    # Lookup site group
+    # Look up site group
     site_grp_list = data_by_site_grp.get(site_info.SITE_GRP_ID)
     # If an empty list, then return None (is unlikely to happen)
     if not site_grp_list:
@@ -107,8 +136,4 @@ def map_to_human_site(up_id, mod_res, mod_pos):
     assert human_res == mod_res
     human_pos = human_site_str[1:]
     return human_pos
-
-if __name__ == '__main__':
-    (data_by_up, data_by_site_grp) = _read_phospho_site_dataset()
-
 

--- a/indra/databases/phosphosite_client.py
+++ b/indra/databases/phosphosite_client.py
@@ -53,13 +53,23 @@ def map_to_human_site(up_id, mod_res, mod_pos):
     human_sites = [s for s in site_grp_list if s.ORGANISM == 'human']
     if not human_sites:
         return None
+    # If there are multiple isoforms, choose the base one
+    # (no hyphen in the accession ID)
     if len(human_sites) > 1:
-        logger.info("More than one human site found for %s, site group %s" %
-                    (up_id, site_info.SITE_GRP_ID))
-    human_site = human_sites[0].MOD_RSD.split('-')[0]
-    human_res = human_site[0]
+        # We assume that multiple human sites only arise from multiple isoforms
+        # of the same protein, which will share an accession ID, and that
+        # only one of these will be the reference sequence (with no hyphen)
+        base_id_sites = [site for site in human_sites
+                         if site.ACC_ID.find('-') == -1]
+        assert len(base_id_sites) == 1
+        human_site = base_id_sites[0]
+    # If there is only one human site, take it
+    else:
+        human_site = human_sites[0]
+    human_site_str = human_site.MOD_RSD.split('-')[0]
+    human_res = human_site_str[0]
     assert human_res == mod_res
-    human_pos = human_site[1:]
+    human_pos = human_site_str[1:]
     return human_pos
 
 if __name__ == '__main__':

--- a/indra/databases/phosphosite_client.py
+++ b/indra/databases/phosphosite_client.py
@@ -18,6 +18,7 @@ _has_data = None
 
 phosphosite_data_file = join(dirname(abspath(__file__)),
                              '../resources/Phosphorylation_site_dataset.tsv')
+
 def has_data():
     """Check if the PhosphoSite data is available and can be loaded.
 

--- a/indra/databases/phosphosite_client.py
+++ b/indra/databases/phosphosite_client.py
@@ -64,11 +64,11 @@ def map_to_human_site(up_id, mod_res, mod_pos):
             logger.debug('\tSite info: acc_id %s, site_grp_id %s' %
                         (si.ACC_ID, si.SITE_GRP_ID))
             if si.ACC_ID == up_id:
-                logger.debug('\tFound entry matching reference acc id')
+                logger.info('\tFound entry matching reference acc id')
                 ref_site_info = si
-        if ref_site_info is not None:
+        if ref_site_info is None:
             site_info = site_info_list[0]
-            logger.debug('Reference sequence match not found, choosing first '
+            logger.info('Reference sequence match not found, choosing first '
                          'entry, acc_id %s site_grp %s' %
                          (site_info.ACC_ID, site_info.SITE_GRP_ID))
         else:
@@ -90,8 +90,15 @@ def map_to_human_site(up_id, mod_res, mod_pos):
         # only one of these will be the reference sequence (with no hyphen)
         base_id_sites = [site for site in human_sites
                          if site.ACC_ID.find('-') == -1]
-        assert len(base_id_sites) == 1, 'Should only be one human ref seq'
-        human_site = base_id_sites[0]
+        if base_id_sites:
+            assert len(base_id_sites) == 1, 'Should only be one human ref seq'
+            human_site = base_id_sites[0]
+        # There is no base ID site, i.e., all mapped sites are for specific
+        # isoforms only, so skip it!
+        else:
+            logger.info('Human isoform matches, but no human ref seq match '
+                        'for %s %s %s; not mapping' % (up_id, mod_res, mod_pos))
+            return None
     # If there is only one human site, take it
     else:
         human_site = human_sites[0]

--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -87,7 +87,7 @@ class SiteMapper(object):
     >>> (valid, mapped) = default_mapper.map_sites([stmt])
     >>> valid
     []
-    >>> mapped
+    >>> mapped  # doctest:+IGNORE_UNICODE
     [
     MappedStatement:
         original_stmt: Phosphorylation(MAP2K1(mods: (phosphorylation, S, 217), (phosphorylation, S, 221)), MAPK1(), T, 183)

--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -100,6 +100,7 @@ class SiteMapper(object):
     def __init__(self, site_map):
         self.site_map = site_map
         self._cache = {}
+        self._sitecount = {}
 
     def map_sites(self, stmts, save_fname=None, do_methionine_offset=False,
                   do_orthology_mapping=False, do_isoform_mapping=False):
@@ -296,6 +297,8 @@ class SiteMapper(object):
             if old_mod.position is None or old_mod.residue is None:
                 continue
             site_key = (agent.name, old_mod.residue, old_mod.position)
+            # Increase our count for this site
+            self._sitecount[site_key] = self._sitecount.get(site_key, 0) + 1
             # First, check the cache to potentially avoid a costly sequence
             # lookup
             cached_site = self._cache.get(site_key)
@@ -349,7 +352,6 @@ class SiteMapper(object):
                 human_pos = phosphosite_client.map_to_human_site(
                               up_rat, old_mod.residue, old_mod.position)
                 if human_pos:
-                    logger.info("Rat site valid!!!")
                     mapped_site = (old_mod.residue, human_pos,
                                    'INFERRED_RAT_SITE')
                     self._cache[site_key] = mapped_site

--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -102,8 +102,8 @@ class SiteMapper(object):
         self._cache = {}
         self._sitecount = {}
 
-    def map_sites(self, stmts, save_fname=None, do_methionine_offset=False,
-                  do_orthology_mapping=False, do_isoform_mapping=False):
+    def map_sites(self, stmts, do_methionine_offset=True,
+                  do_orthology_mapping=True, do_isoform_mapping=True):
         """Check a set of statements for invalid modification sites.
 
         Statements are checked against Uniprot reference sequences to determine
@@ -123,10 +123,21 @@ class SiteMapper(object):
             The statements to check for site errors.
         do_methionine_offset : boolean
             Whether to check for off-by-one errors in site position (possibly)
-            attributable to site numbering based on mature proteins after
+            attributable to site numbering from mature proteins after
             cleavage of the initial methionine. If True, checks the reference
-            sequence for the given residue at 1 site position greater;
-            if the residue is valid at this position, creates the mapping.
+            sequence for a known modification at 1 site position greater
+            than the given one; if there exists such a site, creates the
+            mapping. Default is True.
+        do_orthology_mapping : boolean
+            Whether to check sequence positions for known modification sites
+            in mouse or rat sequences (based on PhosphoSitePlus data). If a
+            mouse/rat site is found that is linked to a site in the human
+            reference sequence, a mapping is created. Default is True.
+        do_isoform_mapping : boolean
+            Whether to check sequence positions for known modifications
+            in other human isoforms of the protein (based on PhosphoSitePlus
+            data). If a site is found that is linked to a site in the human
+            reference sequence, a mapping is created. Default is True.
 
         Returns
         -------
@@ -205,9 +216,9 @@ class SiteMapper(object):
 
         return (valid_statements, mapped_statements)
 
-    def _map_agent_sites(self, agent, do_methionine_offset=False,
-                         do_orthology_mapping=False,
-                         do_isoform_mapping=False):
+    def _map_agent_sites(self, agent, do_methionine_offset=True,
+                         do_orthology_mapping=True,
+                         do_isoform_mapping=True):
         """Check an agent for invalid sites and update if necessary.
 
         Parameters
@@ -216,10 +227,21 @@ class SiteMapper(object):
             Agent to check for invalid modification sites.
         do_methionine_offset : boolean
             Whether to check for off-by-one errors in site position (possibly)
-            attributable to site numbering based on mature proteins after
+            attributable to site numbering from mature proteins after
             cleavage of the initial methionine. If True, checks the reference
-            sequence for the given residue at 1 site position greater;
-            if the residue is valid at this position, creates the mapping.
+            sequence for a known modification at 1 site position greater
+            than the given one; if there exists such a site, creates the
+            mapping. Default is True.
+        do_orthology_mapping : boolean
+            Whether to check sequence positions for known modification sites
+            in mouse or rat sequences (based on PhosphoSitePlus data). If a
+            mouse/rat site is found that is linked to a site in the human
+            reference sequence, a mapping is created. Default is True.
+        do_isoform_mapping : boolean
+            Whether to check sequence positions for known modifications
+            in other human isoforms of the protein (based on PhosphoSitePlus
+            data). If a site is found that is linked to a site in the human
+            reference sequence, a mapping is created. Default is True.
 
         Returns
         -------
@@ -254,9 +276,9 @@ class SiteMapper(object):
         new_agent.mods = new_mod_list
         return (invalid_sites, new_agent)
 
-    def _check_agent_mod(self, agent, mods, do_methionine_offset=False,
-                         do_orthology_mapping=False,
-                         do_isoform_mapping=False):
+    def _check_agent_mod(self, agent, mods, do_methionine_offset=True,
+                         do_orthology_mapping=True,
+                         do_isoform_mapping=True):
         """Check an agent for invalid sites and look for mappings.
 
         Look up each modification site on the agent in Uniprot and then the
@@ -272,8 +294,19 @@ class SiteMapper(object):
             Whether to check for off-by-one errors in site position (possibly)
             attributable to site numbering from mature proteins after
             cleavage of the initial methionine. If True, checks the reference
-            sequence for the given residue at 1 site position greater;
-            if the residue is valid at this position, creates the mapping.
+            sequence for a known modification at 1 site position greater
+            than the given one; if there exists such a site, creates the
+            mapping. Default is True.
+        do_orthology_mapping : boolean
+            Whether to check sequence positions for known modification sites
+            in mouse or rat sequences (based on PhosphoSitePlus data). If a
+            mouse/rat site is found that is linked to a site in the human
+            reference sequence, a mapping is created. Default is True.
+        do_isoform_mapping : boolean
+            Whether to check sequence positions for known modifications
+            in other human isoforms of the protein (based on PhosphoSitePlus
+            data). If a site is found that is linked to a site in the human
+            reference sequence, a mapping is created. Default is True.
 
         Returns
         -------

--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -87,8 +87,15 @@ class SiteMapper(object):
     >>> (valid, mapped) = default_mapper.map_sites([stmt])
     >>> valid
     []
-    >>> mapped # doctest:+ELLIPSIS
-    [<indra.preassembler.sitemapper.MappedStatement object at ...
+    >>> mapped
+    [
+    MappedStatement:
+        original_stmt: Phosphorylation(MAP2K1(mods: (phosphorylation, S, 217), (phosphorylation, S, 221)), MAPK1(), T, 183)
+        mapped_mods: (('MAP2K1', 'S', '217'), ('S', '218', 'off by one'))
+                     (('MAP2K1', 'S', '221'), ('S', '222', 'off by one'))
+                     (('MAPK1', 'T', '183'), ('T', '185', 'off by two; mouse sequence'))
+        mapped_stmt: Phosphorylation(MAP2K1(mods: (phosphorylation, S, 218), (phosphorylation, S, 222)), MAPK1(), T, 185)
+    ]
     >>> ms = mapped[0]
     >>> ms.original_stmt
     Phosphorylation(MAP2K1(mods: (phosphorylation, S, 217), (phosphorylation, S, 221)), MAPK1(), T, 183)

--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -276,14 +276,12 @@ class SiteMapper(object):
                 continue
             # First check for methionine offset
             if do_methionine_offset:
-                logger.info('Checking off by one error: %s' % str(site_key))
                 offset_pos = str(int(old_mod.position) + 1)
                 site_valid_plus_one = uniprot_client.verify_location(
                                         up_id, old_mod.residue, offset_pos)
                 # If it's valid at the offset position, create the mapping
                 # and continue
                 if site_valid_plus_one:
-                    logger.info('Found off by one: %s' % str(site_key))
                     mapped_site = (old_mod.residue, offset_pos,
                                    'INFERRED_METHIONINE_CLEAVAGE')
                     invalid_sites.append((site_key, mapped_site))

--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -288,8 +288,8 @@ class SiteMapper(object):
         up_id = _get_uniprot_id(agent)
         # If the uniprot entry is not found, let it pass
         if not up_id:
-            logger.info("No uniprot ID for %s" % agent.name)
-            return [] # empty list
+            logger.debug("No uniprot ID for %s" % agent.name)
+            return [] # Same effect as valid sites
         # Look up all of the modifications in uniprot, and add them to the list
         # of invalid sites if they are missing
         for old_mod in mods:
@@ -321,7 +321,7 @@ class SiteMapper(object):
             up_id = agent.db_refs.get('UP')
             hgnc_id = agent.db_refs.get('HGNC')
             if not hgnc_id:
-                logger.info("No HGNC ID for %s, only curated sites will be "
+                logger.debug("No HGNC ID for %s, only curated sites will be "
                             "mapped" % agent.name)
             # First, look for other entries in phosphosite for this protein
             # where this sequence position is legit (i.e., other isoforms)

--- a/indra/resources/curated_site_map.csv
+++ b/indra/resources/curated_site_map.csv
@@ -27,7 +27,6 @@ RPS6KA6,S,221,S,232,numbering from RPS6KA1
 RPS6KA6,S,363,S,372,numbering from RPS6KA1
 RPS6KA6,S,380,S,389,numbering from RPS6KA1
 RPS6KA6,T,573,T,581,numbering from RPS6KA1
-RPS6KB1,T,389,,,numbering from isoform alpha 2
 SDC2,Y,180,Y,179,off by one
 SHC1,Y,194,Y,349,numbering from isoform p46
 SHC1,Y,195,Y,350,numbering from isoform p46
@@ -103,3 +102,37 @@ PTPN11,Y,542,Y,546,off by 4
 PTPN11,Y,580,Y,584,off by 4
 ULK1,S,757,S,758,numbering from mouse sequence
 KSR1,S,392,S,406,numbering from mouse sequence
+JAK2,E,47,,,E47 confused with alias for gene TCF3
+JAK2,Y,485,,,Wrong gene; binding site for JAK2 on EPOR
+JAK2,Y,468,,,Wrong gene; binding site for JAK2 on EPOR
+JAK2,Y,504,,,Wrong gene; binding site for JAK2 on EPOR
+JAK2,Y,489,,,Wrong gene; binding site for JAK2 on EPOR
+JAK2,Y,426,,,Wrong gene; binding site for JAK2 on EPOR
+JAK2,Y,456,,,Wrong gene; binding site for JAK2 on EPOR
+JAK2,Y,454,,,Wrong gene; binding site for JAK2 on EPOR
+JAK2,Y,368,,,Wrong gene; binding site for JAK2 on EPOR
+RPS6KB1,T,389,T,412,numbering from isoform alpha 2
+RPS6KB1,S,424,S,447,numbering from isoform alpha 2
+RPS6KB1,S,371,S,394,numbering from isoform alpha 2
+RPS6KB1,T,421,T,444,numbering from isoform alpha 2
+RPS6KB1,T,229,T,252,numbering from isoform alpha 2
+RPS6KB1,E,4,,,incorrect
+RPS6KB1,S,473,,,probable reading error: AKT S473
+RPS6KB1,S,389,T,412,numbering from isoform alpha 2; wrong residue
+RPS6KB1,S,65,,,incorrect
+RPS6KB1,S,411,S,434,numbering from isoform alpha 2
+RPS6KB1,A,549,,,probable reading error: cell line A549
+RPS6KB1,S,2448,,,probable reading error: site on MTOR
+RPS6KB1,H,358,,,incorrect
+RPS6KB1,S,757,,,incorrect
+RPS6KB1,G,1,,,probable reading error: cell cycle
+RPS6KB1,S,308,,,probable reading error: AKT T308
+RPS6KB1,S,6,,,probable reading error: gene name S6
+RPS6KB1,T,424,S,447,probable wrong residue; numbering from isoform alpha 2
+RPS6KB1,T,308,,,probable reading error: AKT T308
+RB1,D,1,,,probable reading error: cyclin D1
+RB1,G,1,,,probable reading error: cell cycle G1
+RB1,Y,79,,,probable reading error: cell line Y79
+RB1,G,0,,,probable reading error: cell cycle G0
+RB1,T,160,,,probable reading error: site T160 on CDK2
+RB1,S,81,,,incorrect

--- a/indra/resources/curated_site_map.csv
+++ b/indra/resources/curated_site_map.csv
@@ -46,8 +46,16 @@ AR,S,578,S,579,off by 1
 AR,Y,534,Y,535,off by 1
 AR,S,210,S,215,numbering from deprecated sequence GenBank A39248
 AR,S,791,S,792,off by 1
+AR,S,81,S,83,off by 2
+AR,S,308,S,310,off by 2
+AR,K,630,K,631,off by 1
+AR,Y,267,Y,269,off by 2
+AR,Y,363,Y,365,off by 2
 BAD,S,112,S,75,numbering from mouse sequence
 BAD,S,136,S,99,numbering from mouse sequence
+BAD,S,155,S,118,numbering from mouse sequence
+BAD,T,201,,,site present in mouse but not in human sequence (corresponds to human A165)
+BAD,S,119,S,118,numbering from bovine sequence
 BLK,Y,388,Y,389,off by 1
 BRAF,S,445,S,446,off by 1
 CAV1,Y,13,Y,14,off by 1
@@ -58,6 +66,12 @@ EGFR,Y,1173,Y,1197,numbering after 24-residue signaling peptide removed
 EGFR,T,654,T,678,numbering after 24-residue signaling peptide removed
 EGFR,Y,845,Y,869,numbering after 24-residue signaling peptide removed
 EGFR,Y,1086,Y,1110,numbering after 24-residue signaling peptide removed
+EGFR,Y,1068,Y,1092,numbering after 24-residue signaling peptide removed
+EGFR,S,1046,S,1070,numbering after 24-residue signaling peptide removed
+EGFR,S,1047,S,1071,numbering after 24-residue signaling peptide removed
+EGFR,Y,1101,Y,1125,numbering after 24-residue signaling peptide removed
+EGFR,T,669,T,693,numbering after 24-residue signaling peptide removed
+EGFR,R,1175,R,1199,numbering after 24-residue signaling peptide removed
 EIF4EBP1,S,11,S,12,off by 1 (methionine removed)
 FOXO4,S,142,S,197,numbering from isoform zeta
 FOXO4,S,207,S,262,numbering from isoform zeta
@@ -82,3 +96,10 @@ SHC1,Y,240,Y,350,numbering from isoform p52
 SRC,Y,416,Y,419,off by 3
 SRC,Y,418,Y,418,off by 1
 SRC,Y,215,Y,216,off by 1
+PRKCD,Y,311,Y,313,off by 2
+BCL2L11,S,65,S,69,numbering from mouse sequence
+SRC,Y,527,Y,530,numbering from chicken sequence
+PTPN11,Y,542,Y,546,off by 4
+PTPN11,Y,580,Y,584,off by 4
+ULK1,S,757,S,758,numbering from mouse sequence
+KSR1,S,392,S,406,numbering from mouse sequence

--- a/indra/resources/curated_site_map.csv
+++ b/indra/resources/curated_site_map.csv
@@ -4,10 +4,10 @@ BRAF,T,151,S,151,wrong residue
 BRAF,S,578,S,579,wrong residue
 BRAF,S,753,T,753,wrong residue
 GAB1,Y,527,Y,627,off by 100
-KSR1,T,260,,,mouse sequence
-KSR1,S,320,,,mouse sequence
+KSR1,T,260,T,274,mouse sequence
+KSR1,S,320,S,334,mouse sequence
 KSR1,S,404,S,406,off by two
-KSR1,S,443,,,mouse sequence
+KSR1,S,443,S,458,mouse sequence
 MAP2K1,S,217,S,218,off by one
 MAP2K1,S,221,S,222,off by one
 MAPK1,T,182,T,185,off by three
@@ -136,3 +136,8 @@ RB1,Y,79,,,probable reading error: cell line Y79
 RB1,G,0,,,probable reading error: cell cycle G0
 RB1,T,160,,,probable reading error: site T160 on CDK2
 RB1,S,81,,,incorrect
+TP53,S,389,S,392,numbering from off-by-one mouse sequence
+RPS6,T,389,,,probable reading error: site on RPS6KB1
+RPS6,S,473,,,probable reading error: AKT S473
+RPS6,T,412,,,probable reading error: site on RPS6KB1
+RPS6,S,2448,,,probable reading error: site on MTOR

--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -130,11 +130,14 @@ def test_filter_source():
     assert(len(st_out) == 1)
     st_out = ac.filter_evidence_source([st1, st2, st3], ['reach'], 'all')
     assert (len(st_out) == 2)
-    st_out = ac.filter_evidence_source([st1, st2, st3], ['bel', 'biopax'], 'one')
+    st_out = ac.filter_evidence_source([st1, st2, st3], ['bel', 'biopax'],
+                                       'one')
     assert (len(st_out) == 2)
-    st_out = ac.filter_evidence_source([st1, st2, st3], ['bel', 'biopax'], 'all')
+    st_out = ac.filter_evidence_source([st1, st2, st3], ['bel', 'biopax'],
+                                       'all')
     assert (len(st_out) == 1)
-    st_out = ac.filter_evidence_source([st1, st2, st3], ['bel', 'biopax'], 'none')
+    st_out = ac.filter_evidence_source([st1, st2, st3], ['bel', 'biopax'],
+                                       'none')
     assert (len(st_out) == 1)
 
 def test_map_grounding():

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -1048,12 +1048,9 @@ def test_model_check_data():
     paths = results[0][1].paths
     scored_paths = mc.score_paths(paths, data)
     assert scored_paths[0][0] == p1
-    assert scored_paths[0][1] == 0
     assert scored_paths[1][0] == p2
-    # of each rule in the path against neighboring observables
-    # Take agents along with values
-    # Need also to be able to map agents to observables
-    # To constrain against data, need to be able to link agents in data
+    assert scored_paths[0][1] > scored_paths[1][1]
+
 
 def test_prune_influence_map():
     kin = Agent('Kin', db_refs={'HGNC': '1'})
@@ -1132,8 +1129,6 @@ def test_prune_influence_map():
 # Does this mean that we need a PySB ComplexPattern -> Agent mapping, that
 # we can subsequently use for refinements?
 
-# Why is
-
 # Need to handle complex statements. Would show that one_step approach
 # would not satisfy constraint, but two-step approach could, where the
 # Complex information was specified.
@@ -1168,6 +1163,3 @@ def test_prune_influence_map():
 # When Ras machine finds a new finding, it can be checked to see if it's
 # satisfied by the model.
 
-
-if __name__ == '__main__':
-    test_distinguish_path_polarity1()

--- a/indra/tests/test_phosphosite_client.py
+++ b/indra/tests/test_phosphosite_client.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import, print_function, unicode_literals
+from builtins import dict, str
+from indra.databases.phosphosite_client import map_to_human_site
+
+def test_map_mouse_to_human():
+    mouse_up_id = 'Q61337'
+    (res, pos) = map_to_human_site(mouse_up_id, 'S', '112')
+    assert res == 'S'
+    assert pos == '75'
+
+if __name__ == '__main__':
+    test_map_mouse_to_human()

--- a/indra/tests/test_phosphosite_client.py
+++ b/indra/tests/test_phosphosite_client.py
@@ -4,9 +4,18 @@ from indra.databases.phosphosite_client import map_to_human_site
 
 def test_map_mouse_to_human():
     mouse_up_id = 'Q61337'
-    (res, pos) = map_to_human_site(mouse_up_id, 'S', '112')
-    assert res == 'S'
+    pos = map_to_human_site(mouse_up_id, 'S', '112')
     assert pos == '75'
 
+def test_isoform_mapping_from_human():
+    up_id = 'P29353'
+    pos = map_to_human_site(up_id, 'Y', '239')
+    assert pos == '349'
+
+def test_isoform_mapping_from_mouse():
+    up_id = 'P29353'
+    pos = map_to_human_site(up_id, 'Y', '239')
+    assert pos == '349'
+
 if __name__ == '__main__':
-    test_map_mouse_to_human()
+    test_isoform_mapping_from_human()

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -112,6 +112,12 @@ def map_sequence(stmts_in, **kwargs):
     ----------
     stmts_in : list[indra.statements.Statement]
         A list of statements to map.
+    do_methionine_offset : boolean
+        Whether to check for off-by-one errors in site position (possibly)
+        attributable to site numbering based on mature proteins after
+        cleavage of the initial methionine. If True, checks the reference
+        sequence for the given residue at 1 site position greater;
+        if the residue is valid at this position, creates the mapping.
     save : Optional[str]
         The name of a pickle file to save the results (stmts_out) into.
 
@@ -121,8 +127,12 @@ def map_sequence(stmts_in, **kwargs):
         A list of mapped statements.
     """
     logger.info('Mapping sites on %d statements...' % len(stmts_in))
+    do_methionine_offset = kwargs.get('do_methionine_offset')
+    if do_methionine_offset is None:
+        do_methionine_offset = False
     sm = SiteMapper(default_site_map)
-    valid, mapped = sm.map_sites(stmts_in)
+    valid, mapped = sm.map_sites(stmts_in,
+                                 do_methionine_offset=do_methionine_offset)
     correctly_mapped_stmts = []
     for ms in mapped:
         if all([True if mm[1] is not None else False

--- a/indra/util/__init__.py
+++ b/indra/util/__init__.py
@@ -57,7 +57,7 @@ def decode_obj(obj, encoding='utf-8'):
 
 def read_unicode_csv(filename, delimiter=',', quotechar='"',
                      quoting=csv.QUOTE_MINIMAL, lineterminator='\n',
-                     encoding='utf-8'):
+                     encoding='utf-8', skiprows=0):
     # Python 3 version
     if sys.version_info[0] >= 3:
         # Open the file in text mode with given encoding
@@ -67,6 +67,9 @@ def read_unicode_csv(filename, delimiter=',', quotechar='"',
             csv_reader = csv.reader(f, delimiter=delimiter, quotechar=quotechar,
                                  quoting=quoting, lineterminator=lineterminator)
             # Now, return the (already decoded) unicode csv_reader generator
+            # Skip rows if necessary
+            for skip_ix in range(skiprows):
+                next(csv_reader)
             for row in csv_reader:
                 yield row
     # Python 2 version
@@ -79,6 +82,9 @@ def read_unicode_csv(filename, delimiter=',', quotechar='"',
                                  quotechar=quotechar.encode(encoding),
                                  quoting=quoting, lineterminator=lineterminator)
             # Iterate over the file and decode each string into unicode
+            # Skip rows if necessary
+            for skip_ix in range(skiprows):
+                next(csv_reader)
             for row in csv_reader:
                 yield [cell.decode(encoding) for cell in row]
 

--- a/models/paper2/get_pc_sites.py
+++ b/models/paper2/get_pc_sites.py
@@ -1,0 +1,45 @@
+import pickle
+from indra.statements import Agent, ModCondition
+from indra.biopax import processor as bpc
+from indra.biopax import pathway_commons_client as pcc
+
+owl_pattern = '/home/bmg16/data/pathwaycommons/PathwayCommons9.%s.BIOPAX.owl'
+dbs = ['psp', 'pid', 'reactome', 'kegg', 'panther']
+
+for db in dbs:
+    owl_file = owl_pattern % db
+    print('Reading %s...' % owl_file)
+    model = pcc.owl_to_model(owl_file)
+    mf_class = bpc._bpimpl('ModificationFeature')
+
+    objs = model.getObjects().toArray()
+
+    agents = []
+    for obj in objs:
+        if not isinstance(obj, mf_class):
+            continue
+        try:
+            res = bpc.BiopaxProcessor._extract_mod_from_feature(obj)
+        except Exception as e:
+            print('ERROR: ' + str(e))
+            continue
+        if not res:
+            continue
+        mod_type, residue, position = res
+        if not residue or not position:
+            continue
+        er  = obj.getEntityFeatureOf()
+        if not er:
+            continue
+        pe = er.getEntityReferenceOf().toArray()
+        if not pe:
+            continue
+        protein = pe[0]
+        name = bpc.BiopaxProcessor._get_element_name(protein)
+        db_refs = bpc.BiopaxProcessor._get_db_refs(protein)
+        agent = Agent(name, mods=[ModCondition(mod_type, residue, position)],
+                      db_refs=db_refs)
+        agents.append(agent)
+
+    with open('pc_%s_modified_agents.pkl' % db, 'wb') as fh:
+        pickle.dump(agents, fh)

--- a/models/paper2/get_pc_sites.py
+++ b/models/paper2/get_pc_sites.py
@@ -35,12 +35,19 @@ for db in dbs:
         if not proteins:
             continue
         for protein in proteins:
+            name = bpc.BiopaxProcessor._get_element_name(protein)
+            db_refs = bpc.BiopaxProcessor._get_db_refs(protein)
+            agent = Agent(name, mods=[mc], db_refs=db_refs)
             reactions = protein.getParticipantOf().toArray()
+            if not reactions:
+                upstream = protein.getMemberPhysicalEntityOf().toArray()
+                for u in upstream:
+                    reactions += u.getParticipantOf().toArray()
             for reaction in reactions:
-                for contr in reaction.getControlledOf().toArray():
-                    name = bpc.BiopaxProcessor._get_element_name(protein)
-                    db_refs = bpc.BiopaxProcessor._get_db_refs(protein)
-                    agent = Agent(name, mods=[mc], db_refs=db_refs)
+                controls = reaction.getControlledOf().toArray()
+                if not controls:
+                    agents.append(agent)
+                for contr in controls:
                     agents.append(agent)
 
     with open('pc_%s_modified_agents.pkl' % db, 'wb') as fh:

--- a/models/paper2/get_pc_sites.py
+++ b/models/paper2/get_pc_sites.py
@@ -4,7 +4,12 @@ from indra.biopax import processor as bpc
 from indra.biopax import pathway_commons_client as pcc
 
 owl_pattern = '/home/bmg16/data/pathwaycommons/PathwayCommons9.%s.BIOPAX.owl'
-dbs = ['psp', 'pid', 'reactome', 'kegg', 'panther']
+dbs = ['psp', 'pid', 'reactome', 'kegg', 'panther', 'hprd', 'ctd']
+
+def get_proteins(mod_feature):
+    # Assume it's a physical entity feature
+    pe = obj.getFeatureOf().toArray()
+    return pe
 
 for db in dbs:
     owl_file = owl_pattern % db
@@ -28,18 +33,16 @@ for db in dbs:
         mod_type, residue, position = res
         if not residue or not position:
             continue
-        er  = obj.getEntityFeatureOf()
-        if not er:
+
+        proteins = get_proteins(obj)
+        if not proteins:
             continue
-        pe = er.getEntityReferenceOf().toArray()
-        if not pe:
-            continue
-        protein = pe[0]
-        name = bpc.BiopaxProcessor._get_element_name(protein)
-        db_refs = bpc.BiopaxProcessor._get_db_refs(protein)
-        agent = Agent(name, mods=[ModCondition(mod_type, residue, position)],
-                      db_refs=db_refs)
-        agents.append(agent)
+        for protein in proteins:
+            name = bpc.BiopaxProcessor._get_element_name(protein)
+            db_refs = bpc.BiopaxProcessor._get_db_refs(protein)
+            agent = Agent(name, mods=[ModCondition(mod_type, residue, position)],
+                          db_refs=db_refs)
+            agents.append(agent)
 
     with open('pc_%s_modified_agents.pkl' % db, 'wb') as fh:
         pickle.dump(agents, fh)

--- a/models/paper2/sitemap_fig.py
+++ b/models/paper2/sitemap_fig.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import, print_function, unicode_literals
+from builtins import dict, str
+
+if __name__ == '__main__':
+    from os.path import join as pjoin
+    from indra.tools import assemble_corpus as ac
+    from collections import OrderedDict, Counter
+    from indra.preassembler.sitemapper import SiteMapper, default_site_map
+    from indra.util import write_unicode_csv
+
+    outf = '../phase3_eval/output'
+
+    prior_stmts = ac.load_statements(pjoin(outf, 'prior.pkl'))
+    reach_stmts = ac.load_statements(pjoin(outf, 'phase3_stmts.pkl'))
+    stmts = ac.map_grounding(prior_stmts + reach_stmts,
+                             save=pjoin(outf, 'gmapped_stmts.pkl'))
+
+    # Look for errors in database statements
+    def get_inc_sites(stmts):
+        sm = SiteMapper(default_site_map)
+        valid, mapped = sm.map_sites(stmts)
+        # Collect stats on most frequently occurring site errors
+        mapped_sites = []
+        unmapped_sites = []
+        for ms in mapped:
+            for mm in ms.mapped_mods:
+                if mm[1]:
+                    mapped_sites.append(mm)
+                else:
+                    unmapped_sites.append(mm)
+        unmapped_count = Counter(unmapped_sites)
+        unmapped_sites = sorted([(k, v) for k, v in unmapped_count.items()],
+                                 key=lambda x: x[1], reverse=True)
+        mapped_count = Counter(mapped_sites)
+        mapped_sites = sorted([(k, v) for k, v in mapped_count.items()],
+                              key=lambda x: x[1], reverse=True)
+        return (unmapped_sites, mapped_sites)
+
+    (db_inc, db_map) = get_inc_sites(stmts)
+
+    rows = []
+    for mm, freq in db_inc + db_map:
+        gene, res, pos = mm[0]
+        mapped = 1 if mm[1] else 0
+        rows.append([gene, res, pos, freq, mapped])
+    rows = sorted(rows, key=lambda x: x[3], reverse=True)
+    write_unicode_csv('incorrect_sites.csv', rows)

--- a/models/paper2/sitemap_fig.py
+++ b/models/paper2/sitemap_fig.py
@@ -2,22 +2,31 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from os.path import join as pjoin
 from indra.tools import assemble_corpus as ac
-from collections import OrderedDict, Counter
+from collections import OrderedDict, Counter, namedtuple, defaultdict
 from indra.preassembler.sitemapper import SiteMapper, default_site_map
 from indra.util import write_unicode_csv, read_unicode_csv
+from indra.util import plot_formatting as pf
 
-def get_incorrect_sites():
+pf.set_fig_params()
+
+from matplotlib import pyplot as plt
+
+SiteInfo = namedtuple('SiteInfo', ['gene', 'res', 'pos', 'freq', 'mapped',
+                                   'mapped_res', 'mapped_pos', 'explanation'])
+
+def get_incorrect_sites(do_methionine_offset=False):
     outf = '../phase3_eval/output'
 
     prior_stmts = ac.load_statements(pjoin(outf, 'prior.pkl'))
-    reach_stmts = ac.load_statements(pjoin(outf, 'phase3_stmts.pkl'))
-    stmts = ac.map_grounding(prior_stmts + reach_stmts,
-                             save=pjoin(outf, 'gmapped_stmts.pkl'))
+    #reach_stmts = ac.load_statements(pjoin(outf, 'phase3_stmts.pkl'))
+    stmts = prior_stmts
+    stmts = ac.map_grounding(stmts, save=pjoin(outf, 'gmapped_stmts.pkl'))
 
     # Look for errors in database statements
     def get_inc_sites(stmts):
         sm = SiteMapper(default_site_map)
-        valid, mapped = sm.map_sites(stmts)
+        valid, mapped = sm.map_sites(stmts,
+                                     do_methionine_offset=do_methionine_offset)
         # Collect stats on most frequently occurring site errors
         mapped_sites = []
         unmapped_sites = []
@@ -40,15 +49,47 @@ def get_incorrect_sites():
     rows = []
     for mm, freq in db_inc + db_map:
         gene, res, pos = mm[0]
-        mapped = 1 if mm[1] else 0
-        rows.append([gene, res, pos, freq, mapped])
+        if mm[1]:
+            mapped = 1
+            (mapped_res, mapped_pos, explanation) = mm[1]
+        else:
+            mapped = 0
+            mapped_res = mapped_pos = explanation = ''
+        rows.append([gene, res, pos, freq, mapped, mapped_res, mapped_pos,
+                     explanation])
     rows = sorted(rows, key=lambda x: x[3], reverse=True)
     write_unicode_csv('incorrect_sites.csv', rows)
+    return [SiteInfo(*row) for row in rows]
 
 def load_incorrect_sites():
     rows = read_unicode_csv('incorrect_sites.csv')
-    return rows
+    return [SiteInfo(*row) for row in rows]
+
+def make_bar_plot(site_info, num_genes=30):
+    # Get counts summed across gene names
+    gene_counts = defaultdict(lambda: 0)
+    for site in site_info:
+        gene_counts[site.gene] += site.freq
+    gene_counts = sorted([(k, v) for k, v in gene_counts.items()],
+                          key=lambda x: x[1], reverse=True)
+    gene_counts = gene_counts[0:num_genes]
+    gene_names = [x[0] for x in gene_counts]
+    site_counts = [x[1] for x in gene_counts]
+
+    plt.ion()
+    ind = range(len(gene_counts))
+    plt.figure(figsize=(4, 2), dpi=150)
+    width = 0.5
+    plt.bar(ind, site_counts)
+    plt.xticks(ind, gene_names, rotation='vertical')
+    plt.ylabel('Num. invalid sites')
+    ax = plt.gca()
+    pf.format_axis(ax)
+    plt.subplots_adjust(bottom=0.31)
+    plt.show()
+    return gene_counts
 
 if __name__ == '__main__':
-    sites = load_incorrect_sites()
-
+    #sites = load_incorrect_sites()
+    sites = get_incorrect_sites(do_methionine_offset=True)
+    gene_counts = make_bar_plot(sites)

--- a/models/paper2/sitemap_fig.py
+++ b/models/paper2/sitemap_fig.py
@@ -16,7 +16,8 @@ pf.set_fig_params()
 SiteInfo = namedtuple('SiteInfo', ['gene', 'res', 'pos', 'freq', 'mapped',
                                    'mapped_res', 'mapped_pos', 'explanation'])
 
-def get_incorrect_sites(do_methionine_offset=False, do_orthology_mapping=False):
+def get_incorrect_sites(do_methionine_offset=False, do_orthology_mapping=False,
+                        do_isoform_mapping=False):
     outf = '../phase3_eval/output'
 
     prior_stmts = ac.load_statements(pjoin(outf, 'prior.pkl'))
@@ -29,7 +30,8 @@ def get_incorrect_sites(do_methionine_offset=False, do_orthology_mapping=False):
         sm = SiteMapper(default_site_map)
         valid, mapped = sm.map_sites(stmts,
                                      do_methionine_offset=do_methionine_offset,
-                                     do_orthology_mapping=do_orthology_mapping)
+                                     do_orthology_mapping=do_orthology_mapping,
+                                     do_isoform_mapping=do_isoform_mapping)
         # Collect stats on most frequently occurring site errors
         mapped_sites = []
         unmapped_sites = []
@@ -68,7 +70,7 @@ def load_incorrect_sites():
     rows = read_unicode_csv('incorrect_sites.csv')
     return [SiteInfo(*row) for row in rows]
 
-def make_bar_plot(site_info, num_genes=60):
+def make_bar_plot(site_info, num_genes=120):
     # Build a dict based on gene name
     # Get counts summed across gene names
     gene_counts = defaultdict(lambda: 0)
@@ -76,7 +78,8 @@ def make_bar_plot(site_info, num_genes=60):
     for site in site_info:
         gene_counts[site.gene] += int(site.freq)
         site_counts[site.gene].append((int(site.freq), int(site.mapped),
-                                       site.explanation))
+                                      site.mapped_res, site.mapped_pos,
+                                      site.explanation))
     # Sort the individual site counts by frequency
     for gene, freq_list in site_counts.items():
         site_counts[gene] = sorted(freq_list, key=lambda x: x[0], reverse=True)
@@ -92,22 +95,30 @@ def make_bar_plot(site_info, num_genes=60):
         for ix, (gene, freq) in enumerate(gene_count_subset):
             # Plot the stacked bars
             bottom = 0
-            for site_freq, mapped, explanation in site_counts[gene]:
+            for site_freq, mapped, mapped_res, mapped_pos, explanation \
+                    in site_counts[gene]:
                 if mapped and \
                         explanation.startswith('INFERRED_METHIONINE_CLEAVAGE'):
                     color = 'b'
-                    handle_key = 'Methione'
+                    handle_key = 'Methionine'
+                elif mapped and not mapped_pos:
+                    color = 'r'
+                    handle_key = 'Curated as incorrect'
                 elif mapped and \
                         explanation.startswith('INFERRED_MOUSE_SITE'):
-                    color = 'r'
+                    color = 'c'
                     handle_key = 'Mouse'
                 elif mapped and \
                         explanation.startswith('INFERRED_RAT_SITE'):
                     color = 'purple'
                     handle_key = 'Rat'
+                elif mapped and \
+                        explanation.startswith('INFERRED_ALTERNATIVE_ISOFORM'):
+                    color = 'orange'
+                    handle_key = 'Alternative isoform'
                 elif mapped:
                     color = 'g'
-                    handle_key = 'Manual'
+                    handle_key = 'Manually mapped'
                 else:
                     color = 'white'
                     handle_key = 'Unmapped'
@@ -116,7 +127,7 @@ def make_bar_plot(site_info, num_genes=60):
                 bottom += site_freq
         plt.xticks(ind + (width / 2.), [x[0] for x in gene_count_subset],
                    rotation='vertical')
-        plt.ylabel('Num. invalid sites')
+        plt.ylabel('Stmts with invalid sites')
         plt.xlim((0, max(ind)+1))
         ax = plt.gca()
         pf.format_axis(ax)
@@ -126,13 +137,15 @@ def make_bar_plot(site_info, num_genes=60):
                        labels=list(handle_dict.keys()), fontsize=pf.fontsize,
                        frameon=False)
         plt.show()
-    plot_sites(gene_counts[0:4], (1, 2), {'bottom': 0.31}, do_legend=False)
-    plot_sites(gene_counts[4:num_genes], (7, 2),
+    plot_sites(gene_counts[0:4], (0.23, 2),
+               {'left': 0.24, 'right': 0.52, 'bottom': 0.31}, do_legend=False)
+    plot_sites(gene_counts[4:num_genes], (11, 2),
                {'bottom': 0.31, 'left': 0.06, 'right':0.96})
     return gene_counts
 
 if __name__ == '__main__':
     #sites = load_incorrect_sites()
     sites = get_incorrect_sites(do_methionine_offset=True,
-                                do_orthology_mapping=True)
+                                do_orthology_mapping=True,
+                                do_isoform_mapping=True)
     gene_counts = make_bar_plot(sites)

--- a/models/paper2/sitemap_fig.py
+++ b/models/paper2/sitemap_fig.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
+from os.path import join as pjoin
+from indra.tools import assemble_corpus as ac
+from collections import OrderedDict, Counter
+from indra.preassembler.sitemapper import SiteMapper, default_site_map
+from indra.util import write_unicode_csv, read_unicode_csv
 
-if __name__ == '__main__':
-    from os.path import join as pjoin
-    from indra.tools import assemble_corpus as ac
-    from collections import OrderedDict, Counter
-    from indra.preassembler.sitemapper import SiteMapper, default_site_map
-    from indra.util import write_unicode_csv
-
+def get_incorrect_sites():
     outf = '../phase3_eval/output'
 
     prior_stmts = ac.load_statements(pjoin(outf, 'prior.pkl'))
@@ -45,3 +44,11 @@ if __name__ == '__main__':
         rows.append([gene, res, pos, freq, mapped])
     rows = sorted(rows, key=lambda x: x[3], reverse=True)
     write_unicode_csv('incorrect_sites.csv', rows)
+
+def load_incorrect_sites():
+    rows = read_unicode_csv('incorrect_sites.csv')
+    return rows
+
+if __name__ == '__main__':
+    sites = load_incorrect_sites()
+


### PR DESCRIPTION
This pull request aims to automate many of the heuristics used to curate sites for the SiteMapper. Sites of post-translational modifications that are inconsistent with the reference sequence but are nevertheless meaningful (i.e., that should be mapped to the reference sequence in order to integrate information) seem to result from the following sources of error:

1. Site position drawn from a non-canonical protein isoform (i.e., not the isoform used for the reference sequence)
2. Site position drawn from the orthologous mouse protein
3. Site position off by one from the reference sequence (most likely due to cleavage of the initial methionine, a common protein modification)

This PR automates the process of validating and mapping inconsistent site positions due to these sources of error. To prevent the occurrence of false positive mappings, it only maps from, and to, sites that are listed in the PhosphoSitePlus database as known to be modified.

For example, we frequently encounter references in both databases and reading to phosphorylation on serine 112 of the protein BAD. However, there is no corresponding serine at position 112 of the human reference sequence. To identify a mapping to the human reference residue, the SiteMapper now does the following:

- Identifies the Uniprot ID for the mouse protein orthologous to human BAD. This uses the HGNC (human genome) to MGI (mouse genome) mapping table incorporated in 62e00039de53a007.
- Searches the PhosphoSitePlus dataset for any known post-translational modification sites on mouse BAD. (This requires that the Phosphosite site dataset be requested from Cell Signaling Technology and downloaded into the indra/resources folder.)
- If there is a serine at position 112 of the mouse sequence that is annotated as modified in PhosphoSitePlus, it is linked to the corresponding human site (serine 75).
- A mapping is created, identified as an inferred site from the mouse sequence, and a new, mapped INDRA Statement is generated.

The mapping procedure checks for matches to an inconsistent site in the following order:

1. another human isoform
2. a mouse protein
3. an off-by-one position (cleaved methionine)

If no match is found, then the manually curated site map table is checked. If the PhosphoSite dataset cannot be loaded, then all of these procedures are skipped and only the site map table is checked.