### PR TITLE
Travis skip slow tests in regular builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - sudo update-java-alternatives -s java-8-oracle
   - sudo apt-get install oracle-java8-set-default
   - export JAVA_HOME="/usr/lib/jvm/java-8-oracle/"
-  - pip install pygraphviz pydot jsonschema coverage python-coveralls boto3 sqlalchemy psycopg2 pgcopy
+  - pip install pygraphviz pydot jsonschema coverage python-coveralls boto3 sqlalchemy psycopg2 pgcopy nose-timer
   - pip install doctest-ignore-unicode
   - pip install git+https://github.com/pybel/pybel.git@master
   - wget http://sorger.med.harvard.edu/data/bachman/Phosphorylation_site_dataset.tsv --directory-prefix=indra/resources/ -nv
@@ -104,7 +104,7 @@ script:
   - nosetests -v -a $NOSEATTR --process-restartworker indra/tests/test_tees.py
   # Now run all INDRA tests
   - nosetests indra -v -a $NOSEATTR -e '.*tees.*' --with-coverage --cover-inclusive
-        --cover-package=indra --with-doctest --with-doctest-ignore-unicode
+        --cover-package=indra --with-doctest --with-doctest-ignore-unicode --with-timer --timer-top-n 10
   # Run NL model examples only when the environmental variable
   # RUN_NL_MODELS is set to true in the Travis build
   # NOTE: if blocks in Travis DO NOT FAIL even if there is

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ install:
         export RUN_SLOW=true;
     fi
   - |
-    if [[ $RUN_SLOW ]]; then
+    if [[ $RUN_SLOW == "true" ]]; then
         sudo apt-get --yes install ruby;
         wget -nv http://sorger.med.harvard.edu/data/bgyori/TEES.tar.bz2;
         tar xjf TEES.tar.bz2;
@@ -97,7 +97,7 @@ script:
   - if [[ $TRAVIS_PULL_REQUEST ]]; then
       export NOSEATTR="!nonpublic";
     fi
-  - if [[ $RUN_SLOW ]]; then
+  - if [[ $RUN_SLOW != "true" ]]; then
       export NOSEATTR="!slow,$NOSEATTR";
     fi
   # First run TEES tests separately for technical reasons

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ before_install:
   - sudo apt-get update
   - pip install numpy scipy sympy cython==0.23.5 nose lxml matplotlib==1.5.0 pandas
   - pip2 install numpy
+  - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+        export RUN_SLOW=true;
+    fi
+  - echo "Run slow setting is: $RUN_SLOW"
 install:
   # INDRA dependencies
   - sudo apt-get install libstdc++6
@@ -64,10 +68,13 @@ install:
   - export REACHPATH=$TRAVIS_BUILD_DIR
   - pip install pycodestyle
   # TEES
-  - sudo apt-get --yes install ruby
-  - wget -nv http://sorger.med.harvard.edu/data/bgyori/TEES.tar.bz2
-  - tar xjf TEES.tar.bz2
-  - mv TEES ~/TEES
+  - |
+    if [[ $RUN_SLOW ]]; then
+        sudo apt-get --yes install ruby;
+        wget -nv http://sorger.med.harvard.edu/data/bgyori/TEES.tar.bz2;
+        tar xjf TEES.tar.bz2;
+        mv TEES ~/TEES;
+    fi
 before_script:
   # Enable plotting on fake display
   - "export DISPLAY=:99.0"
@@ -90,6 +97,9 @@ script:
   - export NOSEATTR="";
   - if [[ $TRAVIS_PULL_REQUEST ]]; then
       export NOSEATTR="!nonpublic";
+    fi
+  - if [[ $RUN_SLOW ]]; then
+      export NOSEATTR="!slow",$NOSEATTR;
     fi
   # First run TEES tests separately for technical reasons
   - nosetests -v --process-restartworker indra/tests/test_tees.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ script:
       export NOSEATTR="!slow",$NOSEATTR;
     fi
   # First run TEES tests separately for technical reasons
-  - nosetests -v --process-restartworker indra/tests/test_tees.py
+  - nosetests -v -a $NOSEATTR --process-restartworker indra/tests/test_tees.py
   # Now run all INDRA tests
   - nosetests indra -v -a $NOSEATTR -e '.*tees.*' --with-coverage --cover-inclusive
         --cover-package=indra --with-doctest --with-doctest-ignore-unicode

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ before_install:
   - sudo apt-get update
   - pip install numpy scipy sympy cython==0.23.5 nose lxml matplotlib==1.5.0 pandas
   - pip2 install numpy
-  - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
-        export RUN_SLOW=true;
-    fi
-  - echo "Run slow setting is: $RUN_SLOW"
 install:
   # INDRA dependencies
   - sudo apt-get install libstdc++6
