### PR TITLE
Update REACH Output

### DIFF
--- a/indra/sources/reach/reach_api.py
+++ b/indra/sources/reach/reach_api.py
@@ -34,10 +34,10 @@ except Exception:
 
 reach_text_url = 'http://agathon.sista.arizona.edu:8080/odinweb/api/text'
 reach_nxml_url = 'http://agathon.sista.arizona.edu:8080/odinweb/api/nxml'
-reach_output_fname = 'reach_output.json'
+default_output_fname = 'reach_output.json'
 
 
-def process_pmc(pmc_id, offline=False):
+def process_pmc(pmc_id, offline=False, output_fname=default_output_fname):
     """Return a ReachProcessor by processing a paper with a given PMC id.
 
     Uses the PMC client to obtain the full text. If it's not available,
@@ -68,11 +68,13 @@ def process_pmc(pmc_id, offline=False):
         fh.write(xml_str.encode('utf-8'))
     ids = id_lookup(pmc_id, 'pmcid')
     pmid = ids.get('pmid')
-    rp = process_nxml_file(fname, citation=pmid, offline=offline)
+    rp = process_nxml_file(fname, citation=pmid, offline=offline,
+                           output_fname=output_fname)
     return rp
 
 
-def process_pubmed_abstract(pubmed_id, offline=False, directory=None):
+def process_pubmed_abstract(pubmed_id, offline=False,
+                            output_fname=default_output_fname):
     """Return a ReachProcessor by processing an abstract with a given Pubmed id.
 
     Uses the Pubmed client to get the abstract. If that fails, None is
@@ -88,9 +90,9 @@ def process_pubmed_abstract(pubmed_id, offline=False, directory=None):
     offline : Optional[bool]
         If set to True, the REACH system is ran offline. Otherwise (by default)
         the web service is called. Default: False
-    directory : Optional[str]
-        The directory to output the reach data to. Defaults to current working
-        directory.
+    output_fname : Optional[str]
+        The file to output the REACH JSON output to.
+        Defaults to reach_output.json in current working directory.
 
     Returns
     -------
@@ -102,7 +104,7 @@ def process_pubmed_abstract(pubmed_id, offline=False, directory=None):
     if abs_txt is None:
         return None
     rp = process_text(abs_txt, citation=pubmed_id, offline=offline,
-                      directory=directory)
+                      output_fname=output_fname)
     if rp and rp.statements:
         for st in rp.statements:
             for ev in st.evidence:
@@ -110,7 +112,8 @@ def process_pubmed_abstract(pubmed_id, offline=False, directory=None):
     return rp
 
 
-def process_text(text, citation=None, offline=False, directory=None):
+def process_text(text, citation=None, offline=False,
+                 output_fname=default_output_fname):
     """Return a ReachProcessor by processing the given text.
 
     Parameters
@@ -124,9 +127,9 @@ def process_text(text, citation=None, offline=False, directory=None):
     offline : Optional[bool]
         If set to True, the REACH system is ran offline. Otherwise (by default)
         the web service is called. Default: False
-    directory : Optional[str]
-        The directory to output the reach data to. Defaults to current working
-        directory.
+    output_fname : Optional[str]
+        The file to output the REACH JSON output to.
+        Defaults to reach_output.json in current working directory.
 
     Returns
     -------
@@ -171,17 +174,13 @@ def process_text(text, citation=None, offline=False, directory=None):
     if not isinstance(json_str, bytes):
         raise TypeError('{} is {} instead of {}'.format(json_str, json_str.__class__, bytes))
 
-    if directory is not None:
-        reach_output_path = os.path.join(directory, reach_output_fname)
-    else:
-        reach_output_path = reach_output_fname
-
-    with open(reach_output_path, 'wb') as fh:
+    with open(output_fname, 'wb') as fh:
         fh.write(json_str)
     return process_json_str(json_str.decode('utf-8'), citation)
 
 
-def process_nxml_str(nxml_str, citation=None, offline=False, directory=None):
+def process_nxml_str(nxml_str, citation=None, offline=False,
+                     output_fname=default_output_fname):
     """Return a ReachProcessor by processing the given NXML string.
 
     NXML is the format used by PubmedCentral for papers in the open
