### PR TITLE
Signor Processor

### DIFF
--- a/doc/modules/sources/index.rst
+++ b/doc/modules/sources/index.rst
@@ -9,3 +9,4 @@ Processors for model input (:py:mod:`indra.sources`)
    reach/index
    trips/index
    ndex_cx/index
+   signor/index

--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -15,6 +15,7 @@ default_probs = {
         'r3': 0.1,
         'phosphosite': 0.01,
         'ndex': 0.049,
+        'signor': 0.049,
         'assertion': 0.0,
         },
     'syst': {
@@ -27,6 +28,7 @@ default_probs = {
         'r3': 0.05,
         'phosphosite': 0.01,
         'ndex': 0.01,
+        'signor': 0.01,
         'assertion': 0.0,
         }
     }

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import, print_function, unicode_literals
+from builtins import dict, str
+from indra.util import read_unicode_csv
+
+
+class SignorProcessor(object):
+    """Processor for Signor dataset available at http://signor.uniroma2.it.
+
+    See publication:
+
+    Perfetto et al., "SIGNOR: a database of causal relationships between
+    biological entities," Nucleic Acids Research, Volume 44, Issue D1, 4
+    January 2016, Pages D548–D554. https://doi.org/10.1093/nar/gkv1048
+
+    Parameters
+    ----------
+    signor_csv : str
+        Path to SIGNOR CSV file.
+    delimiter : str
+        Field delimiter for CSV file. Defaults to semicolon ';'.
+    """
+    def __init__(self, signor_csv, delimiter=';'):
+        self._data = list(read_unicode_csv(signor_csv, delimiter=';'))
+        
+

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -237,7 +237,7 @@ class SignorProcessor(object):
             stmts.append(IncreaseAmount(agent_a, agent_b, evidence=evidence))
         elif row.MECHANISM == 'destabilization' and \
              row.EFFECT in ('down-regulates', 'down-regulates quantity',
-                            'down-regulates quantity by stabilization'):
+                            'down-regulates quantity by destabilization'):
             stmts.append(DecreaseAmount(agent_a, agent_b, evidence=evidence))
         elif row.MECHANISM == 'chemical activation' and \
              row.EFFECT in ('up-regulates', 'up-regulates activity'):

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -224,7 +224,7 @@ class SignorProcessor(object):
                 'MODBSEQ': _n(row.MODBSEQ),
                 'NOTES': _n(row.NOTES),
                 'ANNOTATOR': _n(row.ANNOTATOR)}
