### PR TITLE
New SBGN assembly from PySB model/reaction network

### DIFF
--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -2580,19 +2580,19 @@ def export_sbgn(model):
 
     glyphs = {}
     for idx, species in enumerate(model.species):
-        # There should be a map for these
         glyph = sa._glyph_for_complex_pattern(species)
         if glyph is None:
             continue
         sa._map.append(glyph)
         glyphs[idx] = glyph
     for reaction in model.reactions:
+        # Get all the reactions / products / controllers of the reaction
         reactants = set(reaction['reactants']) - set(reaction['products'])
         products = set(reaction['products']) - set(reaction['reactants'])
         controllers = set(reaction['reactants']) & set(reaction['products'])
         # Add glyph for reaction
         process_glyph = sa._process_glyph('process')
-        # Connect glyphs with arcs
+        # Connect reactants with arcs
         for r in reactants:
             glyph = glyphs.get(r)
             if glyph is None:
@@ -2600,6 +2600,7 @@ def export_sbgn(model):
             else:
                 glyph_id = glyph.attrib['id']
             sa._arc('consumption', glyph_id, process_glyph)
+        # Connect products with arcs
         for p in products:
             glyph = glyphs.get(p)
             if glyph is None:
@@ -2607,6 +2608,7 @@ def export_sbgn(model):
             else:
                 glyph_id = glyph.attrib['id']
             sa._arc('production', process_glyph, glyph_id)
+        # Connect controllers with arcs
         for c in controllers:
             glyph = glyphs[c]
             sa._arc('catalysis', glyph.attrib['id'], process_glyph)

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -2560,12 +2560,14 @@ def export_sbgn(model):
 
     sa = SBGNAssembler()
 
-    glyphs = []
-    for species in model.species:
+    glyphs = {}
+    for idx, species in enumerate(model.species):
         # There should be a map for these
         glyph = sa._glyph_for_complex_pattern(species)
+        if glyph is None:
+            continue
         sa._map.append(glyph)
-        glyphs.append(glyph)
+        glyphs[idx] = glyph
     for reaction in model.reactions:
         reactants = set(reaction['reactants']) - set(reaction['products'])
         products = set(reaction['products']) - set(reaction['reactants'])
@@ -2574,11 +2576,19 @@ def export_sbgn(model):
         process_glyph = sa._process_glyph('process')
         # Connect glyphs with arcs
         for r in reactants:
-            glyph = glyphs[r]
-            sa._arc('consumption', glyph.attrib['id'], process_glyph)
+            glyph = glyphs.get(r)
+            if glyph is None:
+                glyph_id = sa._none_glyph()
+            else:
+                glyph_id = glyph.attrib['id']
+            sa._arc('consumption', glyph_id, process_glyph)
         for p in products:
-            glyph = glyphs[p]
-            sa._arc('production', process_glyph, glyph.attrib['id'])
+            glyph = glyphs.get(p)
+            if glyph is None:
+                glyph_id = sa._none_glyph()
+            else:
+                glyph_id = glyph.attrib['id']
+            sa._arc('production', process_glyph, glyph_id)
         for c in controllers:
             glyph = glyphs[c]
             sa._arc('catalysis', glyph.attrib['id'], process_glyph)

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -899,7 +899,9 @@ class PysbAssembler(object):
             The format to export into, for instance "kappa", "bngl",
             "sbml", "matlab", "mathematica", "potterswheel". See
             http://pysb.readthedocs.io/en/latest/modules/export/index.html
-            for a list of supported formats.
+            for a list of supported formats. In addition to the formats
+            supported by PySB itself, this method also provides "sbgn"
+            output.
 
         file_name : Optional[str]
             An optional file name to save the exported model into.
@@ -908,7 +910,6 @@ class PysbAssembler(object):
         -------
         exp_str : str
             The exported model string
