### PR TITLE
Add text word argument to PubMed search

### DIFF
--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -46,15 +46,42 @@ def send_request(url, data):
 def get_ids(search_term, **kwargs):
     """Search Pubmed for paper IDs given a search term.
 
-    The options are passed as named arguments. For details on parameters that
-    can be used, see
+    Search options can be passed as keyword arguments, some of which are
+    custom keywords identified by this function, while others are passed on
+    as parameters for the request to the PubMed web service
+    For details on parameters that can be used in PubMed searches, see
     https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch Some useful
     parameters to pass are db='pmc' to search PMC instead of pubmed reldate=2
     to search for papers within the last 2 days mindate='2016/03/01',
     maxdate='2016/03/31' to search for papers in March 2016.
+
+    PubMed, by default, limits returned PMIDs to a small number, and this
+    number can be controlled by the "retmax" parameter. This function
+    uses a retmax value of 100,000 by default that can be changed via keyword
+    argument.
+
+    Parameters
+    ----------
+    search_term : str
+        A term for which the PubMed search should be performed.
+    use_text_word : Optional[bool]
+        If True, the "[tw]" string is appended to the search term to constrain
+        the search to "text words", that is words that appear as whole
+        in relevant parts of the PubMed entry (excl. for instance the journal
+        name or publication date) like the title and abstract. Using this
+        option can eliminate spurious search results such as all articles
+        published in June for a search for the "JUN" gene, or journal names
+        that contain Acad for a search for the "ACAD" gene.
+        Default : True
+    kwargs : kwargs
+        Additional keyword arguments to pass to the PubMed search as
+        parameters.
     """
+    use_text_word = kwargs.pop('use_text_word', True)
+    if use_text_word:
+        search_term += '[tw]'
     params = {'term': search_term,
-              'retmax': 1000,
+              'retmax': 100000,
               'retstart': 0,
               'db': 'pubmed',
               'sort': 'pub+date'}

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -57,8 +57,8 @@ def get_ids(search_term, **kwargs):
 
     PubMed, by default, limits returned PMIDs to a small number, and this
     number can be controlled by the "retmax" parameter. This function
-    uses a retmax value of 100,000 by default that can be changed via keyword
-    argument.
+    uses a retmax value of 100,000 by default that can be changed via the
+    corresponding keyword argument.
 
     Parameters
     ----------
@@ -72,6 +72,7 @@ def get_ids(search_term, **kwargs):
         option can eliminate spurious search results such as all articles
         published in June for a search for the "JUN" gene, or journal names
         that contain Acad for a search for the "ACAD" gene.
+        See also: https://www.nlm.nih.gov/bsd/disted/pubmedtutorial/020_760.html
         Default : True
     kwargs : kwargs
         Additional keyword arguments to pass to the PubMed search as

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -14,8 +14,17 @@ def test_get_ids():
 
 @attr('webservice')
 def test_get_no_ids():
-    ids = pubmed_client.get_ids('', retmax=10, db='pubmed')
+    ids = pubmed_client.get_ids('xkcd', retmax=10, db='pubmed')
     assert(not ids)
+
+
+@attr('webservice')
+def test_get_ids():
+    ids1 = pubmed_client.get_ids('JUN', use_text_word=False)
+    ids2 = pubmed_client.get_ids('JUN', use_text_word=True)
+    assert(len(ids1) > len(ids2))
+    assert unicode_strs(ids1)
+    assert unicode_strs(ids2)
 
 
 @attr('webservice')


### PR DESCRIPTION
This PR makes a small but important change to the PubMed client's ID search by adding a default `[tw]` suffix to the search term (see https://www.nlm.nih.gov/bsd/disted/pubmedtutorial/020_760.html) which significantly improves the quality of search results - see docstring itself for some examples. I set adding this suffix as the default, since I think it is advantageous in most use cases, but this may not be the best choice. Any thoughts @johnbachman on whether it should be default or not? I also increased the default `retmax` to a higher number to better cover typical search result sizes.