### PR TITLE
REACH and Eidos together

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,9 @@ install:
   - tar -xf trips_reach_batch4.gz
   - cd $TRAVIS_BUILD_DIR
   - wget http://sorger.med.harvard.edu/data/bachman/reach-82631d-biores-e9ee36.jar -nv
-  - export REACHPATH=$TRAVIS_BUILD_DIR
+  - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
+  - wget http://sorger.med.harvard.edu/data/bgyori/eidos-assembly-0.1-SNAPSHOT.jar -nv
+  - export EIDOSPATH=$TRAVIS_BUILD_DIR/eidos-assembly-0.1-SNAPSHOT.jar
   - pip install pycodestyle
   # TEES
   - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
@@ -82,7 +84,6 @@ before_script:
 script:
   - export TEES_SETTINGS=~/TEES/tees_local_settings.py
   - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR
-  - export CLASSPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
   - export _JAVA_OPTIONS="-Xmx4g -Xms1g"
   # Run standard unit tests
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ script:
   # Run standard unit tests
   - cd $TRAVIS_BUILD_DIR
   # These are files that are ignored so that doctests don't fail
-  - export NOSE_IGNORE_FILES="eidos_reader.py,find_full_text_sentence.py";
+  - export NOSE_IGNORE_FILES="find_full_text_sentence.py";
   # These files are ignored in Python 2 because they only work in Python 3 and
   # doctests on Travis would otherwise fail
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,11 +101,15 @@ script:
   - if [[ $RUN_SLOW != "true" ]]; then
       export NOSEATTR="!slow,$NOSEATTR";
     fi
-  # First run TEES tests separately for technical reasons
+  # First run TEES and Eidos tests separately for technical reasons
   - nosetests -v -a $NOSEATTR --process-restartworker indra/tests/test_tees.py
+  - nosetests -v -a $NOSEATTR indra/tests/test_eidos.py
   # Now run all INDRA tests
-  - nosetests indra -v -a $NOSEATTR -e '.*tees.*' --with-coverage --cover-inclusive
-        --cover-package=indra --with-doctest --with-doctest-ignore-unicode --with-timer --timer-top-n 10
+  - nosetests indra -v -a $NOSEATTR
+        --exclude='.*tees.*' --exclude='.*eidos.*'
+        --with-coverage --cover-inclusive --cover-package=indra
+        --with-doctest --with-doctest-ignore-unicode
+        --with-timer --timer-top-n 10
   # Run NL model examples only when the environmental variable
   # RUN_NL_MODELS is set to true in the Travis build
   # NOTE: if blocks in Travis DO NOT FAIL even if there is

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -107,6 +107,7 @@ framework also needs to be installed in a way that is visible to PySB.
 Detailed instructions are given in the
 `PySB documentation <http://docs.pysb.org/en/latest/installation.html#option-1-install-pysb-natively-on-your-computer>`_.
 