-        return Evidence(source_api='SIGNOR', source_id=row.SIGNOR_ID,
+        return Evidence(source_api='signor', source_id=row.SIGNOR_ID,
                         pmid=row.PMID, text=row.SENTENCE,
                         epistemics=epistemics, annotations=annotations)
 

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -236,8 +236,10 @@ class SignorProcessor(object):
         # if not, don't make a mechanism statement
         if mech_stmt_type and issubclass(mech_stmt_type, Modification):
             # Because this is a modification, check for a residue
-            res_pos = row.RESIDUE
-            mech_stmt = mech_stmt_type(agent_a, agent_b, evidence=evidence)
+            res, pos = _parse_residue_position(row.RESIDUE) \
+                        if row.RESIDUE else (None, None)
+            mech_stmt = mech_stmt_type(agent_a, agent_b, res, pos,
+                                       evidence=evidence)
         elif mech_stmt_type:
             mech_stmt = mech_stmt_type(agent_a, agent_b, evidence=evidence)
         else:
@@ -252,14 +254,19 @@ def _parse_residue_position(respos):
     res = respos[0:3]
     pos = respos[3:]
     # Get the abbreviated amino acid
-    aa = amino_acids_reverse.get(res.lower())
-    if not aa:
+    res = amino_acids_reverse.get(res.lower())
+    if not res:
         logger.warning("Could not get amino acid residue for residue/position "
                        "%s" % respos)
+        return (None, None)
+    # If there's no position, return residue only
+    if not pos:
+        return (res, None)
     # Make sure the position is an integer
     try:
         int(pos)
     except ValueError:
         logger.warning("Could not get valid position for residue/position "
                        "%s" % respos)
+        return (None, None)
     return (res, pos)

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -291,12 +291,13 @@ class SignorProcessor(object):
                 af_agent = deepcopy(agent_b)
                 af_agent.mods = mod_stmt._get_mod_condition()
                 # TODO: Currently this turns any upregulation associated with
-                # the modification into an ActiveForm (even up-regulations
-                # associated with increased amounts). This should be updated
-                # once we have a statement type relating Agent states to
-                # effects on amounts.
+                # the modification into an ActiveForm (even up/down-regulations
+                # associated with amounts). This should be updated once we have
+                # a statement type relating Agent states to effects on amounts.
                 if row.EFFECT.startswith('up'):
                     stmts.append(ActiveForm(af_agent, 'activity', True))
+                elif row.EFFECT.startswith('down'):
+                    stmts.append(ActiveForm(af_agent, 'activity', False))
             else:
                 # Modification
                 residues = _parse_residue_positions(row.RESIDUE)
@@ -311,7 +312,9 @@ class SignorProcessor(object):
                 # TODO: See above.
                 if row.EFFECT.startswith('up'):
                     stmts.append(ActiveForm(af_agent, 'activity', True))
-        # Don't make a new complex statement if 
+                elif row.EFFECT.startswith('down'):
+                    stmts.append(ActiveForm(af_agent, 'activity', False))
+        # For Complex statements, we create an ActiveForm with a BoundCondition.
         elif mech_stmt_type == Complex:
             stmts.append(mech_stmt_type([agent_a, agent_b], evidence=evidence))
             # TODO Add ActiveForm statements here

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -265,10 +265,8 @@ class SignorProcessor(object):
         else:
             mech_stmts = []
 
-        if effect_stmt is not None and \
-           effect_stmt.matches_key() in [s.matches_key() for s in mech_stmts]:
-            logger.warning("Duplicate statement!")
-            #print(repr(row))
+        if effect_stmt is not None:
+            mech_stmts = [m for m in mech_stmts if not m.matches(effect_stmt)]
 
         return (effect_stmt, mech_stmts, None)
 

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -1,3 +1,13 @@
+"""
+An input processor for the SIGNOR database: a database of causal relationships
+between biological entities.
+
+See publication:
+
+Perfetto et al., "SIGNOR: a database of causal relationships between
+biological entities," Nucleic Acids Research, Volume 44, Issue D1, 4
+January 2016, Pages D548-D554. https://doi.org/10.1093/nar/gkv1048
+"""
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from io import StringIO
@@ -122,12 +132,6 @@ _effect_map = {
 class SignorProcessor(object):
     """Processor for Signor dataset, available at http://signor.uniroma2.it.
 
-    See publication:
-
-    Perfetto et al., "SIGNOR: a database of causal relationships between
-    biological entities," Nucleic Acids Research, Volume 44, Issue D1, 4
-    January 2016, Pages D548-D554. https://doi.org/10.1093/nar/gkv1048
-
     Parameters
     ----------
     signor_csv : str
@@ -137,13 +141,13 @@ class SignorProcessor(object):
     delimiter : str
         Field delimiter for CSV file. Defaults to semicolon ';'.
 
-   Attributes
-   ----------
-   no_mech_rows: list of SignorRow namedtuples
-       List of rows where no mechanism statements were generated.
-   no_mech_ctr : collections.Counter
-       Counter listing the frequency of different MECHANISM types in the
-       list of no-mechanism rows.
+    Attributes
+    ----------
+    no_mech_rows: list of SignorRow namedtuples
+        List of rows where no mechanism statements were generated.
+    no_mech_ctr : collections.Counter
+        Counter listing the frequency of different MECHANISM types in the
+        list of no-mechanism rows.
     """
     def __init__(self, signor_csv=None, delimiter=';'):
         # Get generator over the CSV file

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import logging
-from collections import namedtuple
+from collections import namedtuple, Counter, defaultdict
 
 from indra.statements import *
 from indra.util import read_unicode_csv
@@ -53,6 +53,45 @@ _type_db_map = {
     ('chemical', 'PUBCHEM'): 'PUBCHEM',
 }
 
+_mechanism_map = {
+    'catalytic activity': None, # Conversion
+    'oxidoreductase activity': None,
+    'transcriptional activation': None, # IncreaseAmount by tscript
+    'transcriptional repression': None, # DecreaseAmount by tscript
+    'Farnesylation': Farnesylation,
+    'gtpase-activating protein': Gap,
+    'deacetylation': Deacetylation,
+    'demethylation': Demethylation,
+    'dephosphorylation': Dephosphorylation,
+    'destabilization': DecreaseAmount,
+    'guanine nucleotide exchange factor': Gef,
+    'acetylation': Acetylation,
+    'binding': Complex,
+    'cleavage': None, # Important!
+    'desumoylation': Desumoylation,
+    'deubiquitination': Deubiquitination,
+    'glycosylation': Glycosylation,
+    'hydroxylation': Hydroxylation,
+    'neddylation': None, # Neddylation,
+    'chemical activation': Activation,
+    'chemical inhibition': Inhibition,
+    'trimethylation': Methylation,
+    'ubiquitination': Ubiquitination,
+    'post transcriptional regulation': None,
+    'relocalization': Translocation,
+    'small molecule catalysis': None,
+    's-nitrosylation': None,
+    'transcriptional regulation': RegulateAmount, # Subject has tscript activity
+    'translation regulation': None,
+    'tyrosination': None,
+    'lipidation': None,
+    'oxidation': None,
+    'methylation': Methylation,
+    'palmitoylation': Palmitoylation,
+    'phosphorylation': Phosphorylation,
+    'stabilization': IncreaseAmount,
+    'sumoylation': Sumoylation
+}
 
 SignorRow = namedtuple('SignorRow', _signor_fields)
 
@@ -80,6 +119,19 @@ class SignorProcessor(object):
         next(data_iter)
         # Process into a list of SignorRow namedtuples
         self._data = [SignorRow(*r) for r in data_iter]
+        self.statements = []
+
+    def make_model(self):
+        mechs = []
+        mech_map = defaultdict(list)
+        for row in self._data:
+            #self.statements.append(self._process_row(row))
+            key = (row.EFFECT, row.MECHANISM)
+            mechs.append(key)
+            mech_map[key].append(row)
+        mech_ctr = Counter(mechs)
+        mech_ctr = sorted(mech_ctr.items(), key=lambda x: x[1], reverse=True)
+        return (mech_ctr, mech_map)
 
     @staticmethod
     def _get_agent(ent_name, ent_type, id, database):
@@ -102,7 +154,34 @@ class SignorProcessor(object):
             db_refs = {}
         return Agent(name, db_refs=db_refs)
 
-    def _process_row():
-        agent_a = _entity_a(row)
+    #@staticmethod(agent_a, agent_b, mechanism, effect,
+    @staticmethod
+    def _get_evidence(row):
+        # Get epistemics (direct/indirect)
+        epistemics = {}
+        epistemics['direct'] = True if row.DIRECT == 'YES' else False
+        # Get annotations
+        _n = lambda s: s if s else None
+        annotations = {
+                'SEQUENCE': _n(row.SEQUENCE),
+                'TAX_ID': _n(row.TAX_ID),
+                'CELL_DATA': _n(row.CELL_DATA),
+                'TISSUE_DATA': _n(row.TISSUE_DATA),
+                'MODULATOR_COMPLEX': _n(row.MODULATOR_COMPLEX),
+                'TARGET_COMPLEX': _n(row.TARGET_COMPLEX),
+                'MODIFICATIONA': _n(row.MODIFICATIONA),
+                'MODASEQ': _n(row.MODASEQ),
+                'MODIFICATIONB': _n(row.MODIFICATIONB),
+                'MODBSEQ': _n(row.MODBSEQ),
+                'NOTES': _n(row.NOTES),
+                'ANNOTATOR': _n(row.ANNOTATOR)}
+        return Evidence(source_api='SIGNOR', source_id=row.SIGNOR_ID,
+                        pmid=row.PMID, text=row.SENTENCE,
+                        epistemics=epistemics, annotations=annotations)
 
 
+    @staticmethod
+    def _process_row(row):
+        agent_a = _get_agent(row.ENTITYA, row.TYPEA, row.IDA, row.DATABASEA)
+        agent_b = _get_agent(row.ENTITYB, row.TYPEB, row.IDB, row.DATABASEB)
+        

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -315,9 +315,11 @@ class SignorProcessor(object):
                 # associated with amounts). This should be updated once we have
                 # a statement type relating Agent states to effects on amounts.
                 if row.EFFECT.startswith('up'):
-                    stmts.append(ActiveForm(af_agent, 'activity', True))
+                    stmts.append(ActiveForm(af_agent, 'activity', True,
+                                            evidence=evidence))
                 elif row.EFFECT.startswith('down'):
-                    stmts.append(ActiveForm(af_agent, 'activity', False))
+                    stmts.append(ActiveForm(af_agent, 'activity', False,
+                                            evidence=evidence))
             else:
                 # Modification
                 residues = _parse_residue_positions(row.RESIDUE)
@@ -331,9 +333,11 @@ class SignorProcessor(object):
                 af_agent.mods = mcs
                 # TODO: See above.
                 if row.EFFECT.startswith('up'):
-                    stmts.append(ActiveForm(af_agent, 'activity', True))
+                    stmts.append(ActiveForm(af_agent, 'activity', True,
+                                            evidence=evidence))
                 elif row.EFFECT.startswith('down'):
-                    stmts.append(ActiveForm(af_agent, 'activity', False))
+                    stmts.append(ActiveForm(af_agent, 'activity', False,
+                                            evidence=evidence))
         # For Complex statements, we create an ActiveForm with a BoundCondition.
         elif mech_stmt_type == Complex:
             # Complex
@@ -343,9 +347,11 @@ class SignorProcessor(object):
             af_bc_agent = deepcopy(agent_a)
             af_agent.bound_conditions = [BoundCondition(af_bc_agent, True)]
             if row.EFFECT.startswith('up'):
-                stmts.append(ActiveForm(af_agent, 'activity', True))
+                stmts.append(ActiveForm(af_agent, 'activity', True,
+                                        evidence=evidence))
             elif row.EFFECT.startswith('down'):
-                stmts.append(ActiveForm(af_agent, 'activity', False))
+                stmts.append(ActiveForm(af_agent, 'activity', False,
+                                        evidence=evidence))
         # Other mechanism statement types
         elif mech_stmt_type:
             stmts.append(mech_stmt_type(agent_a, agent_b, evidence=evidence))

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -1,6 +1,44 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
+import logging
+from collections import namedtuple
 from indra.util import read_unicode_csv
+
+logger = logging.getLogger('signor')
+
+
+_signor_fields = [
+    'ENTITYA',
+    'TYPEA',
+    'IDA',
+    'DATABASEA',
+    'ENTITYB',
+    'TYPEB',
+    'IDB',
+    'DATABASEB',
+    'EFFECT',
+    'MECHANISM',
+    'RESIDUE',
+    'SEQUENCE',
+    'TAX_ID',
+    'CELL_DATA',
+    'TISSUE_DATA',
+    'MODULATOR_COMPLEX',
+    'TARGET_COMPLEX',
+    'MODIFICATIONA',
+    'MODASEQ',
+    'MODIFICATIONB',
+    'MODBSEQ',
+    'PMID',
+    'DIRECT',
+    'NOTES',
+    'ANNOTATOR',
+    'SENTENCE',
+    'SIGNOR_ID',
+]
+
+
+SignorRow = namedtuple('SignorRow', _signor_fields)
 
 
 class SignorProcessor(object):
@@ -20,6 +58,14 @@ class SignorProcessor(object):
         Field delimiter for CSV file. Defaults to semicolon ';'.
     """
     def __init__(self, signor_csv, delimiter=';'):
-        self._data = list(read_unicode_csv(signor_csv, delimiter=';'))
-        
+        # Get generator over the CSV file
+        data_iter = read_unicode_csv(signor_csv, delimiter=';')
+        # Skip the header row
+        next(data_iter)
+        # Process into a list of SignorRow namedtuples
+        self._data = [SignorRow(*r) for r in data_iter]
+
+    def _process_row(self):
+        pass
+
 

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -316,8 +316,17 @@ class SignorProcessor(object):
                     stmts.append(ActiveForm(af_agent, 'activity', False))
         # For Complex statements, we create an ActiveForm with a BoundCondition.
         elif mech_stmt_type == Complex:
+            # Complex
             stmts.append(mech_stmt_type([agent_a, agent_b], evidence=evidence))
-            # TODO Add ActiveForm statements here
+            # ActiveForm
+            af_agent = deepcopy(agent_b)
+            af_bc_agent = deepcopy(agent_a)
+            af_agent.bound_conditions = [BoundCondition(af_bc_agent, True)]
+            if row.EFFECT.startswith('up'):
+                stmts.append(ActiveForm(af_agent, 'activity', True))
+            elif row.EFFECT.startswith('down'):
+                stmts.append(ActiveForm(af_agent, 'activity', False))
+        # Other mechanism statement types
         elif mech_stmt_type:
             stmts.append(mech_stmt_type(agent_a, agent_b, evidence=evidence))
 

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import logging
+from os.path import join, dirname
 from collections import namedtuple, Counter, defaultdict
 
 from indra.statements import *
@@ -112,6 +113,10 @@ _effect_map = {
     'up-regulates quantity by expression': IncreaseAmount,
     'up-regulates quantity by stabilization': IncreaseAmount
 }
+
+
+signor_default_path = join(dirname(__file__), '..', '..', 'data',
+                          'all_data_23_09_17.csv')
 
 
 class SignorProcessor(object):

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -294,7 +294,6 @@ class SignorProcessor(object):
 
         return stmts
 
-# TODO: Mappings for SIGNOR families, complexes, etc.
 
 def _parse_residue_positions(residue_field):
     # First see if this string contains two positions
@@ -326,5 +325,5 @@ def _parse_residue_positions(residue_field):
 Known issues:
 * The generic "up-regulates" effect type should be mapped to a generic up
   regulation rather than Activation/Inhibition, as it is currently.
-*
+* Mappings for SIGNOR families, complexes, etc.
 """

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import logging
 from collections import namedtuple
+
+from indra.statements import *
 from indra.util import read_unicode_csv
 
 logger = logging.getLogger('signor')
@@ -65,7 +67,11 @@ class SignorProcessor(object):
         # Process into a list of SignorRow namedtuples
         self._data = [SignorRow(*r) for r in data_iter]
 
-    def _process_row(self):
-        pass
+    @staticmethod
+    def _entity_a(row):
+        return Agent('RELA', db_refs={'HGNC': '9955', 'UP': 'Q04206'})
+
+    def _process_row():
+        agent_a = _entity_a(row)
 
 

--- a/indra/sources/signor.py
+++ b/indra/sources/signor.py
@@ -289,7 +289,7 @@ class SignorProcessor(object):
                 stmts.append(mod_stmt)
                 # ActiveForm
                 af_agent = deepcopy(agent_b)
-                af_agent.mods = mod_stmt._get_mod_condition()
+                af_agent.mods = [mod_stmt._get_mod_condition()]
                 # TODO: Currently this turns any upregulation associated with
                 # the modification into an ActiveForm (even up/down-regulations
                 # associated with amounts). This should be updated once we have

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import, print_function, unicode_literals
+from builtins import dict, str
+from os.path import join, dirname
+from indra.sources.signor import SignorProcessor
+
+signor_test_path = join(dirname(__file__), '..', '..', 'data',
+                        'all_data_23_09_17.csv')
+
+def test_parse_csv():
+    sp = SignorProcessor(signor_test_path)
+
+if __name__ == '__main__':
+    test_parse_csv()

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -89,8 +89,9 @@ def test_get_evidence():
 
 
 def test_process_row():
-    stmt = SignorProcessor._process_row(test_row)
-    assert isinstance(stmt, IncreaseAmount)
+    (effect_stmt, mech_stmt, af_stmt) = SignorProcessor._process_row(test_row)
+    assert isinstance(effect_stmt, IncreaseAmount)
+    assert isinstance(mech_stmt, IncreaseAmount)
 
 
 def test_get_mechanism():

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -193,6 +193,47 @@ def test_process_row_binding_complex():
     assert len(stmts[0].agent_list()) == 2
 
 
+def test_process_row_phos_up():
+    test_row = SignorRow(ENTITYA='CHEK2', TYPEA='protein', IDA='O96017',
+            DATABASEA='UNIPROT', ENTITYB='CHEK2', TYPEB='protein', IDB='O96017',
+            DATABASEB='UNIPROT', EFFECT='up-regulates activity',
+            MECHANISM='phosphorylation', RESIDUE='Thr387',
+            SEQUENCE='LMRTLCGtPTYLAPE', TAX_ID='9606', CELL_DATA='BTO:0000007',
+            TISSUE_DATA='', MODULATOR_COMPLEX='', TARGET_COMPLEX='',
+            MODIFICATIONA='', MODASEQ='', MODIFICATIONB='', MODBSEQ='',
+            PMID='11901158', DIRECT='YES', NOTES='', ANNOTATOR='gcesareni',
+            SENTENCE='', SIGNOR_ID='SIGNOR-116131')
+    stmts = SignorProcessor._process_row(test_row)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 3
+    assert isinstance(stmts[0], Activation)
+    assert isinstance(stmts[1], Phosphorylation)
+    assert stmts[1].residue == 'T'
+    assert stmts[1].position == '387'
+    af = stmts[2]
+    assert isinstance(af, ActiveForm)
+    assert len(af.agent.mods) == 1
+    mc = ag.agent.mods[0]
+    assert mc.mod_type == 'phosphorylation'
+    assert mc.residue == 'T'
+    assert mc.position == '387'
+
+
+def test_process_row_phos_down():
+    # TODO
+    pass
+
+
+def test_process_row_complex_up():
+    # TODO
+    pass
+
+
+def test_process_row_complex_down():
+    # TODO
+    pass
+
+
 def test_parse_residue_positions():
     residues = _parse_residue_positions('TYR304')
     assert len(residues) == 1
@@ -225,13 +266,15 @@ def test_parse_residue_positions():
     assert residues[1][1] == '171'
 
 
+
+
 def test_get_mechanism():
     sp = SignorProcessor(signor_test_path)
     assert sp.statements
     globals().update(locals())
 
 if __name__ == '__main__':
-    test_process_row_destab()
+    #test_process_row_destab()
     #test_parse_csv()
     #test_get_agent()
     #test_get_agent_keyerror()
@@ -240,4 +283,4 @@ if __name__ == '__main__':
     #test_process_row_binding()
     #test_process_row_chem_inh()
     #test_parse_residue_positions()
-    #test_get_mechanism()
+    test_get_mechanism()

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -248,15 +248,89 @@ def test_process_row_phos_down():
 
 
 def test_process_row_phos_nores_up():
-    pass
+    test_row = SignorRow(ENTITYA='STK11', TYPEA='protein', IDA='Q15831',
+            DATABASEA='UNIPROT', ENTITYB='AMPK', TYPEB='complex',
+            IDB='SIGNOR-C15', DATABASEB='SIGNOR',
+            EFFECT='up-regulates activity', MECHANISM='phosphorylation',
+            RESIDUE='', SEQUENCE='', TAX_ID='-1', CELL_DATA='', TISSUE_DATA='', 
+            MODULATOR_COMPLEX='', TARGET_COMPLEX='', MODIFICATIONA='',
+            MODASEQ='', MODIFICATIONB='', MODBSEQ='', PMID='14976552',
+            DIRECT='YES', NOTES='', ANNOTATOR='lperfetto',
+            SENTENCE='', SIGNOR_ID='SIGNOR-242602')
+    stmts = SignorProcessor._process_row(test_row)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 3
+    assert isinstance(stmts[0], Activation)
+    assert isinstance(stmts[1], Phosphorylation)
+    assert stmts[1].residue is None
+    assert stmts[1].position is None
+    af = stmts[2]
+    assert isinstance(af, ActiveForm)
+    assert len(af.agent.mods) == 1
+    mc = af.agent.mods[0]
+    assert mc.mod_type == 'phosphorylation'
+    assert mc.residue is None
+    assert mc.position is None
+    assert af.is_active == True
 
 
 def test_process_row_phos_nores_down():
-    pass
+    test_row = SignorRow(ENTITYA='CSNK1D', TYPEA='protein', IDA='P48730',
+            DATABASEA='UNIPROT', ENTITYB='LEF1', TYPEB='protein', IDB='Q9UJU2',
+            DATABASEB='UNIPROT', EFFECT='down-regulates',
+            MECHANISM='phosphorylation', RESIDUE='', SEQUENCE='',
+            TAX_ID='9606', CELL_DATA='', TISSUE_DATA='', MODULATOR_COMPLEX='',
+            TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='', MODIFICATIONB='',
+            MODBSEQ='', PMID='15747065', DIRECT='YES', NOTES='',
+            ANNOTATOR='gcesareni', SENTENCE='', SIGNOR_ID='SIGNOR-134494')
+    stmts = SignorProcessor._process_row(test_row)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 3
+    assert isinstance(stmts[0], Inhibition)
+    assert isinstance(stmts[1], Phosphorylation)
+    assert stmts[1].residue is None
+    assert stmts[1].position is None
+    af = stmts[2]
+    assert isinstance(af, ActiveForm)
+    assert len(af.agent.mods) == 1
+    mc = af.agent.mods[0]
+    assert mc.mod_type == 'phosphorylation'
+    assert mc.residue is None
+    assert mc.position is None
+    assert af.is_active == False
 
 
 def test_process_row_phos_multi_res():
-    pass
+    test_row = SignorRow(ENTITYA='RAF1', TYPEA='protein', IDA='P04049',
+            DATABASEA='UNIPROT', ENTITYB='MAP2K2', TYPEB='protein',
+            IDB='P36507', DATABASEB='UNIPROT', EFFECT='up-regulates',
+            MECHANISM='phosphorylation', RESIDUE='Ser218;Ser222',
+            SEQUENCE='VSGQLIDsMANSFVG;LIDSMANsFVGTRSY', TAX_ID='9606',
+            CELL_DATA='', TISSUE_DATA='', MODULATOR_COMPLEX='',
+            TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='', MODIFICATIONB='',
+            MODBSEQ='', PMID='8157000', DIRECT='YES',
+            NOTES='', ANNOTATOR='gcesareni', SENTENCE='',
+            SIGNOR_ID='SIGNOR-36553')
+    stmts = SignorProcessor._process_row(test_row)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 4
+    assert isinstance(stmts[0], Activation)
+    assert isinstance(stmts[1], Phosphorylation)
+    assert stmts[1].position == '218'
+    assert isinstance(stmts[2], Phosphorylation)
+    assert stmts[2].position == '222'
+    af = stmts[3]
+    assert isinstance(af, ActiveForm)
+    assert len(af.agent.mods) == 2
+    mc0 = af.agent.mods[0]
+    assert mc0.mod_type == 'phosphorylation'
+    assert mc0.residue == 'S'
+    assert mc0.position == '218'
+    mc1 = af.agent.mods[1]
+    assert mc1.mod_type == 'phosphorylation'
+    assert mc1.residue == 'S'
+    assert mc1.position == '222'
+    assert af.is_active == True
 
 
 def test_process_row_complex_up():
@@ -319,3 +393,5 @@ if __name__ == '__main__':
     #test_process_row_chem_inh()
     #test_parse_residue_positions()
     test_get_mechanism()
+    test_process_row_phos_multi_res()
+

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -217,10 +217,45 @@ def test_process_row_phos_up():
     assert mc.mod_type == 'phosphorylation'
     assert mc.residue == 'T'
     assert mc.position == '387'
+    assert af.is_active == True
 
 
 def test_process_row_phos_down():
-    # TODO
+    test_row = SignorRow(ENTITYA='PRKCD', TYPEA='protein', IDA='Q05655',
+            DATABASEA='UNIPROT', ENTITYB='PTPN22', TYPEB='protein',
+            IDB='Q9Y2R2', DATABASEB='UNIPROT', EFFECT='down-regulates',
+            MECHANISM='phosphorylation', RESIDUE='Ser35',
+            SEQUENCE='FLKLKRQsTKYKADK', TAX_ID='9606', CELL_DATA='BTO:0000782',
+            TISSUE_DATA='', MODULATOR_COMPLEX='', TARGET_COMPLEX='',
+            MODIFICATIONA='', MODASEQ='', MODIFICATIONB='', MODBSEQ='',
+            PMID='18056643', DIRECT='YES', NOTES='', ANNOTATOR='llicata',
+            SENTENCE='', SIGNOR_ID='SIGNOR-159591')
+    stmts = SignorProcessor._process_row(test_row)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 3
+    assert isinstance(stmts[0], Inhibition)
+    assert isinstance(stmts[1], Phosphorylation)
+    assert stmts[1].residue == 'S'
+    assert stmts[1].position == '35'
+    af = stmts[2]
+    assert isinstance(af, ActiveForm)
+    assert len(af.agent.mods) == 1
+    mc = af.agent.mods[0]
+    assert mc.mod_type == 'phosphorylation'
+    assert mc.residue == 'S'
+    assert mc.position == '35'
+    assert af.is_active == False
+
+
+def test_process_row_phos_nores_up():
+    pass
+
+
+def test_process_row_phos_nores_down():
+    pass
+
+
+def test_process_row_phos_multi_res():
     pass
 
 

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -5,7 +5,8 @@ from nose.tools import raises
 
 from indra.statements import *
 from indra.databases import hgnc_client
-from indra.sources.signor import SignorProcessor, SignorRow
+from indra.sources.signor import SignorProcessor, SignorRow, \
+                                 _parse_residue_position
 
 def _id(gene):
     return hgnc_client.get_hgnc_id(gene)
@@ -94,6 +95,24 @@ def test_process_row():
     assert isinstance(mech_stmt, IncreaseAmount)
 
 
+def test_parse_residue_position():
+    res, pos = _parse_residue_position('TYR304')
+    assert res == 'Y'
+    assert pos == '304'
+    # Invalid residue
+    res, pos = _parse_residue_position('Foo')
+    assert res is None
+    assert pos is None
+    # Residue but not position
+    res, pos = _parse_residue_position('gly')
+    assert res == 'G'
+    assert pos == None
+    # Position can't be converted to int
+    res, pos = _parse_residue_position('glyxxx')
+    assert res == None
+    assert pos == None
+
+
 def test_get_mechanism():
     sp = SignorProcessor(signor_test_path)
     assert sp.statements
@@ -105,4 +124,5 @@ if __name__ == '__main__':
     test_get_agent_keyerror()
     test_get_evidence()
     test_process_row()
+    test_parse_residue_position()
     test_get_mechanism()

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -20,46 +20,80 @@ test_row = SignorRow(ENTITYA='RELA', TYPEA='protein', IDA='Q04206',
         TAX_ID='10090', CELL_DATA='BTO:0002895', TISSUE_DATA='',
         MODULATOR_COMPLEX='', TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='',
         MODIFICATIONB='', MODBSEQ='', PMID='19530226', DIRECT='YES', NOTES='',
-        ANNOTATOR='gcesareni', SENTENCE="""Together, these results indicate that
-        the Met gene is a direct target of NFkappaB and that Met participates
-        in NFkappaB-mediated cell survival.""", SIGNOR_ID='SIGNOR-241929')
+        ANNOTATOR='gcesareni',
+        SENTENCE="Together, these results indicate that the Met gene is a "\
+                 "direct target of NFkappaB and that Met participates "\
+                 "in NFkappaB-mediated cell survival.",
+        SIGNOR_ID='SIGNOR-241929')
 
 
 def test_parse_csv():
     sp = SignorProcessor(signor_test_path)
     assert isinstance(sp._data, list)
     assert isinstance(sp._data[0], SignorRow)
-    globals().update(locals())
 
 
 def test_get_agent():
     # Protein/gene
     test_ag = Agent('RELA', db_refs={'HGNC': _id('RELA'), 'UP': 'Q04206'})
-    sp_ag = sp._get_agent(test_row.ENTITYA, test_row.TYPEA, test_row.IDA,
-                          test_row.DATABASEA)
+    sp_ag = SignorProcessor._get_agent(test_row.ENTITYA, test_row.TYPEA,
+                                       test_row.IDA, test_row.DATABASEA)
     assert test_ag.matches(sp_ag)
     # Chemical
     test_ag = Agent('AZD1480', db_refs={'PUBCHEM': 'CID:16659841'})
-    sp_ag = sp._get_agent('AZD1480', 'chemical', 'CID:16659841', 'PUBCHEM')
+    sp_ag = SignorProcessor._get_agent('AZD1480', 'chemical', 'CID:16659841',
+                                       'PUBCHEM')
     assert test_ag.matches(sp_ag)
     # Signor phenotype
     test_ag = Agent('Cell cycle progr.', db_refs={'SIGNOR': 'SIGNOR-PH42'})
-    sp_ag = sp._get_agent('Cell cycle progr.', 'phenotype', 'SIGNOR-PH42',
-                          'SIGNOR')
+    sp_ag = SignorProcessor._get_agent('Cell cycle progr.', 'phenotype',
+                                       'SIGNOR-PH42', 'SIGNOR')
     assert test_ag.matches(sp_ag)
     # Ungrounded -- couldn't find a real example in the dataset
     test_ag = Agent('Foobar', db_refs={})
-    sp_ag = sp._get_agent('Foobar', 'pathway', None, None)
+    sp_ag = SignorProcessor._get_agent('Foobar', 'pathway', None, None)
     assert test_ag.matches(sp_ag)
-    sp_ag = sp._get_agent('Foobar', 'antibody', None, None)
+    sp_ag = SignorProcessor._get_agent('Foobar', 'antibody', None, None)
     assert test_ag.matches(sp_ag)
+
 
 @raises(KeyError)
 def test_get_agent_keyerror():
-    sp_ag = sp._get_agent('foo', 'bar', None, None)
+    sp_ag = SignorProcessor._get_agent('foo', 'bar', None, None)
+
+
+def test_get_evidence():
+    ev = SignorProcessor._get_evidence(test_row)
+    assert isinstance(ev, Evidence)
+    assert ev.pmid == '19530226'
+    assert ev.annotations == {
+            'SEQUENCE': None,
+            'TAX_ID': '10090',
+            'CELL_DATA': 'BTO:0002895',
+            'TISSUE_DATA': None,
+            'MODULATOR_COMPLEX': None,
+            'TARGET_COMPLEX': None,
+            'MODIFICATIONA': None,
+            'MODASEQ': None,
+            'MODIFICATIONB': None,
+            'MODBSEQ': None,
+            'NOTES': None,
+            'ANNOTATOR': 'gcesareni',
+        }
+    assert ev.epistemics['direct']
+    assert ev.source_api == 'SIGNOR'
+    assert ev.source_id == 'SIGNOR-241929'
+    assert ev.text == "Together, these results indicate that the Met gene " \
+                      "is a direct target of NFkappaB and that Met " \
+                      "participates in NFkappaB-mediated cell survival."
+
+#def test_get_mechanism():
+#    sp = SignorProcessor(signor_test_path)
+#    mechs, mech_map = sp.make_model()
 
 
 if __name__ == '__main__':
     test_parse_csv()
     test_get_agent()
     test_get_agent_keyerror()
+    test_get_evidence()

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -1,15 +1,54 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from os.path import join, dirname
+
+from indra.statements import *
+from indra.databases import hgnc_client
 from indra.sources.signor import SignorProcessor, SignorRow
+
+def _id(gene):
+    return hgnc_client.get_hgnc_id(gene)
 
 signor_test_path = join(dirname(__file__), '..', '..', 'data',
                         'all_data_23_09_17.csv')
+
+test_row = SignorRow(ENTITYA='RELA', TYPEA='protein', IDA='Q04206',
+        DATABASEA='UNIPROT', ENTITYB='MET', TYPEB='protein', IDB='P08581',
+        DATABASEB='UNIPROT', EFFECT='up-regulates quantity',
+        MECHANISM='transcriptional regulation', RESIDUE='', SEQUENCE='',
+        TAX_ID='10090', CELL_DATA='BTO:0002895', TISSUE_DATA='',
+        MODULATOR_COMPLEX='', TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='',
+        MODIFICATIONB='', MODBSEQ='', PMID='19530226', DIRECT='YES', NOTES='',
+        ANNOTATOR='gcesareni', SENTENCE="""Together, these results indicate that
+        the Met gene is a direct target of NFkappaB and that Met participates
+        in NFkappaB-mediated cell survival.""", SIGNOR_ID='SIGNOR-241929')
+
+signor_entity_types = [
+    'antibody',
+    'protein',
+    'complex',
+    'proteinfamily',
+    'smallmolecule',
+    'pathway',
+    'phenotype',
+    'stimulus',
+    'chemical'
+]
+
 
 def test_parse_csv():
     sp = SignorProcessor(signor_test_path)
     assert isinstance(sp._data, list)
     assert isinstance(sp._data[0], SignorRow)
+    globals().update(locals())
+
+
+def test_entity_a():
+    test_ag = Agent('RELA', db_refs={'HGNC': _id('RELA'), 'UP': 'Q04206'})
+    sp_ag = sp._entity_a(test_row)
+    assert test_ag.matches(sp_ag)
+
 
 if __name__ == '__main__':
     test_parse_csv()
+    test_entity_a()

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -1,13 +1,15 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from os.path import join, dirname
-from indra.sources.signor import SignorProcessor
+from indra.sources.signor import SignorProcessor, SignorRow
 
 signor_test_path = join(dirname(__file__), '..', '..', 'data',
                         'all_data_23_09_17.csv')
 
 def test_parse_csv():
     sp = SignorProcessor(signor_test_path)
+    assert isinstance(sp._data, list)
+    assert isinstance(sp._data[0], SignorRow)
 
 if __name__ == '__main__':
     test_parse_csv()

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -8,12 +8,6 @@ from indra.databases import hgnc_client
 from indra.sources.signor import SignorProcessor, SignorRow, \
                                  _parse_residue_positions
 
-def _id(gene):
-    return hgnc_client.get_hgnc_id(gene)
-
-signor_test_path = join(dirname(__file__), '..', '..', 'data',
-                        'all_data_23_09_17.csv')
-
 
 test_row = SignorRow(ENTITYA='RELA', TYPEA='protein', IDA='Q04206',
         DATABASEA='UNIPROT', ENTITYB='MET', TYPEB='protein', IDB='P08581',
@@ -30,14 +24,17 @@ test_row = SignorRow(ENTITYA='RELA', TYPEA='protein', IDA='Q04206',
 
 
 def test_parse_csv():
-    sp = SignorProcessor(signor_test_path)
+    sp = SignorProcessor()
     assert isinstance(sp._data, list)
     assert isinstance(sp._data[0], SignorRow)
+    assert isinstance(sp.statements, list)
+    assert isinstance(sp.statements[0], Statement)
 
 
 def test_get_agent():
     # Protein/gene
-    test_ag = Agent('RELA', db_refs={'HGNC': _id('RELA'), 'UP': 'Q04206'})
+    test_ag = Agent('RELA', db_refs={'HGNC': hgnc_client.get_hgnc_id('RELA'),
+                                     'UP': 'Q04206'})
     sp_ag = SignorProcessor._get_agent(test_row.ENTITYA, test_row.TYPEA,
                                        test_row.IDA, test_row.DATABASEA)
     assert test_ag.matches(sp_ag)
@@ -416,11 +413,4 @@ def test_parse_residue_positions():
     assert residues[0][1] == '169'
     assert residues[1][0] == 'Y'
     assert residues[1][1] == '171'
-
-
-def test_download_data():
-    sp = SignorProcessor()
-    assert isinstance(sp._data[0], SignorRow)
-    assert sp.statements
-    assert isinstance(sp.statements[0], Statement)
 

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -114,8 +114,7 @@ def test_process_row():
     (effect_stmt, mech_stmts, af_stmt) = SignorProcessor._process_row(test_row)
     assert isinstance(effect_stmt, IncreaseAmount)
     assert isinstance(mech_stmts, list)
-    assert len(mech_stmts) == 1
-    assert isinstance(mech_stmts[0], IncreaseAmount)
+    assert len(mech_stmts) == 0
 
 
 def test_process_row_binding():

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -98,22 +98,6 @@ def test_process_row():
     assert stmts[0].agent_list()[0].activity.activity_type == 'transcription'
 
 
-def test_process_row_binding():
-    test_row_binding = SignorRow(ENTITYA='SERPINA1', TYPEA='protein',
-        IDA='P01009', DATABASEA='UNIPROT', ENTITYB='LRP1', TYPEB='protein',
-        IDB='Q07954', DATABASEB='UNIPROT', EFFECT='up-regulates',
-        MECHANISM='binding', RESIDUE='', SEQUENCE='', TAX_ID='9606',
-        CELL_DATA='', TISSUE_DATA='', MODULATOR_COMPLEX='', TARGET_COMPLEX='',
-        MODIFICATIONA='', MODASEQ='', MODIFICATIONB='', MODBSEQ='',
-        PMID='8626456', DIRECT='YES', NOTES='', ANNOTATOR='gcesareni',
-        SENTENCE='', SIGNOR_ID='SIGNOR-41180')
-    stmts = SignorProcessor._process_row(test_row_binding)
-    assert isinstance(stmts, list)
-    assert len(stmts) == 2
-    assert isinstance(stmts[0], Activation)
-    assert isinstance(stmts[1], Complex)
-
-
 def test_process_row_chem_inh():
     test_row_chem_inh = SignorRow(ENTITYA='722544-51-6', TYPEA='chemical',
         IDA='CID:16007391', DATABASEA='PUBCHEM', ENTITYB='AURKB',
@@ -347,12 +331,15 @@ def test_process_row_complex_up():
     assert len(stmts) == 3
     assert isinstance(stmts[0], Activation)
     assert isinstance(stmts[1], Complex)
+    cplx_agent_a = stmts[1].agent_list()[0]
     cplx_agent_b = stmts[1].agent_list()[1]
     af = stmts[2]
     assert isinstance(af, ActiveForm)
+    # Won't fully match because of bound condition, so we check name
+    assert af.agent.name == cplx_agent_b.name
     assert len(af.agent.bound_conditions) == 1
     bc = af.agent.bound_conditions[0]
-    assert bc.agent.matches(cplx_agent_b)
+    assert bc.agent.matches(cplx_agent_a)
     assert bc.is_bound
     assert af.activity == 'activity'
     assert af.is_active
@@ -372,12 +359,15 @@ def test_process_row_complex_down():
     assert len(stmts) == 3
     assert isinstance(stmts[0], Inhibition)
     assert isinstance(stmts[1], Complex)
+    cplx_agent_a = stmts[1].agent_list()[0]
     cplx_agent_b = stmts[1].agent_list()[1]
     af = stmts[2]
     assert isinstance(af, ActiveForm)
+    # Won't fully match because of bound condition, so we check name
+    assert af.agent.name == cplx_agent_b.name
     assert len(af.agent.bound_conditions) == 1
     bc = af.agent.bound_conditions[0]
-    assert bc.agent.matches(cplx_agent_b)
+    assert bc.agent.matches(cplx_agent_a)
     assert bc.is_bound
     assert af.activity == 'activity'
     assert not af.is_active
@@ -413,25 +403,4 @@ def test_parse_residue_positions():
     assert residues[0][1] == '169'
     assert residues[1][0] == 'Y'
     assert residues[1][1] == '171'
-
-
-
-
-def test_get_mechanism():
-    sp = SignorProcessor(signor_test_path)
-    assert sp.statements
-    globals().update(locals())
-
-if __name__ == '__main__':
-    #test_process_row_destab()
-    #test_parse_csv()
-    #test_get_agent()
-    #test_get_agent_keyerror()
-    #test_get_evidence()
-    #test_process_row()
-    #test_process_row_binding()
-    #test_process_row_chem_inh()
-    #test_parse_residue_positions()
-    test_get_mechanism()
-    test_process_row_phos_multi_res()
 

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -87,13 +87,21 @@ def test_get_evidence():
                       "is a direct target of NFkappaB and that Met " \
                       "participates in NFkappaB-mediated cell survival."
 
-#def test_get_mechanism():
-#    sp = SignorProcessor(signor_test_path)
-#    mechs, mech_map = sp.make_model()
 
+def test_process_row():
+    stmt = SignorProcessor._process_row(test_row)
+    assert isinstance(stmt, IncreaseAmount)
+
+
+def test_get_mechanism():
+    sp = SignorProcessor(signor_test_path)
+    assert sp.statements
+    globals().update(locals())
 
 if __name__ == '__main__':
     test_parse_csv()
     test_get_agent()
     test_get_agent_keyerror()
     test_get_evidence()
+    test_process_row()
+    test_get_mechanism()

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -334,13 +334,53 @@ def test_process_row_phos_multi_res():
 
 
 def test_process_row_complex_up():
-    # TODO
-    pass
+    test_row = SignorRow(ENTITYA='NONO', TYPEA='protein', IDA='Q15233',
+            DATABASEA='UNIPROT', ENTITYB='TOP1', TYPEB='protein', IDB='P11387',
+            DATABASEB='UNIPROT', EFFECT='up-regulates', MECHANISM='binding',
+            RESIDUE='', SEQUENCE='', TAX_ID='9606', CELL_DATA='BTO:0000017',
+            TISSUE_DATA='', MODULATOR_COMPLEX='', TARGET_COMPLEX='',
+            MODIFICATIONA='', MODASEQ='', MODIFICATIONB='', MODBSEQ='',
+            PMID='9756848', DIRECT='YES', NOTES='', ANNOTATOR='miannu',
+            SENTENCE='', SIGNOR_ID='SIGNOR-60557')
+    stmts = SignorProcessor._process_row(test_row)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 3
+    assert isinstance(stmts[0], Activation)
+    assert isinstance(stmts[1], Complex)
+    cplx_agent_b = stmts[1].agent_list()[1]
+    af = stmts[2]
+    assert isinstance(af, ActiveForm)
+    assert len(af.agent.bound_conditions) == 1
+    bc = af.agent.bound_conditions[0]
+    assert bc.agent.matches(cplx_agent_b)
+    assert bc.is_bound
+    assert af.activity == 'activity'
+    assert af.is_active
 
 
 def test_process_row_complex_down():
-    # TODO
-    pass
+    test_row = SignorRow(ENTITYA='XIAP', TYPEA='protein', IDA='P98170',
+            DATABASEA='UNIPROT', ENTITYB='CASP3', TYPEB='protein',
+            IDB='P42574', DATABASEB='UNIPROT', EFFECT='down-regulates activity',
+            MECHANISM='binding', RESIDUE='', SEQUENCE='', TAX_ID='9606',
+            CELL_DATA='', TISSUE_DATA='', MODULATOR_COMPLEX='',
+            TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='', MODIFICATIONB='',
+            MODBSEQ='', PMID='10548111', DIRECT='YES', NOTES='',
+            ANNOTATOR='amattioni', SENTENCE='', SIGNOR_ID='SIGNOR-71954')
+    stmts = SignorProcessor._process_row(test_row)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 3
+    assert isinstance(stmts[0], Inhibition)
+    assert isinstance(stmts[1], Complex)
+    cplx_agent_b = stmts[1].agent_list()[1]
+    af = stmts[2]
+    assert isinstance(af, ActiveForm)
+    assert len(af.agent.bound_conditions) == 1
+    bc = af.agent.bound_conditions[0]
+    assert bc.agent.matches(cplx_agent_b)
+    assert bc.is_bound
+    assert af.activity == 'activity'
+    assert not af.is_active
 
 
 def test_parse_residue_positions():

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -404,3 +404,10 @@ def test_parse_residue_positions():
     assert residues[1][0] == 'Y'
     assert residues[1][1] == '171'
 
+
+def test_download_data():
+    sp = SignorProcessor()
+    assert isinstance(sp._data[0], SignorRow)
+    assert sp.statements
+    assert isinstance(sp.statements[0], Statement)
+

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -139,5 +139,5 @@ if __name__ == '__main__':
     test_get_agent_keyerror()
     test_get_evidence()
     test_process_row()
-    test_parse_residue_position()
+    test_parse_residue_positions()
     test_get_mechanism()

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from os.path import join, dirname
+from nose.tools import raises
 
 from indra.statements import *
 from indra.databases import hgnc_client
@@ -41,8 +42,24 @@ def test_get_agent():
     test_ag = Agent('AZD1480', db_refs={'PUBCHEM': 'CID:16659841'})
     sp_ag = sp._get_agent('AZD1480', 'chemical', 'CID:16659841', 'PUBCHEM')
     assert test_ag.matches(sp_ag)
+    # Signor phenotype
+    test_ag = Agent('Cell cycle progr.', db_refs={'SIGNOR': 'SIGNOR-PH42'})
+    sp_ag = sp._get_agent('Cell cycle progr.', 'phenotype', 'SIGNOR-PH42',
+                          'SIGNOR')
+    assert test_ag.matches(sp_ag)
+    # Ungrounded -- couldn't find a real example in the dataset
+    test_ag = Agent('Foobar', db_refs={})
+    sp_ag = sp._get_agent('Foobar', 'pathway', None, None)
+    assert test_ag.matches(sp_ag)
+    sp_ag = sp._get_agent('Foobar', 'antibody', None, None)
+    assert test_ag.matches(sp_ag)
+
+@raises(KeyError)
+def test_get_agent_keyerror():
+    sp_ag = sp._get_agent('foo', 'bar', None, None)
 
 
 if __name__ == '__main__':
     test_parse_csv()
     test_get_agent()
+    test_get_agent_keyerror()

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -91,7 +91,8 @@ def test_get_evidence():
 
 
 def test_process_row():
-    stmts = SignorProcessor._process_row(test_row)
+    stmts, no_mech = SignorProcessor._process_row(test_row)
+    assert not no_mech
     assert isinstance(stmts, list)
     assert len(stmts) == 1
     assert isinstance(stmts[0], IncreaseAmount)
@@ -108,7 +109,8 @@ def test_process_row_chem_inh():
         MODIFICATIONB='', MODBSEQ='', PMID='Other', DIRECT='YES',
         NOTES='Selleck', ANNOTATOR='gcesareni', SENTENCE='',
         SIGNOR_ID='SIGNOR-190245')
-    stmts = SignorProcessor._process_row(test_row_chem_inh)
+    stmts, no_mech = SignorProcessor._process_row(test_row_chem_inh)
+    assert not no_mech
     assert isinstance(stmts, list)
     assert len(stmts) == 1
     assert isinstance(stmts[0], Inhibition)
@@ -123,7 +125,8 @@ def test_process_row_chem_act():
         MODULATOR_COMPLEX='', TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='',
         MODIFICATIONB='', MODBSEQ='', PMID='16293724', DIRECT='YES', NOTES='',
         ANNOTATOR='gcesareni', SENTENCE='', SIGNOR_ID='SIGNOR-141820')
-    stmts = SignorProcessor._process_row(test_row_chem_act)
+    stmts, no_mech = SignorProcessor._process_row(test_row_chem_act)
+    assert not no_mech
     assert isinstance(stmts, list)
     assert len(stmts) == 1
     assert isinstance(stmts[0], Activation)
@@ -138,7 +141,8 @@ def test_process_row_stab():
             TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='', MODIFICATIONB='',
             MODBSEQ='', PMID='17052192', DIRECT='YES', NOTES='',
             ANNOTATOR='gcesareni', SENTENCE='', SIGNOR_ID='SIGNOR-150135')
-    stmts = SignorProcessor._process_row(test_row_stab)
+    stmts, no_mech = SignorProcessor._process_row(test_row_stab)
+    assert not no_mech
     assert isinstance(stmts, list)
     assert len(stmts) == 1
     assert isinstance(stmts[0], IncreaseAmount)
@@ -155,7 +159,8 @@ def test_process_row_destab():
             MODASEQ='', MODIFICATIONB='', MODBSEQ='', PMID='23721961',
             DIRECT='NO', NOTES='', ANNOTATOR='miannu',
             SENTENCE='', SIGNOR_ID='SIGNOR-252114')