@@ -197,9 +196,9 @@ def process_nxml_str(nxml_str, citation=None, offline=False, directory=None):
     offline : Optional[bool]
         If set to True, the REACH system is ran offline. Otherwise (by default)
         the web service is called. Default: False
-    directory : Optional[str]
-        The directory to output the reach data to. Defaults to current working
-        directory.
+    output_fname : Optional[str]
+        The file to output the REACH JSON output to.
+        Defaults to reach_output.json in current working directory.
 
     Returns
     -------
@@ -247,17 +246,13 @@ def process_nxml_str(nxml_str, citation=None, offline=False, directory=None):
             return None
         json_str = res.text
 
-        if directory is not None:
-            reach_output_path = os.path.join(directory, reach_output_fname)
-        else:
-            reach_output_path = reach_output_fname
-
-        with open(reach_output_path, 'wb') as fh:
+        with open(output_fname, 'wb') as fh:
             fh.write(json_str.encode('utf-8'))
         return process_json_str(json_str, citation)
 
 
-def process_nxml_file(file_name, citation=None, offline=False):
+def process_nxml_file(file_name, citation=None, offline=False,
+                      output_fname=default_output_fname):
     """Return a ReachProcessor by processing the given NXML file.
 
     NXML is the format used by PubmedCentral for papers in the open
@@ -273,6 +268,9 @@ def process_nxml_file(file_name, citation=None, offline=False):
     offline : Optional[bool]
         If set to True, the REACH system is ran offline. Otherwise (by default)
         the web service is called. Default: False
+    output_fname : Optional[str]
+        The file to output the REACH JSON output to.
+        Defaults to reach_output.json in current working directory.
 
     Returns
     -------
@@ -282,7 +280,7 @@ def process_nxml_file(file_name, citation=None, offline=False):
     """
     with open(file_name, 'rb') as f:
         nxml_str = f.read().decode('utf-8')
-        return process_nxml_str(nxml_str, citation, False)
+        return process_nxml_str(nxml_str, citation, False, output_fname)
 
 
 def process_json_file(file_name, citation=None):

