### PR TITLE
Recognize contradictions in multiple Statement types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - wget "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable_Linux.tar.gz" -O bionetgen.tar.gz -nv
   - tar xzf bionetgen.tar.gz
   - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
-  - pip install git+https://github.com/pysb/pysb.git
+  - pip install pysb==1.6.0
   # Biopax/Paxtools dependencies
   - pip install jnius-indra
   # Download a number of useful resource files for testing purposes

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -517,6 +517,20 @@ class Preassembler(object):
         else:
             return unique_stmts
 
+    def find_contradicts(self):
+        """Return pairs of contradicting Statements.
+
+        Return
+        ------
+        contradicts : list(tuple(Statement, Statement))
+            A list of Statement pairs that are contradicting.
+        """
+        contradicts = []
+        for st1, st2 in itertools.combinations(self.stmts, 2):
+            if st1.contradicts(st2, self.hierarchies):
+                contradicts.append((st1, st2))
+        return contradicts
+
 
 def _set_supports_stmt_pairs(stmt_tuples, hierarchies=None,
                              check_entities_match=False):

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -520,8 +520,8 @@ class Preassembler(object):
     def find_contradicts(self):
         """Return pairs of contradicting Statements.
 
-        Return
-        ------
+        Returns
+        -------
         contradicts : list(tuple(Statement, Statement))
             A list of Statement pairs that are contradicting.
         """

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1703,6 +1703,30 @@ class RegulateActivity(Statement):
         else:
             return False
 
+    def contradicts(self, other, hierarchies):
+        # If they aren't opposite classes, it's not a contradiction
+        if {self.__class__, other.__class__} != {Activation, Inhibition}:
+            return False
+
+        # If they aren't opposite classes, it's not a contradiction
+        if self.is_activation == other.is_activation:
+            return False
+        # Skip all instances of not fully specified statements
+        agents = (self.subj, self.obj, other.subj, other.obj)
+        if not all(a is not None for a in agents):
+            return False
+        # If the entities don't match, they can't be contradicting
+        # Here we check pairs of agents at each "position" and
+        # make sure they are the same or they are refinements of each other
+        for self_agent, other_agent in zip(self.agent_list(),
+                                           other.agent_list()):
+            if not (self_agent.entity_matches(other_agent) or \
+                    self_agent.refinement_of(other_agent, hierarchies) or \
+                    other_agent.refinement_of(self_agent, hierarchies)):
+                return False
+        # Otherwise they are contradicting
+        return True
+
     def to_json(self):
         generic = super(RegulateActivity, self).to_json()
         json_dict = _o({'type': generic['type']})

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1310,12 +1310,14 @@ class Modification(Statement):
         if not all(a is not None for a in agents):
             return False
         # If the entities don't match, they can't be contradicting
-        if not self.entities_match(other) and \
-            not (self.enz.refinement_of(other.enz, hierarchies) or
-                 other.enz.refinement_of(self.enz, hierarchies)) and \
-            not (self.sub.refinement_of(other.sub, hierarchies) or
-                 other.sub.refinement_of(self.sub, hierarchies)):
-            return False
+        # Here we check pairs of agents at each "position" and
+        # make sure they are the same or they are refinements of each other
+        for self_agent, other_agent in zip(self.agent_list(),
+                                           other.agent_list()):
+            if not (self_agent.entity_matches(other_agent) or \
+                    self_agent.refinement_of(other_agent, hierarchies) or \
+                    other_agent.refinement_of(self_agent, hierarchies)):
+                return False
         # At this point the entities definitely match so we need to
         # check the specific site that is being modified
         if self.residue == other.residue and self.position == other.position:
@@ -2453,12 +2455,14 @@ class RegulateAmount(Statement):
         if not all(a is not None for a in agents):
             return False
         # If the entities don't match, they can't be contradicting
-        if not self.entities_match(other) and \
-            not (self.subj.refinement_of(other.subj, hierarchies) or
-                 other.subj.refinement_of(self.subj, hierarchies)) and \
-            not (self.obj.refinement_of(other.obj, hierarchies) or
-                 other.obj.refinement_of(self.obj, hierarchies)):
-            return False
+        # Here we check pairs of agents at each "position" and
+        # make sure they are the same or they are refinements of each other
+        for self_agent, other_agent in zip(self.agent_list(),
+                                           other.agent_list()):
+            if not (self_agent.entity_matches(other_agent) or \
+                    self_agent.refinement_of(other_agent, hierarchies) or \
+                    other_agent.refinement_of(self_agent, hierarchies)):
+                return False
         # Otherwise they are contradicting
         return True
 

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1929,6 +1929,33 @@ class ActiveForm(Statement):
         else:
             return False
 