-    stmts = SignorProcessor._process_row(test_row_destab)
+    stmts, no_mech = SignorProcessor._process_row(test_row_destab)
+    assert not no_mech
     assert isinstance(stmts, list)
     assert len(stmts) == 1
     assert isinstance(stmts[0], DecreaseAmount)
@@ -170,7 +175,8 @@ def test_process_row_binding_complex():
             TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='', MODIFICATIONB='',
             MODBSEQ='', PMID='18321988', DIRECT='YES', NOTES='',
             ANNOTATOR='lperfetto', SENTENCE='', SIGNOR_ID='SIGNOR-226693')
-    stmts = SignorProcessor._process_row(test_row)
+    stmts, no_mech = SignorProcessor._process_row(test_row)
+    assert not no_mech
     assert isinstance(stmts, list)
     assert len(stmts) == 1
     assert isinstance(stmts[0], Complex)
@@ -187,7 +193,8 @@ def test_process_row_phos_up():
             MODIFICATIONA='', MODASEQ='', MODIFICATIONB='', MODBSEQ='',
             PMID='11901158', DIRECT='YES', NOTES='', ANNOTATOR='gcesareni',
             SENTENCE='', SIGNOR_ID='SIGNOR-116131')
-    stmts = SignorProcessor._process_row(test_row)
+    stmts, no_mech = SignorProcessor._process_row(test_row)
+    assert not no_mech
     assert isinstance(stmts, list)
     assert len(stmts) == 3
     assert isinstance(stmts[0], Activation)
