### PR TITLE
Update API, tweak cBio client in order to use it with Interactive Pathway Map

### DIFF
--- a/indra/databases/cbio_client.py
+++ b/indra/databases/cbio_client.py
@@ -424,6 +424,8 @@ def get_ccle_mrna(gene_list, cell_lines):
                 value_cell = df[cell_line][df['COMMON'] == gene]
                 if value_cell.empty:
                     mrna_amounts[cell_line][gene] = None
+                elif pandas.isnull(value_cell.values[0]):
+                    mrna_amounts[cell_line][gene] = None
                 else:
                     value = value_cell.values[0]
                     mrna_amounts[cell_line][gene] = value

--- a/indra/databases/cbio_client.py
+++ b/indra/databases/cbio_client.py
@@ -301,7 +301,7 @@ def get_cancer_types(cancer_filter=None):
     return type_ids
 
 
-def get_mutations_ccle(gene_list, cell_lines, mutation_type=None):
+def get_ccle_mutations(gene_list, cell_lines, mutation_type=None):
     """Return a dict of mutations in given genes and cell lines from CCLE.
 
     This is a specialized call to get_mutations tailored to CCLE cell lines.

--- a/indra/databases/cbio_client.py
+++ b/indra/databases/cbio_client.py
@@ -219,6 +219,12 @@ def get_genetic_profiles(study_id, profile_filter=None):
     'cellline_ccle_broad_mutations' for mutations, 'cellline_ccle_broad_CNA'
     for copy number alterations, etc.
 
+    CNA values correspond to the following alterations
+    -2 = homozygous deletion
+    -1 = hemizygous deletion
+     0 = neutral / no change
+     1 = gain
+     2 = high level amplification
 
     Parameters
     ----------

--- a/indra/databases/cbio_client.py
+++ b/indra/databases/cbio_client.py
@@ -172,7 +172,7 @@ def get_profile_data(study_id, gene_list,
             'case_set_id': case_set_id,
             'genetic_profile_id': genetic_profile,
             'gene_list': gene_list_str,
-            'skiprows': 2}
+            'skiprows': -1}
     df = send_request(**data)
     case_list_df = [x for x in df.columns.tolist()
                     if x not in ['GENE_ID', 'COMMON']]

--- a/indra/tests/test_cbio_client.py
+++ b/indra/tests/test_cbio_client.py
@@ -46,8 +46,8 @@ def test_get_ccle_lines_for_mutation():
     assert(len(cl_BRAF_V600E) == 55)
 
 
-def test_get_mutations_ccle():
-    muts = cbio_client.get_mutations_ccle(['BRAF', 'AKT1'],
+def test_get_ccle_mutations():
+    muts = cbio_client.get_ccle_mutations(['BRAF', 'AKT1'],
                                           ['LOXIMVI_SKIN', 'A101D_SKIN'])
     assert len([x for x in muts]) == 2
     assert 'V600E' in muts['LOXIMVI_SKIN']['BRAF']

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -316,7 +316,7 @@ def assemble_loopy():
 
 
 #   CCLE mRNA amounts   #
-@route('/databases/cbio/ccle_mrna_amounts', method=['POST', 'OPTIONS'])
+@route('/databases/cbio/get_ccle_mrna', method=['POST', 'OPTIONS'])
 @allow_cors
 def get_ccle_mrna_levels():
     """Get CCLE mRNA amounts using cBioClient"""
@@ -333,7 +333,7 @@ def get_ccle_mrna_levels():
 
 
 #   CCLE CNA   #
-@route('/databases/cbio/ccle_cna', method=['POST', 'OPTIONS'])
+@route('/databases/cbio/get_ccle_cna', method=['POST', 'OPTIONS'])
 @allow_cors
 def get_ccle_cna():
     """Get CCLE CNA

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -332,6 +332,29 @@ def get_ccle_mrna_levels():
     return res
 
 
+#   CCLE CNA   #
+@route('/databases/cbio/ccle_cna', method=['POST', 'OPTIONS'])
+@allow_cors
+def get_ccle_cna():
+    """Get CCLE CNA
+    -2 = homozygous deletion
+    -1 = hemizygous deletion
+     0 = neutral / no change
+     1 = gain
+     2 = high level amplification
+    """
+    if request.method == 'OPTIONS':
+        return {}
+    response = request.body.read().decode('utf-8')
+    body = json.loads(response)
+    gene_list = body.get('gene_list')
+    cell_lines = body.get('cell_lines')
+    cna = cbio_client.get_ccle_cna(gene_list, cell_lines)
+    cna_str = json.dumps(cna)
+    res = {'cna': cna_str}
+    return res
+
+
 @route('/preassembly/map_grounding', method=['POST', 'OPTIONS'])
 @allow_cors
 def map_grounding():

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -355,6 +355,24 @@ def get_ccle_cna():
     return res
 
 
