### PR TITLE
Fix stmts from json bug

### DIFF
--- a/indra/statements.py
+++ b/indra/statements.py
@@ -2615,6 +2615,12 @@ def stmts_from_json(json_in, on_missing_support='handle'):
     return stmts
 
 
+def get_unresolved_support_uuids(stmts):
+    """Get uuids unresolved in support from stmts from stmts_from_json."""
+    return {s.uuid for stmt in stmts for s in stmt.supports + stmt.supported_by
+            if isinstance(s, Unresolved)}
+
+
 def stmts_to_json(stmts_in):
     if not isinstance(stmts_in, list):
         json_dict = stmts_in.to_json()

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -2607,14 +2607,14 @@ def stmts_from_json(json_in, on_missing_support='handle'):
             uuid_dict[st.uuid] = st
         for st in stmts:
             for i, uid in enumerate(st.supports):
-                try:
+                if uid in uuid_dict.keys():
                     st.supports[i] = uuid_dict[uid]
-                except KeyError:
+                else:
                     handle_missing_support(st.supports, i, uid)
             for i, uid in enumerate(st.supported_by):
-                try:
+                if uid in uuid_dict.keys():
                     st.supported_by[i] = uuid_dict[uid]
-                except KeyError:
+                else:
                     handle_missing_support(st.supported_by, i, uid)
         return stmts
 

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1041,10 +1041,10 @@ class Statement(object):
         stmt_type = json_dict.get('type')
         stmt_cls = getattr(sys.modules[__name__], stmt_type)
         stmt = stmt_cls._from_json(json_dict)
-        evidence = json_dict.get('evidence', [])
+        evidence = json_dict.get('evidence', []).copy()
         stmt.evidence = [Evidence._from_json(ev) for ev in evidence]
-        stmt.supports = json_dict.get('supports', [])
-        stmt.supported_by = json_dict.get('supported_by', [])
+        stmt.supports = json_dict.get('supports', []).copy()
+        stmt.supported_by = json_dict.get('supported_by', []).copy()
         stmt.belief = json_dict.get('belief', 1.0)
         stmt_id = json_dict.get('id')
         if not stmt_id:

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -2596,24 +2596,20 @@ def stmts_from_json(json_in, on_missing_support='handle'):
         A list of indra statements.
     '''
 
-    if not isinstance(json_in, list):
-        st = Statement._from_json(json_in)
-        return st
-    else:
-        stmts = []
-        uuid_dict = {}
-        for json_stmt in json_in:
-            try:
-                st = Statement._from_json(json_stmt)
-            except Exception as e:
-                logger.warning("Error creating statement: %s" % e)
-                continue
-            stmts.append(st)
-            uuid_dict[st.uuid] = st
-        for st in stmts:
-            _promote_support(st.supports, uuid_dict, on_missing_support)
-            _promote_support(st.supported_by, uuid_dict, on_missing_support)
-        return stmts
+    stmts = []
+    uuid_dict = {}
+    for json_stmt in json_in:
+        try:
+            st = Statement._from_json(json_stmt)
+        except Exception as e:
+            logger.warning("Error creating statement: %s" % e)
+            continue
+        stmts.append(st)
+        uuid_dict[st.uuid] = st
+    for st in stmts:
+        _promote_support(st.supports, uuid_dict, on_missing_support)
+        _promote_support(st.supported_by, uuid_dict, on_missing_support)
+    return stmts
 
 
 def stmts_to_json(stmts_in):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -2546,7 +2546,7 @@ class Unresolved(Statement):
 
 
 def _promote_support(sup_list, uuid_dict, on_missing='handle'):
-    """Promote the list of support-related uuids to statements, if possible."""
+    """Promote the list of support-related uuids to Statements, if possible."""
     valid_handling_choices = ['handle', 'error', 'ignore']
     if on_missing not in valid_handling_choices:
         raise InputError('Invalid option for `on_missing_support`: \'%s\'\n'
@@ -2566,9 +2566,9 @@ def _promote_support(sup_list, uuid_dict, on_missing='handle'):
 
 
 def stmts_from_json(json_in, on_missing_support='handle'):
-    '''Get a list of statements from statement jsons.
+    """Get a list of Statements from Statement jsons.
 
-    In the case of pre-assembled statements which have `supports` and
+    In the case of pre-assembled Statements which have `supports` and
     `supported_by` lists, the uuids will be replaced with references to
     Statement objects from the json, where possible. The method of handling
     missing support is controled by the `on_missing_support` key-word argument.
@@ -2576,28 +2576,28 @@ def stmts_from_json(json_in, on_missing_support='handle'):
     Parameters:
     -----------
     json_in : json list
-        A json list containing json dict representations of indra statements,
+        A json list containing json dict representations of INDRA Statements,
         as produced by the `to_json` methods of subclasses of Statement, or
         equivalently by `stmts_to_json`.
     on_missing_support : str
-        Handles the behavoir when a uuid reference in `supports` or
+        Handles the behavior when a uuid reference in `supports` or
         `supported_by` attribute cannot be resolved. This happens because uuids
-        can only be linked to statements contained in the `json_in` list, and
-        some may be missing if only some of all the statements from pre-
+        can only be linked to Statements contained in the `json_in` list, and
+        some may be missing if only some of all the Statements from pre-
         assembly are contained in the list.
 
         Options are:
             'handle' - (default) convert unresolved uuids into `Unresolved`
                 Statement objects.
             'ignore' - Simply omit any uuids that cannot be linked to any
-                statements in the list.
+                Statements in the list.
             'error' - Raise an error upon hitting an un-linkable uuid.
 
     Returns:
     --------
-    stmts : list [Statement]
-        A list of indra statements.
-    '''
+    stmts : list[:py:class:`Statement`]
+        A list of INDRA Statements.
+    """
 
     stmts = []
     uuid_dict = {}

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -900,8 +900,8 @@ class Evidence(object):
         source_id = json_dict.get('source_id')
         pmid = json_dict.get('pmid')
         text = json_dict.get('text')