@@ -214,7 +221,8 @@ def test_process_row_phos_down():
             MODIFICATIONA='', MODASEQ='', MODIFICATIONB='', MODBSEQ='',
             PMID='18056643', DIRECT='YES', NOTES='', ANNOTATOR='llicata',
             SENTENCE='', SIGNOR_ID='SIGNOR-159591')
-    stmts = SignorProcessor._process_row(test_row)
+    stmts, no_mech = SignorProcessor._process_row(test_row)
+    assert not no_mech
     assert isinstance(stmts, list)
     assert len(stmts) == 3
     assert isinstance(stmts[0], Inhibition)
@@ -241,7 +249,8 @@ def test_process_row_phos_nores_up():
             MODASEQ='', MODIFICATIONB='', MODBSEQ='', PMID='14976552',
             DIRECT='YES', NOTES='', ANNOTATOR='lperfetto',
             SENTENCE='', SIGNOR_ID='SIGNOR-242602')
-    stmts = SignorProcessor._process_row(test_row)
+    stmts, no_mech = SignorProcessor._process_row(test_row)
+    assert not no_mech
     assert isinstance(stmts, list)
     assert len(stmts) == 3
     assert isinstance(stmts[0], Activation)
@@ -267,7 +276,8 @@ def test_process_row_phos_nores_down():
             TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='', MODIFICATIONB='',
             MODBSEQ='', PMID='15747065', DIRECT='YES', NOTES='',
             ANNOTATOR='gcesareni', SENTENCE='', SIGNOR_ID='SIGNOR-134494')
