### PR TITLE
Fix reach processor bug

### DIFF
--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -457,11 +457,12 @@ class ReachProcessor(object):
         return mods, muts
 
     def _get_mod_conditions(self, mod_term):
+        """Return a list of ModConditions given a mod term dict."""
         site = mod_term.get('site')
         if site is not None:
             mods = self._parse_site_text(site)
         else:
-            mods = [(None, None)]
+            mods = [Site(None, None)]
 
         mcs = []
         for mod in mods:

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -461,7 +461,7 @@ class ReachProcessor(object):
         if site is not None:
             mods = self._parse_site_text(site)
         else:
-            mods = []
+            mods = [(None, None)]
 
         mcs = []
         for mod in mods:
@@ -472,8 +472,9 @@ class ReachProcessor(object):
                 mc = ModCondition(mod_state[0], residue=mod_res,
                                   position=mod_pos, is_modified=mod_state[1])
                 mcs.append(mc)
-            logger.warning('Unhandled entity modification type: %s'
-                           % mod_type_str)
+            else:
+                logger.warning('Unhandled entity modification type: %s'
+                               % mod_type_str)
         return mcs
 
     def _get_context(self, frame_term):

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -362,6 +362,15 @@ class ReachProcessor(object):
 
         # This is the default name, which can be overwritten
         # below for specific database entries
+        agent_name, db_refs = self._get_db_refs(entity_term)
+
+        mod_terms = entity_term.get('modifications')
+        mods, muts = self._get_mods_and_muts_from_mod_terms(mod_terms)
+
+        agent = Agent(agent_name, db_refs=db_refs, mods=mods, mutations=muts)
+        return agent
+
+    def _get_db_refs(self, entity_term):
         agent_name = self._get_valid_name(entity_term['text'])
         db_refs = {}
         for xr in entity_term['xrefs']:
@@ -423,8 +432,9 @@ class ReachProcessor(object):
             else:
                 logger.warning('Unhandled xref namespace: %s' % ns)
         db_refs['TEXT'] = entity_term['text']
+        return agent_name, db_refs
 
-        mod_terms = entity_term.get('modifications')
+    def _get_mods_and_muts_from_mod_terms(self, mod_terms):
         mods = []
         muts = []
         if mod_terms is not None:
@@ -442,11 +452,9 @@ class ReachProcessor(object):
                     if mut is not None:
                         muts.append(mut)
                 else:
-                    mcs = self._get_mod_conditions(ms)
+                    mcs = self._get_mod_conditions(m)
                     mods.extend(mcs)
-
-        agent = Agent(agent_name, db_refs=db_refs, mods=mods, mutations=muts)
-        return agent
+        return mods, muts
 
     def _get_mod_conditions(self, mod_term):
         site = mod_term.get('site')

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -220,7 +220,6 @@ class ReachProcessor(object):
                     st = DecreaseAmount(*args)
                 self.statements.append(st)
 
-
     def get_complexes(self):
         """Extract INDRA Complex Statements."""
         qstr = "$.events.frames[@.type is 'complex-assembly']"
@@ -268,12 +267,12 @@ class ReachProcessor(object):
                             controllers = list(a.get('args').values())
                             controller_agent =\
                                 self._get_agent_from_entity(controllers[0])