+    def contradicts(self, other, hierarchies):
+        # Make sure the statement types match
+        if type(self) != type(other):
+            return False
+        # Check that the polarity is constradicting up front
+        # TODO: we could also check for cases where the polarities are
+        # the same but some of the state conditions have opposite
+        # polarities, for instance, if the presence/lack of the
+        # same modification activates a given agent, that could be
+        # considered a contradiction.
+        if self.is_active == other.is_active:
+            return False
+        # Check that the activity types are the same
+        # TODO: we could check for refinements here
+        if self.activity != other.activity:
+            return False
+        # If the agents are exactly the same, this is a contradiction
+        if self.agent.matches_key() == other.agent.matches_key():
+            return True
+        # Otherwise, if the two agents are related at the level of entities
+        # and their state is exactly the same, then they contradict
+        if self.agent.state_matches_key() == other.agent.state_matches_key():
+            if self.agent.isa(other.agent, hierarchies) or \
+                other.agent.isa(self.agent, hierarchies):
+                return True
+        return False
+
     def to_json(self):
         generic = super(ActiveForm, self).to_json()
         json_dict = _o({'type': generic['type']})

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -652,12 +652,25 @@ class Agent(Concept):
         self.location = get_valid_location(location)
 
     def matches_key(self):
+        """Return a key to identify the identity and state of the Agent."""
+        key = (self.entity_matches_key(),
+               self.state_matches_key())
+        return str(key)
+
+    def entity_matches_key(self):
+        """Return a key to identify the identity of the Agent not its state."""
+        db_refs_key = 'FPLX:%s;UP:%s;HGNC:%s' % (self.db_refs.get('FPLX'),
+                                                 self.db_refs.get('UP'),
+                                                 self.db_refs.get('HGNC'))
+        return str((self.name, db_refs_key))
+
+    def state_matches_key(self):
+        """Return a key to identify the state of the Agent."""
         # NOTE: Making a set of the mod matches_keys might break if
         # you have an agent with two phosphorylations at serine
         # with unknown sites.
         act_key = (self.activity.matches_key() if self.activity else None)
-        key = (self.entity_matches_key(),
-               sorted([m.matches_key() for m in self.mods]),
+        key = (sorted([m.matches_key() for m in self.mods]),
                sorted([m.matches_key() for m in self.mutations]),
                act_key, self.location,
                len(self.bound_conditions),
@@ -665,12 +678,6 @@ class Agent(Concept):
                      for bc in sorted(self.bound_conditions,
                                       key=lambda x: x.agent.name)))
         return str(key)
-
-    def entity_matches_key(self):
-        db_refs_key = 'FPLX:%s;UP:%s;HGNC:%s' % (self.db_refs.get('FPLX'),
-                                                 self.db_refs.get('UP'),
-                                                 self.db_refs.get('HGNC'))
-        return str((self.name, db_refs_key))
 
     # Function to get the namespace to look in
     def get_grounding(self):

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -9,7 +9,8 @@ from indra.statements import Agent, Phosphorylation, BoundCondition, \
                              Dephosphorylation, Evidence, ModCondition, \
                              ActiveForm, MutCondition, Complex, \
                              Translocation, Activation, Inhibition, \
-                             Deacetylation, Conversion, Concept, Influence
+                             Deacetylation, Conversion, Concept, Influence, \
+                             IncreaseAmount, DecreaseAmount
 from indra.preassembler.hierarchy_manager import hierarchies
 
 def test_duplicates():
@@ -608,3 +609,17 @@ def test_influence_refinement():
     truck_stmt = [st for st in rel_stmts if st.subj.name == 'trucking'][0]
     assert len(truck_stmt.supported_by) == 1
     assert truck_stmt.supported_by[0].subj.name == 'transportation'