--- a/indra/tools/machine/cli.py
+++ b/indra/tools/machine/cli.py
@@ -12,10 +12,10 @@ problems--the code will get executed twice:
 Also see (1) from http://click.pocoo.org/5/setuptools/#setuptools-integration
 """
 
+import os
 import sys
 
 import click
-import os
 
 from indra.tools.machine.config import copy_default_config
 
@@ -23,11 +23,6 @@ from indra.tools.machine.config import copy_default_config
 @click.group()
 def main():
     """INDRA"""
-
-
-#@main.group()
-#def machine():
-#    """RAS Machine"""
 
 
 @main.command()
@@ -73,6 +68,17 @@ def run_with_pmids(model_path, pmids):
     """Run with given list of PMIDs."""
     from indra.tools.machine.machine import run_with_pmids_helper
     run_with_pmids_helper(model_path, pmids)
+
+
+@click.argument('model_path')
+@click.argument('name')
+@click.option('--output', type=click.File('w'))
+def to_cx(model_path, name, output):
+    from indra.tools.machine.machine import load_model, assemble_cx
+    model = load_model(model_path)
+    stmts = model.get_statements()
+    cx_str = assemble_cx(stmts, name)
+    click.echo(cx_str, output)
 
 
 if __name__ == '__main__':

--- a/indra/tools/machine/cli.py
+++ b/indra/tools/machine/cli.py
@@ -70,6 +70,7 @@ def run_with_pmids(model_path, pmids):
     run_with_pmids_helper(model_path, pmids)
 
 
+@main.command()
 @click.argument('model_path')
 @click.argument('name')
 @click.option('--output', type=click.File('w'))

--- a/indra/tools/machine/machine.py
+++ b/indra/tools/machine/machine.py
@@ -98,7 +98,7 @@ def process_paper(model_name, pmid):
     else:
         try:
             txt, txt_format = get_full_text(pmid, 'pmid')
-        except:
+        except Exception:
             return None, None
 
         if txt_format == 'pmc_oa_xml':
@@ -557,7 +557,7 @@ def run_with_search_helper(model_path, config):
             # Put the email_pmids into the pmids dictionary
             pmids['Gmail'] = email_pmids
             logger.info('Collected %d PMIDs from Gmail', len(email_pmids))
-        except:
+        except Exception:
             logger.exception('Could not get PMIDs from Gmail, continuing.')
 
     # Get PMIDs for general search_terms and genes

--- a/indra/tools/machine/machine.py
+++ b/indra/tools/machine/machine.py
@@ -205,6 +205,9 @@ def extend_model(model_name, model, pmids, start_time_local):
 
     logger.info('Found %d unique and novel PMIDS', len(pmids_inv))
 
+    if not os.path.exists(os.path.join(model_name, 'jsons')):
+        os.mkdir(os.path.join(model_name, 'jsons'))
+
     for counter, (pmid, search_terms) in enumerate(pmids_inv.items(), start=1):
         logger.info('[%d/%d] Processing %s for search terms: %s',
                     counter, len(pmids_inv), pmid, search_terms)

--- a/indra/tools/machine/machine.py
+++ b/indra/tools/machine/machine.py
@@ -413,10 +413,10 @@ def get_ndex_cred(config):
     ndex_cred = config.get('ndex')
     if not ndex_cred:
         return
-    elif not ndex_cred.get('user'):
+    elif not ndex_cred.get('user') and 'NDEX_USERNAME' not in os.environ:
         logger.info('NDEx user missing.')
         return
-    elif not ndex_cred.get('password'):
+    elif not ndex_cred.get('password')and 'NDEX_PASSWORD' not in os.environ:
         logger.info('NDEx password missing.')
         return
     elif not ndex_cred.get('network'):

--- a/indra/tools/machine/machine.py
+++ b/indra/tools/machine/machine.py
@@ -101,6 +101,8 @@ def process_paper(model_name, pmid):
     rp : ReachProcessor
         A ReachProcessor containing the extracted INDRA Statements
         in rp.statements.
+    txt_format : str
+        A string representing the format of the text
     """
     json_directory = os.path.join(model_name, 'jsons')
     json_path = os.path.join(json_directory, 'PMID%s.json' % pmid)

--- a/indra/tools/machine/machine.py
+++ b/indra/tools/machine/machine.py
@@ -626,11 +626,15 @@ def run_with_search_helper(model_path, config):
     )
 
 
-def summarize_helper(model_path):
+def load_model(model_path):
     logger.info(time.strftime('%c'))
     logger.info('Loading original model.')
     inc_model_file = os.path.join(model_path, 'model.pkl')
-    model = IncrementalModel(inc_model_file)
+    return IncrementalModel(inc_model_file)
+
+
+def summarize_helper(model_path):
+    model = load_model(model_path)
     stmts = model.get_statements()
     click.echo('Number of statements: {}'.format(len(stmts)))
     agents = model.get_model_agents()

--- a/indra/tools/machine/machine.py
+++ b/indra/tools/machine/machine.py
@@ -71,7 +71,7 @@ def get_searchgenes_pmids(search_genes, num_days):
     for s in search_genes:
         try:
             pmids[s] = pubmed_client.get_ids_for_gene(s, reldate=num_days)
-        except ValueError as e:
+        except ValueError:
             logger.error('Gene symbol %s is invalid')
             continue
     return pmids

--- a/indra/tools/machine/machine.py
+++ b/indra/tools/machine/machine.py
@@ -45,12 +45,12 @@ def build_prior(genes, out_file):
 
 
 def get_email_pmids(gmail_cred):
