### PR TITLE
Add grounding mapping with Agents

### DIFF
--- a/indra/resources/README.txt
+++ b/indra/resources/README.txt
@@ -71,6 +71,10 @@ curated_site_map.tsv
 transcription_factors.tsv
 - manually downloaded from http://fantom.gsc.riken.jp/5/sstar/Browse_Transcription_Factors_hg19
 
+grounding_agents.json
+- manually curated list of grounding mappings to INDRA Agents with states 
+(phosphorylation, mutation, etc.)
+
 Files that don't need periodical updates
 ========================================
 amino_acids.tsv

--- a/indra/resources/grounding_agents.json
+++ b/indra/resources/grounding_agents.json
@@ -1,0 +1,327 @@
+{
+ "p-Akt": {
+  "agent": {
+   "name": "AKT",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "BE": "AKT",
+    "NCIT": "C41625"
+   }
+  },
+  "nl": "AKT that is phosphorylated"
+ },
+ "p-ERK": {
+  "agent": {
+   "name": "ERK",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "BE": "ERK",
+    "NCIT": "C26360"
+   }
+  },
+  "nl": "ERK that is phosphorylated"
+ },
+ "p-mTOR": {
+  "agent": {
+   "name": "MTOR",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "UP": "P42345",
+    "NCIT": "C38929",
+    "HGNC": "3942"
+   }
+  },
+  "nl": "MTOR that is phosphorylated"
+ },
+ "pTyr176-AKT": {
+  "agent": {
+   "name": "AKT",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "residue": "Y",
+     "position": "176",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "BE": "AKT",
+    "NCIT": "C41625"
+   }
+  },
+  "nl": "AKT phosphorylated at Y176"
+ },
+ "AKT-Ser473": {
+  "agent": {
+   "name": "AKT",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "residue": "S",
+     "position": "473",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "BE": "AKT",
+    "NCIT": "C41625"
+   }
+  },
+  "nl": "AKT phosphorylated on serine 473"
+ },
+ "p53S15": {
+  "agent": {
+   "name": "TP53",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "residue": "S",
+     "position": "15",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "UP": "P04637",
+    "NCIT": "C17387",
+    "HGNC": "11998"
+   }
+  },
+  "nl": "TP53 phosphorylated on S15"
+ },
+ "GST-p85": {
+  "agent": {
+   "name": "PI3K",
+   "db_refs": {
+    "BE": "PI3K",
+    "NCIT": "C17270"
+   }
+  },
+  "nl": "PI3K-p85"
+ },
+ "PI": {
+  "agent": {
+   "name": "PI3K",
+   "db_refs": {
+    "BE": "PI3K",
+    "NCIT": "C17270"
+   }
+  },
+  "nl": "PI3K"
+ },
+ "pTpYERK": {
+  "agent": {
+   "name": "ERK",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "residue": "Y",
+     "is_modified": true
+    },
+    {
+     "mod_type": "phosphorylation",
+     "residue": "T",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "BE": "ERK",
+    "NCIT": "C26360"
+   }
+  },
+  "nl": "ERK phosphorylated on tyrosine and threonine"
+ },
+ "PTEN-Ser380/Thr382/Thr383": {
+  "agent": {
+   "name": "PTEN",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "residue": "T",
+     "position": "383",
+     "is_modified": true
+    },
+    {
+     "mod_type": "phosphorylation",
+     "residue": "S",
+     "position": "380",
+     "is_modified": true
+    },
+    {
+     "mod_type": "phosphorylation",
+     "residue": "T",
+     "position": "382",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "UP": "P60484",
+    "NCIT": "C18181",
+    "HGNC": "9588"
+   }
+  },
+  "nl": "PTEN phosphorylated at S380, T382 and T383"
+ },
+ "p-PI3K": {
+  "agent": {
+   "name": "PI3K",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "BE": "PI3K",
+    "NCIT": "C17270"
+   }
+  },
+  "nl": "PI3K that is phosphorylated"
+ },
+ "p-MEK": {
+  "agent": {
+   "name": "MEK",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "BE": "MEK"
+   }
+  },
+  "nl": "MEK that is phosphorylated"
+ },
+ "p-MEK1/2": {
+  "agent": {
+   "name": "MEK",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "BE": "MEK"
+   }
+  },
+  "nl": "MEK that is phosphorylated"
+ },
+ "pERK": {
+  "agent": {
+   "name": "ERK",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "BE": "ERK",
+    "NCIT": "C26360"
+   }
+  },
+  "nl": "ERK that is phosphorylated"
+ },
+ "RAS-GTP": {
+  "agent": {
+   "name": "RAS",
+   "bound_conditions": [
+    {
+     "is_bound": true,
+     "agent": {
+      "name": "GTP",
+      "db_refs": {
+       "TEXT": "GTP",
+       "CHEBI": "CHEBI:15996"
+      }
+     }
+    }
+   ],
+   "db_refs": {
+    "BE": "RAS",
+    "NCIT": "C17061",
+    "NXPFA": "03663"
+   }
+  },
+  "nl": "RAS that is bound to GTP"
+ },
+ "p-AKT": {
+  "agent": {
+   "name": "AKT",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "BE": "AKT",
+    "NCIT": "C41625"
+   }
+  },
+  "nl": "AKT that is phosphorylated"
+ },
+ "p-ERK1/2": {
+  "agent": {
+   "name": "ERK",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "BE": "ERK",
+    "NCIT": "C26360"
+   }
+  },
+  "nl": "ERK that is phosphorylated"
+ },
+ "RasV12": {
+  "agent": {
+   "name": "RAS",
+   "mutations": [{
+     "residue_to": null,
+     "residue_from": "V",
+     "position": "12"
+   }],
+   "db_refs": {
+    "BE": "RAS"
+   }
+  },
+  "nl": "RAS-V12"
+ },
+ "p-C-Raf": {
+  "agent": {
+   "name": "RAF1",
+   "mods": [
+    {
+     "mod_type": "phosphorylation",
+     "is_modified": true
+    }
+   ],
+   "db_refs": {
+    "UP": "P04049",
+    "NCIT": "C17484",
+    "HGNC": "9829"
+   }
+  },
+  "nl": "RAF1 that is phosphorylated"
+ }
+}

