### PR TITLE
Add stalled log timeout option to wait_for_complete

### DIFF
--- a/indra/tools/machine/machine.py
+++ b/indra/tools/machine/machine.py
@@ -418,7 +418,8 @@ def run_machine(model_path, pmids, belief_threshold, search_genes=None,
         job_list = submit_reading('rasmachine', pmid_fname, ['reach'])
 
         # Wait for reading to complete
-        wait_for_complete('run_reach_queue', job_list)
+        wait_for_complete('run_reach_queue', job_list, idle_log_timeout=600,
+                          kill_on_log_timeout=True)
 
     # Load the model
     logger.info(time.strftime('%c'))

--- a/indra/tools/reading/read_pmids.py
+++ b/indra/tools/reading/read_pmids.py
@@ -636,7 +636,7 @@ def run_reach(pmid_list, base_dir, num_cores, start_index, end_index,
 
     logger.info('Using REACH version: %s' % reach_version)
 
-    tmp_dir, _, output_dir, pmids_read, pmids_unread, _ =\
+    tmp_dir, _, output_dir, pmids_read, pmids_unread, num_found =\
         get_content_to_read(
             pmid_list, start_index, end_index, base_dir, num_cores,
             force_fulltext, force_read, 'reach', reach_version
@@ -650,7 +650,7 @@ def run_reach(pmid_list, base_dir, num_cores, start_index, end_index,
             REACH_MEM + MEM_BUFFER
             )
         logger.info("REACH not run.")
-    elif len(pmids_unread) > 0:
+    elif len(pmids_unread) > 0 and num_found > 0:
         # Create the REACH configuration file
         with open(REACH_CONF_FMT_FNAME, 'r') as fmt_file:
             conf_file_path = os.path.join(tmp_dir, 'indra.conf')

--- a/indra/tools/reading/submit_reading_pipeline_aws.py
+++ b/indra/tools/reading/submit_reading_pipeline_aws.py
@@ -310,7 +310,12 @@ if __name__ == '__main__':
     # Create the top-level parser
     parser = argparse.ArgumentParser(
         'submit_reading_pipeline_aws.py',
-        description='Run reading with either the db or remote resources.'
+        description=('Run reading with either the db or remote resources. For '
+                     'more specific help, select one of the Methods with the '
+                     '`-h` option.'),
+        epilog=('Note that `python wait_for_complete.py ...` should be run as '
+                'soon as this command completes successfully. For more '
+                'details use `python wait_for_complete.py -h`.')
         )
     subparsers = parser.add_subparsers(title='Method')
     subparsers.required = True

--- a/indra/tools/reading/wait_for_complete.py
+++ b/indra/tools/reading/wait_for_complete.py
@@ -1,6 +1,4 @@
-import sys
 from argparse import ArgumentParser
-from indra.tools.reading.submit_reading_pipeline_aws import wait_for_complete
 
 if __name__ == '__main__':
     parser = ArgumentParser(
@@ -54,6 +52,8 @@ if __name__ == '__main__':
         help='If a log times out, terminate the offending job.'
         )
     args = parser.parse_args()
+
+    from submit_reading_pipeline_aws import wait_for_complete
 
     job_list = None
     if args.job_list is not None:

--- a/indra/tools/reading/wait_for_complete.py
+++ b/indra/tools/reading/wait_for_complete.py
@@ -35,12 +35,15 @@ if __name__ == '__main__':
     parser.add_argument(
         '--interval', '-i',
         dest='poll_interval',
+        default=10,
         type=int,
-        help='The time interval to wait between job status checks, in seconds.'
+        help=('The time interval to wait between job status checks, in '
+              'seconds (default: %(default)d seconds).')
         )
     parser.add_argument(
         '--timeout', '-T',
         metavar='TIMEOUT',
+        type=int,
         help=('If the logs are not updated for %(metavar)s seconds, '
               'print a warning. If `--kill_on_log_timeout` flag is set, then '
               'the offending jobs will be automatically terminated.')

--- a/indra/tools/reading/wait_for_complete.py
+++ b/indra/tools/reading/wait_for_complete.py
@@ -1,9 +1,61 @@
 import sys
+from argparse import ArgumentParser
 from indra.tools.reading.submit_reading_pipeline_aws import wait_for_complete
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        print("Missing argument. Must specify queue.")
-        print("Usage: python wait_for_complete.py QUEUE")
-        sys.exit(1)
-    wait_for_complete(sys.argv[-1])
+    parser = ArgumentParser(
+        'wait_for_complete.py',
+        usage='%(prog)s [-h] queue_name [options]',
+        description=('Wait for a set of batch jobs to complete, and monitor '
+                     'them as they run.'),
+        epilog=('Jobs can also be monitored, terminated, and otherwise '
+                'managed on the AWS website. However this tool will also tag '
+                'the instances, and should be run whenever a job is submitted '
+                'to AWS.')
+        )
+    parser.add_argument(
+        dest='queue_name',
+        help=('The name of the queue to watch and wait for completion. If no '
+              'jobs are specified, this will wait until all jobs in the queue '
+              'are completed (either SUCCEEDED or FAILED).')
+        )
+    parser.add_argument(
+        '--watch', '-w',
+        dest='job_list',
+        metavar='JOB_ID',
+        nargs='+',
+        help=('Specify particular jobs using their job ids, as reported by '
+              'the submit command. Many ids may be specified.')
+        )
+    parser.add_argument(
+        '--prefix', '-p',
+        dest='job_name_prefix',
+        help='Specify a prefix for the name of the jobs to watch and wait for.'
+        )
+    parser.add_argument(
+        '--interval', '-i',
+        dest='poll_interval',
+        type=int,
+        help='The time interval to wait between job status checks, in seconds.'
+        )
+    parser.add_argument(
+        '--timeout', '-T',
+        metavar='TIMEOUT',
+        help=('If the logs are not updated for %(metavar)s seconds, '
+              'print a warning. If `--kill_on_log_timeout` flag is set, then '
+              'the offending jobs will be automatically terminated.')
+        )
+    parser.add_argument(
+        '--kill_on_timeout', '-K',
+        action='store_true',
+        help='If a log times out, terminate the offending job.'
+        )
+    args = parser.parse_args()
+
+    job_list = None
+    if args.job_list is not None:
+        job_list = [{'jobId': jid} for jid in args.job_list]
+
+    wait_for_complete(args.queue_name, job_list, args.job_name_prefix,
+                      args.poll_interval, args.timeout,
+                      args.kill_on_timeout)

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -30,7 +30,7 @@ def get_jobs(job_queue='run_reach_queue', job_status='RUNNING'):
 
 
 def get_job_log(job_info, log_group_name='/aws/batch/job',
-                write_file=True):
+                write_file=True, verbose=False):
     """Gets the Cloudwatch log associated with the given job.
 
     Parameters
@@ -66,13 +66,15 @@ def get_job_log(job_info, log_group_name='/aws/batch/job',
     elif len(streams) > 1:
         print('More than 1 stream for job, returning first')
     log_stream_name = streams[0]['logStreamName']
-    print("Getting log for %s/%s" % (job_name, job_id))
+    if verbose:
+        print("Getting log for %s/%s" % (job_name, job_id))
     out_file = ('%s_%s.log' % (job_name, job_id)) if write_file else None
-    lines = get_log_by_name(log_group_name, log_stream_name, out_file)
+    lines = get_log_by_name(log_group_name, log_stream_name, out_file, verbose)
     return lines
 
 
-def get_log_by_name(log_group_name, log_stream_name, out_file=None):
+def get_log_by_name(log_group_name, log_stream_name, out_file=None,
+                    verbose=True):
     """Download a log given the log's group and stream name.
 
     Parameters
@@ -105,7 +107,8 @@ def get_log_by_name(log_group_name, log_stream_name, out_file=None):
                 lines += ['%s: %s\n' % (evt['timestamp'], evt['message'])
                           for evt in events]
             kwargs['nextToken'] = response.get('nextForwardToken')
-        print('%d %s' % (len(lines), lines[-1]))
+        if verbose:
+            print('%d %s' % (len(lines), lines[-1]))
     if out_file:
         with open(out_file, 'wt') as f:
             for line in lines:

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -69,6 +69,7 @@ def get_job_log(job_info, log_group_name='/aws/batch/job',
     print("Getting log for %s/%s" % (job_name, job_id))
     out_file = ('%s_%s.log' % (job_name, job_id)) if write_file else None
     lines = get_log_by_name(log_group_name, log_stream_name, out_file)
+    return lines
 
 
 def get_log_by_name(log_group_name, log_stream_name, out_file=None):


### PR DESCRIPTION
Makes it possible to set a timeout on non-updating logs for aws batch jobs, which helps catch jobs that have stalled. There is also an option to automatically kill such jobs, for ease of mind when starting a large job before a vacation.

The command line wait_for_complete tool was also generally improved, using argparse to access all of its features.