-                            bound_agents = [self._get_agent_from_entity(c) 
+                            bound_agents = [self._get_agent_from_entity(c)
                                             for c in controllers[1:]]
                             bound_conditions = [BoundCondition(ba, True) for
                                                 ba in bound_agents]
                             controller_agent.bound_conditions = \
-                                    bound_conditions
+                                bound_conditions
                     else:
                         controller_agent =\
                             self._get_agent_from_entity(controller)
@@ -360,7 +359,8 @@ class ReachProcessor(object):
         except StopIteration:
             logger.debug(' %s is not an entity' % entity_id)
             return None
-        # This is the default name, which can be overwritten 
+
+        # This is the default name, which can be overwritten
         # below for specific database entries
         agent_name = self._get_valid_name(entity_term['text'])
         db_refs = {}
@@ -667,7 +667,7 @@ _site_pattern5 = '^([' + ''.join(list(amino_acids.keys())) + '])$'
 _site_pattern6 = '^(' + '|'.join([v['short_name'].upper() for
                                  v in amino_acids.values()]) + ')$'
 _site_pattern7 = '.*(' + '|'.join([v['indra_name'].upper() for
-                                 v in amino_acids.values()]) + ').*'
+                                   v in amino_acids.values()]) + ').*'
 _site_pattern8 = '([0-9]+)$'
 
 # Subtypes that exist but we don't handle: hydrolysis
@@ -694,6 +694,7 @@ agent_mod_map = {
     'unknown': ('modification', True),
 }
 
+
 def _read_famplex_map():
     fname = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                          '../../resources/famplex_map.tsv')
@@ -705,6 +706,7 @@ def _read_famplex_map():
         be_id = row[2]
         famplex_map[(source_ns, source_id)] = be_id
     return famplex_map
+
 
 famplex_map = _read_famplex_map()
 

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -309,3 +309,12 @@ def assert_pmid(stmt):
         assert(ev.pmid is not None)
         assert(not ev.pmid.startswith('api'))
         assert(not ev.pmid.startswith('PMID'))
+
+
+def test_process_mod_conditions():
+    rp = reach.process_text('The over-expression of CYP24A1 negatively '
+                            'regulates the vitamin D level, which is the '
+                            'causative agent of chronic kidney disease, '
+                            'osteoporosis, and several types of cancers.')
+    assert rp is not None
+    assert rp.statements

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -312,9 +312,7 @@ def assert_pmid(stmt):
 
 
 def test_process_mod_conditions():
-    rp = reach.process_text('The over-expression of CYP24A1 negatively '
-                            'regulates the vitamin D level, which is the '
-                            'causative agent of chronic kidney disease, '
-                            'osteoporosis, and several types of cancers.')
+    rp = reach.process_text('the expression of CYP24A1 negatively regulates '
+                            'vitamin D levels')
     assert rp is not None
     assert rp.statements

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -11,6 +11,7 @@ from indra.statements import IncreaseAmount, DecreaseAmount, Dephosphorylation
 # reading are enabled in tests
 offline_modes = [True]
 
+
 def test_parse_site_text():
     text = ['threonine 185', 'thr 185', 'thr-185',
             'threonine residue 185', 'T185']
@@ -141,6 +142,7 @@ def test_valid_name():
     assert(ReachProcessor._get_valid_name('PI3 Kinase') == 'PI3_Kinase')
     assert(ReachProcessor._get_valid_name('14-3-3') == 'p14_3_3')
 
+
 def test_phosphorylate():
     for offline in offline_modes:
         rp = reach.process_text('MEK1 phosphorylates ERK2.', offline=offline)
@@ -160,7 +162,7 @@ def test_indirect_phosphorylate():
         assert isinstance(s, Dephosphorylation)
         assert s.enz.name == 'DUSP'
         assert s.sub.name == 'ERK'
-        assert s.evidence[0].epistemics.get('direct') == False
+        assert s.evidence[0].epistemics.get('direct') is False
 
 
 def test_regulate_amount():
@@ -182,6 +184,7 @@ def test_regulate_amount():
         assert (s.obj.name == 'DUSP')
         assert unicode_strs(rp.statements)
 