@@ -68,6 +64,9 @@ install:
   - export REACHPATH=$TRAVIS_BUILD_DIR
   - pip install pycodestyle
   # TEES
+  - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+        export RUN_SLOW=true;
+    fi
   - |
     if [[ $RUN_SLOW ]]; then
         sudo apt-get --yes install ruby;

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ script:
       export NOSEATTR="!nonpublic";
     fi
   - if [[ $RUN_SLOW ]]; then
-      export NOSEATTR="!slow",$NOSEATTR;
+      export NOSEATTR="!slow,$NOSEATTR";
     fi
   # First run TEES tests separately for technical reasons
   - nosetests -v -a $NOSEATTR --process-restartworker indra/tests/test_tees.py

--- a/indra/tests/test_chembl_client.py
+++ b/indra/tests/test_chembl_client.py
@@ -50,7 +50,6 @@ def test_target_query():
 
 
 @attr('webservice', 'slow')
-@unittest.skip('This test is very slow and not critical')
 def test_get_drug_inhibition_stmts_vem():
     stmts = chembl_client.get_drug_inhibition_stmts(vem)
     assert(len(stmts) > 0)
@@ -65,7 +64,6 @@ def test_get_drug_inhibition_stmts_vem():
 
 
 @attr('webservice', 'slow')
-@unittest.skip('This test is very slow and not critical')
 def test_get_drug_inhibition_stmts_az628():
     stmts = chembl_client.get_drug_inhibition_stmts(az628)
     assert(len(stmts) > 0)

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import unittest
+from nose.plugins.attrib import attr
 from indra.sources import reach
 from indra.sources.reach.processor import ReachProcessor
 from indra.util import unicode_strs
@@ -170,7 +171,7 @@ def test_process_unicode():
         rp = reach.process_text('MEK1 binds ERK2\U0001F4A9.', offline=offline)
         assert unicode_strs(rp.statements)
 
-@unittest.skip('Taking too long on Travis')
+@attr('slow')
 def test_process_pmc():
     for offline in offline_modes:
         rp = reach.process_pmc('PMC4338247', offline=offline)

--- a/indra/tests/test_tees.py
+++ b/indra/tests/test_tees.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from os.path import join, dirname
 from nose.tools import raises
+from nose.plugins.attrib import attr
 
 from indra.sources.tees import tees_api
 from indra.sources.tees.parse_tees import tees_parse_networkx_to_dot
@@ -12,6 +13,7 @@ _multiprocess_can_split_ = False
 _multiprocess_shared_ = False
 
 
+@attr('slow')
 def test_process_phosphorylation():
     # Test the extraction of phosphorylation with a simple example.
     s = 'Ras leads to the phosphorylation of Braf.'
@@ -37,6 +39,7 @@ def test_process_phosphorylation():
     assert(len(statements[0].evidence) == 1)
 
 
+@attr('slow')
 def test_process_dephosphorylation():
     # Test the extraction of a dephosphorylation sentence. This sentence is
     # processed into two INDRA statements, at least one of which is correct.
@@ -77,6 +80,7 @@ def test_process_dephosphorylation():
     assert(some_statement_correct)
 
 
+@attr('slow')
 def test_process_increase_amount():
     # Test extraction of IncreaseAmount statements from a text description
     # of a substance increasing the expression of some gene.
@@ -106,6 +110,7 @@ def test_process_increase_amount():
     assert(len(statements[0].evidence) == 1)
 
 
+@attr('slow')
 def test_process_decrease_amount():
     # Test extraction of DecreaseAmount statements from a text description
     # of a substance decreasing the expression of some gene.
@@ -134,6 +139,7 @@ def test_process_decrease_amount():
     assert(len(statements[0].evidence) == 1)
 
 
+@attr('slow')
 def test_process_bind():
     # Test extracting of Complex statement from a text description of
     # substances binding to each other.
@@ -162,6 +168,7 @@ def test_process_bind():
     assert(statement0.evidence[0].epistemics['direct'])
 
 
+@attr('slow')
 def test_evidence_text():
     # Test the ability of the processor to extract which sentence in particular
     # lead to the creation of the INDRA statement, amongst a corpus of text
@@ -189,6 +196,7 @@ def test_evidence_text():
     assert(text == 'Ras leads to the phosphorylation of Raf.')
 
 
+@attr('slow')
 def test_evidence_pmid():
     # Test whether the pmid provided to the TEES processor is put into the
     # statement's evidence


### PR DESCRIPTION
This PR changes the Travis config to make it skip some of the slowest tests. In parallel, I scheduled a cron-driven daily build on sorgerlab/indra which runs _all_ the tests, and so will reveal any issues that we might miss because of skipping slow tests. I also added a nice utility called `nose-timer` which shows  how much time each test took and gives an ordered list of the top 10 slowest ones.