### PR TITLE
Improve using protein expressions in assembly

### DIFF
--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -194,6 +194,20 @@ def test_filter_gene_list_one():
                                  remove_bound=True)
     assert(len(st_out[0].sub.bound_conditions) == 0)
 
+
+def test_filter_gene_list_invert():
+    st_out = ac.filter_gene_list([st1, st2], ['a'], 'one', invert=True)
+    assert len(st_out) == 0
+    st_out = ac.filter_gene_list([st1, st2], ['d'], 'one', invert=True)
+    assert len(st_out) == 1
+    assert st_out[0].sub.name == 'b'
+    st_out = ac.filter_gene_list([st1, st2], ['a', 'd'], 'all', invert=True)
+    assert len(st_out) == 1
+    assert st_out[0].sub.name == 'b'
+    st_out = ac.filter_gene_list([st1, st2], ['a', 'b', 'd'], 'all',
+                                 invert=True)
+    assert len(st_out) == 0
+
 def test_filter_gene_list_families():
     stmts_out = ac.filter_gene_list([st16, st17], ['MAPK1'], 'one',
                                     allow_families=False)

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -593,6 +593,9 @@ def filter_gene_list(stmts_in, gene_list, policy, allow_families=False,
         If false (default), looks at agents in the bound conditions in addition
         to those participating in the statement directly when applying the
         specified policy.
+    invert : Optional[bool]
+        If True, the statements that do not match according to the policy
+        are returned. Default: False
 
     Returns
     -------
@@ -611,6 +614,9 @@ def filter_gene_list(stmts_in, gene_list, policy, allow_families=False,
         genes_str = ', '.join(gene_list)
         logger.info('Filtering %d statements for ones containing "%s" of: '
                     '%s...' % (len(stmts_in), policy, genes_str))
+
+    invert = kwargs.get('invert', False)
+
     # If we're allowing families, make a list of all FamPlex IDs that
     # contain members of the gene list, and add them to the filter list
     filter_list = copy(gene_list)
@@ -626,11 +632,15 @@ def filter_gene_list(stmts_in, gene_list, policy, allow_families=False,
     if remove_bound:
         # If requested, remove agents whose names are not in the list from
         # all bound conditions
-        keep_criterion = lambda a: a.name in filter_list
+        if not invert:
+            keep_criterion = lambda a: a.name in filter_list
+        else:
+            keep_criterion = lambda a: a.name not in filter_list
+
         for st in stmts_in:
             for agent in st.agent_list():
                 _remove_bound_conditions(agent, keep_criterion)
-    
+
     if policy == 'one':
         for st in stmts_in:
             found_gene = False
@@ -643,7 +653,7 @@ def filter_gene_list(stmts_in, gene_list, policy, allow_families=False,
                     if agent.name in filter_list:
                         found_gene = True
                         break
-            if found_gene:
+            if (found_gene and not invert) or (not found_gene and invert):
                 stmts_out.append(st)
     elif policy == 'all':
         for st in stmts_in:
@@ -657,17 +667,17 @@ def filter_gene_list(stmts_in, gene_list, policy, allow_families=False,
                     if agent.name not in filter_list:
                         found_genes = False
                         break
-            if found_genes:
+            if (found_genes and not invert) or (not found_genes and invert):
                 stmts_out.append(st)
     else:
         stmts_out = stmts_in
-
 
     logger.info('%d statements after filter...' % len(stmts_out))
     dump_pkl = kwargs.get('save')
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
+
 
 def filter_human_only(stmts_in, **kwargs):
     """Filter out statements that are grounded, but not to a human gene.

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -602,20 +602,16 @@ def filter_gene_list(stmts_in, gene_list, policy, allow_families=False,
     stmts_out : list[indra.statements.Statement]
         A list of filtered statements.
     """
-
-    if 'remove_bound' in kwargs and kwargs['remove_bound']:
-        remove_bound = True
-    else:
-        remove_bound = False
+    invert = kwargs.get('invert', False)
+    remove_bound = kwargs.get('remove_bound', False)
 
     if policy not in ('one', 'all'):
         logger.error('Policy %s is invalid, not applying filter.' % policy)
     else:
         genes_str = ', '.join(gene_list)
-        logger.info('Filtering %d statements for ones containing "%s" of: '
-                    '%s...' % (len(stmts_in), policy, genes_str))
-
-    invert = kwargs.get('invert', False)
+        inv_str = 'not ' if invert else ''
+        logger.info(('Filtering %d statements for ones %scontaining "%s" of: '
+                     '%s...') % (len(stmts_in), inv_str, policy, genes_str))
 
     # If we're allowing families, make a list of all FamPlex IDs that
     # contain members of the gene list, and add them to the filter list


### PR DESCRIPTION
This PR adds two functionalities to assembly:
- adds an optional `inver` flag to `filter_gene_name` to allow filtering out Statements which contain undesirable genes, e.g. ones that aren't expressed in a given context
- adds a `set_expression` method to the `PysbAssembler` which can set initial conditions for protein monomers given a dict of their counts per cell