+
 def test_multiple_enzymes():
     for offline in offline_modes:
         rp = reach.process_text('MEK1 and MEK2 phosphorylate ERK1.',
@@ -197,6 +200,7 @@ def test_multiple_enzymes():
         assert (s.sub.name == 'MAPK3')
         assert unicode_strs(rp.statements)
 
+
 def test_activate():
     for offline in offline_modes:
         rp = reach.process_text('HRAS activates BRAF.', offline=offline)
@@ -206,27 +210,31 @@ def test_activate():
         assert (s.obj.name == 'BRAF')
         assert unicode_strs(rp.statements)
 
+
 def test_bind():
     for offline in offline_modes:
         rp = reach.process_text('MEK1 binds ERK2.', offline=offline)
         assert(len(rp.statements) == 1)
         assert unicode_strs(rp.statements)
 
+
 def test_be_grounding():
     for offline in offline_modes:
         rp = reach.process_text('MEK activates ERK.', offline=offline)
         assert(len(rp.statements) == 1)
         assert unicode_strs(rp.statements)
-        if offline == True:
+        if offline is True:
             st = rp.statements[0]
             assert(st.subj.db_refs.get('FPLX') == 'MEK')
             assert(st.obj.db_refs.get('FPLX') == 'ERK')
+
 
 def test_activity():
     for offline in offline_modes:
         rp = reach.process_text('MEK1 activates ERK2.', offline=offline)
         assert(len(rp.statements) == 1)
         assert unicode_strs(rp.statements)
+
 
 def test_mutation():
     for offline in offline_modes:
@@ -264,6 +272,7 @@ def test_process_unicode():
         rp = reach.process_text('MEK1 binds ERK2\U0001F4A9.', offline=offline)
         assert unicode_strs(rp.statements)
 
+
 @attr('slow')
 def test_process_pmc():
     for offline in offline_modes:
@@ -272,10 +281,12 @@ def test_process_pmc():
             assert_pmid(stmt)
         assert unicode_strs(rp.statements)
 
+
 def test_process_unicode_abstract():
     for offline in offline_modes:
         rp = reach.process_pubmed_abstract('27749056', offline=offline)
         assert unicode_strs(rp.statements)
+
 
 def test_hgnc_from_up():
     for offline in offline_modes:
@@ -292,9 +303,9 @@ def test_hgnc_from_up():
         assert mapk1.db_refs['UP'] == 'P28482'
         assert unicode_strs(rp.statements)
 
+
 def assert_pmid(stmt):
     for ev in stmt.evidence:
         assert(ev.pmid is not None)
         assert(not ev.pmid.startswith('api'))
         assert(not ev.pmid.startswith('PMID'))
-

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -311,8 +311,23 @@ def assert_pmid(stmt):
         assert(not ev.pmid.startswith('PMID'))
 
 
-def test_process_mod_conditions():
-    rp = reach.process_text('the expression of CYP24A1 negatively regulates '
-                            'vitamin D levels')
-    assert rp is not None
-    assert rp.statements
+def test_process_mod_condition1():
+    for offline in offline_modes:
+        rp = reach.process_text('the expression of CYP24A1 negatively '
+                                'regulates vitamin D levels')
+        assert rp is not None
+        assert rp.statements
+        mcs = rp.statements[0].obj.mod_conditions
+
+
+def test_process_mod_condition2():
+    for offline in offline_modes:
+        rp = reach.process_text('MEK1 activates ERK1 that is phosphorylated.')
+        assert rp is not None
+        assert len(rp.statements) == 1
+        mcs = rp.statements[0].obj.mod_conditions
+        assert len(mcs) == 1
+        assert mcs[0].mod_type == 'phosphorylation'
+        assert mcs[0].residue is None
+        assert mcs[0].position is None
+        assert mcs[0].is_modified is True

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -312,22 +312,22 @@ def assert_pmid(stmt):
 
 
 def test_process_mod_condition1():
+    test_cases = [
+        ('MEK1 activates ERK1 that is phosphorylated.',
+         'phosphorylation', None, None, True),
+        ('MEK1 activates ERK1 that is phosphorylated on tyrosine.',
+         'phosphorylation', 'Y', None, True),
+        ('MEK1 activates ERK1 that is phosphorylated on Y185.',
+         'phosphorylation', 'Y', '185', True),
+        ]
     for offline in offline_modes:
-        rp = reach.process_text('the expression of CYP24A1 negatively '
-                                'regulates vitamin D levels')
-        assert rp is not None
-        assert rp.statements
-        mcs = rp.statements[0].obj.mod_conditions
-
-
-def test_process_mod_condition2():
-    for offline in offline_modes:
-        rp = reach.process_text('MEK1 activates ERK1 that is phosphorylated.')
-        assert rp is not None
-        assert len(rp.statements) == 1
-        mcs = rp.statements[0].obj.mod_conditions
-        assert len(mcs) == 1
-        assert mcs[0].mod_type == 'phosphorylation'
-        assert mcs[0].residue is None
-        assert mcs[0].position is None
-        assert mcs[0].is_modified is True
+        for sentence, mod_type, residue, position, is_modified in test_cases:
+            rp = reach.process_text(sentence)
+            assert rp is not None
+            assert len(rp.statements) == 1
+            mcs = rp.statements[0].obj.mods
+            assert len(mcs) == 1
+            assert mcs[0].mod_type == mod_type
+            assert mcs[0].residue == residue
+            assert mcs[0].position == position
+            assert mcs[0].is_modified == is_modified

--- a/indra/tools/reading/db_reading/read_db.py
+++ b/indra/tools/reading/db_reading/read_db.py
@@ -6,12 +6,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import logging
 import random
-import zlib
 import pickle
-import json
 from math import log10, floor, ceil
 from datetime import datetime
-from indra.tools.reading.util.script_tools import get_parser, make_statements, \
+from indra.tools.reading.util.script_tools import get_parser, make_statements,\
                                              StatementData
 
 logger = logging.getLogger('make_db_readings')
@@ -545,15 +543,7 @@ def get_db_readings(id_dict, readers, force_fulltext=False, batch_size=1000,
         )
     if previous_readings_query is not None:
         prev_readings = [
-            ReadingData(
-                r.text_content_id,
-                r.reader,
-                r.reader_version,
-                r.format,
-                json.loads(zlib.decompress(r.bytes, 16+zlib.MAX_WBITS)
-                           .decode('utf8')),
-                r.id
-                )
+            ReadingData.from_db_reading(r)
             for r in previous_readings_query.yield_per(batch_size)
             ]
     else:
@@ -681,7 +671,7 @@ def produce_readings(id_dict, reader_list, verbose=False,
         except Exception as e:
             logger.exception(e)
             if pickle_file is None:
-                pickle_file = ("failure_reading_dump_%s.pkl" 
+                pickle_file = ("failure_reading_dump_%s.pkl"
                                % datetime.now().strftime('%Y%m%d_%H%M%S'))
             logger.error("Cound not upload readings. Results are pickled in: "
                          + pickle_file)

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -575,6 +575,15 @@ class ReadingData(object):
         return
 
     @classmethod
+    def from_db_reading(cls, db_reading):
+        return cls(db_reading.text_content_id, db_reading.reader,
+                   db_reading.reader_version, db_reading.format,
+                   json.loads(zlib.decompress(db_reading.bytes,
+                                              16+zlib.MAX_WBITS)
+                              .decode('utf8')),
+                   db_reading.id)
+
+    @classmethod
     def get_cols(self):
         """Get the columns for the tuple returned by `make_tuple`."""
         return ('text_content_id', 'reader', 'reader_version', 'format',


### PR DESCRIPTION
First and foremost, this fixes a bug in the reach processor due to a misspelled variable (line 445 in the old and 455 in the new version of `indra/sources/reach/processor.py`). This PR also:
- adds a test for that failure
- refactors the surrounding code in the reach processor for smaller methods
- adds a constructor to more easily get a ReadingData instance from a database reading record (used to find example of the bug)
- Makes minor PEP-8 improvements.

Fixes #500
Fixes #502