-
         """
         # Handle SBGN as special case
         if format == 'sbgn':
@@ -2549,6 +2550,23 @@ class PysbPreassembler(object):
         to_agent.activity = from_agent.activity
 
 def export_sbgn(model):
+    """Return an SBGN model string corresponding to the PySB model.
+
+    This function first calls generate_equations on the PySB model to obtain
+    a reaction network (i.e. individual species, reactions). It then iterates
+    over each reaction and and instantiates its reactants, products, and the
+    process itself as SBGN glyphs and arcs.
+
+    Parameters
+    ----------
+    model : pysb.core.Model
+        A PySB model to be exported into SBGN
+
+    Returns
+    -------
+    sbgn_str : str
+        An SBGN model as string
+    """
     import lxml.etree
     import lxml.builder
     from pysb.bng import generate_equations

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -2580,7 +2580,7 @@ def export_sbgn(model):
             glyph = glyphs[p]
             sa._arc('production', process_glyph, glyph.attrib['id'])
         for c in controllers:
-            glyph = glyphs[p]
+            glyph = glyphs[c]
             sa._arc('catalysis', glyph.attrib['id'], process_glyph)
 
     sbgn_str = sa.print_model()

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -2593,5 +2593,5 @@ def export_sbgn(model):
             glyph = glyphs[c]
             sa._arc('catalysis', glyph.attrib['id'], process_glyph)
 
-    sbgn_str = sa.print_model()
+    sbgn_str = sa.print_model().decode('utf-8')
     return sbgn_str

--- a/indra/assemblers/sbgn_assembler.py
+++ b/indra/assemblers/sbgn_assembler.py
@@ -309,6 +309,7 @@ class SBGNAssembler(object):
         return glyph
 
     def _glyph_for_complex_pattern(self, pattern):
+        """Add glyph and member glyphs for a PySB ComplexPattern."""
         # Make the main glyph for the agent
         monomer_glyphs = []
         for monomer_pattern in pattern.monomer_patterns:
@@ -328,6 +329,7 @@ class SBGNAssembler(object):
         return monomer_glyphs[0]
 
     def _glyph_for_monomer_pattern(self, pattern):
+        """Add glyph for a PySB MonomerPattern."""
         pattern.matches_key = lambda: str(pattern)
         agent_id = self._make_agent_id(pattern)
         # Handle sources and sinks

--- a/indra/assemblers/sbgn_assembler.py
+++ b/indra/assemblers/sbgn_assembler.py
@@ -329,6 +329,10 @@ class SBGNAssembler(object):
     def _glyph_for_monomer_pattern(self, pattern):
         pattern.matches_key = lambda: str(pattern)
         agent_id = self._make_agent_id(pattern)
+        # Handle sources and sinks
+        if pattern.monomer.name in ('__source', '__sink'):
+            return None
+        # Handle molecules
         glyph = emaker.glyph(emaker.label(text=pattern.monomer.name),
                              emaker.bbox(x='0', y='0', w='140', h='60'),
                              class_('macromolecule'), id=agent_id)

--- a/indra/assemblers/sbgn_assembler.py
+++ b/indra/assemblers/sbgn_assembler.py
@@ -36,6 +36,14 @@ class SBGNAssembler(object):
         The structure of the SBGN model that is assembled, represented as an
         XML ElementTree.
     """
+
+    process_style = {'x': '0', 'y': '0', 'w': '20', 'h': '20'}
+    source_sink_style = {'x': '0', 'y': '0', 'w': '20', 'h': '20'}
+    monomer_style = {'x': '0', 'y': '0', 'w': '50', 'h': '30'}
+    complex_style = {'x': '0', 'y': '0', 'w': '60', 'h': '60'}
+    entity_type_style = {'x': '0', 'y': '0', 'w': '20', 'h': '15'}
+    entity_state_style = {'x': '1', 'y': '0', 'w': '20', 'h': '15'}
+
     def __init__(self, statements=None):
         if not statements:
             self.statements = []
@@ -234,14 +242,14 @@ class SBGNAssembler(object):
 
     def _process_glyph(self, class_name):
         process_id = self._make_id()
