### PR TITLE
Handle multiple sites in site text, broader handling of mutation patterns

### DIFF
--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -575,7 +575,7 @@ class ReachProcessor(object):
 
     @staticmethod
     def _parse_mutation(s):
-        m = re.match(r'([A-Z])([0-9]+)([A-Z])', s.upper())
+        m = re.match(r'([A-Z]+)([0-9]+)([A-Z]+)', s.upper())
         if m is not None:
             parts = [str(g) for g in m.groups()]
             residue_from = get_valid_residue(parts[0])

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -116,7 +116,7 @@ class ReachProcessor(object):
             else:
                 # residue = None
                 # pos = None
-                mods = []
+                mods = [(None, None)]
 
             for mod in mods:
                 residue, pos = mod

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -111,14 +111,12 @@ class ReachProcessor(object):
                     site = a['text']
             theme_agent = self._get_agent_from_entity(theme)
             if site is not None:
-                # residue, pos = self._parse_site_text(site)
                 mods = self._parse_site_text(site)
             else:
-                # residue = None
-                # pos = None
                 mods = [(None, None)]
 
             for mod in mods:
+                # Add up to one statement for each site
                 residue, pos = mod
 
                 # Now we need to look for all regulation event to get to the
@@ -451,12 +449,9 @@ class ReachProcessor(object):
     def _get_mod_conditions(self, mod_term):
         site = mod_term.get('site')
         if site is not None:
-            #mod_res, mod_pos = self._parse_site_text(site)
             mods = self._parse_site_text(site)
         else:
             mods = []
-            # mod_res = None
-            # mod_pos = None
 
         mcs = []
         for mod in mods:
@@ -464,12 +459,10 @@ class ReachProcessor(object):
             mod_type_str = mod_term['type'].lower()
             mod_state = agent_mod_map.get(mod_type_str)
             if mod_state is not None:
-                mc = ModCondition(mod_state[0], residue=mod_res, position=mod_pos,
-                                  is_modified=mod_state[1])
-                #return mc
+                mc = ModCondition(mod_state[0], residue=mod_res,
+                                  position=mod_pos, is_modified=mod_state[1])
                 mcs.append(mc)
             logger.warning('Unhandled entity modification type: %s' % mod_type_str)
-            #return None
         return mcs
 
     def _get_context(self, frame_term):

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -16,35 +16,45 @@ def test_parse_site_text():
             'threonine residue 185', 'T185']
     assert unicode_strs(text)
     for t in text:
-        residue, site = ReachProcessor._parse_site_text(t)
+        sites = ReachProcessor._parse_site_text(t)
+        assert(len(sites) == 1)
+        residue, site = sites[0]
         assert(residue == 'T')
         assert(site == '185')
         assert unicode_strs((residue, site))
 
 def test_parse_site_text_number():
     t = '135'
-    residue, site = ReachProcessor._parse_site_text(t)
+    sites = ReachProcessor._parse_site_text(t)
+    assert(len(sites) == 1)
+    residue, site = sites[0]
     assert(residue is None)
     assert(site == '135')
     assert(unicode_strs(site))
 
 def test_parse_site_text_number_first():
     t = '293T'
-    residue, site = ReachProcessor._parse_site_text(t)
+    sites = ReachProcessor._parse_site_text(t)
+    assert(len(sites) == 1)
+    residue, site = sites[0]
     assert(residue == 'T')
     assert(site == '293')
     assert(unicode_strs((residue, site)))
 
 def test_parse_site_text_number_first_space():
     t = '293 T'
-    residue, site = ReachProcessor._parse_site_text(t)
+    sites = ReachProcessor._parse_site_text(t)
+    assert(len(sites) == 1)
+    residue, site = sites[0]
     assert(residue == 'T')
     assert(site == '293')
     assert(unicode_strs((residue, site)))
 
 def test_parse_site_text_other_aa():
     t = 'A431'
-    residue, site = ReachProcessor._parse_site_text(t)
+    sites = ReachProcessor._parse_site_text(t)
+    assert(len(sites) == 1)
+    residue, site = sites[0]
     assert(residue == 'A')
     assert(site == '431')
     assert(unicode_strs((residue, site)))
@@ -53,10 +63,51 @@ def test_parse_site_residue_only():
     text = ['serine residue', 'serine', 'a serine site', 's', 'ser']
     assert unicode_strs(text)
     for t in text:
