### PR TITLE
Offline reading with TRIPS/DRUM

### DIFF
--- a/indra/sources/trips/drum_reader.py
+++ b/indra/sources/trips/drum_reader.py
@@ -1,0 +1,40 @@
+import sys
+import random
+from indra.sources import trips
+from kqml import KQMLModule, KQMLPerformative, KQMLList
+
+class DrumReader(KQMLModule):
+    def __init__(self, **kwargs):
+        super(DrumReader, self).__init__(**kwargs)
+        self.msg_counter = random.randint(1, 100000)
+        self.ready()
+        self.extractions = None
+        self.read_text('MEK phosphorylates ERK1.')
+        self.read_text('BRAF phosphorylates MEK1.')
+
+    def read_text(self, text):
+        msg_id = 'RT000%s' % self.msg_counter
+        kqml_perf = _get_perf(text, msg_id)
+        self.send(kqml_perf)
+        self.msg_counter += 1
+
+    def receive_reply(self, msg, content):
+        extractions = content.gets(':extractions')
+        self.extractions = extractions
+        tp = trips.process_xml(self.extractions)
+        print(tp.statements)
+
+def _get_perf(text, msg_id):
+    text = text.encode('utf-8')
+    msg = KQMLPerformative('REQUEST')
+    msg.set('receiver', 'DRUM')
+    content = KQMLList('run-text')
+    content.sets('text', text)
+    msg.set('content', content)
+    msg.set('reply-with', msg_id)
+    return msg
+
+if __name__ == '__main__':
+    # NOTE: drum/bin/trips-drum needs to be running
+    dr = DrumReader(name='DrumReader')
+    dr.start()

--- a/indra/sources/trips/drum_reader.py
+++ b/indra/sources/trips/drum_reader.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
+import os
 import sys
 import random
 import logging
@@ -13,6 +14,33 @@ except ImportError:
 logger = logging.getLogger('drum_reader')
 
 class DrumReader(KQMLModule):
+    """Agent which processes text through a local TRIPS/DRUM instance.
+
+    This class is implemented as a communicative agent which sends and receives
+    KQML messages through a socket. It sends text (ideally in small blocks
+    like one sentence at a time) to the running DRUM instance and receives
+    extraction knowledge base (EKB) XML responses asynchronously through
+    the socket. To install DRUM and its dependencies locally, follow
+    instructions at: https://github.com/wdebeaum/drum
+    Once installed, run `drum/bin/trips-drum -nouser` to run DRUM without
+    a GUI. Once DRUM is running, this class can be instantiated as
+    `dr = DrumReader(to_read=text_list)`, at which point it attempts to
+    connect to DRUM via the socket and send the texts for reading.
+    Receiving responses can be started as `dr.start()` which waits for
+    responses from the reader and returns when all responses were received.
+    Once finished, the list of EKB XML extractions can be accessed via
+    `dr.extractions`.
+
+    Parameters
+    ----------
+    to_read : list[str]
+        A list of text strings to read with DRUM.
+
+    Attributes
+    ----------
+    extractions : list[str]
+        A list of EKB XML extractions corresponding to the input text list.
+    """
     def __init__(self, **kwargs):
         if not have_kqml:
             raise ImportError('Install the `pykqml` package to use ' +
@@ -51,7 +79,6 @@ def _get_perf(text, msg_id):
     return msg
 
 if __name__ == '__main__':
-    # NOTE: drum/bin/trips-drum needs to be running
     to_read = ['MEK phosphorylates ERK1.', 'BRAF phosphorylates MEK1.']
     dr = DrumReader(to_read=to_read)
     dr.start()

--- a/indra/sources/trips/drum_reader.py
+++ b/indra/sources/trips/drum_reader.py
@@ -1,18 +1,22 @@
+from __future__ import absolute_import, print_function, unicode_literals
+from builtins import dict, str
 import sys
 import random
-from indra.sources import trips
+import logging
 from kqml import KQMLModule, KQMLPerformative, KQMLList
+
+logger = logging.getLogger('drum_reader')
 
 class DrumReader(KQMLModule):
     def __init__(self, **kwargs):
         self.to_read = kwargs.pop('to_read', None)
-        super(DrumReader, self).__init__(**kwargs)
+        super(DrumReader, self).__init__(name='DrumReader')
         self.msg_counter = random.randint(1, 100000)
         self.ready()
         self.extractions = []
-        for text in to_read:
+        self.reply_counter = len(self.to_read)
+        for text in self.to_read:
             self.read_text(text)
-        self.reply_counter = len(to_read)
 
     def read_text(self, text):
         print('Reading %s' % text)
@@ -23,8 +27,7 @@ class DrumReader(KQMLModule):
 
     def receive_reply(self, msg, content):
         extractions = content.gets(':extractions')
-        tp = trips.process_xml(extractions)
-        self.extractions += tp.statements
+        self.extractions.append(extractions)
         self.reply_counter -= 1
         if self.reply_counter == 0:
             self.exit(0)
@@ -42,5 +45,5 @@ def _get_perf(text, msg_id):
 if __name__ == '__main__':
     # NOTE: drum/bin/trips-drum needs to be running
     to_read = ['MEK phosphorylates ERK1.', 'BRAF phosphorylates MEK1.']
-    dr = DrumReader(name='DrumReader', to_read=to_read)
+    dr = DrumReader(to_read=to_read)
     dr.start()

--- a/indra/sources/trips/drum_reader.py
+++ b/indra/sources/trips/drum_reader.py
@@ -3,12 +3,20 @@ from builtins import dict, str
 import sys
 import random
 import logging
-from kqml import KQMLModule, KQMLPerformative, KQMLList
+try:
+    from kqml import KQMLModule, KQMLPerformative, KQMLList
+    have_kqml = True
+except ImportError:
+    KQMLModule = object
+    have_kqml = False
 
 logger = logging.getLogger('drum_reader')
 
 class DrumReader(KQMLModule):
     def __init__(self, **kwargs):
+        if not have_kqml:
+            raise ImportError('Install the `pykqml` package to use ' +
+                              'the DrumReader')
         self.to_read = kwargs.pop('to_read', None)
         super(DrumReader, self).__init__(name='DrumReader')
         self.msg_counter = random.randint(1, 100000)

--- a/indra/sources/trips/trips_api.py
+++ b/indra/sources/trips/trips_api.py
@@ -46,8 +46,6 @@ def process_text(text, save_xml_name='trips_output.xml', save_xml_pretty=True,
     if not offline:
         html = trips_client.send_query(text, service_endpoint)
         xml = trips_client.get_xml(html)
-        if save_xml_name:
-            trips_client.save_xml(xml, save_xml_name, save_xml_pretty)
     else:
         if offline_reading:
             try:
@@ -75,6 +73,9 @@ def process_text(text, save_xml_name='trips_output.xml', save_xml_pretty=True,
                 Once installed, run drum/bin/trips-drum in a separate process.
                 """
             logger.error(msg)
+            return None
+    if save_xml_name:
+        trips_client.save_xml(xml, save_xml_name, save_xml_pretty)
     return process_xml(xml)
 
 


### PR DESCRIPTION
Adds an interface to read texts offline with TRIPS/DRUM if DRUM is set up and running locally. `indra.sources.trips.drum_reader.DrumReader` can be used independently, or through `indra.sources.trips.trips_api.read_text` with the new `offline=True` option.