### PR TITLE
Improve docs

### DIFF
--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1324,7 +1324,7 @@ class Autophosphorylation(SelfModification):
     p38 bound to TAB1 cis-autophosphorylates itself (see :pmid:`19155529`).
 
     >>> tab1 = Agent('TAB1')
-    >>> p38_tab1 = Agent('P38', bound_conditions=(BoundCondition(tab1)))
+    >>> p38_tab1 = Agent('P38', bound_conditions=[BoundCondition(tab1)])
     >>> autophos = Autophosphorylation(p38_tab1)
     """
     pass

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -165,12 +165,12 @@ class BoundCondition(object):
     EGFR bound to EGF:
 
     >>> egf = Agent('EGF')
-    >>> egfr = Agent('EGFR', bound_conditions=(BoundCondition(egf)))
+    >>> egfr = Agent('EGFR', bound_conditions=[BoundCondition(egf)])
 
     BRAF *not* bound to a 14-3-3 protein (YWHAB):
 
     >>> ywhab = Agent('YWHAB')
-    >>> braf = Agent('BRAF', bound_conditions=(BoundCondition(ywhab, False)))
+    >>> braf = Agent('BRAF', bound_conditions=[BoundCondition(ywhab, False)])
     """
     def __init__(self, agent, is_bound=True):
         self.agent = agent


### PR DESCRIPTION
Fixed a typo where a single item in parentheses is not turned to a tuple without a trailing comma. Replaced with brackets as a list instead to keep it pretty.