### PR TITLE
Allow PMID override and document Sparser API

### DIFF
--- a/indra/sources/sparser/processor.py
+++ b/indra/sources/sparser/processor.py
@@ -83,6 +83,23 @@ class SparserJSONProcessor(object):
             # Step 5: Append to list of Statements
             self.statements.append(stmt)
 
+    def set_statements_pmid(self, pmid):
+        """Set the evidence PMID of Statements that have been extracted.
+
+        pmid : str
+            The PMID to be used in the Evidence objects of the Statements
+            that were extracted by the processor.
+        """
+        # Replace PMID value in JSON dict first
+        for stmt in self.json_stmts:
+            evs = stmt.get('evidence', [])
+            for ev in evs:
+                ev['pmid'] = pmid
+        # Replace PMID value in extracted Statements next
+        for stmt in self.statements:
+            for ev in stmt.evidence:
+                ev.pmid = pmid
+
 
 def _fix_agent(agent):
     if agent is None:

--- a/indra/sources/sparser/sparser_api.py
+++ b/indra/sources/sparser/sparser_api.py
@@ -39,9 +39,11 @@ def process_text(text, output_fmt='json', outbuf=None, cleanup=True, key=''):
     outbuf : Optional[file]
         A file like object that the Sparser output is written to.
     cleanup : Optional[bool]
-        ?
-    key : Optional[?]
-        ?
+        If True, the temporary file created, which is used as an input
+        file for Sparser, is removed. Default: True
+    key : Optional[str]
+        A key which is embedded into the name of the temporary file
+        passed to Sparser for reading. Default is empty string.
 
     Returns
     -------