-    M = gmail_client.gmail_login(gmail_cred.get('user'),
+    mailbox = gmail_client.gmail_login(gmail_cred.get('user'),
                                  gmail_cred.get('password'))
-    gmail_client.select_mailbox(M, 'INBOX')
+    gmail_client.select_mailbox(mailbox, 'INBOX')
     num_days = int(gmail_cred.get('num_days', 10))
     logger.info('Searching last %d days of emails', num_days)
-    pmids = gmail_client.get_message_pmids(M, num_days)
+    pmids = gmail_client.get_message_pmids(mailbox, num_days)
     return pmids
 
 

--- a/indra/tools/machine/machine.py
+++ b/indra/tools/machine/machine.py
@@ -19,7 +19,6 @@ from indra.tools.machine import gmail_client
 from indra.tools.machine import twitter_client
 from indra.tools.gene_network import GeneNetwork
 from indra.tools.incremental_model import IncrementalModel
-from indra.sources.reach.reach_api import reach_output_fname
 from indra.literature import pubmed_client, get_full_text, elsevier_client
 
 try:
@@ -120,25 +119,17 @@ def process_paper(model_name, pmid):
         except Exception:
             return None, None
 
-        reach_output_path = os.path.join(model_name, reach_output_fname)
-
         if txt_format == 'pmc_oa_xml':
             rp = reach.process_nxml_str(txt, citation=pmid, offline=True,
-                                        directory=model_name)
-            if os.path.exists(reach_output_path):
-                shutil.move(reach_output_path, json_path)
+                                        output_fname=json_path)
         elif txt_format == 'elsevier_xml':
             # Extract the raw text from the Elsevier XML
             txt = elsevier_client.extract_text(txt)
             rp = reach.process_text(txt, citation=pmid, offline=True,
-                                    directory=model_name)
-            if os.path.exists(reach_output_path):
-                shutil.move(reach_output_path, json_path)
+                                    output_fname=json_path)
         elif txt_format == 'abstract':
             rp = reach.process_text(txt, citation=pmid, offline=True,
-                                    directory=model_name)
-            if os.path.exists(reach_output_path):
-                shutil.move(reach_output_path, json_path)
+                                    output_fname=json_path)
         else:
             rp = None
     if rp is not None:

--- a/indra/tools/machine/machine.py
+++ b/indra/tools/machine/machine.py
@@ -224,10 +224,10 @@ def extend_model(model_name, model, pmids, start_time_local):
             nexisting += 1
 
         if not rp.statements:
-            logger.info('No statement from PMID%s (%s)' % \
+            logger.info('No statement from PMID%s (%s)' %
                         (pmid, txt_format))
         else:
-            logger.info('%d statements from PMID%s (%s)' % \
+            logger.info('%d statements from PMID%s (%s)' %
                         (len(rp.statements), pmid, txt_format))
         model.add_statements(pmid, rp.statements)
 
@@ -285,13 +285,13 @@ def filter_db_highbelief(stmts_in, db_names, belief_cutoff):
         supp = []
         for st in stmt.supports:
             sources = set([ev.source_api for ev in st.evidence])
-            if st.belief >= belief_cutoff or \
-                sources.intersection(db_names):
+            if (st.belief >= belief_cutoff or
+                sources.intersection(db_names)):
                 supp.append(st)
         for st in stmt.supported_by:
             sources = set([ev.source_api for ev in st.evidence])
-            if st.belief >= belief_cutoff or \
-                sources.intersection(db_names):
+            if (st.belief >= belief_cutoff or
+               sources.intersection(db_names)):
                 supp_by.append(st)
         stmt.supports = supp
         stmt.supported_by = supp_by

--- a/indra/tools/machine/machine.py
+++ b/indra/tools/machine/machine.py
@@ -252,12 +252,12 @@ def get_config(config_fname):
         fh = open(config_fname, 'rt')
     except IOError as e:
         logger.error('Could not open configuration file %s.' % config_fname)
-        raise(e)
+        raise e
     try:
         config = yaml.load(fh)
     except Exception as e:
         logger.error('Could not parse YAML configuration %s.' % config_fname)
-        raise(e)
+        raise e
 
     return config
 


### PR DESCRIPTION
First, this merge has a bit of code cleanup for the INDRA machine. More importantly, it adds an extra kwarg to the processing functions in the REACH API  (`indra.sources.reach.reach_api`) that allows for the directory where output gets stuck to be specified. 

Before, it just stuck the `reach_output.json` in whatever folder was the current working directory. This only doesn't cause a problem if you run the INDRA machine from in the same directory as where the `config.yaml` file and `jsons` folder are. Now, it can be run from an arbirary point on the file system, and still know where to put `reach_output.json`.