-        annotations = json_dict.get('annotations', {})
-        epistemics = json_dict.get('epistemics', {})
+        annotations = json_dict.get('annotations', {}).copy()
+        epistemics = json_dict.get('epistemics', {}).copy()
         ev = Evidence(source_api=source_api, source_id=source_id,
                       pmid=pmid, text=text, annotations=annotations,
                       epistemics=epistemics)
@@ -1041,10 +1041,10 @@ class Statement(object):
         stmt_type = json_dict.get('type')
         stmt_cls = getattr(sys.modules[__name__], stmt_type)
         stmt = stmt_cls._from_json(json_dict)
-        evidence = json_dict.get('evidence', []).copy()
+        evidence = json_dict.get('evidence', [])
         stmt.evidence = [Evidence._from_json(ev) for ev in evidence]
-        stmt.supports = json_dict.get('supports', []).copy()
-        stmt.supported_by = json_dict.get('supported_by', []).copy()
+        stmt.supports = json_dict.get('supports', [])[:]
+        stmt.supported_by = json_dict.get('supported_by', [])[:]
         stmt.belief = json_dict.get('belief', 1.0)
         stmt_id = json_dict.get('id')
         if not stmt_id:

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -2541,6 +2541,9 @@ class Unresolved(Statement):
         super(Unresolved, self).__init__()
         self.uuid = uuid_str
 
+    def __str__(self):
+        return "%s(%s)" % (type(self).__name__, self.uuid)
+
 
 def _promote_support(sup_list, uuid_dict, on_missing='handle'):
     """Promote the list of support-related uuids to statements, if possible."""

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1181,7 +1181,7 @@ def test_serialize():
     ev1 = Evidence(text='1\U0001F4A9')
     st = Phosphorylation(Agent('a\U0001F4A9'), Agent('b'), evidence=[ev1])
     jstr = st.to_json()
-    st2 = stmts_from_json(jstr)
+    st2 = stmts_from_json([jstr])[0]
     assert(st.equals(st2))
     assert unicode_strs((ev1, st, st2))
 

--- a/indra/tests/test_statements_serialization.py
+++ b/indra/tests/test_statements_serialization.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
+
 from indra.statements import *
-from indra.util import unicode_strs
 
 ev = Evidence(source_api='bel', pmid='12345', epistemics={'direct': True},
               text='This is the evidence.')
+
 
 def test_mod_condition_from():
     jd = {'mod_type': 'phosphorylation', 'residue': 'S'}
@@ -13,6 +14,7 @@ def test_mod_condition_from():
     assert(mc.mod_type == 'phosphorylation')
     assert(mc.position is None)
 
+
 def test_agent_mod_condition():
     a = Agent('MAP2K1', mods=[ModCondition('phosphorylation', 'serine', 218),
                               ModCondition('phosphorylation', 'serine', 222)])
@@ -20,69 +22,79 @@ def test_agent_mod_condition():
     jd2 = Agent._from_json(jd).to_json()
     assert(jd == jd2)
 
+
 def test_modification():
     stmt = Phosphorylation(Agent('a'), Agent('b'), 'S', evidence=[ev])
     jd = stmt.to_json()