@@ -66,9 +68,11 @@ def process_nxml_str(nxml_str, output_fmt='json', outbuf=None, cleanup=True,
     outbuf : Optional[file]
         A file like object that the Sparser output is written to.
     cleanup : Optional[bool]
-        ?
-    key : Optional[?]
-        ?
+        If True, the temporary file created in this function,
+        which is used as an input file for Sparser, is removed. Default: True
+    key : Optional[str]
+        A key which is embedded into the name of the temporary file
+        passed to Sparser for reading. Default is empty string.
 
     Returns
     -------

--- a/indra/sources/sparser/sparser_api.py
+++ b/indra/sources/sparser/sparser_api.py
@@ -113,7 +113,7 @@ def process_nxml_file(fname, output_fmt='json', outbuf=None, cleanup=True):
     sp : SparserXMLProcessor or SparserJSONProcessor depending on what output
     format was chosen.
     """
-    ret = None
+    sp = None
     out_fname = None
     try:
         out_fname = run_sparser(fname, output_fmt, outbuf)
@@ -158,7 +158,7 @@ def process_sparser_output(output_fname, output_fmt='json'):
         else:
             xml_str = fh.read()
             sp = process_xml(xml_str)
-    return ret
+    return sp
 
 
 def process_json_dict(json_dict):

--- a/indra/sources/sparser/sparser_api.py
+++ b/indra/sources/sparser/sparser_api.py
@@ -1,12 +1,13 @@
-"""Provide an api used to run and get statements from the sparser reading tool.
+"""Provides an API used to run and get Statements from the Sparser
+reading system.
 """
 
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 
-__all__ = ['get_version', 'process_text', 'process_xml', 'process_nxml_file',
-           'process_nxml_str', 'make_sparser_nxml_from_text', 'run_sparser',
-           'process_json_dict']
+__all__ = ['process_text', 'process_nxml_str', 'process_nxml_file',
+           'process_sparser_output', 'process_json_dict', 'process_xml',
+           'run_sparser', 'get_version']
 
 import os
 import json
@@ -25,14 +26,169 @@ sparser_path_var = 'SPARSERPATH'
 sparser_path = os.environ.get(sparser_path_var)
 
 
-def get_version():
-    assert sparser_path is not None, "Sparser path is not defined."
-    with open(os.path.join(sparser_path, 'version.txt'), 'r') as f:
-        version = f.read().strip()
-    return version
+def process_text(text, output_fmt='json', outbuf=None, cleanup=True, key=''):
+    """Return processor with Statements extracted by reading text with Sparser.
+
+    Parameters
+    ----------
+    text : str
+        The text to be processed
+    output_fmt: Optional[str]
+        The output format to obtain from Sparser, with the two options being
+        'json' and 'xml'. Default: 'json'
+    outbuf : Optional[file]
+        A file like object that the Sparser output is written to.
+    cleanup : Optional[bool]
+        ?
+    key : Optional[?]
+        ?
+
+    Returns
+    -------
+    SparserXMLProcessor or SparserJSONProcessor depending on what output
+    format was chosen.
+    """
+    nxml_str = make_nxml_from_text(text)
+    return process_nxml_str(nxml_str, output_fmt, outbuf, cleanup, key)
+
+
+def process_nxml_str(nxml_str, output_fmt='json', outbuf=None, cleanup=True,
+                     key=''):
+    """Return processor with Statements extracted by reading an NXML string.
+
+    Parameters
+    ----------
+    nxml_str : str
+        The string value of the NXML-formatted paper to be read.
+    output_fmt: Optional[str]
+        The output format to obtain from Sparser, with the two options being
+        'json' and 'xml'. Default: 'json'
+    outbuf : Optional[file]
+        A file like object that the Sparser output is written to.
+    cleanup : Optional[bool]
+        ?
+    key : Optional[?]
+        ?
+
+    Returns
+    -------
+    SparserXMLProcessor or SparserJSONProcessor depending on what output
+    format was chosen.
+    """
+    tmp_fname = 'PMC%s_%d.nxml' % (key, mp.current_process().pid)
+    with open(tmp_fname, 'wb') as fh:
+        fh.write(nxml_str.encode('utf-8'))
+    try:
+        sp = process_nxml_file(tmp_fname, output_fmt, outbuf, cleanup)
+    finally:
+        if cleanup and os.path.exists(tmp_fname):
+            os.remove(tmp_fname)
+    return sp
+
+
+def process_nxml_file(fname, output_fmt='json', outbuf=None, cleanup=True):
+    """Return processor with Statements extracted by reading an NXML file.
+
+    Parameters
+    ----------
+    fname : str
+        The path to the NXML file to be read.
+    output_fmt: Optional[str]
+        The output format to obtain from Sparser, with the two options being
+        'json' and 'xml'. Default: 'json'
+    outbuf : Optional[file]
+        A file like object that the Sparser output is written to.
+    cleanup : Optional[bool]
+        ?
+
+    Returns
+    -------
+    sp : SparserXMLProcessor or SparserJSONProcessor depending on what output
+    format was chosen.
+    """
+    ret = None
+    out_fname = None
+    try:
+        out_fname = run_sparser(fname, output_fmt, outbuf)
+        sp = process_sparser_output(out_fname, output_fmt)
+    except Exception as e:
+        logger.error("Sparser failed to run on %s." % fname)
+        logger.exception(e)
+    finally:
+        if out_fname is not None and os.path.exists(out_fname) and cleanup:
+            os.remove(out_fname)
+
+    return sp
+
+
+def process_sparser_output(output_fname, output_fmt='json'):
+    """Return a processor with Statements extracted from Sparser XML or JSON
+
+    Parameters
+    ----------
+    output_fname : str
+        The path to the Sparser output file to be processed. The file can
+        either be JSON or XML output from Sparser, with the output_fmt
+        parameter defining what format is assumed to be processed.
+    output_fmt : Optional[str]
+        The format of the Sparser output to be processed, can either be
+        'json' or 'xml'. Default: 'json'
+
+    Returns
+    -------
+    sp : SparserXMLProcessor or SparserJSONProcessor depending on what output
+    format was chosen.
+    """
+    if output_fmt not in ['json', 'xml']:
+        logger.error("Unrecognized output format '%s'." % output_fmt)
+        return None
+
+    sp = None
+    with open(output_fname, 'rt') as fh:
+        if output_fmt == 'json':
+            json_dict = json.load(fh)
+            sp = process_json_dict(json_dict)
+        else:
+            xml_str = fh.read()
+            sp = process_xml(xml_str)
+    return ret
+
+
+def process_json_dict(json_dict):
+    """Return processor with Statements extracted from a Sparser JSON.
+
+    Parameters
+    ----------
+    json_dict : dict
+        The JSON object obtained by reading content with Sparser, using the
+        'json' output mode.
+
+    Returns
+    -------
+    sp : SparserJSONProcessor
+        A SparserJSONProcessor which has extracted Statements as its
+        statements attribute.
+    """
+    sp = SparserJSONProcessor(json_dict)
+    sp.get_statements()
+    return sp
 
 
 def process_xml(xml_str):
+    """Return processor with Statements extracted from a Sparser XML.
+
+    Parameters
+    ----------
+    xml_str : str
+        The XML string obtained by reading content with Sparser, using the
+        'xml' output mode.
+
+    Returns
+    -------
+    sp : SparserXMLProcessor
+        A SparserXMLProcessor which has extracted Statements as its
+        statements attribute.
+    """
     try:
         tree = ET.XML(xml_str, parser=UTB())
     except ET.ParseError as e:
@@ -44,6 +200,25 @@ def process_xml(xml_str):
 
 
 def run_sparser(fname, output_fmt, outbuf=None):
+    """Return the path to reading output after running Sparser reading.
+
+    Parameters
+    ----------
+    fname : str
+        The path to an input file to be processed. Due to the Spaser
+        executable's assumptions, the file name needs to start with PMC
+        and should be an NXML formatted file.
+    output_fmt : Optional[str]
+        The format in which Sparser should produce its output, can either be
+        'json' or 'xml'.
+    outbuf : Optional[file]
+        A file like object that the Sparser output is written to.
+
+    Returns
+    -------
+    output_path : str
+        The path to the output file created by Sparser.
+    """
     if not sparser_path or not os.path.exists(sparser_path):
         logger.error('Sparser executable not set in %s' % sparser_path_var)
         return None
@@ -70,69 +245,39 @@ def run_sparser(fname, output_fmt, outbuf=None):
     return output_path
 
 
-def convert_sparser_output(output_fname, output_fmt='json'):
-    if output_fmt not in ['json', 'xml']:
-        logger.error("Unrecognized output format '%s'." % output_fmt)
-        return None
+def get_version():
+    """Return the version of the Sparser executable on the path.
 
-    ret = None
-    with open(output_fname, 'rt') as fh:
-        if output_fmt == 'json':
-            json_dict = json.load(fh)
-            ret = process_json_dict(json_dict)
-        else:
-            xml_str = fh.read()
-            ret = process_xml(xml_str)
-    return ret
+    Returns
+    -------
+    version : str
+        The version of Sparser that is found on the Sparser path.
+    """
+    assert sparser_path is not None, "Sparser path is not defined."
+    with open(os.path.join(sparser_path, 'version.txt'), 'r') as f:
+        version = f.read().strip()
+    return version
 
 
-def process_nxml_file(fname, output_fmt='json', outbuf=None, cleanup=True):
-    ret = None
-    out_fname = None
-    try:
-        out_fname = run_sparser(fname, output_fmt, outbuf)
-        ret = convert_sparser_output(out_fname, output_fmt)
-    except Exception as e:
-        logger.error("Sparser failed to run on %s." % fname)
-        logger.exception(e)
-    finally:
-        if out_fname is not None and os.path.exists(out_fname) and cleanup:
-            os.remove(out_fname)
+def make_nxml_from_text(text):
+    """Return raw text wrapped in NXML structure.
 
-    return ret
+    Parameters
+    ----------
+    text : str
+        The raw text content to be wrapped in an NXML structure.
 
-
-def make_sparser_nxml_from_text(text):
+    Returns
+    -------
+    nxml_str : str
+        The NXML string wrapping the raw text input.
+    """
     text = _escape_xml(text)
     header = '<?xml version="1.0" encoding="UTF-8" ?>' + \
         '<OAI-PMH><article><body><sec id="s1"><p>'
     footer = '</p></sec></body></article></OAI-PMH>'
     nxml_str = header + text + footer
     return nxml_str
-
-
-def process_text(text, output_fmt='json', outbuf=None, cleanup=True, key=''):
-    nxml_str = make_sparser_nxml_from_text(text)
-    return process_nxml_str(nxml_str, output_fmt, outbuf, cleanup, key)
-
-
-def process_nxml_str(nxml_str, output_fmt='json', outbuf=None, cleanup=True,
-                     key=''):
-    tmp_fname = 'PMC%s_%d.nxml' % (key, mp.current_process().pid)
-    with open(tmp_fname, 'wb') as fh:
-        fh.write(nxml_str.encode('utf-8'))
-    try:
-        ret = process_nxml_file(tmp_fname, output_fmt, outbuf, cleanup)
-    finally:
-        if cleanup and os.path.exists(tmp_fname):
-            os.remove(tmp_fname)
-    return ret
-
-
-def process_json_dict(json_dict):
-    sp = SparserJSONProcessor(json_dict)
-    sp.get_statements()
-    return sp
 
 
 def _process_elementtree(tree):

--- a/indra/sources/sparser/sparser_api.py
+++ b/indra/sources/sparser/sparser_api.py
@@ -40,7 +40,8 @@ def process_text(text, output_fmt='json', outbuf=None, cleanup=True, key=''):
         A file like object that the Sparser output is written to.
     cleanup : Optional[bool]
         If True, the temporary file created, which is used as an input
-        file for Sparser, is removed. Default: True
+        file for Sparser, as well as the output file created by Sparser
+        are removed. Default: True
     key : Optional[str]
         A key which is embedded into the name of the temporary file
         passed to Sparser for reading. Default is empty string.
@@ -69,7 +70,8 @@ def process_nxml_str(nxml_str, output_fmt='json', outbuf=None, cleanup=True,
         A file like object that the Sparser output is written to.
     cleanup : Optional[bool]
         If True, the temporary file created in this function,
-        which is used as an input file for Sparser, is removed. Default: True
+        which is used as an input file for Sparser, as well as the
+        output file created by Sparser are removed. Default: True
     key : Optional[str]
         A key which is embedded into the name of the temporary file
         passed to Sparser for reading. Default is empty string.
@@ -103,7 +105,8 @@ def process_nxml_file(fname, output_fmt='json', outbuf=None, cleanup=True):
     outbuf : Optional[file]
         A file like object that the Sparser output is written to.
     cleanup : Optional[bool]
-        ?
+        If True, the output file created by Sparser is removed.
+        Default: True
 
     Returns
     -------

--- a/indra/tests/test_reading_scripts_old.py
+++ b/indra/tests/test_reading_scripts_old.py
@@ -64,6 +64,9 @@ def _check_blind_result(reader):
 
 def _check_result(stmts):
     assert len(stmts), "No statements found."
+    assert all([stmt.evidence[0].pmid == pmid for pmid in stmts.keys()
+                for stmt in stmts[pmid]]), \
+        "pmids in evidence do not match true pmids."
 
 
 def test_get_proc_num():

--- a/indra/tools/reading/read_pmids.py
+++ b/indra/tools/reading/read_pmids.py
@@ -386,6 +386,9 @@ def read_pmid(pmid, source, cont_path, sparser_version, outbuf=None,
     if sp is None:
         logger.error('Failed to run sparser on pmid: %s.' % pmid)
         return
+    # At this point, we rewrite the PMID in the Evidence of Sparser
+    # Statements according to the actual PMID that was read.
+    sp.set_statements_pmid(pmid)
     s3_client.put_reader_output('sparser', sp.json_stmts, pmid,
                                 sparser_version, source)
     return sp.statements

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -346,7 +346,7 @@ class SparserReader(Reader):
                     new_fpath = path.join(self.tmp_dir, new_fname)
                     with open(fpath, 'r') as f_old:
                         content = f_old.read()
-                    nxml_str = sparser.make_sparser_nxml_from_text(content)
+                    nxml_str = sparser.make_nxml_from_text(content)
                     with open(new_fpath, 'w') as f_new:
                         f_new.write(nxml_str)
                     file_list.append(new_fpath)
@@ -360,7 +360,7 @@ class SparserReader(Reader):
                         )
                 elif item.format == formats.TEXT:
                     txt_bts = zlib.decompress(item.content, 16+zlib.MAX_WBITS)
-                    nxml_str = sparser.make_sparser_nxml_from_text(
+                    nxml_str = sparser.make_nxml_from_text(
                         txt_bts.decode('utf8')
                         )
                     add_nxml_file(item.id, nxml_str.encode('utf8'))

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -578,6 +578,7 @@ class ReadingData(object):
                          % (self.reader, self.tcid))
             stmts = []
         else:
+            processor.set_statements_pmid(None)
             stmts = processor.statements
         return stmts
 


### PR DESCRIPTION
@pagreene, please implement the necessary additions in readers.py to make sure the PMID setting in the Evidences of Statements is set correctly right after this line: https://github.com/sorgerlab/indra/blob/master/indra/tools/reading/readers.py#L572. Also, please add at least one test to make sure the PMID override works.