### PR TITLE
Influence refinements

### DIFF
--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -59,6 +59,8 @@ class EidosJsonLdProcessor(object):
                 if 'modifiers' in x['states'][0].keys():
                     return [mod['text'] for mod in
                             x['states'][0]['modifiers']]
+                else:
+                    return []
             else:
                 return []
 
@@ -97,9 +99,9 @@ class EidosJsonLdProcessor(object):
                 obj = entity_dict[event['destinations'][0]['@id']]
 
                 subj_delta = {'adjectives': get_adjectives(subj),
-                            'polarity': get_polarity(subj)}
+                              'polarity': get_polarity(subj)}
                 obj_delta = {'adjectives': get_adjectives(obj),
-                            'polarity': get_polarity(obj)}
+                             'polarity': get_polarity(obj)}
 
                 evidence = self._get_evidence(event)
 

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -2464,6 +2464,40 @@ class Influence(IncreaseAmount):
         self.subj_delta = subj_delta
         self.obj_delta = obj_delta
 
+    def refinement_of(self, other, hierarchies):
+        def delta_refinement(dself, dother):
+            # Polarities are either equal
+            if dself['polarity'] == dother['polarity']:
+                pol_refinement = True
+            # Or this one has a polarity and the other doesn't
+            elif dself['polarity'] is not None and dother['polarity'] is None:
+                pol_refinement = True
+            else:
+                pol_refinement = False
+
+            # If other's adjectives are a subset of this
+            if set(dother['adjectives']).issubset(set(dself['adjectives'])):
+                adj_refinement = True
+            else:
+                adj_refinement = False
+            return pol_refinement and adj_refinement
+
+        # Make sure the statement types match
+        if type(self) != type(other):
+            return False
+
+        # Check agent arguments
+        subj_refinement = self.subj.refinement_of(other.subj, hierarchies)
+        obj_refinement = self.obj.refinement_of(other.obj, hierarchies)
+        subjd_refinement = delta_refinement(self.subj_delta, other.subj_delta)
+        objd_refinement = delta_refinement(self.obj_delta, other.obj_delta)
+        return (subj_refinement and obj_refinement and
+                subjd_refinement and objd_refinement)
+
+    def equals(self, other):
+        matches = super(RegulateAmount, self).equals(other)
+        return matches
+
     def overall_polarity(self):
         # Set p1 and p2 to None / 1 / -1 depending on polarity
         p1 = self.subj_delta['polarity']

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -2506,6 +2506,15 @@ class Influence(IncreaseAmount):
             delta_equals(self.obj_delta, other.obj_delta)
         return matches
 
+    def matches_key(self):
+        key = (type(self), self.subj.matches_key(),
+               self.obj.matches_key(),
+               self.subj_delta['polarity'],
+               set(self.subj_delta['adjectives']),
+               self.obj_delta['polarity'],
+               set(self.obj_delta['adjectives']))
+        return str(key)
+
     def overall_polarity(self):
         # Set p1 and p2 to None / 1 / -1 depending on polarity
         p1 = self.subj_delta['polarity']

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -2495,7 +2495,15 @@ class Influence(IncreaseAmount):
                 subjd_refinement and objd_refinement)
 
     def equals(self, other):
-        matches = super(RegulateAmount, self).equals(other)
+        def delta_equals(dself, dother):
+            if (dself['polarity'] == dother['polarity']) and \
+                (set(dself['adjectives']) == set(dother['adjectives'])):
+                return True
+            else:
+                return False
+        matches = super(Influence, self).equals(other) and \
+            delta_equals(self.subj_delta, other.subj_delta) and \
+            delta_equals(self.obj_delta, other.obj_delta)
         return matches
 
     def overall_polarity(self):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -545,6 +545,10 @@ class Concept(object):
                 db_id = None
             else:
                 db_id = sorted(db_id, key=lambda x: x[1], reverse=True)[0][0]
+        # If there is no db_id then we actually reset the db_ns to None
+        # to make sure we don't consider this a potential isa
+        if db_id is None:
+            db_ns = None
         return (db_ns, db_id)
 
     def isa(self, other, hierarchies):

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1679,3 +1679,10 @@ def test_influence_refinement_of():
                I(pos_adj, nopol_noadj), hierarchies)
     assert not I(pos_adj2, nopol_noadj).refinement_of(
                I(pos_adj3, nopol_noadj), hierarchies)
+    pos_adj4 = {'polarity': 1, 'adjectives': ['large', 'significant']}
+    assert I(pos_adj3, nopol_noadj).equals(
+           I(pos_adj4, nopol_noadj))
+    assert not I(nopol_adj, neg_noadj).equals(
+               I(nopol_adj, nopol_noadj))
+    assert not I(nopol_adj, neg_noadj).equals(
+               I(nopol_noadj, neg_noadj))

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1679,10 +1679,21 @@ def test_influence_refinement_of():
                I(pos_adj, nopol_noadj), hierarchies)
     assert not I(pos_adj2, nopol_noadj).refinement_of(
                I(pos_adj3, nopol_noadj), hierarchies)