-    stmts = SignorProcessor._process_row(test_row)
+    stmts, no_mech = SignorProcessor._process_row(test_row)
+    assert not no_mech
     assert isinstance(stmts, list)
     assert len(stmts) == 3
     assert isinstance(stmts[0], Inhibition)
@@ -295,7 +305,8 @@ def test_process_row_phos_multi_res():
             MODBSEQ='', PMID='8157000', DIRECT='YES',
             NOTES='', ANNOTATOR='gcesareni', SENTENCE='',
             SIGNOR_ID='SIGNOR-36553')
-    stmts = SignorProcessor._process_row(test_row)
+    stmts, no_mech = SignorProcessor._process_row(test_row)
+    assert not no_mech
     assert isinstance(stmts, list)
     assert len(stmts) == 4
     assert isinstance(stmts[0], Activation)
@@ -326,7 +337,8 @@ def test_process_row_complex_up():
             MODIFICATIONA='', MODASEQ='', MODIFICATIONB='', MODBSEQ='',
             PMID='9756848', DIRECT='YES', NOTES='', ANNOTATOR='miannu',
             SENTENCE='', SIGNOR_ID='SIGNOR-60557')
-    stmts = SignorProcessor._process_row(test_row)
+    stmts, no_mech = SignorProcessor._process_row(test_row)
+    assert not no_mech
     assert isinstance(stmts, list)
     assert len(stmts) == 3
     assert isinstance(stmts[0], Activation)
