### PR TITLE
Cyjs assembler

### DIFF
--- a/indra/assemblers/cyjs_assembler.py
+++ b/indra/assemblers/cyjs_assembler.py
@@ -486,10 +486,10 @@ def _get_db_refs(agent):
 
 def _get_stmt_type(stmt):
     if isinstance(stmt, AddModification):
-        edge_type = 'Modification'
+        edge_type = stmt.__class__.__name__
         edge_polarity = 'positive'
     elif isinstance(stmt, RemoveModification):
-        edge_type = 'Modification'
+        edge_type = stmt.__class__.__name__
         edge_polarity = 'negative'
     elif isinstance(stmt, SelfModification):
         edge_type = 'SelfModification'

--- a/indra/assemblers/cyjs_assembler.py
+++ b/indra/assemblers/cyjs_assembler.py
@@ -401,11 +401,13 @@ class CyJSAssembler(object):
         for key, val in edge_dict.items():
             if len(val) > 1:
                 edges_to_remove += val
-        self._edges = [x for x in self._edges
-                       if x['data']['id'] not in edges_to_remove]
         for key, val in edge_dict.items():
             if len(val) > 1:
-                self._add_edge(key[0], key[1], key[2], key[3], val)
+                edge_uuids = [e['data']['uuid_list'][0] for e in self._edges
+                              if e['data']['id'] in val]
+                self._add_edge(key[0], key[1], key[2], key[3], edge_uuids)
+        self._edges = [x for x in self._edges
+                       if x['data']['id'] not in edges_to_remove]
         # edit edges on parent nodes and make new edges for them
         edges_to_add = [[], []]  # [group_edges, uuid_lists]
         for e in self._edges:

--- a/indra/assemblers/cyjs_assembler.py
+++ b/indra/assemblers/cyjs_assembler.py
@@ -293,13 +293,23 @@ class CyJSAssembler(object):
         return edge_dict
 
     def _add_edge(self, edge_type, source, target, edge_polarity, uuid):
+        edge_dict = self._get_edge_dict()
+        uuids = collections.defaultdict(lambda: [])
         edge = {'data': {'i': edge_type,
                          'source': source, 'target': target,
                          'polarity': edge_polarity}}
-        edge['data']['id'] = self._get_new_id()
+        data = edge['data']
+        key = tuple([data['i'], data['source'],
+                    data['target'], data['polarity']])
+        if key in edge_dict:
+            val = edge_dict[key]
+            edge = [e for e in self._edges if e['data']['id'] == val][0]
+        else:
+            edge['data']['id'] = self._get_new_id()
         if type(uuid) is not list:
             uuid = [uuid]
-        edge['data']['uuid_list'] = uuid
+        edge['data']['uuid_list'] = edge['data'].get('uuid_list', [])
+        edge['data']['uuid_list'] += uuid
         self._edges.append(edge)
         return
 


### PR DESCRIPTION
- Topologically identical edges are now collapsed under a common edge with a list of uuids, independent of node grouping and edge grouping which is now used exclusively to generate compound elements.
- Modification edges now have the statement class name as their type. (e.g. - previously a phosphorylation would previously have been recorded as Modification, while now it is recorded as Phosphorylation).