### PR TITLE
Optimize and speed up influence map pruning

### DIFF
--- a/indra/explanation/model_checker.py
+++ b/indra/explanation/model_checker.py
@@ -722,30 +722,37 @@ class ModelChecker(object):
         """
         logger.info('Removing self loops')
         im = self.get_im()
+
         # First, remove all self-loops
         for e in im.edges():
             if e[0] == e[1]:
                 logger.info('Removing self loop: %s', e)
                 im.remove_edge(e[0], e[1])
+
         # Remove parameter nodes from influence map
         remove_im_params(self.model, im)
+
         # Now compare nodes pairwise and look for overlap between child nodes
+        logger.info('Get successorts of each node')
         successors = im.successors_iter
         succ_dict = {}
-        logger.info('Get successorts of each node')
         for node in im.nodes():
             succ_dict[node] = set(successors(node))
+        # Group nodes by number of successors
+        groups = itertools.groupby(im.nodes(), key=lambda x: len(succ_dict[x]))
         logger.info('Compare combinations of successors')
-        combos = itertools.combinations(im.nodes(), 2)
         edges_to_remove = []
-        for ix, (p1, p2) in enumerate(combos):
-            # Children are identical except for mutual relationship
-            if succ_dict[p1].difference(succ_dict[p2]) == set([p2]) and \
-               succ_dict[p2].difference(succ_dict[p1]) == set([p1]):
-                for u, v in ((p1, p2), (p2, p1)):
-                    edges_to_remove.append((u, v))
-                    logger.debug('Will remove edge (%s, %s) with polarity %s',
-                                 u, v, _get_edge_sign(im, (u, v)))
+        for gix, group in groups:
+            combos = itertools.combinations(group, 2)
+            for ix, (p1, p2) in enumerate(combos):
+                # Children are identical except for mutual relationship
+                if succ_dict[p1].difference(succ_dict[p2]) == set([p2]) and \
+                   succ_dict[p2].difference(succ_dict[p1]) == set([p1]):
+                    for u, v in ((p1, p2), (p2, p1)):
+                        edges_to_remove.append((u, v))
+                        logger.debug(('Will remove edge (%s, %s) with '
+                                      'polarity %s'),
+                                     u, v, _get_edge_sign(im, (u, v)))
         for edge in im.edges():
             if edge in edges_to_remove:
                 im.remove_edge(edge[0], edge[1])

--- a/indra/explanation/model_checker.py
+++ b/indra/explanation/model_checker.py
@@ -720,10 +720,10 @@ class ModelChecker(object):
         removal from affecting the lists of rule children during the comparison
         process.
         """
-        logger.info('Removing self loops')
         im = self.get_im()
 
         # First, remove all self-loops
+        logger.info('Removing self loops')
         for e in im.edges():
             if e[0] == e[1]:
                 logger.info('Removing self loop: %s', e)

--- a/indra/explanation/model_checker.py
+++ b/indra/explanation/model_checker.py
@@ -727,26 +727,25 @@ class ModelChecker(object):
             if e[0] == e[1]:
                 logger.info('Removing self loop: %s', e)
                 im.remove_edge(e[0], e[1])
-        # Now compare nodes pairwise and look for overlap between child nodes
-        edges_to_remove = []
+        # Remove parameter nodes from influence map
         remove_im_params(self.model, im)
+        # Now compare nodes pairwise and look for overlap between child nodes
         successors = im.successors_iter
         succ_dict = {}
         logger.info('Get successorts of each node')
         for node in im.nodes():
             succ_dict[node] = set(successors(node))
         logger.info('Compare combinations of successors')
-        combos = list(itertools.combinations(im.nodes(), 2))
+        combos = itertools.combinations(im.nodes(), 2)
+        edges_to_remove = []
         for ix, (p1, p2) in enumerate(combos):
             # Children are identical except for mutual relationship
             if succ_dict[p1].difference(succ_dict[p2]) == set([p2]) and \
                succ_dict[p2].difference(succ_dict[p1]) == set([p1]):
                 for u, v in ((p1, p2), (p2, p1)):
-                    edge = (u, v)
-                    edges_to_remove.append(edge)
-                    edge_sign = _get_edge_sign(im, edge)
+                    edges_to_remove.append((u, v))
                     logger.debug('Will remove edge (%s, %s) with polarity %s',
-                                 u, v, edge_sign)
+                                 u, v, _get_edge_sign(im, (u, v)))
         for edge in im.edges():
             if edge in edges_to_remove:
                 im.remove_edge(edge[0], edge[1])

--- a/indra/explanation/model_checker.py
+++ b/indra/explanation/model_checker.py
@@ -754,12 +754,12 @@ class ModelChecker(object):
                    succ_dict[p2].difference(succ_dict[p1]) == set([p1]):
                     for u, v in ((p1, p2), (p2, p1)):
                         edges_to_remove.append((u, v))
-                        logger.debug(('Will remove edge (%s, %s) with '
-                                      'polarity %s'),
-                                     u, v, _get_edge_sign(im, (u, v)))
-        for edge in im.edges():
-            if edge in edges_to_remove:
-                im.remove_edge(edge[0], edge[1])
+                        logger.debug('Will remove edge (%s, %s)', u, v)
+        logger.info('Removing %d edges from influence map' %
+                    len(edges_to_remove))
+        # Now remove all the edges to be removed with a single call
+        im.remove_edges_from(edges_to_remove)
+
 
 def _find_sources_sample(im, target, sources, polarity, rule_obs_dict,
                          agent_to_obs, agents_values):

--- a/indra/explanation/model_checker.py
+++ b/indra/explanation/model_checker.py
@@ -738,9 +738,13 @@ class ModelChecker(object):
         succ_dict = {}
         for node in im.nodes():
             succ_dict[node] = set(successors(node))
-        # Group nodes by number of successors
-        groups = itertools.groupby(im.nodes(), key=lambda x: len(succ_dict[x]))
+        # Sort and then group nodes by number of successors
         logger.info('Compare combinations of successors')
+        group_key_fun = lambda x: len(succ_dict[x])
+        nodes_sorted = sorted(im.nodes(), key=group_key_fun)
+        groups = itertools.groupby(nodes_sorted, key=group_key_fun)
+        # Now iterate over each group and then construct combinations
+        # within the group to check for shared sucessors
         edges_to_remove = []
         for gix, group in groups:
             combos = itertools.combinations(group, 2)


### PR DESCRIPTION
This PR makes two important optimizations in influence map pruning:
- it groups nodes by the number of successors and only compares pairs of nodes within each group
- removes the identified edges as a bunch instead of iterating over all the edges
On an influence map with 150k nodes, this results in at least a 1000x-fold speedup.

Fixes #496 