### PR TITLE
Enable Travis cache for significant speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - "2.7"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - pip install git+https://github.com/pysb/pysb.git
   - export KAPPAPATH=$TRAVIS_BUILD_DIR/KaSim
   - |
-    if [[ ! -d "$KAPPAPATH" ]]; then
+    if [[ ! -f "$KAPPAPATH/KaSim" ]]; then
       # Kappa
       sudo apt-get install -y ocaml-nox opam aspcud;
       # First install ocamlfind via opam (needed to build KaSim/KaSa)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
-cache: pip
+cache:
+  - $HOME/.cache/pip
+  - $TRAVIS_BUILD_DIR/KaSim
 python:
   - "2.7"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ install:
   # - opam install -y ocamlbuild yojson
   # Install KaSim/KaSa
   # - git clone https://github.com/Kappa-Dev/KaSim.git
+  - echo `pwd`
+  - echo $TRAVIS_BUILD_DIR
   - cd KaSim
   # KaSim as of 5/1/2017
   # - git checkout 0733210

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 cache:
-  - $HOME/.cache/pip
-  - $TRAVIS_BUILD_DIR/KaSim
+  directories:
+    - $HOME/.cache/pip
+    - $TRAVIS_BUILD_DIR/KaSim
 python:
   - "2.7"
   - "3.5"
@@ -9,10 +10,10 @@ addons:
     apt:
         sources:
             - avsm
-#        packages:
-#            - ocaml-nox
-#            - opam
-#            - aspcud
+        packages:
+            - ocaml-nox
+            - opam
+            - aspcud
 before_install:
   - sudo add-apt-repository --yes ppa:webupd8team/java
   - sudo apt-get update
@@ -35,17 +36,15 @@ install:
   - pip install git+https://github.com/pysb/pysb.git
   # Kappa
   # First install ocamlfind via opam (needed to build KaSim/KaSa)
-  # - opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
-  # - opam install -y conf-which base-bytes
-  # - opam install -y ocamlbuild yojson
+  - opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
+  - opam install -y conf-which base-bytes
+  - opam install -y ocamlbuild yojson
   # Install KaSim/KaSa
-  # - git clone https://github.com/Kappa-Dev/KaSim.git
-  - echo `pwd`
-  - echo $TRAVIS_BUILD_DIR
+  - git clone https://github.com/Kappa-Dev/KaSim.git
   - cd KaSim
   # KaSim as of 5/1/2017
-  # - git checkout 0733210
-  # - make all
+  - git checkout 0733210
+  - make all
   - export KAPPAPATH=`pwd`
   - cd ../
   # Biopax/Paxtools dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ addons:
     apt:
         sources:
             - avsm
-        packages:
-            - ocaml-nox
-            - opam
-            - aspcud
+#        packages:
+#            - ocaml-nox
+#            - opam
+#            - aspcud
 before_install:
   - sudo add-apt-repository --yes ppa:webupd8team/java
   - sudo apt-get update
@@ -35,15 +35,15 @@ install:
   - pip install git+https://github.com/pysb/pysb.git
   # Kappa
   # First install ocamlfind via opam (needed to build KaSim/KaSa)
-  - opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
-  - opam install -y conf-which base-bytes
-  - opam install -y ocamlbuild yojson
+  # - opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
+  # - opam install -y conf-which base-bytes
+  # - opam install -y ocamlbuild yojson
   # Install KaSim/KaSa
-  - git clone https://github.com/Kappa-Dev/KaSim.git
+  # - git clone https://github.com/Kappa-Dev/KaSim.git
   - cd KaSim
   # KaSim as of 5/1/2017
-  - git checkout 0733210
-  - make all
+  # - git checkout 0733210
+  # - make all
   - export KAPPAPATH=`pwd`
   - cd ../
   # Biopax/Paxtools dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ addons:
     apt:
         sources:
             - avsm
-        packages:
-            - ocaml-nox
-            - opam
-            - aspcud
 before_install:
   - sudo add-apt-repository --yes ppa:webupd8team/java
   - sudo apt-get update
@@ -34,19 +30,23 @@ install:
   - tar xzf bionetgen.tar.gz
   - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
   - pip install git+https://github.com/pysb/pysb.git
-  # Kappa
-  # First install ocamlfind via opam (needed to build KaSim/KaSa)
-  - opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env)
-  - opam install -y conf-which base-bytes
-  - opam install -y ocamlbuild yojson
-  # Install KaSim/KaSa
-  - git clone https://github.com/Kappa-Dev/KaSim.git
-  - cd KaSim
-  # KaSim as of 5/1/2017
-  - git checkout 0733210
-  - make all
-  - export KAPPAPATH=`pwd`
-  - cd ../
+  - export KAPPAPATH=$TRAVIS_BUILD_DIR/KaSim
+  - |
+    if [[ ! -d "$KAPPAPATH" ]]; then
+      # Kappa
+      sudo apt-get install -y ocaml-nox opam aspcud;
+      # First install ocamlfind via opam (needed to build KaSim/KaSa)
+      opam init -a git://github.com/ocaml/opam-repository && eval $(opam config env);
+      opam install -y conf-which base-bytes;
+      opam install -y ocamlbuild yojson;
+      # Install KaSim/KaSa
+      git clone https://github.com/Kappa-Dev/KaSim.git;
+      cd $KAPPAPATH;
+      # KaSim as of 5/1/2017
+      git checkout 0733210;
+      make all;
+      cd $TRAVIS_BUILD_DIR;
+    fi
   # Biopax/Paxtools dependencies
   - pip install jnius-indra
   # Install NDEx package

--- a/indra/tests/test_chembl_client.py
+++ b/indra/tests/test_chembl_client.py
@@ -4,6 +4,7 @@ from indra.statements import Agent
 from indra.databases import chembl_client
 from indra.util import unicode_strs
 from nose.plugins.attrib import attr
+import unittest
 
 vem = Agent('VEMURAFENIB', db_refs={'CHEBI': '63637', 'TEXT': 'VEMURAFENIB'})
 az628 = Agent('AZ628', db_refs={'CHEBI': '91354'})
@@ -48,7 +49,8 @@ def test_target_query():
     assert(target['target_type'] == 'SINGLE PROTEIN')
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
+@unittest.skip('This test is very slow and not critical')
 def test_get_drug_inhibition_stmts_vem():
     stmts = chembl_client.get_drug_inhibition_stmts(vem)
     assert(len(stmts) > 0)
@@ -62,7 +64,8 @@ def test_get_drug_inhibition_stmts_vem():
             assert(ev.source_id)
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
+@unittest.skip('This test is very slow and not critical')
 def test_get_drug_inhibition_stmts_az628():
     stmts = chembl_client.get_drug_inhibition_stmts(az628)
     assert(len(stmts) > 0)


### PR DESCRIPTION
This PR enables the use of the Travis cache (https://docs.travis-ci.com/user/caching/) for pip packages and the Kappa build. It's implemented in a way that if the cache doesn't exist yet (on the given Travis job for the given fork) Kappa is built once. This speeds up each build by up to 8 minutes. I also skip a couple of non-essential but slow tests here to speed up by another minute or so. The end result: builds run in ~13.5 minutes on Python 2 and ~11.5 minutes on Python 3.