-    g = stmt.to_graph()
+    stmt.to_graph()
     jd2 = Statement._from_json(jd).to_json()
     assert(jd == jd2)
+
 
 def test_selfmodification():
     stmt = Autophosphorylation(Agent('a'), 'Y', '1234', evidence=[ev])
     jd = stmt.to_json()
-    g = stmt.to_graph()
+    stmt.to_graph()
     jd2 = Statement._from_json(jd).to_json()
     assert(jd == jd2)
+
 
 def test_activation():
     stmt = Activation(Agent('a'), Agent('b'), 'kinase', evidence=[ev])
     jd = stmt.to_json()
-    g = stmt.to_graph()
+    stmt.to_graph()
     jd2 = Statement._from_json(jd).to_json()
     assert(jd == jd2)
+
 
 def test_amount():
     stmt = IncreaseAmount(Agent('a'), Agent('b'), evidence=[ev])
     jd = stmt.to_json()
-    g = stmt.to_graph()
+    stmt.to_graph()
     jd2 = Statement._from_json(jd).to_json()
     assert(jd == jd2)
+
 
 def test_active_form():
     stmt = ActiveForm(Agent('a', location='nucleus'), 'kinase', False,
                       evidence=[ev])
     jd = stmt.to_json()
-    g = stmt.to_graph()
+    stmt.to_graph()
     jd2 = Statement._from_json(jd).to_json()
     assert(jd == jd2)
+
 
 def test_complex():
     stmt = Complex([Agent('a'), Agent('b')], evidence=[ev])
     jd = stmt.to_json()
-    g = stmt.to_graph()
+    stmt.to_graph()
     jd2 = Statement._from_json(jd).to_json()
     assert(jd == jd2)
+
 
 def test_translocation():
     stmt = Translocation(Agent('a'), 'cytoplasm', 'nucleus', evidence=[ev])
     jd = stmt.to_json()
-    g = stmt.to_graph()
+    stmt.to_graph()
     jd2 = Statement._from_json(jd).to_json()
     assert(jd == jd2)
+
 
 def test_gap():
     stmt = Gap(Agent('a'), Agent('b'), evidence=[ev])
     jd = stmt.to_json()
-    g = stmt.to_graph()
+    stmt.to_graph()
     jd2 = Statement._from_json(jd).to_json()
     assert(jd == jd2)
+
 
 def test_gef():
     stmt = Gef(Agent('a'), Agent('b'), evidence=[ev])
     jd = stmt.to_json()
-    g = stmt.to_graph()
+    stmt.to_graph()
     jd2 = Statement._from_json(jd).to_json()
     assert(jd == jd2)
+
 
 def test_supports():
     stmt1 = Gap(Agent('B'), Agent('B'), evidence=[ev])
@@ -103,5 +115,5 @@ def test_supports():
     assert(len(stmts2[1].supported_by) == 1)
     assert(stmts2[0].supports[0] == stmts2[1])
     assert(stmts2[1].supported_by[0] == stmts2[0])
-    g = stmt1.to_graph()
-    g = stmt2.to_graph()
+    stmt1.to_graph()
+    stmt2.to_graph()

--- a/indra/tests/test_statements_serialization.py
+++ b/indra/tests/test_statements_serialization.py
@@ -96,11 +96,20 @@ def test_gef():
     assert(jd == jd2)
 
 
+def __make_support_link(supporting_stmt, supported_stmt):
+    if supporting_stmt.supports is None:
+        supporting_stmt.supports = []
+    supporting_stmt.supports.append(supported_stmt)
+    if supported_stmt.supported_by is None:
+        supporting_stmt.supported_by = []
+    supported_stmt.supported_by.append(supporting_stmt)
+    return
+
+
 def test_supports():
     stmt1 = Gap(Agent('B'), Agent('B'), evidence=[ev])
     stmt2 = Gap(Agent('a'), Agent('b'), evidence=[ev])
-    stmt1.supports = [stmt2]
-    stmt2.supported_by = [stmt1]
+    __make_support_link(stmt2, stmt1)
     jd1 = stmt1.to_json()
     jd2 = stmt2.to_json()
     jds = [jd1, jd2]
@@ -117,3 +126,60 @@ def test_supports():
     assert(stmts2[1].supported_by[0] == stmts2[0])
     stmt1.to_graph()
     stmt2.to_graph()
