### PR TITLE
Recognize contradictions and other related assembly generalizations

### DIFF
--- a/indra/preassembler/hierarchy_manager.py
+++ b/indra/preassembler/hierarchy_manager.py
@@ -67,17 +67,16 @@ class HierarchyManager(object):
                 children_list.append(child)
                 self._children[parent] = children_list
 
-    def merge_with(self, other_hm):
-        """Merge this hierarchy manager with another one.
+    def extend_with(self, rdf_file):
+        """Extend the RDF graph of this HierarchyManager with another RDF file.
 
         Parameters
         ----------
-        other_hm : indra.preassembler.hierarchy_manager.HierarchyManager
-            Another HierarchyManager instance with which this one should
-            be merged. The two RDF graphs are combined and this
-            HierarchyManager is reinitialized.
+        rdf_file : str
+            An RDF file which is parsed such that the current graph and the
+            graph described by the file are merged.
         """
-        self.graph = self.graph + other_hm.graph
+        self.graph.parse(os.path.abspath(rdf_file), format='nt')
         self.initialize()
 
     def build_transitive_closures(self):

--- a/indra/preassembler/hierarchy_manager.py
+++ b/indra/preassembler/hierarchy_manager.py
@@ -67,6 +67,19 @@ class HierarchyManager(object):
                 children_list.append(child)
                 self._children[parent] = children_list
 
+    def merge_with(self, other_hm):
+        """Merge this hierarchy manager with another one.
+
+        Parameters
+        ----------
+        other_hm : indra.preassembler.hierarchy_manager.HierarchyManager
+            Another HierarchyManager instance with which this one should
+            be merged. The two RDF graphs are combined and this
+            HierarchyManager is reinitialized.
+        """
+        self.graph = self.graph + other_hm.graph
+        self.initialize()
+
     def build_transitive_closures(self):
         """Build the transitive closures of the hierarchy.
 

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1092,6 +1092,10 @@ class Statement(object):
             return False
         return True
 
+    def contradicts(self, other, hierarchies):
+        # Placeholder for implementation in subclasses
+        return False
+
     def to_json(self):
         """Return serialized Statement as a json dict."""
         stmt_type = type(self).__name__
@@ -2518,6 +2522,16 @@ class Influence(IncreaseAmount):
                self.obj_delta['polarity'],
                set(self.obj_delta['adjectives']))
         return str(key)
+
+    def contradicts(self, other, hierarchies):
+        if self.entities_match(other) or \
+            self.refinement_of(other, hierarchies) or \
+            other.refinement_of(self, hierarchies):
+            sp = self.overall_polarity()
+            op = other.overall_polarity()
+            if sp and op and sp * op == -1:
+                return True
+        return False
 
     def overall_polarity(self):
         # Set p1 and p2 to None / 1 / -1 depending on polarity

--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -57,6 +57,18 @@ def test_filter_grounded_only():
     st_out = ac.filter_grounded_only([st3])
     assert len(st_out) == 0
 
+
+def test_filter_grounded_only_score():
+    c1 = Concept('x', db_refs={'a': [('x', 0.5), ('y', 0.8)]})
+    c2 = Concept('x', db_refs={'a': [('x', 0.7), ('y', 0.9)]})
+    st1 = Influence(c1, c2)
+    assert len(ac.filter_grounded_only([st1])) == 1
+    assert len(ac.filter_grounded_only([st1], score_threshold=0.4)) == 1
+    assert len(ac.filter_grounded_only([st1], score_threshold=0.6)) == 1
+    assert len(ac.filter_grounded_only([st1], score_threshold=0.85)) == 0
+    assert len(ac.filter_grounded_only([st1], score_threshold=0.95)) == 0
+
+
 def test_filter_uuid_list():
     st_out = ac.filter_uuid_list([st1, st4], [st1.uuid])
     assert len(st_out) == 1

--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -67,6 +67,9 @@ def test_filter_grounded_only_score():
     assert len(ac.filter_grounded_only([st1], score_threshold=0.6)) == 1
     assert len(ac.filter_grounded_only([st1], score_threshold=0.85)) == 0
     assert len(ac.filter_grounded_only([st1], score_threshold=0.95)) == 0
+    c3 = Concept('x', db_refs={'a': []})
+    st2 = Influence(c1, c3)
+    assert len(ac.filter_grounded_only([st2])) == 0
 
 
 def test_filter_uuid_list():

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1708,3 +1708,13 @@ def test_influence_refinement_of():
     pos_adj4 = {'polarity': 1, 'adjectives': ['large', 'significant']}
     assert I(pos_adj3, nopol_noadj).matches_key() == \
            I(pos_adj4, nopol_noadj).matches_key()
+
+    # Contradicts
+    assert I(pos_adj, neg_noadj).contradicts(
+           I(neg_adj, neg_noadj), hierarchies)
+    assert I(pos_adj, neg_noadj).contradicts(
+           I(pos_adj, pos_noadj), hierarchies)
+    assert not I(pos_adj, neg_noadj).contradicts(
+               I(pos_adj, neg_adj), hierarchies)
+    assert not I(pos_adj, neg_noadj).contradicts(
+               I(neg_adj, pos_adj), hierarchies)

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -331,6 +331,9 @@ def filter_grounded_only(stmts_in, **kwargs):
     ----------
     stmts_in : list[indra.statements.Statement]
         A list of statements to filter.
+    score_threshold : Optional[float]
+        If scored groundings are available in a list and the highest score
+        if below this threshold, the Statement is filtered out.
     save : Optional[str]
         The name of a pickle file to save the results (stmts_out) into.
 
@@ -342,6 +345,7 @@ def filter_grounded_only(stmts_in, **kwargs):
     logger.info('Filtering %d statements for grounded agents...' % 
                 len(stmts_in))
     stmts_out = []
+    score_threshold = kwargs.get('score_threshold')
     for st in stmts_in:
         grounded = True
         for agent in st.agent_list():
@@ -349,6 +353,16 @@ def filter_grounded_only(stmts_in, **kwargs):
                 if (not agent.db_refs) or \
                    ((len(agent.db_refs) == 1) and agent.db_refs.get('TEXT')):
                     grounded = False
+                    break
+                # Handle scored list of agents if we have a threshold
+                if score_threshold:
+                    for key, val in agent.db_refs.items():
+                        if isinstance(val, list):
+                            high_score = sorted(val, key=lambda x: x[1],
+                                                reverse=True)[0][1]
+                            if high_score < score_threshold:
+                                grounded = False
+                if not grounded:
                     break
         if grounded:
             stmts_out.append(st)


### PR DESCRIPTION
This PR:
- adds a `contradicts` method to Statements and implements recognizing contradictions for Influences
- implements the merging of a hierarchy with another one, which allows making a single HierarchyManager from multiple RDF files
- generalizes `filter_grounded_only` in `assemble_corpus` to handle scored groundings and to take a threshold parameter on scores