--- a/indra/resources/grounding_agents.json
+++ b/indra/resources/grounding_agents.json
@@ -323,5 +323,21 @@
    }
   },
   "nl": "RAF1 that is phosphorylated"
+ },
+ "Smad2/3-T220/T179": {
+  "nl": "SMAD2/3 that is phosphorylated on threonine",
+  "agent" :{
+    "name": "SMAD2_3",
+    "mods": [
+     {
+      "mod_type": "phosphorylation",
+      "residue": "T",
+      "is_modified": true
+     }
+    ],
+    "db_refs": {
+     "BE": "SMAD2_3"
+    }
+   }
  }
 }

--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -855,6 +855,29 @@ class TripsProcessor(object):
             _stmt_location_to_agents(st, location)
             self.statements.append(st)
 
+    def get_agents(self):
+        """Return list of INDRA Agents corresponding to TERMs in the EKB.
+
+        This is meant to be used when entities e.g. "phosphorylated ERK",
+        rather than events need to be extracted from processed natural
+        language. These entities with their respective states are represented
+        as INDRA Agents.
+
+        Returns
+        -------
+        agents : list[indra.statements.Agent]
+            List of INDRA Agents extracted from EKB.
+        """
+        terms = self.tree.findall('TERM')
+        agents = []
+        for term in terms:
+            term_id = term.attrib.get('id')
+            if term_id:
+                agent = self._get_agent_by_id(term_id, None)
+                if agent:
+                    agents.append(agent)
+        return agents
+
     def _get_cell_loc_by_id(self, term_id):
         term = self.tree.find("TERM/[@id='%s']" % term_id)
         if term is None:

--- a/indra/tests/test_groundingmapper.py
+++ b/indra/tests/test_groundingmapper.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.preassembler.grounding_mapper import *
-from indra.statements import Agent, Phosphorylation, Evidence
+from indra.statements import Agent, Phosphorylation, Complex, Evidence
 from indra.util import unicode_strs
 from nose.tools import raises
 
@@ -182,3 +182,12 @@ def test_in_place_overwrite_of_gm():
     gmap_after_mapping = gm.gm
     assert set(gmap_after_mapping['ERK1'].keys()) == set(['TEXT', 'UP'])
 
+def test_map_agent():
+    erk = Agent('ERK1', db_refs={'TEXT': 'ERK1'})
+    p_erk = Agent('P-ERK', db_refs={'TEXT': 'p-ERK'})
+    stmt = Complex([erk, p_erk])
+    gm = GroundingMapper(default_grounding_map, default_agent_map)
+    mapped_stmts = gm.map_agents([stmt])
+    mapped_ag = mapped_stmts[0].members[1]
+    assert mapped_ag.name == 'ERK'
+    assert mapped_ag.db_refs.get('BE') == 'ERK'

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -20,6 +20,7 @@ from indra.tools.expand_families import Expander
 from indra.preassembler.hierarchy_manager import hierarchies
 from indra.preassembler.grounding_mapper import GroundingMapper
 from indra.preassembler.grounding_mapper import gm as grounding_map
+from indra.preassembler.grounding_mapper import default_agent_map as agent_map
 from indra.preassembler.sitemapper import SiteMapper, default_site_map
 
 logger = logging.getLogger('assemble_corpus')
@@ -101,7 +102,7 @@ def map_grounding(stmts_in, **kwargs):
     do_rename = kwargs.get('do_rename')
     if do_rename is None:
         do_rename = True
-    gm = GroundingMapper(grounding_map)
+    gm = GroundingMapper(grounding_map, agent_map)
     stmts_out = gm.map_agents(stmts_in, do_rename=do_rename)
     dump_pkl = kwargs.get('save')
     if dump_pkl:


### PR DESCRIPTION
The current GroundingMapper only overrides database references of Agents but cannot change the state of Agents it maps. There are some cases when the original text string defines the state of the Agent (like "p-ERK") and in some cases we want to map these directly to INDRA Agents. This PR adds a resource file with a small number of such mappings and allows the GroundingMapper to use these.