-        residue, site = ReachProcessor._parse_site_text(t)
+        sites = ReachProcessor._parse_site_text(t)
+        assert(len(sites) == 1)
+        residue, site = sites[0]
         assert unicode_strs((residue, site))
         assert(residue == 'S')
         assert(site is None)
+
+def test_parse_site_multiple():
+    sites = ReachProcessor._parse_site_text('638/641')
+    assert(len(sites) == 2)
+    assert(sites[0][0] == None)
+    assert(sites[0][1] == '638')
+    assert(sites[1][0] == None)
+    assert(sites[1][1] == '641')
+
+    sites = ReachProcessor._parse_site_text('992,1068')
+    assert(len(sites) == 2)
+    assert(sites[0][0] == None)
+    assert(sites[0][1] == '992')
+    assert(sites[1][0] == None)
+    assert(sites[1][1] == '1068')
+
+    sites = ReachProcessor._parse_site_text('Y1221/1222')
+    assert(len(sites) == 2)
+    assert(sites[0][0] == 'Y')
+    assert(sites[0][1] == '1221')
+    assert(sites[1][0] == None)
+    assert(sites[1][1] == '1222')
+
+    sites = ReachProcessor._parse_site_text('Tyr-577/576')
+    assert(len(sites) == 2)
+    assert(sites[0][0] == 'Y')
+    assert(sites[0][1] == '577')
+    assert(sites[1][0] == None)
+    assert(sites[1][1] == '576')
+
+    sites = ReachProcessor._parse_site_text('S199/S202/T205')
+    assert(len(sites) == 3)
+    assert(sites[0][0] == 'S')
+    assert(sites[0][1] == '199')
+    assert(sites[1][0] == 'S')
+    assert(sites[1][1] == '202')
+    assert(sites[2][0] == 'T')
+    assert(sites[2][1] == '205')
+
 
 def test_valid_name():
     assert(ReachProcessor._get_valid_name('') == '')

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -255,6 +255,7 @@ def test_hgnc_from_up():
     for offline in offline_modes:
         rp = reach.process_text('MEK1 phosphorylates ERK2.',
                                 offline=offline)
+        import ipdb;ipdb.set_trace()
         assert len(rp.statements) == 1
         st = rp.statements[0]
         (map2k1, mapk1) = st.agent_list()

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -255,7 +255,6 @@ def test_hgnc_from_up():
     for offline in offline_modes:
         rp = reach.process_text('MEK1 phosphorylates ERK2.',
                                 offline=offline)
-        import ipdb;ipdb.set_trace()
         assert len(rp.statements) == 1
         st = rp.statements[0]
         (map2k1, mapk1) = st.agent_list()

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -23,6 +23,7 @@ def test_parse_site_text():
         assert(site == '185')
         assert unicode_strs((residue, site))
 
+
 def test_parse_site_text_number():
     t = '135'
     sites = ReachProcessor._parse_site_text(t)
@@ -31,6 +32,7 @@ def test_parse_site_text_number():
     assert(residue is None)
     assert(site == '135')
     assert(unicode_strs(site))
+
 
 def test_parse_site_text_number_first():
     t = '293T'
@@ -41,6 +43,7 @@ def test_parse_site_text_number_first():
     assert(site == '293')
     assert(unicode_strs((residue, site)))
 
+
 def test_parse_site_text_number_first_space():
     t = '293 T'
     sites = ReachProcessor._parse_site_text(t)
@@ -50,6 +53,7 @@ def test_parse_site_text_number_first_space():
     assert(site == '293')
     assert(unicode_strs((residue, site)))
 
+
 def test_parse_site_text_other_aa():
     t = 'A431'
     sites = ReachProcessor._parse_site_text(t)
@@ -58,6 +62,7 @@ def test_parse_site_text_other_aa():
     assert(residue == 'A')
     assert(site == '431')
     assert(unicode_strs((residue, site)))
+
 
 def test_parse_site_residue_only():
     text = ['serine residue', 'serine', 'a serine site', 's', 'ser']
@@ -70,33 +75,34 @@ def test_parse_site_residue_only():
         assert(residue == 'S')
         assert(site is None)
 
+
 def test_parse_site_multiple():
     sites = ReachProcessor._parse_site_text('638/641')
     assert(len(sites) == 2)