+
+
+def test_supports_missing_uuids():
+    stmts = [Gap(Agent('A%d' % i), Agent('B%d' % i), evidence=[ev])
+             for i in range(3)]
+    for stmt in stmts[1:]:
+        __make_support_link(stmts[0], stmt)
+    __make_support_link(stmts[2], stmts[1])
+
+    # Test that the example set works correctly
+    output_stmts = stmts_from_json(stmts_to_json(stmts), 'error')
+    assert len(output_stmts) is len(stmts),\
+        "Expected %d statements, got %d." % (len(stmts), len(output_stmts))
+    assert all([any([s_out.matches(s_in) for s_in in stmts])
+                for s_out in output_stmts]),\
+        "Output statements do not match input statements."
+    all_input_supports = [s for attr in ['supports', 'supported_by']
+                          for stmt in stmts for s in getattr(stmt, attr)]
+
+    # Test the behavior when some statements are missing.
+    for missing_stmt in stmts:
+        print("Performing knock-out of %s." % str(missing_stmt))
+        input_stmts = stmts[:]
+        input_stmts.remove(missing_stmt)
+        stmts_json = stmts_to_json(input_stmts)
+
+        # Test 'handle' behavior (default)
+        output_stmts = stmts_from_json(stmts_json, 'handle')
+        assert len(output_stmts) == 2,\
+            "Got %d stmts, not 2 when using 'handle'." % len(output_stmts)
+        all_supports = [s for attr in ['supports', 'supported_by']
+                        for stmt in output_stmts for s in getattr(stmt, attr)]
+        unresolved_supports = [s for s in all_supports
+                               if isinstance(s, Unresolved)]
+        assert len(all_supports) is len(all_input_supports),\
+            "Missing some supports in 'handle' behavior."
+        assert 0 < len(unresolved_supports) < len(all_input_supports),\
+            "No outputs are of type Unresolved for 'handle' behavior."
+
+        # Test 'ignore' behavior
+        output_stmts = stmts_from_json(stmts_json, 'ignore')
+        assert len(output_stmts) == 2,\
+            "Got %d stmts, not 2 when using 'ignore'." % len(output_stmts)
+        all_supports = [s for attr in ['supports', 'supported_by']
+                        for stmt in output_stmts for s in getattr(stmt, attr)]
+        exp_num_remaining = len(all_input_supports) - len(unresolved_supports)
+        assert len(all_supports) == exp_num_remaining,\
+            ("Expected %d remaining support stmts, but got %d using 'ignore'."
+             % (exp_num_remaining, len(all_supports)))
+
+        # Test 'error' behavior
+        try:
+            output_stmts = stmts_from_json(stmts_json, 'error')
+            assert False, "Failed to error when passing partial set of stmts."
+        except UnresolvedUuidError:
+            pass
+    return

--- a/indra/tests/test_statements_serialization.py
+++ b/indra/tests/test_statements_serialization.py
@@ -161,6 +161,8 @@ def test_supports_missing_uuids():
         print("Number of supports for 'handle': %d." % len(all_supports))
         unresolved_supports = [s for s in all_supports
                                if isinstance(s, Unresolved)]
+        unresolved_uuids = get_unresolved_support_uuids(output_stmts)
+        assert unresolved_uuids == {s.uuid for s in unresolved_supports}
         print("Number of unresolved supports: %d." % len(unresolved_supports))
         exp_num_handle_supports = (len(all_input_supports)
                                    - exp_num_supports_removed)

--- a/models/fallahi_eval/sources/process_r3.py
+++ b/models/fallahi_eval/sources/process_r3.py
@@ -25,7 +25,7 @@ def read_stmts(fname):
     for js in jsons:
         if not isinstance(js['evidence'], list):
             js['evidence'] = [js['evidence']]
-        st = stmts_from_json(js)
+        st = stmts_from_json([js])[0]
         if not hasattr(st.agent, 'mutations'):
             st.agent.mutations = []
         if not hasattr(st.agent, 'location'):

--- a/models/phase3_eval/process_r3.py
+++ b/models/phase3_eval/process_r3.py
@@ -22,7 +22,7 @@ def read_stmts(fname):
     for js in jsons:
         if not isinstance(js['evidence'], list):
             js['evidence'] = [js['evidence']]
-        st = stmts_from_json(js)
+        st = stmts_from_json([js])[0]
         if not hasattr(st.agent, 'mutations'):
             st.agent.mutations = []
         if not hasattr(st.agent, 'location'):


### PR DESCRIPTION
This fixes a couple of bugs surrounding serialization of indra statement:
- When converting pre-assembled statements from json, uuids that can't be resolved are handled in 3 different ways, controlled by a keyword argument (see documentation for details).
- When converting any statement from json, the copy lists rather than pass references from the json, preventing complicated cross-contamination of the input json when modifying the resulting statements.
- Implement test to check these features.