### PR TITLE
Tag tests with attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,9 @@ script:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       export NOSE_IGNORE_FILES="manage_content.py,build_sample_set.py,_require_python3.py";
     fi
-  - export NOSEATTR=""
+  - export NOSEATTR="";
   - if [[ $TRAVIS_PULL_REQUEST ]]; then
-      export NOSEATTR="!nonpublic"
+      export NOSEATTR="!nonpublic";
     fi
   - nosetests indra -v --with-doctest --with-doctest-ignore-unicode
         --with-coverage --cover-inclusive --cover-package=indra -a $NOSEATTR

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,12 @@ script:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       export NOSE_IGNORE_FILES="manage_content.py,build_sample_set.py,_require_python3.py";
     fi
+  - export NOSEATTR=""
+  - if [[ $TRAVIS_PULL_REQUEST ]]; then
+      export NOSEATTR="!nonpublic"
+    fi
   - nosetests indra -v --with-doctest --with-doctest-ignore-unicode
-        --with-coverage --cover-inclusive --cover-package=indra
+        --with-coverage --cover-inclusive --cover-package=indra -a $NOSEATTR
   # Run NL model examples only when the environmental variable
   # RUN_NL_MODELS is set to true in the Travis build
   # NOTE: if blocks in Travis DO NOT FAIL even if there is

--- a/indra/databases/biogrid_client.py
+++ b/indra/databases/biogrid_client.py
@@ -57,6 +57,8 @@ def get_interactors(gene_name):
 def get_statements(gene_list):
     res_dict = _send_request(gene_list, include_interactors=True)
     statements = []
+    if res_dict is None:
+        return statements
     for int_id, interaction in res_dict.items():
         agent_a_name = interaction['OFFICIAL_SYMBOL_A']
         agent_b_name = interaction['OFFICIAL_SYMBOL_B']

--- a/indra/tests/test_bel.py
+++ b/indra/tests/test_bel.py
@@ -6,6 +6,7 @@ from indra.util import unicode_strs
 from indra.sources import bel
 from indra.sources.bel.belrdf_processor import BelRdfProcessor
 from indra.statements import RegulateAmount
+from nose.plugins.attrib import attr
 
 concept_prefix = 'http://www.openbel.org/bel/namespace//'
 entity_prefix = 'http://www.openbel.org/bel/'
@@ -20,6 +21,7 @@ def assert_pmids(stmts):
             if ev.pmid is not None:
                 assert(ev.pmid.isdigit())
 
+@attr('webservice')
 def test_bel_ndex_query():
     bp = bel.process_ndex_neighborhood(['NFKB1'])
     assert_pmids(bp.statements)
@@ -67,6 +69,3 @@ def test_get_transcription():
     assert len(transcription_stmts) == 8
     pass
 
-
-if __name__ == '__main__':
-    test_get_transcription()

--- a/indra/tests/test_benchmarks.py
+++ b/indra/tests/test_benchmarks.py
@@ -5,6 +5,7 @@ from indra.benchmarks import bioprocesses as bp
 from indra.benchmarks import complexes as cp
 from indra.benchmarks import phosphorylations as phos
 from indra.util import unicode_strs