-    pos_adj4 = {'polarity': 1, 'adjectives': ['large', 'significant']}
-    assert I(pos_adj3, nopol_noadj).equals(
-           I(pos_adj4, nopol_noadj))
+
+    # Equivalences
     assert not I(nopol_adj, neg_noadj).equals(
                I(nopol_adj, nopol_noadj))
     assert not I(nopol_adj, neg_noadj).equals(
                I(nopol_noadj, neg_noadj))
+    pos_adj4 = {'polarity': 1, 'adjectives': ['large', 'significant']}
+    assert I(pos_adj3, nopol_noadj).equals(
+           I(pos_adj4, nopol_noadj))
+
+    # Matches keys
+    assert I(nopol_adj, neg_noadj).matches_key() != \
+           I(nopol_adj, nopol_noadj).matches_key()
+    assert I(nopol_adj, neg_noadj).matches_key() != \
+           I(nopol_noadj, neg_noadj).matches_key()
+    pos_adj4 = {'polarity': 1, 'adjectives': ['large', 'significant']}
+    assert I(pos_adj3, nopol_noadj).matches_key() == \
+           I(pos_adj4, nopol_noadj).matches_key()

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1641,3 +1641,41 @@ def test_concept_isa():
     c2 = Concept('b', db_refs={'EIDOS': [('events/human/conflict', 1.0)]})
     assert c1.refinement_of(c2, {'entity': hm})
     assert not c2.refinement_of(c1, {'entity': hm})
+
+
+def test_influence_refinement_of():
+    c1 = Concept('production')
+    c2 = Concept('price')
+    nopol_noadj = {'polarity': None, 'adjectives': []}
+    nopol_adj = {'polarity': None, 'adjectives': ['small']}
+    neg_noadj = {'polarity': -1, 'adjectives': []}
+    neg_adj = {'polarity': -1, 'adjectives': ['small']}
+    pos_noadj = {'polarity': 1, 'adjectives': []}
+    pos_adj = {'polarity': 1, 'adjectives': ['small']}
+    pos_adj2 = {'polarity': 1, 'adjectives': ['small', 'tiny']}
+    pos_adj3 = {'polarity': 1, 'adjectives': ['significant', 'large']}
+    I = lambda x, y: Influence(c1, c2, x, y)
+    # Has polarity vs doesn't have polarity
+    assert I(pos_adj, nopol_noadj).refinement_of(
+           I(nopol_adj, nopol_noadj), hierarchies)
+    assert I(nopol_adj, pos_noadj).refinement_of(
+           I(nopol_adj, nopol_noadj), hierarchies)
+    assert I(nopol_adj, neg_noadj).refinement_of(
+           I(nopol_adj, nopol_noadj), hierarchies)
+    # Has adjective vs doesn't have adjective
+    assert I(neg_adj, nopol_adj).refinement_of(
+           I(neg_noadj, nopol_adj), hierarchies)
+    assert I(pos_adj, nopol_adj).refinement_of(
+           I(pos_noadj, nopol_adj), hierarchies)
+    assert I(nopol_adj, nopol_adj).refinement_of(
+           I(nopol_noadj, nopol_adj), hierarchies)
+    # Opposite polarity
+    assert not I(neg_noadj, nopol_noadj).refinement_of(
+               I(pos_noadj, nopol_noadj), hierarchies)
+    # Adjective subsets
+    assert I(pos_adj2, nopol_noadj).refinement_of(
+           I(pos_adj, nopol_noadj), hierarchies)
+    assert not I(pos_adj3, nopol_noadj).refinement_of(
+               I(pos_adj, nopol_noadj), hierarchies)
+    assert not I(pos_adj2, nopol_noadj).refinement_of(
+               I(pos_adj3, nopol_noadj), hierarchies)

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1624,12 +1624,14 @@ def test_concept_get_grounding():
     d4 = {'TEXT': 'b', 'BBN': 'a'}
     d5 = {'EIDOS': [('a', 1.0), ('b', 0.8)]}
     d6 = {'EIDOS': [('b', 0.8), ('a', 1.0)]}
+    d7 = {'EIDOS': []}
     assert Concept('a', db_refs=d1).get_grounding() == (None, None)
     assert Concept('b', db_refs=d2).get_grounding() == ('EIDOS', 'c')
     assert Concept('c', db_refs=d3).get_grounding() == ('BBN', 'z')
     assert Concept('d', db_refs=d4).get_grounding() == ('BBN', 'a')
     assert Concept('e', db_refs=d5).get_grounding() == ('EIDOS', 'a')
     assert Concept('f', db_refs=d6).get_grounding() == ('EIDOS', 'a')
+    assert Concept('g', db_refs=d7).get_grounding() == (None, None)
 
 
 def test_concept_isa():


### PR DESCRIPTION
Implements `refinement_of`, `equals` and `matches_key` for Influences, which allows consistent preassembly of Influences with various `subj_delta` and `obj_delta` arguments.

Fixes #437 