+@route('/databases/cbio/get_mutations_ccle', method=['POST', 'OPTIONS'])
+@allow_cors
+def get_mutations_ccle():
+    """Get CCLE mutations
+    returns the amino acid changes for a given list of genes and cell lines
+    """
+    if request.method == 'OPTIONS':
+        return {}
+    response = request.body.read().decode('utf-8')
+    body = json.loads(response)
+    gene_list = body.get('gene_list')
+    cell_lines = body.get('cell_lines')
+    mutations = cbio_client.get_mutations_ccle(gene_list, cell_lines)
+    mutations_str = json.dumps(mutations)
+    res = {'mutations': mutations_str}
+    return res
+
+
 @route('/preassembly/map_grounding', method=['POST', 'OPTIONS'])
 @allow_cors
 def map_grounding():

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -327,8 +327,7 @@ def get_ccle_mrna_levels():
     gene_list = body.get('gene_list')
     cell_lines = body.get('cell_lines')
     mrna_amounts = cbio_client.get_ccle_mrna(gene_list, cell_lines)
-    mrna_amounts_str = json.dumps(mrna_amounts)
-    res = {'mrna_amounts': mrna_amounts_str}
+    res = {'mrna_amounts': mrna_amounts}
     return res
 
 
@@ -350,8 +349,7 @@ def get_ccle_cna():
     gene_list = body.get('gene_list')
     cell_lines = body.get('cell_lines')
     cna = cbio_client.get_ccle_cna(gene_list, cell_lines)
-    cna_str = json.dumps(cna)
-    res = {'cna': cna_str}
+    res = {'cna': cna}
     return res
 
 
@@ -367,9 +365,8 @@ def get_ccle_mutations():
     body = json.loads(response)
     gene_list = body.get('gene_list')
     cell_lines = body.get('cell_lines')
-    mutations_str = json.dumps(mutations)
-    res = {'mutations': mutations_str}
     mutations = cbio_client.get_ccle_mutations(gene_list, cell_lines)
+    res = {'mutations': mutations}
     return res
 
 

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -355,9 +355,9 @@ def get_ccle_cna():
     return res
 
 
-@route('/databases/cbio/get_mutations_ccle', method=['POST', 'OPTIONS'])
+@route('/databases/cbio/get_ccle_mutations', method=['POST', 'OPTIONS'])
 @allow_cors
-def get_mutations_ccle():
+def get_ccle_mutations():
     """Get CCLE mutations
     returns the amino acid changes for a given list of genes and cell lines
     """
@@ -367,9 +367,9 @@ def get_mutations_ccle():
     body = json.loads(response)
     gene_list = body.get('gene_list')
     cell_lines = body.get('cell_lines')
-    mutations = cbio_client.get_mutations_ccle(gene_list, cell_lines)
     mutations_str = json.dumps(mutations)
     res = {'mutations': mutations_str}
+    mutations = cbio_client.get_ccle_mutations(gene_list, cell_lines)
     return res
 
 

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -7,6 +7,7 @@ from indra.statements import *
 from indra.assemblers import PysbAssembler, CxAssembler, GraphAssembler,\
     CyJSAssembler, SifAssembler
 import indra.tools.assemble_corpus as ac
+from indra.databases import cbio_client
 
 logger = logging.getLogger('rest_api')
 logger.setLevel(logging.DEBUG)
@@ -311,6 +312,23 @@ def assemble_loopy():
     sa.make_model(use_name_as_key=True)
     model_str = sa.print_loopy(as_url=True)
     res = {'loopy_url': model_str}
+    return res
+
+
+#   CCLE mRNA amounts   #
+@route('/databases/cbio/ccle_mrna_amounts', method=['POST', 'OPTIONS'])
+@allow_cors
+def get_ccle_mrna_levels():
+    """Get CCLE mRNA amounts using cBioClient"""
+    if request.method == 'OPTIONS':
+        return {}
+    response = request.body.read().decode('utf-8')
+    body = json.loads(response)
+    gene_list = body.get('gene_list')
+    cell_lines = body.get('cell_lines')
+    mrna_amounts = cbio_client.get_ccle_mrna(gene_list, cell_lines)
+    mrna_amounts_str = json.dumps(mrna_amounts)
+    res = {'mrna_amounts': mrna_amounts_str}
     return res
 
 