-        process_glyph = emaker.glyph(emaker.bbox(x='0', y='0', w='20', h='20'),
+        process_glyph = emaker.glyph(emaker.bbox(**self.process_style),
                                      class_(class_name), id=process_id)
         self._map.append(process_glyph)
         return process_id
 
     def _none_glyph(self):
         glyph_id = self._make_id()
-        none_glyph = emaker.glyph(emaker.bbox(x='0', y='0', w='20', h='20'),
+        none_glyph = emaker.glyph(emaker.bbox(**self.source_sink_style),
                                   class_('source and sink'), id=glyph_id)
         self._map.append(none_glyph)
         return glyph_id
@@ -252,14 +260,14 @@ class SBGNAssembler(object):
         agent_id = self._make_agent_id(agent)
         agent_type = _get_agent_type(agent)
         glyph = emaker.glyph(emaker.label(text=agent.name),
-                             emaker.bbox(x='0', y='0', w='140', h='60'),
+                             emaker.bbox(**self.monomer_style),
                              class_(agent_type), id=agent_id)
 
         # Make a glyph for the agent type
         # TODO: handle other agent types
         type_glyph = emaker.glyph(emaker.label(text='mt:prot'),
                                   class_('unit of information'),
-                                  emaker.bbox(x='0', y='0', w='53', h='18'),
+                                  emaker.bbox(**self.entity_type_style),
                                   id=self._make_id())
         glyph.append(type_glyph)
 
@@ -275,7 +283,7 @@ class SBGNAssembler(object):
             value = states[m.mod_type][1 if m.is_modified else 0]
             state = emaker.state(variable=variable, value=value)
             state_glyph = \
-                emaker.glyph(state, emaker.bbox(x='1', y='1', w='70', h='30'),
+                emaker.glyph(state, emaker.bbox(**self.entity_state_style),
                              class_('state variable'), id=self._make_id())
             glyph.append(state_glyph)
         if agent.activity:
@@ -283,7 +291,7 @@ class SBGNAssembler(object):
             state = emaker.state(variable=abbrevs[agent.activity.activity_type],
                                  value=value)
             state_glyph = \
-                emaker.glyph(state, emaker.bbox(x='1', y='1', w='70', h='30'),
+                emaker.glyph(state, emaker.bbox(**self.entity_state_style),
                              class_('state variable'), id=self._make_id())
             glyph.append(state_glyph)
 
@@ -298,7 +306,7 @@ class SBGNAssembler(object):
             # are given and so members has only 1 element
             if len(members) > 1:
                 complex_glyph = \
-                    emaker.glyph(emaker.bbox(x='1', y='1', w='70', h='30'),
+                    emaker.glyph(emaker.bbox(**self.complex_style),
                                  class_('complex'), id=self._make_id())
                 for member in members:
                     complex_glyph.append(member)
@@ -320,7 +328,7 @@ class SBGNAssembler(object):
             pattern.matches_key = lambda: str(pattern)
             agent_id = self._make_agent_id(pattern)
             complex_glyph = \
-                emaker.glyph(emaker.bbox(x='1', y='1', w='70', h='30'),
+                emaker.glyph(emaker.bbox(**self.complex_style),
                              class_('complex'), id=agent_id)
             for glyph in monomer_glyphs:
                 glyph.attrib['id'] = agent_id + glyph.attrib['id']
@@ -337,12 +345,12 @@ class SBGNAssembler(object):
             return None
         # Handle molecules
         glyph = emaker.glyph(emaker.label(text=pattern.monomer.name),
-                             emaker.bbox(x='0', y='0', w='140', h='60'),
+                             emaker.bbox(**self.monomer_style),
                              class_('macromolecule'), id=agent_id)
         # Add a glyph for type
         type_glyph = emaker.glyph(emaker.label(text='mt:prot'),
                                   class_('unit of information'),
-                                  emaker.bbox(x='0', y='0', w='53', h='18'),
+                                  emaker.bbox(**self.entity_type_style),
                                   id=self._make_id())
         glyph.append(type_glyph)
         for site, value in pattern.site_conditions.items():
@@ -350,7 +358,7 @@ class SBGNAssembler(object):
                 continue
             state = emaker.state(variable=site, value=value)
             state_glyph = \
-                emaker.glyph(state, emaker.bbox(x='1', y='1', w='70', h='30'),
+                emaker.glyph(state, emaker.bbox(**self.entity_state_style),
                              class_('state variable'), id=self._make_id())
             glyph.append(state_glyph)
         return glyph

--- a/indra/assemblers/sbgn_assembler.py
+++ b/indra/assemblers/sbgn_assembler.py
@@ -37,12 +37,12 @@ class SBGNAssembler(object):
         XML ElementTree.
     """
 
-    process_style = {'x': '0', 'y': '0', 'w': '20', 'h': '20'}
-    source_sink_style = {'x': '0', 'y': '0', 'w': '20', 'h': '20'}
-    monomer_style = {'x': '0', 'y': '0', 'w': '50', 'h': '30'}
-    complex_style = {'x': '0', 'y': '0', 'w': '60', 'h': '60'}
-    entity_type_style = {'x': '0', 'y': '0', 'w': '20', 'h': '15'}
-    entity_state_style = {'x': '1', 'y': '0', 'w': '20', 'h': '15'}
+    process_style = {'x': '0', 'y': '0', 'w': '10', 'h': '10'}
+    source_sink_style = {'x': '0', 'y': '0', 'w': '10', 'h': '10'}
+    monomer_style = {'x': '0', 'y': '0', 'w': '60', 'h': '30'}
+    complex_style = {'x': '1', 'y': '1', 'w': '60', 'h': '65'}
+    entity_type_style = {'x': '0', 'y': '0', 'w': '30', 'h': '12'}
+    entity_state_style = {'x': '1', 'y': '1', 'w': '28', 'h': '12'}
 
     def __init__(self, statements=None):
         if not statements:
@@ -263,13 +263,14 @@ class SBGNAssembler(object):
                              emaker.bbox(**self.monomer_style),
                              class_(agent_type), id=agent_id)
 
+        # Temporarily remove
         # Make a glyph for the agent type
         # TODO: handle other agent types
-        type_glyph = emaker.glyph(emaker.label(text='mt:prot'),
-                                  class_('unit of information'),
-                                  emaker.bbox(**self.entity_type_style),
-                                  id=self._make_id())
-        glyph.append(type_glyph)
+        #type_glyph = emaker.glyph(emaker.label(text='mt:prot'),
+        #                          class_('unit of information'),
+        #                          emaker.bbox(**self.entity_type_style),
+        #                          id=self._make_id())
+        #glyph.append(type_glyph)
 
         # Make glyphs for agent state
         # TODO: handle location, mutation
@@ -347,12 +348,13 @@ class SBGNAssembler(object):
         glyph = emaker.glyph(emaker.label(text=pattern.monomer.name),
                              emaker.bbox(**self.monomer_style),
                              class_('macromolecule'), id=agent_id)
+        # Temporarily remove this
         # Add a glyph for type
-        type_glyph = emaker.glyph(emaker.label(text='mt:prot'),
-                                  class_('unit of information'),
-                                  emaker.bbox(**self.entity_type_style),
-                                  id=self._make_id())
-        glyph.append(type_glyph)
+        #type_glyph = emaker.glyph(emaker.label(text='mt:prot'),
+        #                          class_('unit of information'),
+        #                          emaker.bbox(**self.entity_type_style),
+        #                          id=self._make_id())
+        #glyph.append(type_glyph)
         for site, value in pattern.site_conditions.items():
             if value is None or isinstance(value, int):
                 continue

--- a/indra/assemblers/sbgn_assembler.py
+++ b/indra/assemblers/sbgn_assembler.py
@@ -322,6 +322,7 @@ class SBGNAssembler(object):
                 emaker.glyph(emaker.bbox(x='1', y='1', w='70', h='30'),
                              class_('complex'), id=agent_id)
             for glyph in monomer_glyphs:
+                glyph.attrib['id'] = agent_id + glyph.attrib['id']
                 complex_glyph.append(glyph)
             return complex_glyph
         return monomer_glyphs[0]

--- a/indra/assemblers/sbgn_assembler.py
+++ b/indra/assemblers/sbgn_assembler.py
@@ -331,9 +331,15 @@ class SBGNAssembler(object):
         agent_id = self._make_agent_id(pattern)
         glyph = emaker.glyph(emaker.label(text=pattern.monomer.name),
                              emaker.bbox(x='0', y='0', w='140', h='60'),
-                             class_('protein'), id=agent_id)
+                             class_('macromolecule'), id=agent_id)
+        # Add a glyph for type
+        type_glyph = emaker.glyph(emaker.label(text='mt:prot'),
+                                  class_('unit of information'),
+                                  emaker.bbox(x='0', y='0', w='53', h='18'),
+                                  id=self._make_id())
+        glyph.append(type_glyph)
         for site, value in pattern.site_conditions.items():
-            if value is None:
+            if value is None or isinstance(value, int):
                 continue
             state = emaker.state(variable=site, value=value)
             state_glyph = \


### PR DESCRIPTION
This PR adds a new style of SBGN Assembly which starts with a PySB model rather than INDRA Statements. Once a reaction network is generated from a PySB model, saving into this style of SBGN is merely an export task, therefore this is accessible via `PysbAssembler.export_model`. The advantage of this is that SBGN generated this was is guaranteed to be causally connected. The disadvantage is that it requires a reaction network to be generated which (1) may not exist if certain initial conditions are not met (2) may be infinite (3) may be finite but very complex and hard to layout and visualize. The advantage of the earlier SBGN assembly style (still accessible in `indra.assemblers.sbgn_assembler.SBGNAssembler` is that it can be generated from any INDRA Statement content with less restrictions on having to constitute a reaction network, and its complexity scales with the number of Statements being assembled. However, there may be apparent causal disconnects in the visualized model.