### PR TITLE
Allow Bioentities families in filter_gene_list

### DIFF
--- a/indra/preassembler/hierarchy_manager.py
+++ b/indra/preassembler/hierarchy_manager.py
@@ -8,6 +8,8 @@ try:
 except ImportError:
     from functools32 import lru_cache
 
+from indra.preassembler.make_entity_hierarchy import ns_map
+
 logger = logging.getLogger('hierarchy_manager')
 
 class HierarchyManager(object):
@@ -325,6 +327,20 @@ class HierarchyManager(object):
         else:
             raise ValueError('Unknown namespace %s' % ns)
 
+    @staticmethod
+    def ns_id_from_uri(uri):
+        try:
+            (ag_ns, ag_id) = rdflib.namespace.split_uri(uri)
+        except Exception:
+            # Handle one special case here for HGNC IDs
+            db_id = uri.split('/')[-1]
+            if db_id.startswith('HGNC:'):
+                ag_ns = 'http://identifiers.org/hgnc.symbol/'
+                ag_id = hgnc_client.get_hgnc_name(db_id[5:])
+        ag_ns_name = ns_map.get(ag_ns)
+        if ag_ns_name is None:
+            raise UnknownNamespaceException('Unknown namespace %s' % ag_ns)
+        return (ag_ns_name, ag_id)
 
 # Load the default entity and modification hierarchies
 entity_file_path = os.path.join(os.path.dirname(__file__),

--- a/indra/preassembler/hierarchy_manager.py
+++ b/indra/preassembler/hierarchy_manager.py
@@ -329,14 +329,13 @@ class HierarchyManager(object):
 
     @staticmethod
     def ns_id_from_uri(uri):
-        try:
-            (ag_ns, ag_id) = rdflib.namespace.split_uri(uri)
-        except Exception:
-            # Handle one special case here for HGNC IDs
-            db_id = uri.split('/')[-1]
-            if db_id.startswith('HGNC:'):
-                ag_ns = 'http://identifiers.org/hgnc.symbol/'
-                ag_id = hgnc_client.get_hgnc_name(db_id[5:])
+        sep_ix = uri.rfind('/') + 1
+        ag_ns = uri[0:sep_ix]
+        ag_id = uri[sep_ix:]
+        # Handle one special case here for HGNC IDs
+        if ag_id.startswith('HGNC:'):
+            ag_ns = 'http://identifiers.org/hgnc.symbol/'
+            ag_id = hgnc_client.get_hgnc_name(db_id[5:])
         ag_ns_name = ns_map.get(ag_ns)
         if ag_ns_name is None:
             raise UnknownNamespaceException('Unknown namespace %s' % ag_ns)

--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -14,6 +14,7 @@ g = Agent('g', db_refs={'BE': 'ERK'})
 h = Agent('g', mods=['x', 'y'], mutations=['x', 'y'], activity='x',
                location='nucleus', bound_conditions=['x', 'y', 'z'])
 mapk1 = Agent('MAPK1', db_refs={'HGNC':'6871', 'UP':'P28482'})
+erk = Agent('ERK', db_refs={'BE': 'ERK'})
 st1 = Phosphorylation(a, b)
 st2 = Phosphorylation(a, d)
 st3 = Phosphorylation(c, d)
@@ -29,9 +30,10 @@ st12 = Phosphorylation(a, b, evidence=[Evidence(epistemics={'direct': True})])
 st13 = Phosphorylation(a, b, evidence=[Evidence(epistemics={'direct': False})])
 st14 = Activation(a, b, 'activity')
 st15 = Activation(a, b, 'kinase')
-st16 = Phosphorylation(a, mapk1)
 st14.supports = [st15]
 st15.supported_by = [st14]
+st16 = Phosphorylation(a, mapk1)
+st17 = Phosphorylation(a, erk)
 st1.belief = 0.9
 st2.belief = 0.8
 st3.belief = 0.7
@@ -86,15 +88,15 @@ def test_filter_gene_list_one():
     assert(len(st_out) == 2)
 
 def test_filter_gene_list_families():
-    stmts_out = ac.filter_gene_list([st10, st16], ['MAPK1'], 'one',
+    stmts_out = ac.filter_gene_list([st16, st17], ['MAPK1'], 'one',
                                     allow_families=False)
     assert len(stmts_out) == 1
     assert stmts_out[0] == st16
-    stmts_out = ac.filter_gene_list([st10, st16], ['MAPK1'], 'one',
+    stmts_out = ac.filter_gene_list([st16, st17], ['MAPK1'], 'one',
                                     allow_families=True)
     assert len(stmts_out) == 2
-    assert st10 in stmts_out
     assert st16 in stmts_out
+    assert st17 in stmts_out
 
 def test_run_preassembly():
     st_out = ac.run_preassembly([st1, st3, st5, st6])

--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -249,7 +249,3 @@ def test_filter_mutation_status():
     deletions = ['a']
     st_out = ac.filter_mutation_status([st1, st2], mutations, deletions)
     assert(len(st_out) == 0)
-
-
-if __name__ == '__main__':
-    test_filter_gene_list_families()

--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -13,6 +13,7 @@ f = Agent('b', db_refs={'UP': 'P28028', 'TEXT': 'b'})
 g = Agent('g', db_refs={'BE': 'ERK'})
 h = Agent('g', mods=['x', 'y'], mutations=['x', 'y'], activity='x',
                location='nucleus', bound_conditions=['x', 'y', 'z'])
+mapk1 = Agent('MAPK1', db_refs={'HGNC':'6871', 'UP':'P28482'})
 st1 = Phosphorylation(a, b)
 st2 = Phosphorylation(a, d)
 st3 = Phosphorylation(c, d)
@@ -28,6 +29,7 @@ st12 = Phosphorylation(a, b, evidence=[Evidence(epistemics={'direct': True})])
 st13 = Phosphorylation(a, b, evidence=[Evidence(epistemics={'direct': False})])
 st14 = Activation(a, b, 'activity')
 st15 = Activation(a, b, 'kinase')
+st16 = Phosphorylation(a, mapk1)
 st14.supports = [st15]
 st15.supported_by = [st14]
 st1.belief = 0.9
@@ -82,6 +84,17 @@ def test_filter_gene_list_one():
     assert(len(st_out) == 1)
     st_out = ac.filter_gene_list([st1, st2], ['a', 'b'], 'invalid')
     assert(len(st_out) == 2)
+
+def test_filter_gene_list_families():
+    stmts_out = ac.filter_gene_list([st10, st16], ['MAPK1'], 'one',
+                                    allow_families=False)
+    assert len(stmts_out) == 1
+    assert stmts_out[0] == st16
+    stmts_out = ac.filter_gene_list([st10, st16], ['MAPK1'], 'one',
+                                    allow_families=True)
+    assert len(stmts_out) == 2
+    assert st10 in stmts_out
+    assert st16 in stmts_out
 
 def test_run_preassembly():
     st_out = ac.run_preassembly([st1, st3, st5, st6])
@@ -234,3 +247,7 @@ def test_filter_mutation_status():
     deletions = ['a']
     st_out = ac.filter_mutation_status([st1, st2], mutations, deletions)
     assert(len(st_out) == 0)
+
+
+if __name__ == '__main__':
+    test_filter_gene_list_families()

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -443,7 +443,7 @@ def filter_belief(stmts_in, belief_cutoff, **kwargs):
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
 
-def filter_gene_list(stmts_in, gene_list, policy, allow_families=True,
+def filter_gene_list(stmts_in, gene_list, policy, allow_families=False,
                      **kwargs):
     """Return statements that contain genes given in a list.
 
@@ -458,9 +458,9 @@ def filter_gene_list(stmts_in, gene_list, policy, allow_families=True,
         statements that contain at least one of the list of genes and
         possibly others not in the list "all": keep statements that only
         contain genes given in the list
-    allow_families : bool
+    allow_families : Optional[bool]
         Will include statements involving Bioentities families containing one
-        of the genes in the gene list.
+        of the genes in the gene list. Default: False
     save : Optional[str]
         The name of a pickle file to save the results (stmts_out) into.
 


### PR DESCRIPTION
Addresses issue #286. Allows statements containing family-level agents to be included in a gene-list based filter, by looking up the Bioentities families that are parents of the genes in the list.