@@ -354,7 +366,8 @@ def test_process_row_complex_down():
             TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='', MODIFICATIONB='',
             MODBSEQ='', PMID='10548111', DIRECT='YES', NOTES='',
             ANNOTATOR='amattioni', SENTENCE='', SIGNOR_ID='SIGNOR-71954')
-    stmts = SignorProcessor._process_row(test_row)
+    stmts, no_mech = SignorProcessor._process_row(test_row)
+    assert not no_mech
     assert isinstance(stmts, list)
     assert len(stmts) == 3
     assert isinstance(stmts[0], Inhibition)

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -80,7 +80,7 @@ def test_get_evidence():
             'ANNOTATOR': 'gcesareni',
         }
     assert ev.epistemics['direct']
-    assert ev.source_api == 'SIGNOR'
+    assert ev.source_api == 'signor'
     assert ev.source_id == 'SIGNOR-241929'
     assert ev.text == "Together, these results indicate that the Met gene " \
                       "is a direct target of NFkappaB and that Met " \

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -14,6 +14,7 @@ def _id(gene):
 signor_test_path = join(dirname(__file__), '..', '..', 'data',
                         'all_data_23_09_17.csv')
 
+
 test_row = SignorRow(ENTITYA='RELA', TYPEA='protein', IDA='Q04206',
         DATABASEA='UNIPROT', ENTITYB='MET', TYPEB='protein', IDB='P08581',
         DATABASEB='UNIPROT', EFFECT='up-regulates quantity',
@@ -27,27 +28,6 @@ test_row = SignorRow(ENTITYA='RELA', TYPEA='protein', IDA='Q04206',
                  "in NFkappaB-mediated cell survival.",
         SIGNOR_ID='SIGNOR-241929')
 
-test_row_binding = SignorRow(ENTITYA='SERPINA1', TYPEA='protein', IDA='P01009', 
-        DATABASEA='UNIPROT', ENTITYB='LRP1', TYPEB='protein', IDB='Q07954',
-        DATABASEB='UNIPROT', EFFECT='up-regulates', MECHANISM='binding',
-        RESIDUE='', SEQUENCE='', TAX_ID='9606', CELL_DATA='', TISSUE_DATA='',
-        MODULATOR_COMPLEX='', TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='',
-        MODIFICATIONB='', MODBSEQ='', PMID='8626456', DIRECT='YES', NOTES='',
-        ANNOTATOR='gcesareni', SENTENCE='In vitro binding studies revealed '\
-                'that antithrombin iii (atiii)thrombin, heparin cofactor ii '\
-                '(hcii)thrombin, and ?1-antitrypsin (?1AT)trypsin bound to '\
-                'purified lrp',
-        SIGNOR_ID='SIGNOR-41180')
-
-test_row_dup1 = SignorRow(ENTITYA='722544-51-6', TYPEA='chemical',
-        IDA='CID:16007391', DATABASEA='PUBCHEM', ENTITYB='AURKB',
-        TYPEB='protein', IDB='Q96GD4', DATABASEB='UNIPROT',
-        EFFECT='down-regulates', MECHANISM='chemical inhibition', RESIDUE='',
-        SEQUENCE='', TAX_ID='9606', CELL_DATA='', TISSUE_DATA='',
-        MODULATOR_COMPLEX='', TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='',
-        MODIFICATIONB='', MODBSEQ='', PMID='Other', DIRECT='YES',
-        NOTES='Selleck', ANNOTATOR='gcesareni', SENTENCE='',
-        SIGNOR_ID='SIGNOR-190245')
 
 def test_parse_csv():
     sp = SignorProcessor(signor_test_path)
@@ -119,6 +99,14 @@ def test_process_row():
 
 
 def test_process_row_binding():
+    test_row_binding = SignorRow(ENTITYA='SERPINA1', TYPEA='protein',
+        IDA='P01009', DATABASEA='UNIPROT', ENTITYB='LRP1', TYPEB='protein',
+        IDB='Q07954', DATABASEB='UNIPROT', EFFECT='up-regulates',
+        MECHANISM='binding', RESIDUE='', SEQUENCE='', TAX_ID='9606',
+        CELL_DATA='', TISSUE_DATA='', MODULATOR_COMPLEX='', TARGET_COMPLEX='',
+        MODIFICATIONA='', MODASEQ='', MODIFICATIONB='', MODBSEQ='',
+        PMID='8626456', DIRECT='YES', NOTES='', ANNOTATOR='gcesareni',
+        SENTENCE='', SIGNOR_ID='SIGNOR-41180')
     stmts = SignorProcessor._process_row(test_row_binding)
     assert isinstance(stmts, list)
     assert len(stmts) == 2
@@ -126,11 +114,83 @@ def test_process_row_binding():
     assert isinstance(stmts[1], Complex)
 
 
-def test_process_row_dup1():
-    stmts = SignorProcessor._process_row(test_row_dup1)
+def test_process_row_chem_inh():
+    test_row_chem_inh = SignorRow(ENTITYA='722544-51-6', TYPEA='chemical',
+        IDA='CID:16007391', DATABASEA='PUBCHEM', ENTITYB='AURKB',
+        TYPEB='protein', IDB='Q96GD4', DATABASEB='UNIPROT',
+        EFFECT='down-regulates', MECHANISM='chemical inhibition', RESIDUE='',
+        SEQUENCE='', TAX_ID='9606', CELL_DATA='', TISSUE_DATA='',
+        MODULATOR_COMPLEX='', TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='',
+        MODIFICATIONB='', MODBSEQ='', PMID='Other', DIRECT='YES',
+        NOTES='Selleck', ANNOTATOR='gcesareni', SENTENCE='',
+        SIGNOR_ID='SIGNOR-190245')
+    stmts = SignorProcessor._process_row(test_row_chem_inh)
     assert isinstance(stmts, list)
     assert len(stmts) == 1
     assert isinstance(stmts[0], Inhibition)
+
+
+def test_process_row_chem_act():
+    test_row_chem_act = SignorRow(ENTITYA='Prostaglandin E2',
+        TYPEA='smallmolecule', IDA='CID:5280360', DATABASEA='PUBCHEM',
+        ENTITYB='GNG12', TYPEB='protein', IDB='Q9UBI6', DATABASEB='UNIPROT',
+        EFFECT='up-regulates', MECHANISM='chemical activation', RESIDUE='',
+        SEQUENCE='', TAX_ID='9606', CELL_DATA='', TISSUE_DATA='',
+        MODULATOR_COMPLEX='', TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='',
+        MODIFICATIONB='', MODBSEQ='', PMID='16293724', DIRECT='YES', NOTES='',
+        ANNOTATOR='gcesareni', SENTENCE='', SIGNOR_ID='SIGNOR-141820')
+    stmts = SignorProcessor._process_row(test_row_chem_act)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], Activation)
+
+
+def test_process_row_stab():
+    test_row_stab = SignorRow(ENTITYA='UCHL5', TYPEA='protein', IDA='Q9Y5K5',
+            DATABASEA='UNIPROT', ENTITYB='TGFBR1', TYPEB='protein',
+            IDB='P36897', DATABASEB='UNIPROT', EFFECT='up-regulates',
+            MECHANISM='stabilization', RESIDUE='', SEQUENCE='', TAX_ID='9606',
+            CELL_DATA='', TISSUE_DATA='', MODULATOR_COMPLEX='',
+            TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='', MODIFICATIONB='',
+            MODBSEQ='', PMID='17052192', DIRECT='YES', NOTES='',
+            ANNOTATOR='gcesareni', SENTENCE='', SIGNOR_ID='SIGNOR-150135')
+    stmts = SignorProcessor._process_row(test_row_stab)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], IncreaseAmount)
+
+
+def test_process_row_destab():
+    test_row_destab = SignorRow(ENTITYA='INS', TYPEA='protein', IDA='P01308',
+            DATABASEA='UNIPROT', ENTITYB='APOB', TYPEB='protein', IDB='P04114',
+            DATABASEB='UNIPROT',
+            EFFECT='down-regulates quantity by destabilization',
+            MECHANISM='destabilization', RESIDUE='', SEQUENCE='',
+            TAX_ID='9606', CELL_DATA='BTO:0000575', TISSUE_DATA='',
+            MODULATOR_COMPLEX='', TARGET_COMPLEX='', MODIFICATIONA='',
+            MODASEQ='', MODIFICATIONB='', MODBSEQ='', PMID='23721961',
+            DIRECT='NO', NOTES='', ANNOTATOR='miannu',
+            SENTENCE='', SIGNOR_ID='SIGNOR-252114')
+    stmts = SignorProcessor._process_row(test_row_destab)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], DecreaseAmount)
+
+
+def test_process_row_binding_complex():
+    test_row = SignorRow(ENTITYA='ATG5', TYPEA='protein', IDA='Q9H1Y0',
+            DATABASEA='UNIPROT', ENTITYB='ATG12/5/16L1', TYPEB='complex',
+            IDB='SIGNOR-C109', DATABASEB='SIGNOR', EFFECT='form complex',
+            MECHANISM='binding', RESIDUE='', SEQUENCE='', TAX_ID='9606',
+            CELL_DATA='', TISSUE_DATA='BTO:0000007', MODULATOR_COMPLEX='',
+            TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='', MODIFICATIONB='',
+            MODBSEQ='', PMID='18321988', DIRECT='YES', NOTES='',
+            ANNOTATOR='lperfetto', SENTENCE='', SIGNOR_ID='SIGNOR-226693')
+    stmts = SignorProcessor._process_row(test_row)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], Complex)
+    assert len(stmts[0].agent_list()) == 2
 
 
 def test_parse_residue_positions():