+.. _pyjniussetup:
 
 Pyjnius
 ```````

--- a/doc/modules/sources/eidos/index.rst
+++ b/doc/modules/sources/eidos/index.rst
@@ -1,0 +1,42 @@
+Eidos (:py:mod:`indra.sources.eidos`)
+=====================================
+Eidos is an open-domain machine reading system which uses a cascade of grammars
+to extract causal events from free text. It is ideal for modeling applications
+that are not specific to a given domain like molecular biology.
+
+To set up reading with Eidos, the Eidos system and its dependencies need to be
+compiled and packaged as a fat JAR:
+
+.. code-block:: bash
+
+    git clone https://github.com/clulab/eidos.git
+    cd eidos
+    sbt assembly
+
+This creates a JAR file in eidos/target/scala[version]/eidos-[version].jar.
+Set the absolute path to this file on the EIDOSPATH environmental variable
+and then append EIDOSPATH to the CLASSPATH environmental variable (entries
+are separated by colons).
+
+The `pyjnius` package needs to be set up and operational to use Eidos reading
+in Python. For more details, see :ref:`pyjniussetup` setup instructions in
+the documentation.
+
+
+Eidos API (:py:mod:`indra.sources.eidos.eidos_api`)
+---------------------------------------------------
+
+.. automodule:: indra.sources.eidos.eidos_api
+    :members:
+
+Eidos Processor (:py:mod:`indra.sources.eidos.processor`)
+---------------------------------------------------------
+
+.. automodule:: indra.sources.eidos.processor
+    :members:
+
+Eidos Reader (:py:mod:`indra.sources.eidos.eidos_reader`)
+---------------------------------------------------------
+
+.. automodule:: indra.sources.eidos.eidos_reader
+    :members:

--- a/doc/modules/sources/index.rst
+++ b/doc/modules/sources/index.rst
@@ -1,5 +1,5 @@
-Processors for model input (:py:mod:`indra.sources`)
-====================================================
+Processors for knowledge input (:py:mod:`indra.sources`)
+========================================================
 
 .. toctree::
    :maxdepth: 3
@@ -12,3 +12,4 @@ Processors for model input (:py:mod:`indra.sources`)
    signor/index
    geneways/index
    tees/index
+   eidos/index

--- a/indra/sources/eidos/eidos_api.py
+++ b/indra/sources/eidos/eidos_api.py
@@ -12,9 +12,10 @@ try:
     # For text reading
     from .eidos_reader import EidosReader
     eidos_reader = EidosReader()
-except Exception:
+except Exception as e:
     logger.error('Could not instantiate Eidos reader, text reading '
                  'will not be available.')
+    logger.exception(e)
     eidos_reader = None
 
 

--- a/indra/sources/eidos/eidos_reader.py
+++ b/indra/sources/eidos/eidos_reader.py
@@ -1,4 +1,30 @@
+import os
 import json
+
+# Before the import, we have to deal with the CLASSPATH to avoid clashes
+# with REACH.
+def _set_classpath():
+    clp = os.environ.get('CLASSPATH')
+    eip = os.environ.get('EIDOSPATH')
+    rep = os.environ.get('REACHPATH')
+    clp_parts = clp.split(':') if clp else []
+    new_clp_parts = []
+    has_eidos = False
+    # Look at all the parts of the CLASSPATH
+    for part in clp_parts:
+        # If REACH is on the CLASSPATH, remove it
+        if os.path.abspath(part) != rep:
+            new_clp_parts.append(part)
+        # If Eidos is not on the CLASSPATH, add it
+        if os.path.abspath(part) == eip:
+            has_eidos = True
+    if not has_eidos:
+        new_clp_parts.append(eip)
+    # Set the new CLASSPATH
+    new_clp = ':'.join(new_clp_parts)
+    os.environ['CLASSPATH'] = new_clp
+_set_classpath()
+
 from indra.java_vm import autoclass, JavaException
 
 

--- a/indra/sources/eidos/eidos_reader.py
+++ b/indra/sources/eidos/eidos_reader.py
@@ -13,12 +13,12 @@ def _set_classpath():
     # Look at all the parts of the CLASSPATH
     for part in clp_parts:
         # If REACH is on the CLASSPATH, remove it
-        if os.path.abspath(part) != rep:
+        if not rep or os.path.abspath(part) != rep:
             new_clp_parts.append(part)
         # If Eidos is not on the CLASSPATH, add it
-        if os.path.abspath(part) == eip:
+        if eip and os.path.abspath(part) == eip:
             has_eidos = True
-    if not has_eidos:
+    if eip and not has_eidos:
         new_clp_parts.append(eip)
     # Set the new CLASSPATH
     new_clp = ':'.join(new_clp_parts)

--- a/indra/sources/reach/reach_api.py
+++ b/indra/sources/reach/reach_api.py
@@ -23,7 +23,6 @@ logger = logging.getLogger('reach')
 
 try:
     # For offline reading
-    from indra.java_vm import autoclass, JavaException
     from .reach_reader import ReachReader
     reach_reader = ReachReader()
     try_offline = True

--- a/indra/sources/reach/reach_reader.py
+++ b/indra/sources/reach/reach_reader.py
@@ -15,12 +15,12 @@ def _set_classpath():
     # Look at all the parts of the CLASSPATH
     for part in clp_parts:
         # If Eidos is on the CLASSPATH, remove it
-        if os.path.abspath(part) != eip:
+        if not eip or os.path.abspath(part) != eip:
             new_clp_parts.append(part)
         # If REACH is not on the CLASSPATH, add it
-        if os.path.abspath(part) == rep:
+        if rep and os.path.abspath(part) == rep:
             has_reach = True
-    if not has_reach:
+    if rep and not has_reach:
         new_clp_parts.append(rep)
     # Set the new CLASSPATH
     new_clp = ':'.join(new_clp_parts)

--- a/indra/sources/reach/reach_reader.py
+++ b/indra/sources/reach/reach_reader.py
@@ -1,6 +1,33 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
+import os
 import logging
+
+# Before the import, we have to deal with the CLASSPATH to avoid clashes
+# with Eidos.
+def _set_classpath():
+    clp = os.environ.get('CLASSPATH')
+    eip = os.environ.get('EIDOSPATH')
+    rep = os.environ.get('REACHPATH')
+    clp_parts = clp.split(':') if clp else []
+    new_clp_parts = []
+    has_reach = False
+    # Look at all the parts of the CLASSPATH
+    for part in clp_parts:
+        # If Eidos is on the CLASSPATH, remove it
+        if os.path.abspath(part) != eip:
+            new_clp_parts.append(part)
+        # If REACH is not on the CLASSPATH, add it
+        if os.path.abspath(part) == rep:
+            has_reach = True
+    if not has_reach:
+        new_clp_parts.append(rep)
+    # Set the new CLASSPATH
+    new_clp = ':'.join(new_clp_parts)
+    os.environ['CLASSPATH'] = new_clp
+_set_classpath()
+
+
 from indra.java_vm import autoclass, JavaException
 
 logger = logging.getLogger('reach_reader')

--- a/indra/tests/test_eidos.py
+++ b/indra/tests/test_eidos.py
@@ -18,3 +18,14 @@ def test_process_json():
     assert stmt.subj_delta.get('adjectives') == ['large']
     assert stmt.obj_delta.get('adjectives') == ['seriously']
     print(stmt)
+
+
+def test_process_text():
+    ep = eidos.process_text('The cost of fuel decreases water trucking.')
+    assert ep is not None
+    assert len(ep.statements) == 1
+    stmt = ep.statements[0]
+    assert isinstance(stmt, Influence)
+    assert stmt.subj.name == 'cost of fuel'
+    assert stmt.obj.name == 'water trucking'
+    assert stmt.obj_delta.get('polarity') == -1

--- a/indra/tools/reading/pmid_reading/read_pmids.py
+++ b/indra/tools/reading/pmid_reading/read_pmids.py
@@ -614,31 +614,21 @@ def run_reach(pmid_list, base_dir, num_cores, start_index, end_index,
     logger.info('Running REACH with force_read=%s' % force_read)
     logger.info('Running REACH with force_fulltext=%s' % force_fulltext)
 
-    # Get the path to the reach directory.
+    # Get the path to the REACH JAR
     path_to_reach = os.environ.get('REACHPATH', None)
     if path_to_reach is None or not os.path.exists(path_to_reach):
         logger.warning(
             'Reach path not set or invalid. Check REACHPATH environment var.'
             )
         return {}, {}
-    patt = re.compile('reach-(.*?)\.jar')
 
-    # Find the jar file.
-    for fname in os.listdir(path_to_reach):
-        m = patt.match(fname)
-        if m is not None:
-            reach_ex = os.path.join(path_to_reach, fname)
-            break
-    else:
-        logger.warning("Could not find reach jar in reach dir.")
-        return {}, {}
+    logger.info('Using REACH jar at: %s' % path_to_reach)
 
-    logger.info('Using REACH jar at: %s' % reach_ex)
-
-    # Get the reach version.
+    # Get the REACH version
     reach_version = os.environ.get('REACH_VERSION', None)
     if reach_version is None:
         logger.info('REACH version not set in REACH_VERSION')
+        m = re.match('reach-(.*?)\.jar', os.path.basename(path_to_reach))
         reach_version = re.sub('-SNAP.*?$', '', m.groups()[0])
 
     logger.info('Using REACH version: %s' % reach_version)
@@ -671,7 +661,7 @@ def run_reach(pmid_list, base_dir, num_cores, start_index, end_index,
         # Run REACH!
         logger.info("Beginning reach.")
         args = ['java', '-Xmx24000m', '-Dconfig.file=%s' % conf_file_path,
-                '-jar', reach_ex]
+                '-jar', path_to_reach]
         p = subprocess.Popen(args, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         if verbose:

--- a/indra/tools/reading/pmid_reading/read_pmids_aws.py
+++ b/indra/tools/reading/pmid_reading/read_pmids_aws.py
@@ -74,10 +74,10 @@ if __name__ == '__main__':
     client = boto3.client('s3')
     bucket_name = 'bigmech'
     pmid_list_key = 'reading_results/%s/pmids' % args.basename
-    path_to_reach = os.environ.get('REACH_JAR_PATH')
+    path_to_reach = os.environ.get('REACHPATH')
     reach_version = os.environ.get('REACH_VERSION')
     if path_to_reach is None or reach_version is None:
-        print('REACH_JAR_PATH and/or REACH_VERSION not defined, exiting.')
+        print('REACHPATH and/or REACH_VERSION not defined, exiting.')
         sys.exit(1)
 
     try:

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -157,33 +157,24 @@ class ReachReader(Reader):
 
     def _check_reach_env(self):
         """Check that the environment supports runnig reach."""
-        # Get the path to the reach directory.
+        # Get the path to the REACH JAR
         path_to_reach = environ.get('REACHPATH', None)
         if path_to_reach is None or not path.exists(path_to_reach):
             raise ReachError(
                 'Reach path unset or invalid. Check REACHPATH environment var.'
                 )
-        patt = re.compile('reach-(.*?)\.jar')
 
-        # Find the jar file.
-        for fname in listdir(path_to_reach):
-            m = patt.match(fname)
-            if m is not None:
-                reach_ex = path.join(path_to_reach, fname)
-                break
-        else:
-            raise ReachError("Could not find reach jar in reach dir.")
-
-        logger.debug('Using REACH jar at: %s' % reach_ex)
+        logger.debug('Using REACH jar at: %s' % path_to_reach)
 
         # Get the reach version.
         reach_version = environ.get('REACH_VERSION', None)
         if reach_version is None:
             logger.debug('REACH version not set in REACH_VERSION')
+            m = re.match('reach-(.*?)\.jar', path.basename(path_to_reach))
             reach_version = re.sub('-SNAP.*?$', '', m.groups()[0])
 
         logger.debug('Using REACH version: %s' % reach_version)
-        return reach_ex, reach_version
+        return path_to_reach, reach_version
 
     def write_content(self, text_content):
         def write_content_file(ext):


### PR DESCRIPTION
This PR adds some CLASSPATH handling to allow more conveniently using REACH and Eidos and allow testing both on Travis. REACHPATH and EIDOSPATH point to the JAR file of each system. These two paths can either be on the CLASSPATH set by the user, or, if not on the CLASSPATH, the right one is added to the CLASSPATH in the respective reach_reader.py or eidos_reader.py.

One change is that REACHPATH now points to the REACH JAR rather than the folder that the REACH JAR is in, this is updated in the various readers. A simultaneous update in indra_deps_docker is ready to be pushed if this is merged.

This fixes #394 to the extent that both readers (and Biopax) can be used with a single fixed setting of environment variables, but due to fundamental limitations in jnius, using both readers in the same session is still not possible (i.e. `from indra.sources import reach, eidos` and then using both wouldn't work). It also fixes #359.