+from nose.plugins.attrib import attr
 
 eval_file = join(dirname(abspath(__file__)),
                  '../benchmarks/assembly_eval/batch4/reach/' +
@@ -20,6 +21,7 @@ eval_file = join(dirname(abspath(__file__)),
 #    assert gene_set
 #    assert unicode_strs(gene_set)
 
+@attr('nonpublic', 'webservice')
 def test_complexes():
     """Smoke test to see if complexes analysis works."""
     cp.analyze(eval_file)

--- a/indra/tests/test_biogrid.py
+++ b/indra/tests/test_biogrid.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.databases import biogrid_client
 from indra.util import unicode_strs
+from nose.plugins.attrib import attr
 
+@attr('webservice', 'nonpublic')
 def test_biogrid_request():
     results = biogrid_client._send_request(['MAP2K1', 'MAPK1'])
+    assert results is not None
     assert unicode_strs(results)

--- a/indra/tests/test_biopax.py
+++ b/indra/tests/test_biopax.py
@@ -8,6 +8,7 @@ from indra.databases import uniprot_client
 from indra.util import unicode_strs
 from indra.preassembler import Preassembler
 from indra.preassembler.hierarchy_manager import hierarchies
+from nose.plugins.attrib import attr
 
 model_path = os.path.dirname(os.path.abspath(__file__)) +\
              '/../../data/biopax_test.owl'
@@ -154,6 +155,8 @@ def test_get_entity_mods():
     mod_pos = set([m.position for m in mods])
     assert(mod_pos == set(['1035', '1056', '1128', '1188', '1242']))
 
+
+@attr('webservice')
 def test_pathsfromto():
     bp = biopax.process_pc_pathsfromto(['MAP2K1'], ['MAPK1'])
     assert_pmids(bp.statements)

--- a/indra/tests/test_cbio_client.py
+++ b/indra/tests/test_cbio_client.py
@@ -1,30 +1,36 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.databases import cbio_client
+from nose.plugins.attrib import attr
 
 
+@attr('webservice')
 def test_get_cancer_studies():
     study_ids = cbio_client.get_cancer_studies('paad')
     assert(len(study_ids) > 0)
     assert('paad_tcga' in study_ids)
 
 
+@attr('webservice')
 def test_get_cancer_types():
     type_ids = cbio_client.get_cancer_types('lung')
     assert(len(type_ids) > 0)
 
 
+@attr('webservice')
 def test_get_genetic_profiles():
     genetic_profiles = \
         cbio_client.get_genetic_profiles('paad_icgc', 'mutation')
     assert(len(genetic_profiles) > 0)
 
 
+@attr('webservice')
 def test_get_num_sequenced():
     num_case = cbio_client.get_num_sequenced('paad_tcga')
     assert(num_case > 0)
 
 
+@attr('webservice')
 def test_send_request_ccle():
     """Sends a request and gets back a dataframe of all cases in ccle study.
 
@@ -36,6 +42,7 @@ def test_send_request_ccle():
     assert(len(df) > 0)
 
 
+@attr('webservice')
 def test_get_ccle_lines_for_mutation():
     """Check how many lines have BRAF V600E mutations.
 
@@ -46,6 +53,7 @@ def test_get_ccle_lines_for_mutation():
     assert(len(cl_BRAF_V600E) == 55)
 
 
+@attr('webservice')
 def test_get_ccle_mutations():
     muts = cbio_client.get_ccle_mutations(['BRAF', 'AKT1'],
                                           ['LOXIMVI_SKIN', 'A101D_SKIN'])
@@ -58,6 +66,7 @@ def test_get_ccle_mutations():
     assert len(muts['A101D_SKIN']['AKT1']) == 0
 
 
+@attr('webservice')
 def test_get_profile_data():
     profile_data = cbio_client.get_profile_data(cbio_client.ccle_study,
                                                 ['BRAF', 'PTEN'],
@@ -70,6 +79,7 @@ def test_get_profile_data():
     assert len(profile_data) > 0
 
 
+@attr('webservice')
 def test_get_ccle_cna():
     profile_data = cbio_client.get_ccle_cna(['BRAF', 'AKT1'],
                                             ['LOXIMVI_SKIN', 'SKMEL30_SKIN'])
@@ -80,6 +90,7 @@ def test_get_ccle_cna():
     assert len(profile_data) == 2
 
 
+@attr('webservice')
 def test_get_ccle_mrna():
     mrna = cbio_client.get_ccle_mrna(['XYZ', 'MAP2K1'], ['A375_SKIN'])
     assert('A375_SKIN' in mrna)
@@ -91,6 +102,7 @@ def test_get_ccle_mrna():
     assert(mrna['XXX'] is None)
 
 
+@attr('webservice')
 def test_get_ccle_cna_big():
     """
     Get the CNA data on 124 genes in 4 cell lines. Expect to have CNA values

--- a/indra/tests/test_chebi_client.py
+++ b/indra/tests/test_chebi_client.py
@@ -2,16 +2,19 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.databases import chebi_client
 from indra.util import unicode_strs
+from nose.plugins.attrib import attr
 
+
+@attr('webservice')
 def test_read_chebi_to_pubchem():
     (ctop, ptoc) = chebi_client.read_chebi_to_pubchem()
     assert ctop['85673'] == '252150010'
     assert ptoc['252150010'] == '85673'
     assert unicode_strs((ctop, ptoc))
 
+
+@attr('webservice')
 def test_read_chebi_to_chembl():
     ctoc = chebi_client.read_chebi_to_chembl()
     assert ctoc['50729'] == 'CHEMBL58'
     assert unicode_strs(ctoc)
-
-

--- a/indra/tests/test_chebi_client.py
+++ b/indra/tests/test_chebi_client.py
@@ -5,7 +5,6 @@ from indra.util import unicode_strs
 from nose.plugins.attrib import attr
 
 
-@attr('webservice')
 def test_read_chebi_to_pubchem():
     (ctop, ptoc) = chebi_client.read_chebi_to_pubchem()
     assert ctop['85673'] == '252150010'
@@ -13,7 +12,6 @@ def test_read_chebi_to_pubchem():
     assert unicode_strs((ctop, ptoc))
 
 
-@attr('webservice')
 def test_read_chebi_to_chembl():
     ctoc = chebi_client.read_chebi_to_chembl()
     assert ctoc['50729'] == 'CHEMBL58'

--- a/indra/tests/test_chembl_client.py
+++ b/indra/tests/test_chembl_client.py
@@ -3,6 +3,7 @@ from builtins import dict, str
 from indra.statements import Agent
 from indra.databases import chembl_client
 from indra.util import unicode_strs
+from nose.plugins.attrib import attr
 
 vem = Agent('VEMURAFENIB', db_refs={'CHEBI': '63637', 'TEXT': 'VEMURAFENIB'})
 az628 = Agent('AZ628', db_refs={'CHEBI': '91354'})
@@ -11,13 +12,14 @@ braf = Agent('BRAF', db_refs={'HGNC': '1097', 'NCIT': 'C51194',
 vem_chembl_id = 'CHEMBL1229517'
 braf_chembl_id = 'CHEMBL5145'
 query_dict_vem_activity = {'query': 'activity',
-                            'params': {'molecule_chembl_id': vem_chembl_id,
-                                       'limit': 10000}}
+                           'params': {'molecule_chembl_id': vem_chembl_id,
+                                      'limit': 10000}}
 query_dict_BRAF_target = {'query': 'target',
                           'params': {'target_chembl_id': braf_chembl_id,
-                          'limit': 1}}
+                                     'limit': 1}}
 
 
+@attr('webservice')
 def test_get_inhibitions():
     stmt = chembl_client.get_inhibition(vem, braf)
     assert(stmt is not None)
@@ -30,6 +32,7 @@ def test_get_inhibitions():
         assert(ev.source_id)
 
 
+@attr('webservice')
 def test_activity_query():
     res = chembl_client.send_query(query_dict_vem_activity)
     assert(res['page_meta']['total_count'] == len(res['activities']))
@@ -39,11 +42,13 @@ def test_activity_query():
         assert(e_t in assay_types)
 
 
+@attr('webservice')
 def test_target_query():
     target = chembl_client.query_target(braf_chembl_id)
     assert(target['target_type'] == 'SINGLE PROTEIN')
 
 
+@attr('webservice')
 def test_get_drug_inhibition_stmts_vem():
     stmts = chembl_client.get_drug_inhibition_stmts(vem)
     assert(len(stmts) > 0)
@@ -57,6 +62,7 @@ def test_get_drug_inhibition_stmts_vem():
             assert(ev.source_id)
 
 
+@attr('webservice')
 def test_get_drug_inhibition_stmts_az628():
     stmts = chembl_client.get_drug_inhibition_stmts(az628)
     assert(len(stmts) > 0)

--- a/indra/tests/test_context.py
+++ b/indra/tests/test_context.py
@@ -2,8 +2,9 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.databases import context_client
 from indra.util import unicode_strs
+from nose.plugins.attrib import attr
 
-
+@attr('webservice')
 def test_get_protein_expression():
     res = context_client.get_protein_expression(['EGFR'], ['BT20_BREAST'])
     assert(res is not None)
@@ -13,6 +14,7 @@ def test_get_protein_expression():
     assert unicode_strs(res)
 
 
+@attr('webservice')
 def test_get_mutations():
     res = context_client.get_mutations(['BRAF'], ['A375_SKIN'])
     assert(res is not None)
@@ -22,6 +24,7 @@ def test_get_mutations():
     assert unicode_strs(res)
 
 
+@attr('webservice')
 def test_get_protein_expression_gene_missing():
     protein_amounts = context_client.get_protein_expression(['EGFR', 'XYZ'],
                                                             ['BT20_BREAST'])
@@ -30,6 +33,7 @@ def test_get_protein_expression_gene_missing():
     assert(protein_amounts['BT20_BREAST']['XYZ'] is None)
 
 
+@attr('webservice')
 def test_get_protein_expression_cell_type_missing():
     protein_amounts = context_client.get_protein_expression(['EGFR'],
                                                             ['BT20_BREAST', 'XYZ'])
@@ -39,6 +43,7 @@ def test_get_protein_expression_cell_type_missing():
     assert(protein_amounts['XYZ'] is None)
 
 
+@attr('webservice')
 def test_get_mutations_gene_missing():
     mutations = context_client.get_mutations(['BRAF', 'XYZ'], ['A375_SKIN'])
     assert('A375_SKIN' in mutations)
@@ -46,6 +51,7 @@ def test_get_mutations_gene_missing():
     assert(not mutations['A375_SKIN']['XYZ'])
 
 
+@attr('webservice')
 def test_get_mutations_cell_type_missing():
     mutations = context_client.get_mutations(['BRAF'], ['A375_SKIN', 'XYZ'])
     assert('A375_SKIN' in mutations)

--- a/indra/tests/test_crossref_client.py
+++ b/indra/tests/test_crossref_client.py
@@ -2,17 +2,23 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.literature import crossref_client
 from indra.util import unicode_strs
+from nose.plugins.attrib import attr
 
 test_doi = '10.1016/j.ccell.2016.02.010'
 
 example_ids = {'pmid': '25361007',
                'pmcid': 'PMC4322985',
                'doi': '10.18632/oncotarget.2555'}
+
+
+@attr('webservice')
 def test_doi_query():
     mapped_doi = crossref_client.doi_query(example_ids['pmid'])
     assert mapped_doi == example_ids['doi']
     assert unicode_strs(mapped_doi)
 
+
+@attr('webservice')
 def test_get_metadata():
     metadata = crossref_client.get_metadata(test_doi)
     assert(metadata['DOI'] == test_doi)
@@ -20,6 +26,8 @@ def test_get_metadata():
     metadata = crossref_client.get_metadata('xyz')
     assert(metadata is None)
 
+
+@attr('webservice')
 def test_get_publisher():
     publisher = crossref_client.get_publisher(test_doi)
     assert(publisher == 'Elsevier BV')
@@ -27,6 +35,8 @@ def test_get_publisher():
     publisher = crossref_client.get_publisher('xyz')
     assert(publisher is None)
 
+
+@attr('webservice')
 def test_get_fulltext_links():
     links = crossref_client.get_fulltext_links(test_doi)
     content_types = [l.get('content-type') for l in links]
@@ -36,6 +46,8 @@ def test_get_fulltext_links():
     links = crossref_client.get_fulltext_links('xyz')
     assert(links is None)
 
+
+@attr('webservice')
 def test_get_license_links():
     links = crossref_client.get_license_links(test_doi)
     assert(links[0] == 'http://www.elsevier.com/tdm/userlicense/1.0/')
@@ -43,6 +55,8 @@ def test_get_license_links():
     links = crossref_client.get_license_links('xyz')
     assert(links is None)
 
+
+@attr('webservice')
 def test_get_url():
     url = crossref_client.get_url(test_doi)
     assert url == 'http://dx.doi.org/10.1016/j.ccell.2016.02.010'

--- a/indra/tests/test_db.py
+++ b/indra/tests/test_db.py
@@ -95,7 +95,7 @@ def get_db_with_content():
 #==============================================================================
 # The following are tests for the database manager itself.
 #==============================================================================
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_create_tables():
     "Test the create_tables feature"
     db = get_db()
@@ -103,7 +103,7 @@ def test_create_tables():
     assert_contents_equal(db.get_active_tables(), db.get_tables())
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_insert_and_query_pmid():
     "Test that we can add a text_ref and get the text_ref back."
     db = get_db()
@@ -115,7 +115,7 @@ def test_insert_and_query_pmid():
     assert_equal(entries[0].id, text_ref_id, "Got back wrong text_ref_id.")
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_uniqueness_text_ref_doi_pmid():
     "Test uniqueness enforcement behavior for text_ref insertion."
     db = get_db()
@@ -131,7 +131,7 @@ def test_uniqueness_text_ref_doi_pmid():
     assert False, "Uniqueness was not enforced."
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_uniqueness_text_ref_url():
     "Test whether the uniqueness imposed on the url of text_refs is enforced."
     db = get_db()
@@ -144,7 +144,7 @@ def test_uniqueness_text_ref_url():
     assert False, "Uniqueness was not enforced."
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_get_abstracts():
     "Test the ability to get a list of abstracts."
     db = get_db()
@@ -209,7 +209,7 @@ def test_get_abstracts():
     assert_contents_equal(expected, received, "Didn't get expected abstracts.")
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_get_all_pmids():
     "Test whether we get all the pmids."
     db = get_db()
@@ -231,7 +231,7 @@ if IS_PY3 and not path.exists(TEST_FTP):
 
 
 @needs_py3
-@attr('has-special-deps', 'slow')
+@attr('nonpublic', 'slow')
 def test_full_upload():
     "Test whether we can perform a targeted upload to a test db."
     # This uses a specially curated sample directory designed to access most
@@ -264,7 +264,7 @@ def test_full_upload():
 
 
 @needs_py3
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_multiple_pmids():
     "Test that pre-existing pmids are correctly handled."
     db = get_db()
@@ -278,7 +278,7 @@ def test_multiple_pmids():
 
 
 @needs_py3
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_multible_pmc_oa_content():
     "Test to make sure repeated content is handled correctly."
     db = get_db()
@@ -292,7 +292,7 @@ def test_multible_pmc_oa_content():
 
 
 @needs_py3
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_multiple_text_ref_pmc_oa():
     "Test whether a duplicate text ref in pmc oa is handled correctly."
     db = get_db()
@@ -308,7 +308,7 @@ def test_multiple_text_ref_pmc_oa():
 
 
 @needs_py3
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_id_handling_pmc_oa():
     "Test every conceivable combination pmid/pmcid presense."
     db = get_db()
@@ -375,7 +375,7 @@ def test_id_handling_pmc_oa():
 
 
 @needs_py3
-@attr('has-special-deps', 'slow')
+@attr('nonpublic', 'slow')
 def test_ftp_service():
     "Test the NIH FTP access client on the content managers."
     cases = [

--- a/indra/tests/test_db.py
+++ b/indra/tests/test_db.py
@@ -16,16 +16,17 @@ if version_info.major is not 3:
 if IS_PY3:
     from indra.db.manage_content import Medline, PmcOA, Manuscripts
 
-defaults = get_defaults()
-test_defaults = {k: v for k, v in defaults.items() if 'test' in k}
-
-# Get host for the test database from system defaults.
-# TODO: implement setup-teardown system.
 if '-a' in argv:
     attr_str = argv[argv.index('-a')+1]
     if any([not_attr in attr_str for not_attr in
             ('!nonpublic', '!webservice')]):
         raise SkipTest("Every tests is nonpublic and a webservice.")
+
+defaults = get_defaults()
+test_defaults = {k: v for k, v in defaults.items() if 'test' in k}
+
+# Get host for the test database from system defaults.
+# TODO: implement setup-teardown system.
 TEST_HOST = None
 TEST_HOST_TYPE = ''
 key_list = list(test_defaults.keys())

--- a/indra/tests/test_db.py
+++ b/indra/tests/test_db.py
@@ -9,6 +9,7 @@ from nose.tools import assert_equal
 from functools import wraps
 from sqlalchemy.exc import IntegrityError
 from indra.db import DatabaseManager, texttypes, get_defaults
+from nose.plugins.attrib import attr
 IS_PY3 = True
 if version_info.major is not 3:
     IS_PY3 = False
@@ -94,6 +95,7 @@ def get_db_with_content():
 #==============================================================================
 # The following are tests for the database manager itself.
 #==============================================================================
+@attr('has-special-deps')
 def test_create_tables():
     "Test the create_tables feature"
     db = get_db()
@@ -101,6 +103,7 @@ def test_create_tables():
     assert_contents_equal(db.get_active_tables(), db.get_tables())
 
 
+@attr('has-special-deps')
 def test_insert_and_query_pmid():
     "Test that we can add a text_ref and get the text_ref back."
     db = get_db()
@@ -112,6 +115,7 @@ def test_insert_and_query_pmid():
     assert_equal(entries[0].id, text_ref_id, "Got back wrong text_ref_id.")
 
 
+@attr('has-special-deps')
 def test_uniqueness_text_ref_doi_pmid():
     "Test uniqueness enforcement behavior for text_ref insertion."
     db = get_db()
@@ -127,6 +131,7 @@ def test_uniqueness_text_ref_doi_pmid():
     assert False, "Uniqueness was not enforced."
 
 
+@attr('has-special-deps')
 def test_uniqueness_text_ref_url():
     "Test whether the uniqueness imposed on the url of text_refs is enforced."
     db = get_db()
@@ -139,6 +144,7 @@ def test_uniqueness_text_ref_url():
     assert False, "Uniqueness was not enforced."
 
 
+@attr('has-special-deps')
 def test_get_abstracts():
     "Test the ability to get a list of abstracts."
     db = get_db()
@@ -203,6 +209,7 @@ def test_get_abstracts():
     assert_contents_equal(expected, received, "Didn't get expected abstracts.")
 
 
+@attr('has-special-deps')
 def test_get_all_pmids():
     "Test whether we get all the pmids."
     db = get_db()
@@ -224,6 +231,7 @@ if IS_PY3 and not path.exists(TEST_FTP):
 
 
 @needs_py3
+@attr('has-special-deps', 'slow')
 def test_full_upload():
     "Test whether we can perform a targeted upload to a test db."
     # This uses a specially curated sample directory designed to access most
@@ -256,6 +264,7 @@ def test_full_upload():
 
 
 @needs_py3
+@attr('has-special-deps')
 def test_multiple_pmids():
     "Test that pre-existing pmids are correctly handled."
     db = get_db()
@@ -269,6 +278,7 @@ def test_multiple_pmids():
 
 
 @needs_py3
+@attr('has-special-deps')
 def test_multible_pmc_oa_content():
     "Test to make sure repeated content is handled correctly."
     db = get_db()
@@ -282,6 +292,7 @@ def test_multible_pmc_oa_content():
 
 
 @needs_py3
+@attr('has-special-deps')
 def test_multiple_text_ref_pmc_oa():
     "Test whether a duplicate text ref in pmc oa is handled correctly."
     db = get_db()
@@ -297,6 +308,7 @@ def test_multiple_text_ref_pmc_oa():
 
 
 @needs_py3
+@attr('has-special-deps')
 def test_id_handling_pmc_oa():
     "Test every conceivable combination pmid/pmcid presense."
     db = get_db()
@@ -363,6 +375,7 @@ def test_id_handling_pmc_oa():
 
 
 @needs_py3
+@attr('has-special-deps', 'slow')
 def test_ftp_service():
     "Test the NIH FTP access client on the content managers."
     cases = [

--- a/indra/tests/test_db.py
+++ b/indra/tests/test_db.py
@@ -3,7 +3,7 @@ from builtins import dict, str
 
 import re
 from os import remove, path
-from sys import version_info
+from sys import version_info, argv
 from nose import SkipTest
 from nose.tools import assert_equal
 from functools import wraps
@@ -21,6 +21,11 @@ test_defaults = {k: v for k, v in defaults.items() if 'test' in k}
 
 # Get host for the test database from system defaults.
 # TODO: implement setup-teardown system.
+if '-a' in argv:
+    attr_str = argv[argv.index('-a')+1]
+    if any([not_attr in attr_str for not_attr in
+            ('!nonpublic', '!webservice')]):
+        raise SkipTest("Every tests is nonpublic and a webservice.")
 TEST_HOST = None
 TEST_HOST_TYPE = ''
 key_list = list(test_defaults.keys())

--- a/indra/tests/test_elsevier_client.py
+++ b/indra/tests/test_elsevier_client.py
@@ -4,7 +4,7 @@ from indra.literature import elsevier_client as ec
 from nose.plugins.attrib import attr
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_get_fulltext_article():
     # This article is not open access so in order to get a full text response
     # with a body element requires full text access keys to be correctly
@@ -14,7 +14,7 @@ def test_get_fulltext_article():
     assert text is not None
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_get_abstract():
     # If we have an API key but are not on an approved IP or don't have a
     # necessary institution key, we should still be able to get the abstract.
@@ -25,7 +25,7 @@ def test_get_abstract():
     assert text is not None
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_get_converted_article_body():
     """Make sure we can get fulltext of an article that has
     ja:converted-article as its principal sub-element."""
@@ -36,7 +36,7 @@ def test_get_converted_article_body():
     assert body
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_get_rawtext():
     """Make sure we can get content of an article that has content in
     xocs:rawtext"""
@@ -47,7 +47,7 @@ def test_get_rawtext():
     assert body
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_article():
     # PMID: 11302724
     doi = '10.1006/bbrc.2001.4693'

--- a/indra/tests/test_elsevier_client.py
+++ b/indra/tests/test_elsevier_client.py
@@ -4,7 +4,7 @@ from indra.literature import elsevier_client as ec
 from nose.plugins.attrib import attr
 
 
-@attr('nonpublic')
+@attr('nonpublic', 'webservice')
 def test_get_fulltext_article():
     # This article is not open access so in order to get a full text response
     # with a body element requires full text access keys to be correctly
@@ -14,7 +14,7 @@ def test_get_fulltext_article():
     assert text is not None
 
 
-@attr('nonpublic')
+@attr('nonpublic', 'webservice')
 def test_get_abstract():
     # If we have an API key but are not on an approved IP or don't have a
     # necessary institution key, we should still be able to get the abstract.
@@ -25,7 +25,7 @@ def test_get_abstract():
     assert text is not None
 
 
-@attr('nonpublic')
+@attr('nonpublic', 'webservice')
 def test_get_converted_article_body():
     """Make sure we can get fulltext of an article that has
     ja:converted-article as its principal sub-element."""
@@ -36,7 +36,7 @@ def test_get_converted_article_body():
     assert body
 
 
-@attr('nonpublic')
+@attr('nonpublic', 'webservice')
 def test_get_rawtext():
     """Make sure we can get content of an article that has content in
     xocs:rawtext"""
@@ -47,7 +47,7 @@ def test_get_rawtext():
     assert body
 
 
-@attr('nonpublic')
+@attr('nonpublic', 'webservice')
 def test_article():
     # PMID: 11302724
     doi = '10.1006/bbrc.2001.4693'

--- a/indra/tests/test_elsevier_client.py
+++ b/indra/tests/test_elsevier_client.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
-import unittest
 from indra.literature import elsevier_client as ec
+from nose.plugins.attrib import attr
 
+
+@attr('has-special-deps')
 def test_get_fulltext_article():
     # This article is not open access so in order to get a full text response
     # with a body element requires full text access keys to be correctly
@@ -11,6 +13,8 @@ def test_get_fulltext_article():
     text = ec.get_article(doi)
     assert text is not None
 
+
+@attr('has-special-deps')
 def test_get_abstract():
     # If we have an API key but are not on an approved IP or don't have a
     # necessary institution key, we should still be able to get the abstract.
@@ -20,6 +24,8 @@ def test_get_abstract():
     text = ec.get_abstract(doi)
     assert text is not None
 
+
+@attr('has-special-deps')
 def test_get_converted_article_body():
     """Make sure we can get fulltext of an article that has
     ja:converted-article as its principal sub-element."""
@@ -29,6 +35,8 @@ def test_get_converted_article_body():
     body = ec.extract_text(xml_str)
     assert body
 
+
+@attr('has-special-deps')
 def test_get_rawtext():
     """Make sure we can get content of an article that has content in
     xocs:rawtext"""
@@ -38,6 +46,8 @@ def test_get_rawtext():
     body = ec.extract_text(xml_str)
     assert body
 
+
+@attr('has-special-deps')
 def test_article():
     # PMID: 11302724
     doi = '10.1006/bbrc.2001.4693'

--- a/indra/tests/test_hgnc_client.py
+++ b/indra/tests/test_hgnc_client.py
@@ -2,41 +2,56 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.databases import hgnc_client
 from indra.util import unicode_strs
+from nose.plugins.attrib import attr
 
+
+@attr('webservice')
 def test_get_uniprot_id():
     hgnc_id = '6840'
     uniprot_id = hgnc_client.get_uniprot_id(hgnc_id)
     assert(uniprot_id == 'Q02750')
     assert unicode_strs(uniprot_id)
 
+
+@attr('webservice')
 def test_get_uniprot_id_none():
     # This HGNC entry doesn't have a UniProt ID
     hgnc_id = '12027'
     uniprot_id = hgnc_client.get_uniprot_id(hgnc_id)
     assert(uniprot_id is None)
 
+
+@attr('webservice')
 def test_get_hgnc_name():
     hgnc_id = '3236'
     hgnc_name = hgnc_client.get_hgnc_name(hgnc_id)
     assert(hgnc_name == 'EGFR')
     assert unicode_strs(hgnc_name)
 
+
+@attr('webservice')
 def test_get_hgnc_name_nonexistent():
     hgnc_id = '123456'
     hgnc_name = hgnc_client.get_hgnc_name(hgnc_id)
     assert(hgnc_name is None)
     assert unicode_strs(hgnc_name)
 
+
+@attr('webservice')
 def test_entrez_hgnc():
     entrez_id = '653509'
     hgnc_id = hgnc_client.get_hgnc_from_entrez(entrez_id)
     assert(hgnc_id == '10798')
 
+
+@attr('webservice')
 def test_entrez_hgnc_none():
     entrez_id = 'xxx'
     hgnc_id = hgnc_client.get_hgnc_from_entrez(entrez_id)
     assert(hgnc_id is None)
 
+
+@attr('webservice')
 def test_mouse_map():
     hgnc_id1 = hgnc_client.get_hgnc_from_mouse('109599')
     hgnc_id2 = hgnc_client.get_hgnc_from_mouse('MGI:109599')
@@ -45,6 +60,8 @@ def test_mouse_map():
     hgnc_id = hgnc_client.get_hgnc_from_mouse('xxx')
     assert(hgnc_id is None)
 
+
+@attr('webservice')
 def test_rat_map():
     hgnc_id1 = hgnc_client.get_hgnc_from_rat('6496784')
     hgnc_id2 = hgnc_client.get_hgnc_from_rat('RGD:6496784')

--- a/indra/tests/test_hgnc_client.py
+++ b/indra/tests/test_hgnc_client.py
@@ -5,7 +5,6 @@ from indra.util import unicode_strs
 from nose.plugins.attrib import attr
 
 
-@attr('webservice')
 def test_get_uniprot_id():
     hgnc_id = '6840'
     uniprot_id = hgnc_client.get_uniprot_id(hgnc_id)
@@ -13,7 +12,6 @@ def test_get_uniprot_id():
     assert unicode_strs(uniprot_id)
 
 
-@attr('webservice')
 def test_get_uniprot_id_none():
     # This HGNC entry doesn't have a UniProt ID
     hgnc_id = '12027'
@@ -21,7 +19,6 @@ def test_get_uniprot_id_none():
     assert(uniprot_id is None)
 
 
-@attr('webservice')
 def test_get_hgnc_name():
     hgnc_id = '3236'
     hgnc_name = hgnc_client.get_hgnc_name(hgnc_id)
@@ -37,21 +34,18 @@ def test_get_hgnc_name_nonexistent():
     assert unicode_strs(hgnc_name)
 
 
-@attr('webservice')
 def test_entrez_hgnc():
     entrez_id = '653509'
     hgnc_id = hgnc_client.get_hgnc_from_entrez(entrez_id)
     assert(hgnc_id == '10798')
 
 
-@attr('webservice')
 def test_entrez_hgnc_none():
     entrez_id = 'xxx'
     hgnc_id = hgnc_client.get_hgnc_from_entrez(entrez_id)
     assert(hgnc_id is None)
 
 
-@attr('webservice')
 def test_mouse_map():
     hgnc_id1 = hgnc_client.get_hgnc_from_mouse('109599')
     hgnc_id2 = hgnc_client.get_hgnc_from_mouse('MGI:109599')
@@ -61,7 +55,6 @@ def test_mouse_map():
     assert(hgnc_id is None)
 
 
-@attr('webservice')
 def test_rat_map():
     hgnc_id1 = hgnc_client.get_hgnc_from_rat('6496784')
     hgnc_id2 = hgnc_client.get_hgnc_from_rat('RGD:6496784')

--- a/indra/tests/test_literature.py
+++ b/indra/tests/test_literature.py
@@ -2,19 +2,26 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.literature import id_lookup, get_full_text
 from indra.util import unicode_strs
+from nose.plugins.attrib import attr
 
+
+@attr('webservice')
 def test_get_full_text_pmc():
     txt, txt_format = get_full_text('PMC4322985', 'pmcid')
     assert(txt_format == 'pmc_oa_xml')
     assert(len(txt) > 300000)
     assert unicode_strs((txt, txt_format))
 
+
+@attr('webservice')
 def test_get_full_text_doi():
     txt, txt_format = get_full_text('10.18632/oncotarget.2555', 'doi')
     assert(txt_format == 'pmc_oa_xml')
     assert(len(txt) > 300000)
     assert unicode_strs((txt, txt_format))
 
+
+@attr('webservice')
 def test_get_full_text_pubmed_abstract():
     # DOI lookup in CrossRef fails for this one because of page mismatch
     txt, txt_format = get_full_text('27075779', 'pmid')
@@ -22,10 +29,14 @@ def test_get_full_text_pubmed_abstract():
     assert(len(txt) > 800)
     assert unicode_strs((txt, txt_format))
 
+
+@attr('webservice')
 def test_id_lookup():
     res = id_lookup('17513615', 'pmid')
     assert res['doi'] == '10.1158/1535-7163.MCT-06-0807'
 
+
+@attr('webservice')
 def test_id_lookup_no_pmid():
     """Look up a paper that has a PMCID and DOI but not PMID."""
     res = id_lookup('10.1083/jcb.1974if', 'doi')
@@ -33,6 +44,7 @@ def test_id_lookup_no_pmid():
     res = id_lookup('PMC3352949', 'pmcid')
     assert res['doi'] == '10.1083/jcb.1974if'
     assert unicode_strs(res)
+
 
 def test_cr_fulltext_elsevier():
     """Test the ability to obtain publications from Elsevier using the
@@ -54,6 +66,7 @@ def test_cr_fulltext_elsevier():
     assert type == 'text/xml'
     """
 
+
 def test_cr_fulltext_wiley():
     """Test the ability to obtain publications from Wiley using the
     CrossRef Clickthrough API. Note: requires a cr_clickthrough_key file
@@ -72,11 +85,13 @@ def test_cr_fulltext_wiley():
     assert content is None
     """
 
+
 def test_other_fulltexts_with_link():
     """Test the ability to obtain publications from other publishers that have
     a full text link and a text-mining compatible license (e.g., Hindawi, which
     uses a Creative Commons License)."""
     pass
+
 
 def test_fulltext_asbmb():
     #(content, type) = get_full_text('14761976', 'pmid')

--- a/indra/tests/test_ndex_client.py
+++ b/indra/tests/test_ndex_client.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.databases import ndex_client
+from nose.plugins.attrib import attr
 
 
+@attr('webservice')
 def test_ndex_ver():
     assert(ndex_client._increment_ndex_ver(None) == '1.0')
     assert(ndex_client._increment_ndex_ver('') == '1.0')

--- a/indra/tests/test_ndex_client.py
+++ b/indra/tests/test_ndex_client.py
@@ -4,7 +4,6 @@ from indra.databases import ndex_client
 from nose.plugins.attrib import attr
 
 
-@attr('webservice')
 def test_ndex_ver():
     assert(ndex_client._increment_ndex_ver(None) == '1.0')
     assert(ndex_client._increment_ndex_ver('') == '1.0')

--- a/indra/tests/test_ndex_cx_processor.py
+++ b/indra/tests/test_ndex_cx_processor.py
@@ -7,6 +7,7 @@ from indra.databases import hgnc_client
 from indra.statements import Agent, Statement
 from requests.exceptions import HTTPError
 from nose.tools import raises
+from nose.plugins.attrib import attr
 
 
 path_this = os.path.dirname(os.path.abspath(__file__))
@@ -66,12 +67,14 @@ def test_get_statements():
             assert ev.source_api == 'ndex'
 
 
+@attr('webservice')
 def test_get_cx_from_ndex():
     # Ras Machine network
     ncp = process_ndex_network('50e3dff7-133e-11e6-a039-06603eb7f303')
 
 
 @raises(HTTPError)
+@attr('webservice')
 def test_get_cx_from_ndex_unauth():
     # This network should error because unauthorized without username/pwd
     ncp = process_ndex_network('df1fea48-8cfb-11e7-a10d-0ac135e8bacf')

--- a/indra/tests/test_phosphosite_client.py
+++ b/indra/tests/test_phosphosite_client.py
@@ -1,21 +1,29 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.databases.phosphosite_client import map_to_human_site
+from nose.plugins.attrib import attr
 
+
+@attr('webservice')
 def test_map_mouse_to_human():
     mouse_up_id = 'Q61337'
     pos = map_to_human_site(mouse_up_id, 'S', '112')
     assert pos == '75'
 
+
+@attr('webservice')
 def test_isoform_mapping_from_human():
     up_id = 'P29353'
     pos = map_to_human_site(up_id, 'Y', '239')
     assert pos == '349'
 
+
+@attr('webservice')
 def test_isoform_mapping_from_mouse():
     up_id = 'P29353'
     pos = map_to_human_site(up_id, 'Y', '239')
     assert pos == '349'
+
 
 if __name__ == '__main__':
     test_isoform_mapping_from_human()

--- a/indra/tests/test_phosphosite_client.py
+++ b/indra/tests/test_phosphosite_client.py
@@ -4,21 +4,18 @@ from indra.databases.phosphosite_client import map_to_human_site
 from nose.plugins.attrib import attr
 
 
-@attr('webservice')
 def test_map_mouse_to_human():
     mouse_up_id = 'Q61337'
     pos = map_to_human_site(mouse_up_id, 'S', '112')
     assert pos == '75'
 
 
-@attr('webservice')
 def test_isoform_mapping_from_human():
     up_id = 'P29353'
     pos = map_to_human_site(up_id, 'Y', '239')
     assert pos == '349'
 
 
-@attr('webservice')
 def test_isoform_mapping_from_mouse():
     up_id = 'P29353'
     pos = map_to_human_site(up_id, 'Y', '239')

--- a/indra/tests/test_pmc_client.py
+++ b/indra/tests/test_pmc_client.py
@@ -10,7 +10,7 @@ example_ids = {'pmid': '25361007',
                'doi': '10.18632/oncotarget.2555'}
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_id_lookup_pmid_no_prefix_no_idtype():
     ids = pmc_client.id_lookup('25361007')
     assert(ids['doi'] == example_ids['doi'])
@@ -19,7 +19,7 @@ def test_id_lookup_pmid_no_prefix_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_id_lookup_pmid_with_prefix_no_idtype():
     ids = pmc_client.id_lookup('PMID25361007')
     assert(ids['doi'] == example_ids['doi'])
@@ -28,7 +28,7 @@ def test_id_lookup_pmid_with_prefix_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_id_lookup_pmcid_no_idtype():
     ids = pmc_client.id_lookup('PMC4322985')
     assert(ids['doi'] == example_ids['doi'])
@@ -37,7 +37,7 @@ def test_id_lookup_pmcid_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_id_lookup_pmcid_idtype():
     ids = pmc_client.id_lookup('PMC4322985', idtype='pmcid')
     assert(ids['doi'] == example_ids['doi'])
@@ -46,7 +46,7 @@ def test_id_lookup_pmcid_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_id_lookup_pmcid_no_prefix_idtype():
     ids = pmc_client.id_lookup('4322985', idtype='pmcid')
     assert(ids['doi'] == example_ids['doi'])
@@ -55,7 +55,7 @@ def test_id_lookup_pmcid_no_prefix_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_id_lookup_doi_no_prefix_no_idtype():
     ids = pmc_client.id_lookup('10.18632/oncotarget.2555')
     assert(ids['doi'] == example_ids['doi'])
@@ -64,7 +64,7 @@ def test_id_lookup_doi_no_prefix_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_id_lookup_doi_prefix_no_idtype():
     ids = pmc_client.id_lookup('DOI10.18632/oncotarget.2555')
     assert(ids['doi'] == example_ids['doi'])
@@ -73,13 +73,13 @@ def test_id_lookup_doi_prefix_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 @raises(ValueError)
 def test_invalid_idtype():
     ids = pmc_client.id_lookup('DOI10.18632/oncotarget.2555', idtype='foo')
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_get_xml():
     pmc_id = '4322985'
     xml_str = pmc_client.get_xml(pmc_id)
@@ -87,7 +87,7 @@ def test_get_xml():
     assert unicode_strs((pmc_id, xml_str))
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_get_xml_PMC():
     pmc_id = 'PMC4322985'
     xml_str = pmc_client.get_xml(pmc_id)
@@ -95,7 +95,7 @@ def test_get_xml_PMC():
     assert unicode_strs((pmc_id, xml_str))
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_get_xml_invalid():
     pmc_id = '9999999'
     xml_str = pmc_client.get_xml(pmc_id)

--- a/indra/tests/test_pmc_client.py
+++ b/indra/tests/test_pmc_client.py
@@ -3,11 +3,14 @@ from builtins import dict, str
 from indra.literature import pmc_client
 from nose.tools import raises
 from indra.util import unicode_strs
+from nose.plugins.attrib import attr
 
 example_ids = {'pmid': '25361007',
                'pmcid': 'PMC4322985',
                'doi': '10.18632/oncotarget.2555'}
 
+
+@attr('webservice')
 def test_id_lookup_pmid_no_prefix_no_idtype():
     ids = pmc_client.id_lookup('25361007')
     assert(ids['doi'] == example_ids['doi'])
@@ -15,6 +18,8 @@ def test_id_lookup_pmid_no_prefix_no_idtype():
     assert(ids['pmcid'] == example_ids['pmcid'])
     assert unicode_strs(ids)
 
+
+@attr('webservice')
 def test_id_lookup_pmid_with_prefix_no_idtype():
     ids = pmc_client.id_lookup('PMID25361007')
     assert(ids['doi'] == example_ids['doi'])
@@ -22,6 +27,8 @@ def test_id_lookup_pmid_with_prefix_no_idtype():
     assert(ids['pmcid'] == example_ids['pmcid'])
     assert unicode_strs(ids)
 
+
+@attr('webservice')
 def test_id_lookup_pmcid_no_idtype():
     ids = pmc_client.id_lookup('PMC4322985')
     assert(ids['doi'] == example_ids['doi'])
@@ -29,6 +36,8 @@ def test_id_lookup_pmcid_no_idtype():
     assert(ids['pmcid'] == example_ids['pmcid'])
     assert unicode_strs(ids)
 
+
+@attr('webservice')
 def test_id_lookup_pmcid_idtype():
     ids = pmc_client.id_lookup('PMC4322985', idtype='pmcid')
     assert(ids['doi'] == example_ids['doi'])
@@ -36,6 +45,8 @@ def test_id_lookup_pmcid_idtype():
     assert(ids['pmcid'] == example_ids['pmcid'])
     assert unicode_strs(ids)
 
+
+@attr('webservice')
 def test_id_lookup_pmcid_no_prefix_idtype():
     ids = pmc_client.id_lookup('4322985', idtype='pmcid')
     assert(ids['doi'] == example_ids['doi'])
@@ -43,6 +54,8 @@ def test_id_lookup_pmcid_no_prefix_idtype():
     assert(ids['pmcid'] == example_ids['pmcid'])
     assert unicode_strs(ids)
 
+
+@attr('webservice')
 def test_id_lookup_doi_no_prefix_no_idtype():
     ids = pmc_client.id_lookup('10.18632/oncotarget.2555')
     assert(ids['doi'] == example_ids['doi'])
@@ -50,6 +63,8 @@ def test_id_lookup_doi_no_prefix_no_idtype():
     assert(ids['pmcid'] == example_ids['pmcid'])
     assert unicode_strs(ids)
 
+
+@attr('webservice')
 def test_id_lookup_doi_prefix_no_idtype():
     ids = pmc_client.id_lookup('DOI10.18632/oncotarget.2555')
     assert(ids['doi'] == example_ids['doi'])
@@ -57,22 +72,30 @@ def test_id_lookup_doi_prefix_no_idtype():
     assert(ids['pmcid'] == example_ids['pmcid'])
     assert unicode_strs(ids)
 
+
+@attr('webservice')
 @raises(ValueError)
 def test_invalid_idtype():
     ids = pmc_client.id_lookup('DOI10.18632/oncotarget.2555', idtype='foo')
 
+
+@attr('webservice')
 def test_get_xml():
     pmc_id = '4322985'
     xml_str = pmc_client.get_xml(pmc_id)
     assert(xml_str is not None)
     assert unicode_strs((pmc_id, xml_str))
 
+
+@attr('webservice')
 def test_get_xml_PMC():
     pmc_id = 'PMC4322985'
     xml_str = pmc_client.get_xml(pmc_id)
     assert(xml_str is not None)
     assert unicode_strs((pmc_id, xml_str))
 
+
+@attr('webservice')
 def test_get_xml_invalid():
     pmc_id = '9999999'
     xml_str = pmc_client.get_xml(pmc_id)

--- a/indra/tests/test_pmc_client.py
+++ b/indra/tests/test_pmc_client.py
@@ -10,7 +10,7 @@ example_ids = {'pmid': '25361007',
                'doi': '10.18632/oncotarget.2555'}
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice')
 def test_id_lookup_pmid_no_prefix_no_idtype():
     ids = pmc_client.id_lookup('25361007')
     assert(ids['doi'] == example_ids['doi'])
@@ -19,7 +19,7 @@ def test_id_lookup_pmid_no_prefix_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice')
 def test_id_lookup_pmid_with_prefix_no_idtype():
     ids = pmc_client.id_lookup('PMID25361007')
     assert(ids['doi'] == example_ids['doi'])
@@ -28,7 +28,7 @@ def test_id_lookup_pmid_with_prefix_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice')
 def test_id_lookup_pmcid_no_idtype():
     ids = pmc_client.id_lookup('PMC4322985')
     assert(ids['doi'] == example_ids['doi'])
@@ -37,7 +37,7 @@ def test_id_lookup_pmcid_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice')
 def test_id_lookup_pmcid_idtype():
     ids = pmc_client.id_lookup('PMC4322985', idtype='pmcid')
     assert(ids['doi'] == example_ids['doi'])
@@ -46,7 +46,7 @@ def test_id_lookup_pmcid_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice')
 def test_id_lookup_pmcid_no_prefix_idtype():
     ids = pmc_client.id_lookup('4322985', idtype='pmcid')
     assert(ids['doi'] == example_ids['doi'])
@@ -55,7 +55,7 @@ def test_id_lookup_pmcid_no_prefix_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice')
 def test_id_lookup_doi_no_prefix_no_idtype():
     ids = pmc_client.id_lookup('10.18632/oncotarget.2555')
     assert(ids['doi'] == example_ids['doi'])
@@ -64,7 +64,7 @@ def test_id_lookup_doi_no_prefix_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice')
 def test_id_lookup_doi_prefix_no_idtype():
     ids = pmc_client.id_lookup('DOI10.18632/oncotarget.2555')
     assert(ids['doi'] == example_ids['doi'])
@@ -73,13 +73,12 @@ def test_id_lookup_doi_prefix_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice', 'nonpublic')
 @raises(ValueError)
 def test_invalid_idtype():
     ids = pmc_client.id_lookup('DOI10.18632/oncotarget.2555', idtype='foo')
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice')
 def test_get_xml():
     pmc_id = '4322985'
     xml_str = pmc_client.get_xml(pmc_id)
@@ -87,7 +86,7 @@ def test_get_xml():
     assert unicode_strs((pmc_id, xml_str))
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice')
 def test_get_xml_PMC():
     pmc_id = 'PMC4322985'
     xml_str = pmc_client.get_xml(pmc_id)
@@ -95,7 +94,7 @@ def test_get_xml_PMC():
     assert unicode_strs((pmc_id, xml_str))
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice')
 def test_get_xml_invalid():
     pmc_id = '9999999'
     xml_str = pmc_client.get_xml(pmc_id)

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -2,16 +2,23 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.literature import pubmed_client
 from indra.util import unicode_strs
+from nose.plugins.attrib import attr
 
+
+@attr('webservice')
 def test_get_ids():
     ids = pubmed_client.get_ids('braf', retmax=10, db='pubmed')
     assert(len(ids) == 10)
     assert unicode_strs(ids)
 
+
+@attr('webservice')
 def test_get_no_ids():
     ids = pubmed_client.get_ids('', retmax=10, db='pubmed')
     assert(not ids)
 
+
+@attr('webservice')
 def test_get_pmc_ids():
     ids = pubmed_client.get_ids('braf', retmax=10, db='pmc')
     assert(len(ids) == 10)
@@ -19,52 +26,72 @@ def test_get_pmc_ids():
                 i.startswith('4')]) == 10)
     assert unicode_strs(ids)
 
+
+@attr('webservice')
 def test_get_title():
     title = pubmed_client.get_title('27754804')
     assert(title)
     assert(title.lower().startswith('targeting autophagy'))
 
+
+@attr('webservice')
 def test_get_title_prefix():
     title = pubmed_client.get_title('PMID27754804')
     assert(title)
     assert(title.lower().startswith('targeting autophagy'))
 
+
+@attr('webservice')
 def test_expand_pagination():
     pages = '456-7'
     new_pages = pubmed_client.expand_pagination(pages)
     assert(new_pages == '456-457')
 
+
+@attr('webservice')
 def test_get_abstract_notitle():
     abstract = pubmed_client.get_abstract('27754804', prepend_title=False)
     assert(abstract.startswith('The RAF inhibitor'))
     assert(abstract.endswith('vemurafenib.'))
     assert unicode_strs(abstract)
 
+
+@attr('webservice')
 def test_get_abstract_title():
     abstract = pubmed_client.get_abstract('27754804', prepend_title=True)
     assert(abstract.lower().startswith('targeting autophagy'))
     assert(abstract.endswith('vemurafenib.'))
     assert unicode_strs(abstract)
 
+
+@attr('webservice')
 def test_get_abstract2():
     # Try another one
     abstract = pubmed_client.get_abstract('27123883')
     assert unicode_strs(abstract)
 
+
+@attr('webservice')
 def test_get_no_abstract():
     abstract = pubmed_client.get_abstract('xx')
     assert(abstract is None)
 
+
+@attr('webservice')
 def test_get_ids_for_gene():
     ids = pubmed_client.get_ids_for_gene('EXOC1')
     assert ids
     assert unicode_strs(ids)
 
+
+@attr('webservice')
 def test_get_metadata_for_ids():
     pmids = ['27123883', '27121204', '27115606']
     metadata = pubmed_client.get_metadata_for_ids(pmids)
     assert unicode_strs(metadata)
 
+
+@attr('webservice')
 def test_send_request_invalid():
     res = pubmed_client.send_request('http://xxxxxxx', data={})
     assert res is None

--- a/indra/tests/test_reading_scripts.py
+++ b/indra/tests/test_reading_scripts.py
@@ -6,6 +6,7 @@ import random
 import zlib
 from os import path, mkdir
 from nose import SkipTest
+from nose.plugins.attrib import attr
 
 from indra.tools.reading import read_db as rdb
 from indra.tools.reading.read_files import read_files
@@ -189,6 +190,7 @@ def test_get_reader_children():
         "Expected only 2 readers, but got %s." % str(readers)
 
 
+@attr('slow')
 def test_reading_content_insert():
     "Test the content primary through-put of make_db_readings."
     db = get_db_with_content()
@@ -235,6 +237,7 @@ def test_reading_content_insert():
     assert len(db.select_all(db.Agents)), "No agents added."
 
 
+@attr('slow')
 def test_read_db():
     "Test the low level make_db_readings functionality with various settings."
     # Prep the inputs.
@@ -271,6 +274,7 @@ def test_read_db():
         "Did not get old readings when force_read=False."
 
 
+@attr('slow')
 def test_produce_readings():
     "Comprehensive test of the high level production of readings."
     # Prep the inputs.
@@ -326,6 +330,7 @@ def test_produce_readings():
     assert all([rd.reading_id is None for rd in outputs_4])
 
 
+@attr('slow')
 def test_read_files():
     "Test that the system can read files."
     db = get_db_with_content()
@@ -377,6 +382,7 @@ def test_sparser_parallel_one_batch():
         "Expected to get %d results, but got %d." % (N_exp, N_res)
 
 
+@attr('slow')
 def test_multi_batch_run():
     "Test that reading works properly with multiple batches run."
     db = get_db_with_content()
@@ -389,6 +395,7 @@ def test_multi_batch_run():
     rdb.upload_readings(outputs)
 
 
+@attr('slow')
 def test_multiproc_statements():
     "Test the multiprocessing creation of statements."
     db = get_db_with_content()

--- a/indra/tests/test_reading_scripts.py
+++ b/indra/tests/test_reading_scripts.py
@@ -150,7 +150,7 @@ def test_get_clauses():
     assert 'IN' in str(clause) and 'OR' in str(clause)
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_get_content():
     "Test that content querries are correctly formed."
     db = get_db_with_content()
@@ -184,7 +184,7 @@ def test_get_content():
         "Expected None when passing no ids."
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_get_reader_children():
     "Test method for getting reader objects."
     readers = get_readers()
@@ -192,7 +192,7 @@ def test_get_reader_children():
         "Expected only 2 readers, but got %s." % str(readers)
 
 
-@attr('slow', 'has-special-deps')
+@attr('slow', 'nonpublic')
 def test_reading_content_insert():
     "Test the content primary through-put of make_db_readings."
     db = get_db_with_content()
@@ -239,7 +239,7 @@ def test_reading_content_insert():
     assert len(db.select_all(db.Agents)), "No agents added."
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_read_db():
     "Test the low level make_db_readings functionality with various settings."
     # Prep the inputs.
@@ -276,7 +276,7 @@ def test_read_db():
         "Did not get old readings when force_read=False."
 
 
-@attr('slow', 'has-special-deps')
+@attr('slow', 'nonpublic')
 def test_produce_readings():
     "Comprehensive test of the high level production of readings."
     # Prep the inputs.
@@ -332,7 +332,7 @@ def test_produce_readings():
     assert all([rd.reading_id is None for rd in outputs_4])
 
 
-@attr('slow', 'has-special-deps')
+@attr('slow', 'nonpublic')
 def test_read_files():
     "Test that the system can read files."
     db = get_db_with_content()
@@ -360,7 +360,7 @@ def test_read_files():
     assert N_out == N_exp, "Expected %d outputs, got %d." % (N_exp, N_out)
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_sparser_parallel():
     "Test running sparser in parallel."
     db = get_db_with_content()
@@ -374,7 +374,7 @@ def test_sparser_parallel():
         "Expected to get %d results, but got %d." % (N_exp, N_res)
 
 
-@attr('has-special-deps')
+@attr('nonpublic')
 def test_sparser_parallel_one_batch():
     "Test that sparser runs with multiple procs with batches of 1."
     db = get_db_with_content()
@@ -387,7 +387,7 @@ def test_sparser_parallel_one_batch():
         "Expected to get %d results, but got %d." % (N_exp, N_res)
 
 
-@attr('slow', 'has-special-deps')
+@attr('slow', 'nonpublic')
 def test_multi_batch_run():
     "Test that reading works properly with multiple batches run."
     db = get_db_with_content()
@@ -400,7 +400,7 @@ def test_multi_batch_run():
     rdb.upload_readings(outputs)
 
 
-@attr('slow', 'has-special-deps')
+@attr('slow', 'nonpublic')
 def test_multiproc_statements():
     "Test the multiprocessing creation of statements."
     db = get_db_with_content()

--- a/indra/tests/test_reading_scripts.py
+++ b/indra/tests/test_reading_scripts.py
@@ -150,6 +150,7 @@ def test_get_clauses():
     assert 'IN' in str(clause) and 'OR' in str(clause)
 
 
+@attr('has-special-deps')
 def test_get_content():
     "Test that content querries are correctly formed."
     db = get_db_with_content()
@@ -183,6 +184,7 @@ def test_get_content():
         "Expected None when passing no ids."
 
 
+@attr('has-special-deps')
 def test_get_reader_children():
     "Test method for getting reader objects."
     readers = get_readers()
@@ -190,7 +192,7 @@ def test_get_reader_children():
         "Expected only 2 readers, but got %s." % str(readers)
 
 
-@attr('slow')
+@attr('slow', 'has-special-deps')
 def test_reading_content_insert():
     "Test the content primary through-put of make_db_readings."
     db = get_db_with_content()
@@ -237,7 +239,7 @@ def test_reading_content_insert():
     assert len(db.select_all(db.Agents)), "No agents added."
 
 
-@attr('slow')
+@attr('has-special-deps')
 def test_read_db():
     "Test the low level make_db_readings functionality with various settings."
     # Prep the inputs.
@@ -274,7 +276,7 @@ def test_read_db():
         "Did not get old readings when force_read=False."
 
 
-@attr('slow')
+@attr('slow', 'has-special-deps')
 def test_produce_readings():
     "Comprehensive test of the high level production of readings."
     # Prep the inputs.
@@ -330,7 +332,7 @@ def test_produce_readings():
     assert all([rd.reading_id is None for rd in outputs_4])
 
 
-@attr('slow')
+@attr('slow', 'has-special-deps')
 def test_read_files():
     "Test that the system can read files."
     db = get_db_with_content()
@@ -358,18 +360,21 @@ def test_read_files():
     assert N_out == N_exp, "Expected %d outputs, got %d." % (N_exp, N_out)
 
 
+@attr('has-special-deps')
 def test_sparser_parallel():
     "Test running sparser in parallel."
     db = get_db_with_content()
     sparser_reader = SparserReader(n_proc=2)
     tc_list = db.select_all(db.TextContent)
     result = sparser_reader.read(tc_list, verbose=True)
+    assert False
     N_exp = len(tc_list)
     N_res = len(result)
     assert N_exp == N_res, \
         "Expected to get %d results, but got %d." % (N_exp, N_res)
 
 
+@attr('has-special-deps')
 def test_sparser_parallel_one_batch():
     "Test that sparser runs with multiple procs with batches of 1."
     db = get_db_with_content()
@@ -382,7 +387,7 @@ def test_sparser_parallel_one_batch():
         "Expected to get %d results, but got %d." % (N_exp, N_res)
 
 
-@attr('slow')
+@attr('slow', 'has-special-deps')
 def test_multi_batch_run():
     "Test that reading works properly with multiple batches run."
     db = get_db_with_content()
@@ -395,7 +400,7 @@ def test_multi_batch_run():
     rdb.upload_readings(outputs)
 
 
-@attr('slow')
+@attr('slow', 'has-special-deps')
 def test_multiproc_statements():
     "Test the multiprocessing creation of statements."
     db = get_db_with_content()

--- a/indra/tests/test_relevance_client.py
+++ b/indra/tests/test_relevance_client.py
@@ -3,17 +3,21 @@ from builtins import dict, str
 import unittest
 from indra.databases import relevance_client
 from indra.util import unicode_strs
+from nose.plugins.attrib import attr
 
 network_uuid = '50e3dff7-133e-11e6-a039-06603eb7f303'
 
+
+@attr('webservice')
 @unittest.skip('Relevance service currently offline')
 def test_get_heat_kernel():
     kernel_id = relevance_client.get_heat_kernel(network_uuid)
     assert kernel_id is not None
 
+
+@attr('webservice')
 @unittest.skip('Relevance service currently offline')
 def test_get_relevant_nodes():
     nodes = relevance_client.get_relevant_nodes(network_uuid,
                                                 ['MAPK1', 'MAPK3'])
     assert unicode_strs(nodes)
-

--- a/indra/tests/test_rest_api.py
+++ b/indra/tests/test_rest_api.py
@@ -1,5 +1,7 @@
 import requests
+from nose.plugins.attrib import attr
 
+@attr('webservice')
 def test_rest_api_responsive():
     stmt_str = '{"statements": [{"sbo": "http://identifiers.org/sbo/SBO:0000526", "type": "Complex", "id": "acc6d47c-f622-41a4-8ae9-d7b0f3d24a2f", "members": [{"db_refs": {"TEXT": "MEK", "BE": "MEK"}, "name": "MEK"}, {"db_refs": {"TEXT": "ERK", "NCIT": "C26360", "BE": "ERK"}, "name": "ERK"}], "evidence": [{"text": "MEK binds ERK", "source_api": "trips"}]}]}'
     url = 'http://ec2-54-88-146-250.compute-1.amazonaws.com:8080/' + \

--- a/indra/tests/test_s3_client.py
+++ b/indra/tests/test_s3_client.py
@@ -3,7 +3,10 @@ from builtins import dict, str
 from indra.literature import s3_client
 from indra.util import unicode_strs
 import zlib
+from nose.plugins.attrib import attr
 
+
+@attr('webservice')
 def test_check_pmid():
     pmid = s3_client.check_pmid(12345)
     assert pmid == 'PMID12345'
@@ -15,17 +18,23 @@ def test_check_pmid():
     assert pmid == 'PMID12345'
     assert unicode_strs(pmid)
 
+
+@attr('webservice')
 def test_get_pmid_key():
     pmid = '12345'
     pmid_key = s3_client.get_pmid_key(pmid)
     assert pmid_key == s3_client.prefix + 'PMID12345'
     assert unicode_strs(pmid_key)
 
+
+@attr('webservice')
 def test_filter_keys():
     pmid_key = s3_client.get_pmid_key('1001287')
     key_list = s3_client.filter_keys(pmid_key)
     assert len(key_list) == 4
 
+
+@attr('webservice')
 def test_get_gz_object():
     # Get XML
     key = 'papers/PMID27297883/fulltext/txt'
@@ -36,10 +45,14 @@ def test_get_gz_object():
     obj = s3_client.get_gz_object(key)
     assert unicode_strs(obj)
 
+
+@attr('webservice')
 def test_get_gz_object_nosuchkey():
     obj = s3_client.get_gz_object('foobar')
     assert obj is None
 
+
+@attr('webservice')
 def test_get_full_text():
     (content, content_type) = s3_client.get_full_text('27297883')
     assert unicode_strs((content, content_type))
@@ -54,6 +67,8 @@ def test_get_full_text():
     (content, content_type) = s3_client.get_full_text('000000')
     assert content is None and content_type is None
 
+
+@attr('webservice')
 def test_put_full_text():
     full_text = 'test_put_full_text'
     pmid_test = 'PMID000test1'
@@ -64,6 +79,8 @@ def test_put_full_text():
     assert content_type == 'pmc_oa_txt'
     assert unicode_strs(content)
 
+
+@attr('webservice')
 def test_put_abstract():
     abstract = 'test_put_abstract'
     pmid_test = 'PMID000test2'
@@ -74,9 +91,11 @@ def test_put_abstract():
     assert content_type == 'abstract'
     assert unicode_strs(content)
 
+
+@attr('webservice')
 def test_reach_output():
     # Test put_reach_output
-    reach_data = {'foo': 1, 'bar':{'baz': 2}}
+    reach_data = {'foo': 1, 'bar': {'baz': 2}}
     pmid = 'PMID000test3'
     reach_version = '42'
     source_text = 'pmc_oa_txt'
@@ -91,6 +110,8 @@ def test_reach_output():
     assert ret_source_text == source_text
     assert unicode_strs(ret_reach_version)
 
+
+@attr('webservice')
 def test_gzip_string():
     content = 'asdf'
     content_enc = s3_client.gzip_string(content, 'content')
@@ -98,11 +119,13 @@ def test_gzip_string():
     content_dec_uni = content_dec.decode('utf-8')
     assert content == content_dec_uni
 
+
+@attr('webservice')
 def test_get_upload_content():
     pmid_s3_no_content = 'PMID000foobar'
     (ct, ct_type) = s3_client.get_upload_content(pmid_s3_no_content)
-    assert ct == None
-    assert ct_type == None
+    assert ct is None
+    assert ct_type is None
 
     pmid_s3_abstract_only = 'PMID000test4'
     s3_client.put_abstract(pmid_s3_abstract_only, 'foo')

--- a/indra/tests/test_s3_client.py
+++ b/indra/tests/test_s3_client.py
@@ -46,6 +46,7 @@ def test_get_gz_object():
     assert unicode_strs(obj)
 
 
+@attr('webservice', 'nonpublic')
 def test_get_gz_object_nosuchkey():
     obj = s3_client.get_gz_object('foobar')
     assert obj is None

--- a/indra/tests/test_s3_client.py
+++ b/indra/tests/test_s3_client.py
@@ -6,7 +6,7 @@ import zlib
 from nose.plugins.attrib import attr
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_check_pmid():
     pmid = s3_client.check_pmid(12345)
     assert pmid == 'PMID12345'
@@ -19,7 +19,7 @@ def test_check_pmid():
     assert unicode_strs(pmid)
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_get_pmid_key():
     pmid = '12345'
     pmid_key = s3_client.get_pmid_key(pmid)
@@ -27,14 +27,14 @@ def test_get_pmid_key():
     assert unicode_strs(pmid_key)
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_filter_keys():
     pmid_key = s3_client.get_pmid_key('1001287')
     key_list = s3_client.filter_keys(pmid_key)
     assert len(key_list) == 4
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_get_gz_object():
     # Get XML
     key = 'papers/PMID27297883/fulltext/txt'
@@ -46,13 +46,12 @@ def test_get_gz_object():
     assert unicode_strs(obj)
 
 
-@attr('webservice')
 def test_get_gz_object_nosuchkey():
     obj = s3_client.get_gz_object('foobar')
     assert obj is None
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_get_full_text():
     (content, content_type) = s3_client.get_full_text('27297883')
     assert unicode_strs((content, content_type))
@@ -68,7 +67,7 @@ def test_get_full_text():
     assert content is None and content_type is None
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_put_full_text():
     full_text = 'test_put_full_text'
     pmid_test = 'PMID000test1'
@@ -80,7 +79,7 @@ def test_put_full_text():
     assert unicode_strs(content)
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_put_abstract():
     abstract = 'test_put_abstract'
     pmid_test = 'PMID000test2'
@@ -92,7 +91,7 @@ def test_put_abstract():
     assert unicode_strs(content)
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_reach_output():
     # Test put_reach_output
     reach_data = {'foo': 1, 'bar': {'baz': 2}}
@@ -111,7 +110,6 @@ def test_reach_output():
     assert unicode_strs(ret_reach_version)
 
 
-@attr('webservice')
 def test_gzip_string():
     content = 'asdf'
     content_enc = s3_client.gzip_string(content, 'content')
@@ -120,7 +118,7 @@ def test_gzip_string():
     assert content == content_dec_uni
 
 
-@attr('webservice')
+@attr('webservice', 'nonpublic')
 def test_get_upload_content():
     pmid_s3_no_content = 'PMID000foobar'
     (ct, ct_type) = s3_client.get_upload_content(pmid_s3_no_content)

--- a/indra/tests/test_trips.py
+++ b/indra/tests/test_trips.py
@@ -6,8 +6,10 @@ import indra.statements as ist
 from indra.sources import trips
 from indra.assemblers import PysbAssembler
 from indra.util import unicode_strs
+from nose.plugins.attrib import attr
 
 test_small_file = join(dirname(__file__), 'test_small.xml')
+
 
 def assert_if_hgnc_then_up(st):
     agents = st.agent_list()
@@ -18,6 +20,7 @@ def assert_if_hgnc_then_up(st):
             if hgnc_id and not up_id:
                 assert(False)
 
+
 def assert_grounding_value_or_none(st):
     agents = st.agent_list()
     for a in agents:
@@ -27,6 +30,7 @@ def assert_grounding_value_or_none(st):
                 if not v:
                     assert(v is None)
 
+@attr('webservice')
 def test_phosphorylation():
     tp = trips.process_text('BRAF phosphorylates MEK1 at Ser222.')
     assert(len(tp.statements) == 1)
@@ -40,6 +44,8 @@ def test_phosphorylation():
     assert st.sub.db_refs['TEXT'] == 'MEK1'
     assert unicode_strs((tp, st))
 
+
+@attr('webservice')
 def test_mod_cond():
     tp = trips.process_text('Phosphorylated BRAF binds ubiquitinated MAP2K1.')
     assert(len(tp.statements) == 1)
@@ -56,6 +62,8 @@ def test_mod_cond():
     assert_grounding_value_or_none(st)
     assert(st.evidence)
 
+
+@attr('webservice')
 def test_ubiquitination():
     tp = trips.process_text('MDM2 ubiquitinates TP53.')
     assert(len(tp.statements) == 1)
@@ -66,6 +74,8 @@ def test_ubiquitination():
     assert_if_hgnc_then_up(st)
     assert(st.evidence)
 
+
+@attr('webservice')
 def test_phosphorylation_noresidue():
     tp = trips.process_text('BRAF phosphorylates MEK1.')
     assert(len(tp.statements) == 1)
@@ -78,6 +88,8 @@ def test_phosphorylation_noresidue():
     assert_grounding_value_or_none(st)
     assert(st.evidence)
 
+
+@attr('webservice')
 def test_phosphorylation_nosite():
     tp = trips.process_text('BRAF phosphorylates MEK1 at Serine.')
     assert(len(tp.statements) == 1)
@@ -90,6 +102,8 @@ def test_phosphorylation_nosite():
     assert_grounding_value_or_none(st)
     assert(st.evidence)
 
+
+@attr('webservice')
 def test_actmod():
     tp = trips.process_text('MEK1 phosphorylated at Ser222 is activated.')
     assert(len(tp.statements) == 1)
@@ -104,6 +118,8 @@ def test_actmod():
     assert_grounding_value_or_none(st)
     assert(st.evidence)
 
+
+@attr('webservice')
 def test_actmods():
     tp = trips.process_text('MEK1 phosphorylated at Ser 218 and Ser222 is activated.')
     assert(len(tp.statements) == 1)
@@ -119,6 +135,8 @@ def test_actmods():
     assert_grounding_value_or_none(st)
     assert(st.evidence)
 
+
+@attr('webservice')
 def test_actform_bound():
     tp = trips.process_text('HRAS bound to GTP is activated.')
     assert(len(tp.statements) == 1)
@@ -132,6 +150,8 @@ def test_actform_bound():
     assert_grounding_value_or_none(st)
     assert(st.evidence)
 
+
+@attr('webservice')
 def test_actform_muts():
     tp = trips.process_text('BRAF V600E is activated.')
     assert(len(tp.statements) == 1)
@@ -146,6 +166,8 @@ def test_actform_muts():
     assert_grounding_value_or_none(st)
     assert(st.evidence)
 
+
+@attr('webservice')
 def test_actmods2():
     tp = trips.process_text('BRAF phosphorylated at Ser536 binds MEK1.')
     assert(len(tp.statements) == 1)
@@ -160,6 +182,8 @@ def test_actmods2():
     assert_grounding_value_or_none(st)
     assert(st.evidence)
 
+
+@attr('webservice')
 def test_synthesis():
     tp = trips.process_text('NFKB transcribes IKB.')
     assert(len(tp.statements) == 1)
@@ -172,6 +196,8 @@ def test_synthesis():
     assert_grounding_value_or_none(st)
     assert(st.evidence)
 
+
+@attr('webservice')
 def test_degradation():
     tp = trips.process_text('MDM2 degrades TP53.')
     assert(len(tp.statements) == 1)

--- a/indra/tests/test_uniprot_client.py
+++ b/indra/tests/test_uniprot_client.py
@@ -2,15 +2,22 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.databases import uniprot_client
 from indra.util import unicode_strs
+from nose.plugins.attrib import attr
 
+
+@attr('webservice')
 def test_query_protein_exists():
     g = uniprot_client.query_protein('P00533')
     assert(g is not None)
 
+
+@attr('webservice')
 def test_query_protein_nonexist():
     g = uniprot_client.query_protein('XXXX')
     assert(g is None)
 
+
+@attr('webservice')
 def test_query_protein_deprecated():
     g = uniprot_client.query_protein('Q8NHX1')
     assert(g is not None)
@@ -21,6 +28,8 @@ def test_query_protein_deprecated():
     assert gene_name == 'MAPK3'
     assert unicode_strs(gene_name)
 
+
+@attr('webservice')
 def test_get_family_members():
     members = uniprot_client.get_family_members('RAF')
     assert('ARAF' in members)
@@ -28,10 +37,13 @@ def test_get_family_members():
     assert('RAF1' in members)
     assert unicode_strs(members)
 
+
+@attr('webservice')
 def test_get_gene_name_human():
     gene_name = uniprot_client.get_gene_name('P00533')
     assert(gene_name == 'EGFR')
     assert unicode_strs(gene_name)
+
 
 '''
 The below test can be used as a template
@@ -47,87 +59,131 @@ def test_get_gene_name_no_table_entry():
     assert(gene_name is None)
 '''
 
+
+@attr('webservice')
 def test_get_gene_name_nonhuman():
     gene_name = uniprot_client.get_gene_name('P31938')
     assert(gene_name == 'Map2k1')
     assert unicode_strs(gene_name)
 
+
+@attr('webservice')
 def test_get_gene_name_unreviewed():
     gene_name = uniprot_client.get_gene_name('X6RK18', web_fallback=False)
     assert(gene_name == 'EXO5')
     assert unicode_strs(gene_name)
 
+
+@attr('webservice')
 def test_get_gene_name_no_gene_name():
     gene_name = uniprot_client.get_gene_name('P04434', web_fallback=False)
     assert(gene_name is None)
     gene_name = uniprot_client.get_gene_name('P04434', web_fallback=True)
     assert(gene_name is None)
 
+
+@attr('webservice')
 def test_get_gene_name_multiple_gene_names():
     gene_name = uniprot_client.get_gene_name('Q5VWM5')
     assert(gene_name == 'PRAMEF9')
 
+
+@attr('webservice')
 def test_is_human():
     assert(uniprot_client.is_human('P00533'))
 
+
+@attr('webservice')
 def test_not_is_human():
     assert(not uniprot_client.is_human('P31938'))
 
+
+@attr('webservice')
 def test_noentry_is_human():
     assert(not uniprot_client.is_human('XXXX'))
 
+
+@attr('webservice')
 def test_get_sequence():
     seq = uniprot_client.get_sequence('P00533')
     assert(len(seq) > 1000)
     assert unicode_strs(seq)
 
+
+@attr('webservice')
 def test_get_modifications():
     mods = uniprot_client.get_modifications('P27361')
     assert(('Phosphothreonine', 202) in mods)
     assert(('Phosphotyrosine', 204) in mods)
     assert unicode_strs(mods)
 
+
+@attr('webservice')
 def test_verify_location():
-    assert(uniprot_client.verify_location('P27361', 'T', 202)) 
+    assert(uniprot_client.verify_location('P27361', 'T', 202))
     assert(not uniprot_client.verify_location('P27361', 'S', 202))
     assert(not uniprot_client.verify_location('P27361', 'T', -1))
     assert(not uniprot_client.verify_location('P27361', 'T', 10000))
 
+
+@attr('webservice')
 def test_get_mnemonic():
     mnemonic = uniprot_client.get_mnemonic('Q02750')
     assert(mnemonic == 'MP2K1_HUMAN')
     assert unicode_strs(mnemonic)
 
+
+@attr('webservice')
 def test_is_secondary_primary():
     assert(not uniprot_client.is_secondary('Q02750'))
 
+
+@attr('webservice')
 def test_is_secondary_secondary():
     assert(uniprot_client.is_secondary('Q96J62'))
 
+
+@attr('webservice')
 def test_get_primary_id_primary():
     assert(uniprot_client.get_primary_id('Q02750') == 'Q02750')
 
+
+@attr('webservice')
 def test_get_primary_id_secondary_hashuman():
     assert(uniprot_client.get_primary_id('Q96J62') == 'P61978')
 
+
+@attr('webservice')
 def test_get_primary_id_secondary_nohuman():
     assert(uniprot_client.get_primary_id('P31848') in
            ['P0A5M5', 'P9WIU6', 'P9WIU7'])
 
+
+@attr('webservice')
 def test_mouse_from_up():
     assert(uniprot_client.get_mgi_id('P28028') == '88190')
 
+
+@attr('webservice')
 def test_up_from_mouse():
     assert(uniprot_client.get_id_from_mgi('88190') == 'P28028')
 
+
+@attr('webservice')
 def test_rat_from_up():
     assert(uniprot_client.get_rgd_id('O08773') == '620003')
 
+
+@attr('webservice')
 def test_up_from_rat():
     assert(uniprot_client.get_id_from_rgd('620003') == 'O08773')
 
+
+@attr('webservice')
 def test_mouse_from_human():
     assert(uniprot_client.get_mouse_id('P15056') == 'P28028')
 
+
+@attr('webservice')
 def test_rat_from_human():
     assert(uniprot_client.get_rat_id('P04049') == 'P11345')

--- a/indra/tests/test_uniprot_client.py
+++ b/indra/tests/test_uniprot_client.py
@@ -38,7 +38,6 @@ def test_get_family_members():
     assert unicode_strs(members)
 
 
-@attr('webservice')
 def test_get_gene_name_human():
     gene_name = uniprot_client.get_gene_name('P00533')
     assert(gene_name == 'EGFR')
@@ -60,14 +59,12 @@ def test_get_gene_name_no_table_entry():
 '''
 
 
-@attr('webservice')
 def test_get_gene_name_nonhuman():
     gene_name = uniprot_client.get_gene_name('P31938')
     assert(gene_name == 'Map2k1')
     assert unicode_strs(gene_name)
 
 
-@attr('webservice')
 def test_get_gene_name_unreviewed():
     gene_name = uniprot_client.get_gene_name('X6RK18', web_fallback=False)
     assert(gene_name == 'EXO5')
@@ -82,23 +79,19 @@ def test_get_gene_name_no_gene_name():
     assert(gene_name is None)
 
 
-@attr('webservice')
 def test_get_gene_name_multiple_gene_names():
     gene_name = uniprot_client.get_gene_name('Q5VWM5')
     assert(gene_name == 'PRAMEF9')
 
 
-@attr('webservice')
 def test_is_human():
     assert(uniprot_client.is_human('P00533'))
 
 
-@attr('webservice')
 def test_not_is_human():
     assert(not uniprot_client.is_human('P31938'))
 
 
-@attr('webservice')
 def test_noentry_is_human():
     assert(not uniprot_client.is_human('XXXX'))
 
@@ -126,64 +119,52 @@ def test_verify_location():
     assert(not uniprot_client.verify_location('P27361', 'T', 10000))
 
 
-@attr('webservice')
 def test_get_mnemonic():
     mnemonic = uniprot_client.get_mnemonic('Q02750')
     assert(mnemonic == 'MP2K1_HUMAN')
     assert unicode_strs(mnemonic)
 
 
-@attr('webservice')
 def test_is_secondary_primary():
     assert(not uniprot_client.is_secondary('Q02750'))
 
 
-@attr('webservice')
 def test_is_secondary_secondary():
     assert(uniprot_client.is_secondary('Q96J62'))
 
 
-@attr('webservice')
 def test_get_primary_id_primary():
     assert(uniprot_client.get_primary_id('Q02750') == 'Q02750')
 
 
-@attr('webservice')
 def test_get_primary_id_secondary_hashuman():
     assert(uniprot_client.get_primary_id('Q96J62') == 'P61978')
 
 
-@attr('webservice')
 def test_get_primary_id_secondary_nohuman():
     assert(uniprot_client.get_primary_id('P31848') in
            ['P0A5M5', 'P9WIU6', 'P9WIU7'])
 
 
-@attr('webservice')
 def test_mouse_from_up():
     assert(uniprot_client.get_mgi_id('P28028') == '88190')
 
 
-@attr('webservice')
 def test_up_from_mouse():
     assert(uniprot_client.get_id_from_mgi('88190') == 'P28028')
 
 
-@attr('webservice')
 def test_rat_from_up():
     assert(uniprot_client.get_rgd_id('O08773') == '620003')
 
 
-@attr('webservice')
 def test_up_from_rat():
     assert(uniprot_client.get_id_from_rgd('620003') == 'O08773')
 
 
-@attr('webservice')
 def test_mouse_from_human():
     assert(uniprot_client.get_mouse_id('P15056') == 'P28028')
 
 
-@attr('webservice')
 def test_rat_from_human():
     assert(uniprot_client.get_rat_id('P04049') == 'P11345')


### PR DESCRIPTION
Implement some attributes to the nosetests. Use these attributes to skip tests that require nonpublic environment variables during a pull request in travis tests. This pull request should test that feature.
 
Addresses: https://github.com/sorgerlab/indra/issues/354