--- a/rest_api/docs/api_spec.js
+++ b/rest_api/docs/api_spec.js
@@ -789,6 +789,50 @@ var api_spec = {
         }
       }
     },
+    "/databases/cbio/get_ccle_mutations": {
+      "post": {
+        "tags": [
+          "databases"
+        ],
+        "summary": "Query CCLE for mutations (CNAs) using the cBioPortal client",
+        "operationId": "get_ccle_mutations",
+        "description": "Returns mutations for the provided list of genes and cell lines within CCLE",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "contextRequestObj",
+            "description": "object with a key of \"gene_list\" referencing a list of HGNC symbols and a key of \"cell_lines\" referencing a list of CCLE cell line names.",
+            "schema": {
+              "$ref": "#/definitions/contextRequestObj"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CNAs levels obtained.",
+            "example" : {
+              "mutations": {
+                "SKMEL28_SKIN": {
+                  "BRAF": [
+                    "V600E"
+                  ],
+                  "MAP2K1": []
+                },
+                "BT20_BREAST": {
+                  "BRAF": [],
+                  "MAP2K1": []
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/rest_api/docs/api_spec.js
+++ b/rest_api/docs/api_spec.js
@@ -746,6 +746,49 @@ var api_spec = {
         }
       }
     },
+    "/databases/cbio/get_ccle_cna": {
+      "post": {
+        "tags": [
+          "databases"
+        ],
+        "summary": "Query CCLE for copy number alterations (CNAs) using the cBioPortal client",
+        "operationId": "get_ccle_cna",
+        "description": "Returns CNAs for the provided list of genes and cell lines within CCLE",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "contextRequestObj",
+            "description": "object with a key of \"gene_list\" referencing a list of HGNC symbols and a key of \"cell_lines\" referencing a list of CCLE cell line names.",
+            "schema": {
+              "$ref": "#/definitions/contextRequestObj"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CNAs levels obtained.",
+            "example" : {
+              "cna": {
+                "SKMEL28_SKIN": {
+                  "BRAF": 1,
+                  "MAP2K1": -1
+                },
+                "BT20_BREAST": {
+                  "BRAF": 1,
+                  "MAP2K1": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     }
   },
   "definitions": {

--- a/rest_api/docs/api_spec.js
+++ b/rest_api/docs/api_spec.js
@@ -744,6 +744,33 @@ var api_spec = {
         }
       }
     },
+    "gene_list": {
+      "type": "array",
+      "example": [
+        "BRAF",
+        "MAP2K1"
+      ]},
+    "cell_lines": {
+      "type": "array",
+      "example": [
+        "SKMEL28_SKIN",
+        "BT20_BREAST"
+      ]},
+    "contextRequestObj": {
+      "type": "object",
+      "required": [
+        "gene_list",
+        "cell_lines"
+      ],
+      "properties": {
+        "gene_list": {
+          "$ref": "#/definitions/gene_list"
+        },
+        "cell_lines": {
+          "$ref": "#/definitions/cell_lines"
+        }
+      }
+    },
     "genesSourceTargetObj": {
       "type": "object",
       "required": [

--- a/rest_api/docs/api_spec.js
+++ b/rest_api/docs/api_spec.js
@@ -702,6 +702,50 @@ var api_spec = {
           }
         }
       }
+    },
+    "/databases/cbio/get_ccle_mrna": {
+      "post": {
+        "tags": [
+          "databases"
+        ],
+        "summary": "Query CCLE for mRNA amounts using the cBioPortal client",
+        "operationId": "get_ccle_mrna",
+        "description": "Returns mRNA amounts for the provided list of genes and cell lines within CCLE",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "contextRequestObj",
+            "description": "object with a key of \"gene_list\" referencing a list of HGNC symbols and a key of \"cell_lines\" referencing a list of CCLE cell line names.",
+            "schema": {
+              "$ref": "#/definitions/contextRequestObj"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "mRNA levels obtained.",
+            "example" : {
+              "mrna_amounts": {
+                "SKMEL28_SKIN": {
+                  "BRAF": 6.2354449999999995,
+                  "MAP2K1": 10.26864
+                },
+                "BT20_BREAST": {
+                  "BRAF": 8.774852000000001,
+                  "MAP2K1": 12.08755
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     }
   },
   "definitions": {


### PR DESCRIPTION
- added API endpoints for `cbio_client` functions:
    - `get_mutations_ccle`
    - `get_ccle_mrna`
    - `get_ccle_cna`
- minor change to `cbio_client.get_profile_data` function
    - now uses adaptive line skipping which was previously implemented but unused in this function