+
+
+def test_find_contradicts():
+    st1 = Inhibition(Agent('a'), Agent('b'))
+    st2 = Activation(Agent('a'), Agent('b'))
+    st3 = IncreaseAmount(Agent('a'), Agent('b'))
+    st4 = DecreaseAmount(Agent('a'), Agent('b'))
+    pa = Preassembler(hierarchies, [st1, st2, st3, st4])
+    contradicts = pa.find_contradicts()
+    assert len(contradicts) == 2
+    for s1, s2 in contradicts:
+        assert {s1.uuid, s2.uuid} in ({st1.uuid, st2.uuid},
+                                      {st3.uuid, st4.uuid})
+

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1750,3 +1750,14 @@ def test_regulate_amount_contradicts():
     assert not st1.contradicts(st3, hierarchies)
     assert not st1.contradicts(st4, hierarchies)
     assert not st2.contradicts(st4, hierarchies)
+
+
+def test_regulate_activity_contradicts():
+    st1 = Activation(Agent('a'), Agent('b'))
+    st2 = Inhibition(Agent('a'), Agent('b'))
+    st3 = Inhibition(Agent('a'), Agent('c'))
+    st4 = Activation(Agent('b'), Agent('a'))
+    assert st1.contradicts(st2, hierarchies)
+    assert not st1.contradicts(st3, hierarchies)
+    assert not st1.contradicts(st4, hierarchies)
+    assert not st2.contradicts(st4, hierarchies)

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1718,3 +1718,35 @@ def test_influence_refinement_of():
                I(pos_adj, neg_adj), hierarchies)
     assert not I(pos_adj, neg_noadj).contradicts(
                I(neg_adj, pos_adj), hierarchies)
+
+
+def test_modification_contradicts():
+    st1 = Phosphorylation(Agent('a'), Agent('b'))
+    st2 = Dephosphorylation(Agent('a'), Agent('b'))
+    st3 = Dephosphorylation(Agent('a'), Agent('b'), 'S')
+    st4 = Dephosphorylation(Agent('a'), Agent('b'), 'S', '123')
+    st5 = Phosphorylation(Agent('a'), Agent('b'), 'S', '123')
+    st6 = Phosphorylation(Agent('a'), Agent('b'), 'T', '234')
+    st7 = Phosphorylation(None, Agent('b'))
+    st8 = Dephosphorylation(Agent('a'), Agent('c'))
+
+    assert st1.contradicts(st2, hierarchies)
+    assert not st1.contradicts(st7, hierarchies)
+    assert not st1.contradicts(st5, hierarchies)
+    assert not st4.contradicts(st6, hierarchies)
+    assert st4.contradicts(st5, hierarchies)
+    assert not st3.contradicts(st6, hierarchies)
+    assert not st1.contradicts(st8, hierarchies)
+    # TODO: add tests with Agent refinement
+    # TODO: add tests with other Modification types
+
+
+def test_regulate_amount_contradicts():
+    st1 = IncreaseAmount(Agent('a'), Agent('b'))
+    st2 = DecreaseAmount(Agent('a'), Agent('b'))
+    st3 = DecreaseAmount(Agent('a'), Agent('c'))
+    st4 = IncreaseAmount(Agent('b'), Agent('a'))
+    assert st1.contradicts(st2, hierarchies)
+    assert not st1.contradicts(st3, hierarchies)
+    assert not st1.contradicts(st4, hierarchies)
+    assert not st2.contradicts(st4, hierarchies)

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1761,3 +1761,16 @@ def test_regulate_activity_contradicts():
     assert not st1.contradicts(st3, hierarchies)
     assert not st1.contradicts(st4, hierarchies)
     assert not st2.contradicts(st4, hierarchies)
+
+
+def test_active_form_contradicts():
+    mc1 = ModCondition('phosphorylation', 'S', None, True)
+    mc2 = ModCondition('phosphorylation', 'S', None, False)
+    st1 = ActiveForm(Agent('a', mods=[mc1]), 'kinase', True)
+    st2 = ActiveForm(Agent('a', mods=[mc1]), 'kinase', False)
+    st3 = ActiveForm(Agent('a', mods=[mc1]), 'activity', False)
+    st4 = ActiveForm(Agent('a', mods=[mc2]), 'activity', False)
+    assert st1.contradicts(st2, hierarchies)
+    assert not st1.contradicts(st3, hierarchies)
+    assert not st3.contradicts(st4, hierarchies)
+    assert not st1.contradicts(st4, hierarchies)


### PR DESCRIPTION
This PR extends the `contradicts` method to multiple Statement types: RegulateAmount, RegulateActivity, Modification and ActiveForm. It also adds a basic (not optimized) method to the Preassembler to find pairs of contradicting Statements in a set of Statements.