@@ -171,12 +231,13 @@ def test_get_mechanism():
     globals().update(locals())
 
 if __name__ == '__main__':
+    test_process_row_destab()
     #test_parse_csv()
     #test_get_agent()
     #test_get_agent_keyerror()
     #test_get_evidence()
     #test_process_row()
-    test_process_row_binding()
-    #test_process_row_dup1()
+    #test_process_row_binding()
+    #test_process_row_chem_inh()
     #test_parse_residue_positions()
     #test_get_mechanism()

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -23,18 +23,6 @@ test_row = SignorRow(ENTITYA='RELA', TYPEA='protein', IDA='Q04206',
         the Met gene is a direct target of NFkappaB and that Met participates
         in NFkappaB-mediated cell survival.""", SIGNOR_ID='SIGNOR-241929')
 
-signor_entity_types = [
-    'antibody',
-    'protein',
-    'complex',
-    'proteinfamily',
-    'smallmolecule',
-    'pathway',
-    'phenotype',
-    'stimulus',
-    'chemical'
-]
-
 
 def test_parse_csv():
     sp = SignorProcessor(signor_test_path)
@@ -43,12 +31,18 @@ def test_parse_csv():
     globals().update(locals())
 
 
-def test_entity_a():
+def test_get_agent():
+    # Protein/gene
     test_ag = Agent('RELA', db_refs={'HGNC': _id('RELA'), 'UP': 'Q04206'})
-    sp_ag = sp._entity_a(test_row)
+    sp_ag = sp._get_agent(test_row.ENTITYA, test_row.TYPEA, test_row.IDA,
+                          test_row.DATABASEA)
+    assert test_ag.matches(sp_ag)
+    # Chemical
+    test_ag = Agent('AZD1480', db_refs={'PUBCHEM': 'CID:16659841'})
+    sp_ag = sp._get_agent('AZD1480', 'chemical', 'CID:16659841', 'PUBCHEM')
     assert test_ag.matches(sp_ag)
 
 
 if __name__ == '__main__':
     test_parse_csv()
-    test_entity_a()
+    test_get_agent()

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -111,27 +111,26 @@ def test_get_evidence():
 
 
 def test_process_row():
-    (effect_stmt, mech_stmts, af_stmt) = SignorProcessor._process_row(test_row)
-    assert isinstance(effect_stmt, IncreaseAmount)
-    assert isinstance(mech_stmts, list)
-    assert len(mech_stmts) == 0
+    stmts = SignorProcessor._process_row(test_row)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], IncreaseAmount)
+    assert stmts[0].agent_list()[0].activity.activity_type == 'transcription'
 
 
 def test_process_row_binding():
-    (effect_stmt, mech_stmts, af_stmt) = \
-                    SignorProcessor._process_row(test_row_binding)
-    assert isinstance(effect_stmt, Activation)
-    assert isinstance(mech_stmts, list)
-    assert len(mech_stmts) == 1
-    assert isinstance(mech_stmts[0], Complex)
+    stmts = SignorProcessor._process_row(test_row_binding)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 2
+    assert isinstance(stmts[0], Activation)
+    assert isinstance(stmts[1], Complex)
 
 
 def test_process_row_dup1():
-    (effect_stmt, mech_stmts, af_stmt) = \
-                    SignorProcessor._process_row(test_row_dup1)
-    assert isinstance(effect_stmt, Inhibition)
-    assert isinstance(mech_stmts, list)
-    assert len(mech_stmts) == 0
+    stmts = SignorProcessor._process_row(test_row_dup1)
+    assert isinstance(stmts, list)
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], Inhibition)
 
 
 def test_parse_residue_positions():
@@ -172,14 +171,12 @@ def test_get_mechanism():
     globals().update(locals())
 
 if __name__ == '__main__':
-    test_process_row_dup1()
-    """
-    test_parse_csv()
-    test_get_agent()
-    test_get_agent_keyerror()
-    test_get_evidence()
-    test_process_row()
+    #test_parse_csv()
+    #test_get_agent()
+    #test_get_agent_keyerror()
+    #test_get_evidence()
+    #test_process_row()
     test_process_row_binding()
-    test_parse_residue_positions()
-    test_get_mechanism()
-    """
+    #test_process_row_dup1()
+    #test_parse_residue_positions()
+    #test_get_mechanism()

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -27,6 +27,27 @@ test_row = SignorRow(ENTITYA='RELA', TYPEA='protein', IDA='Q04206',
                  "in NFkappaB-mediated cell survival.",
         SIGNOR_ID='SIGNOR-241929')
 
+test_row_binding = SignorRow(ENTITYA='SERPINA1', TYPEA='protein', IDA='P01009', 
+        DATABASEA='UNIPROT', ENTITYB='LRP1', TYPEB='protein', IDB='Q07954',
+        DATABASEB='UNIPROT', EFFECT='up-regulates', MECHANISM='binding',
+        RESIDUE='', SEQUENCE='', TAX_ID='9606', CELL_DATA='', TISSUE_DATA='',
+        MODULATOR_COMPLEX='', TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='',
+        MODIFICATIONB='', MODBSEQ='', PMID='8626456', DIRECT='YES', NOTES='',
+        ANNOTATOR='gcesareni', SENTENCE='In vitro binding studies revealed '\
+                'that antithrombin iii (atiii)thrombin, heparin cofactor ii '\
+                '(hcii)thrombin, and ?1-antitrypsin (?1AT)trypsin bound to '\
+                'purified lrp',
+        SIGNOR_ID='SIGNOR-41180')
+
+test_row_dup1 = SignorRow(ENTITYA='722544-51-6', TYPEA='chemical',
+        IDA='CID:16007391', DATABASEA='PUBCHEM', ENTITYB='AURKB',
+        TYPEB='protein', IDB='Q96GD4', DATABASEB='UNIPROT',
+        EFFECT='down-regulates', MECHANISM='chemical inhibition', RESIDUE='',
+        SEQUENCE='', TAX_ID='9606', CELL_DATA='', TISSUE_DATA='',
+        MODULATOR_COMPLEX='', TARGET_COMPLEX='', MODIFICATIONA='', MODASEQ='',
+        MODIFICATIONB='', MODBSEQ='', PMID='Other', DIRECT='YES',
+        NOTES='Selleck', ANNOTATOR='gcesareni', SENTENCE='',
+        SIGNOR_ID='SIGNOR-190245')
 
 def test_parse_csv():
     sp = SignorProcessor(signor_test_path)
@@ -97,6 +118,23 @@ def test_process_row():
     assert isinstance(mech_stmts[0], IncreaseAmount)
 
 
+def test_process_row_binding():
+    (effect_stmt, mech_stmts, af_stmt) = \
+                    SignorProcessor._process_row(test_row_binding)
+    assert isinstance(effect_stmt, Activation)
+    assert isinstance(mech_stmts, list)
+    assert len(mech_stmts) == 1
+    assert isinstance(mech_stmts[0], Complex)
+
+
+def test_process_row_dup1():
+    (effect_stmt, mech_stmts, af_stmt) = \
+                    SignorProcessor._process_row(test_row_dup1)
+    assert isinstance(effect_stmt, Inhibition)
+    assert isinstance(mech_stmts, list)
+    assert len(mech_stmts) == 0
+
+
 def test_parse_residue_positions():
     residues = _parse_residue_positions('TYR304')
     assert len(residues) == 1
@@ -128,16 +166,21 @@ def test_parse_residue_positions():
     assert residues[1][0] == 'Y'
     assert residues[1][1] == '171'
 
+
 def test_get_mechanism():
     sp = SignorProcessor(signor_test_path)
     assert sp.statements
     globals().update(locals())
 
 if __name__ == '__main__':
+    test_process_row_dup1()
+    """
     test_parse_csv()
     test_get_agent()
     test_get_agent_keyerror()
     test_get_evidence()
     test_process_row()
+    test_process_row_binding()
     test_parse_residue_positions()
     test_get_mechanism()
+    """

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -213,7 +213,7 @@ def test_process_row_phos_up():
     af = stmts[2]
     assert isinstance(af, ActiveForm)
     assert len(af.agent.mods) == 1
-    mc = ag.agent.mods[0]
+    mc = af.agent.mods[0]
     assert mc.mod_type == 'phosphorylation'
     assert mc.residue == 'T'
     assert mc.position == '387'

--- a/indra/util/__init__.py
+++ b/indra/util/__init__.py
@@ -66,7 +66,9 @@ def read_unicode_csv(filename, delimiter=',', quotechar='"',
             generator = read_unicode_csv_fileobj(f, delimiter=delimiter,
                                             quotechar=quotechar,
                                             quoting=quoting,
-                                            lineterminator=lineterminator)
+                                            lineterminator=lineterminator,
+                                            encoding=encoding,
+                                            skiprows=skiprows)
             for row in generator:
                 yield row
     # Python 2 version
@@ -76,7 +78,9 @@ def read_unicode_csv(filename, delimiter=',', quotechar='"',
             generator = read_unicode_csv_fileobj(f, delimiter=delimiter,
                                             quotechar=quotechar,
                                             quoting=quoting,
-                                            lineterminator=lineterminator)
+                                            lineterminator=lineterminator,
+                                            encoding=encoding,
+                                            skiprows=skiprows)
             for row in generator:
                 yield row
 


### PR DESCRIPTION
Adds a processor for the interaction data in Signor (see http://signor.uniroma2.it). The processor is implemented as a single module, `indra/sources/signor.py`. The data can either be downloaded from the Signor site at the point of use (which is the default behavior) or cached locally, in which case the SignorProcessor is initialized with a path to the CSV file. The SignorProcessor can be instantiated very simply as follows:

```
from indra.sources.signor import SignorProcessor
sp = SignorProcessor()
```

The extracted statements are then contained in `sp.statements`.

Each row in the Signor dataset contains an "EFFECT" relation, which includes up/down regulation and complex formation. This information is used to create `Activation`, `Inhibition`, `IncreaseAmount`, and `DecreaseAmount` Statements. Most rows (though not all) also contain MECHANISM relations, which can be quite detailed. Not all of these can be mapped to INDRA Statements at present; the ones that are mapped are created and others are stored for inspection in the `SignorProcessor.no_mech_rows` and `SignorProcessor.no_mech_ctr` attributes. Further, some effect/mechanism pairs describe only a single mechanism (for example, the EFFECT 'up-regulation' coupled to the MECHANISM 'transcriptional regulation'). In this case only a single statement is generated. Finally, modification and binding events coupled to an up or down regulation are also used to generate `ActiveForm` Statements with `ModConditions` or `BoundConditions` set on the target agent, respectively.

As of today the Signor dataset, with 18,562 rows, produces 44,087 INDRA Statements, with 388 mechanism relations not giving rise to INDRA Statements and distributed as follows:

```
 ('relocalization', 184),
 ('cleavage', 93),
 ('small molecule catalysis', 65),
 ('transcriptional regulation', 18), # Note: these are due to unknown polarity
 ('neddylation', 11),
 ('tyrosination', 7),
 ('post transcriptional regulation', 4),
 ('translation regulation', 3),
 ('s-nitrosylation', 1),
 ('oxidation', 1),
 ('lipidation', 1)]
```

Closes issue #321.

Some known issues:
* SignorProcessor should be included in the documentation
* The generic "up-regulates" effect type should ultimately be mapped to a generic up regulation rather than Activation/Inhibition, as it is currently.
* Mappings for SIGNOR families, complexes, etc. (see Bioentities issues)
* Need a Statement similar to ActiveForms but representing effects on amounts ("StateEffect")
* Implement translocation statements