-    assert(sites[0][0] == None)
+    assert(sites[0][0] is None)
     assert(sites[0][1] == '638')
-    assert(sites[1][0] == None)
+    assert(sites[1][0] is None)
     assert(sites[1][1] == '641')
 
     sites = ReachProcessor._parse_site_text('992,1068')
     assert(len(sites) == 2)
-    assert(sites[0][0] == None)
+    assert(sites[0][0] is None)
     assert(sites[0][1] == '992')
-    assert(sites[1][0] == None)
+    assert(sites[1][0] is None)
     assert(sites[1][1] == '1068')
 
     sites = ReachProcessor._parse_site_text('Y1221/1222')
     assert(len(sites) == 2)
     assert(sites[0][0] == 'Y')
     assert(sites[0][1] == '1221')
-    assert(sites[1][0] == None)
+    assert(sites[1][0] == 'Y')
     assert(sites[1][1] == '1222')
 
     sites = ReachProcessor._parse_site_text('Tyr-577/576')
     assert(len(sites) == 2)
     assert(sites[0][0] == 'Y')
     assert(sites[0][1] == '577')
-    assert(sites[1][0] == None)
+    assert(sites[1][0] == 'Y')
     assert(sites[1][1] == '576')
 
     sites = ReachProcessor._parse_site_text('S199/S202/T205')
@@ -106,6 +112,24 @@ def test_parse_site_multiple():
     assert(sites[1][0] == 'S')
     assert(sites[1][1] == '202')
     assert(sites[2][0] == 'T')
+    assert(sites[2][1] == '205')
+
+    sites = ReachProcessor._parse_site_text('S199/202/T205')
+    assert(len(sites) == 3)
+    assert(sites[0][0] == 'S')
+    assert(sites[0][1] == '199')
+    assert(sites[1][0] is None)
+    assert(sites[1][1] == '202')
+    assert(sites[2][0] == 'T')
+    assert(sites[2][1] == '205')
+
+    sites = ReachProcessor._parse_site_text('S199/202/205')
+    assert(len(sites) == 3)
+    assert(sites[0][0] == 'S')
+    assert(sites[0][1] == '199')
+    assert(sites[1][0] == 'S')
+    assert(sites[1][1] == '202')
+    assert(sites[2][0] == 'S')
     assert(sites[2][1] == '205')
 
 
@@ -217,6 +241,7 @@ def test_mutation():
         assert(braf.mutations[0].residue_to == 'E')
         assert unicode_strs(rp.statements)
 
+
 def test_parse_mutation():
     mut = ReachProcessor._parse_mutation('V600E')
     assert(mut.residue_from == 'V')
@@ -232,6 +257,7 @@ def test_parse_mutation():
     assert(mut.residue_from == 'V')
     assert(mut.position == '34')
     assert(mut.residue_to == 'L')
+
 
 def test_process_unicode():
     for offline in offline_modes:

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -166,6 +166,22 @@ def test_mutation():
         assert(braf.mutations[0].residue_to == 'E')
         assert unicode_strs(rp.statements)
 
+def test_parse_mutation():
+    mut = ReachProcessor._parse_mutation('V600E')
+    assert(mut.residue_from == 'V')
+    assert(mut.position == '600')
+    assert(mut.residue_to == 'E')
+
+    mut = ReachProcessor._parse_mutation('Leu174Arg')
+    assert(mut.residue_from == 'L')
+    assert(mut.position == '174')
+    assert(mut.residue_to == 'R')
+
+    mut = ReachProcessor._parse_mutation('val34leu')
+    assert(mut.residue_from == 'V')
+    assert(mut.position == '34')
+    assert(mut.residue_to == 'L')
+
 def test_process_unicode():
     for offline in offline_modes:
         rp = reach.process_text('MEK1 binds ERK2\U0001F4A9.', offline=offline)


### PR DESCRIPTION
Note: we may or may not be handling multiple site patterns in the desirable way, see details below.

This PR:
1. Handles mutation patterns with residues described with more than one letter (such as Leu174Arg)

2. Handles site patterns with multiple sites, separated by either a comma or a slash (such as S199/S202/T205 or 992,1068). If the site text describes a modification to an agent, adds a ModCondition to agent.mods for each entry in the comma or slash separated site list. If the site text modifies a modification statement, creates one modification statement per site list entry (is this the desired behavior?)