### PR TITLE
Only check for elsevier API keys when necessary

### DIFF
--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -40,6 +40,8 @@ elsevier_ns = {'dc': 'http://purl.org/dc/elements/1.1/',
                'atom': 'http://www.w3.org/2005/Atom',
                'prism': 'http://prismstandard.org/namespaces/basic/2.0/'}
 ELSEVIER_KEYS = None
+API_KEY_ENV_NAME = 'ELSEVIER_API_KEY'
+INST_KEY_ENV_NAME = 'ELSEVIER_INST_KEY'
 
 
 def _ensure_api_keys(task_desc, failure_ret=None):
@@ -52,8 +54,6 @@ def _ensure_api_keys(task_desc, failure_ret=None):
     def check_func_wrapper(func):
         @wraps(func)
         def check_api_keys(*args, **kwargs):
-            api_key_env_name = 'ELSEVIER_API_KEY'
-            inst_key_env_name = 'ELSEVIER_INST_KEY'
             global ELSEVIER_KEYS
             if ELSEVIER_KEYS is None:
                 ELSEVIER_KEYS = {}
@@ -67,22 +67,22 @@ def _ensure_api_keys(task_desc, failure_ret=None):
 
                 # Try to read in Elsevier API keys. For each key, first check
                 # the environment variables, then check the INDRA config file.
-                if not has_config(inst_key_env_name):
+                if not has_config(INST_KEY_ENV_NAME):
                     logger.warning('Institution API key %s not found in config '
                                    'file or environment variable: this will '
                                    'limit access for %s'
-                                   % (inst_key_env_name, task_desc))
-                ELSEVIER_KEYS['X-ELS-Insttoken'] = get_config(inst_key_env_name)
+                                   % (INST_KEY_ENV_NAME, task_desc))
+                ELSEVIER_KEYS['X-ELS-Insttoken'] = get_config(INST_KEY_ENV_NAME)
 
-                if not has_config(api_key_env_name):
+                if not has_config(API_KEY_ENV_NAME):
                     logger.error('API key %s not found in configuration file '
                                  'or environment variable: cannot %s'
-                                 % (api_key_env_name, task_desc))
+                                 % (API_KEY_ENV_NAME, task_desc))
                     return failure_ret
-                ELSEVIER_KEYS['X-ELS-APIKey'] = get_config(api_key_env_name)
+                ELSEVIER_KEYS['X-ELS-APIKey'] = get_config(API_KEY_ENV_NAME)
             elif 'X-ELS-APIKey' not in ELSEVIER_KEYS.keys():
                 logger.error('No Elsevier API key %s found: cannot %s'
-                             % (api_key_env_name, task_desc))
+                             % (API_KEY_ENV_NAME, task_desc))
                 return failure_ret
             return func(*args, **kwargs)
         return check_api_keys

--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -93,9 +93,10 @@ def _ensure_api_keys(task_desc, failure_ret=None):
 def check_entitlement(doi):
     """Check whether IP and credentials enable access to content for a doi.
 
-    WARNING - DEPRECATED
+    This function uses the entitlement endpoint of the Elsevier API to check
+    whether an article is available to a given institution. Note that this
+    feature of the API is itself not available for all institution keys.
     """
-    # TODO: Make this doe what it says it does or remove it
     if doi.lower().startswith('doi:'):
         doi = doi[4:]
     url = '%s/%s' % (elsevier_entitlement_url, doi)
@@ -269,27 +270,6 @@ def get_dois(query_str, count=100):
     doi_tags = tree.findall('atom:entry/prism:doi', elsevier_ns)
     dois = [dt.text for dt in doi_tags]
     return dois
-
-
-def _get_pdf_attachment(full_text_elem):
-    attachments = full_text_elem.findall('xocs:doc/xocs:meta/'
-                                         'xocs:attachment-metadata-doc/'
-                                         'xocs:attachments', elsevier_ns)
-    for att_elem in attachments:
-        web_pdf = att_elem.find('xocs:web-pdf', elsevier_ns)
-        if web_pdf is None:
-            continue
-        # Check for a MAIN pdf
-        pdf_purpose = web_pdf.find('xocs:web-pdf-purpose', elsevier_ns)
-        if not pdf_purpose.text == 'MAIN':
-            continue
-        else:
-            return 'pdf'
-        #locations = web_pdf.findall('xocs:ucs-locator', elsevier_ns)
-        #for loc in locations:
-        #    logger.info("PDF location: %s" % loc.text)
-    #logger.info('Could not find PDF attachment.')
-    return None
 
 
 def _get_article_body(full_text_elem):

--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -147,10 +147,14 @@ def download_article(id_val, id_type='doi', on_retry=False):
             logger.error("Still breaking speed limit after waiting.")
             logger.error("Elsevier response: %s" % res.text)
             return None
-    elif not res.status_code == 200:
+    elif res.status_code != 200:
         logger.error('Could not download article %s: status code %d' %
                      (url, res.status_code))
         logger.error('Elsevier response: %s' % res.text)
+        return None
+    elif res.content.decode('utf-8').startswith('<service-error>'):
+        logger.error('Got a service error with 200 status: %s'
+                     % res.content.decode('utf-8'))
         return None
     # Return the XML content as a unicode string, assuming UTF-8 encoding
     return res.content.decode('utf-8')

--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -57,14 +57,6 @@ def _ensure_api_keys(task_desc, failure_ret=None):
             global ELSEVIER_KEYS
             if ELSEVIER_KEYS is None:
                 ELSEVIER_KEYS = {}
-                # THE API KEY IS NOT UNDER VERSION CONTROL FOR SECURITY
-                # For more information see http://dev.elsevier.com/
-
-                # Using this file is deprecated.
-                # global API_KEY_FILE
-                # path_to_here = os.path.dirname(os.path.realpath(__file__))
-                # API_KEY_FILE = os.path.join(path_to_here, 'elsevier_api_keys')
-
                 # Try to read in Elsevier API keys. For each key, first check
                 # the environment variables, then check the INDRA config file.
                 if not has_config(INST_KEY_ENV_NAME):

--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -42,41 +42,46 @@ elsevier_ns = {'dc': 'http://purl.org/dc/elements/1.1/',
 ELSEVIER_KEYS = None
 
 
-def ensure_api_keys(func):
-    @wraps(func)
-    def check_api_keys(*args, **kwargs):
-        global ELSEVIER_KEYS
-        if ELSEVIER_KEYS is None:
-            ELSEVIER_KEYS = {}
-            # THE API KEY IS NOT UNDER VERSION CONTROL FOR SECURITY
-            # For more information see http://dev.elsevier.com/
-            global API_KEY_FILE
-            API_KEY_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                        'elsevier_api_keys')
-            api_key_env_name = 'ELSEVIER_API_KEY'
-            inst_key_env_name = 'ELSEVIER_INST_KEY'
+def ensure_api_keys(failure_msg, failure_ret=None):
+    def check_func_wrapper(func):
+        @wraps(func)
+        def check_api_keys(*args, **kwargs):
+            global ELSEVIER_KEYS
+            if ELSEVIER_KEYS is None:
+                ELSEVIER_KEYS = {}
+                # THE API KEY IS NOT UNDER VERSION CONTROL FOR SECURITY
+                # For more information see http://dev.elsevier.com/
 
-            # Try to read in Elsevier API keys. For each key, first check the
-            # environment variables, then check the INDRA configuration file.
-            if not has_config(inst_key_env_name):
-                logger.error('API key %s not found in configuration file or '
-                             'environment variable.' % inst_key_env_name)
-            ELSEVIER_KEYS['X-ELS-Insttoken'] = get_config(inst_key_env_name)
+                # Using this file is deprecated.
+                # global API_KEY_FILE
+                # path_to_here = os.path.dirname(os.path.realpath(__file__))
+                # API_KEY_FILE = os.path.join(path_to_here, 'elsevier_api_keys')
 
-            if not has_config(api_key_env_name):
-                logger.error('API key %s not found in configuration file or '
-                             'environment variable.' % api_key_env_name)
-            if has_config(api_key_env_name):
+                api_key_env_name = 'ELSEVIER_API_KEY'
+                inst_key_env_name = 'ELSEVIER_INST_KEY'
+
+                # Try to read in Elsevier API keys. For each key, first check
+                # the environment variables, then check the INDRA config file.
+                if not has_config(inst_key_env_name):
+                    logger.error('API key %s not found in configuration file '
+                                 'or environment variable: %s'
+                                 % (inst_key_env_name, failure_msg))
+                    return failure_ret
+                ELSEVIER_KEYS['X-ELS-Insttoken'] = get_config(inst_key_env_name)
+
+                if not has_config(api_key_env_name):
+                    logger.error('API key %s not found in configuration file '
+                                 'or environment variable: %s'
+                                 % (api_key_env_name, failure_msg))
+                    return failure_ret
                 ELSEVIER_KEYS['X-ELS-APIKey'] = get_config(api_key_env_name)
-        return func(*args, **kwargs)
-    return check_api_keys
+            return func(*args, **kwargs)
+        return check_api_keys
+    return check_func_wrapper
 
 
-@ensure_api_keys
+@ensure_api_keys('could not check article entitlement', False)
 def check_entitlement(doi):
-    if ELSEVIER_KEYS is None:
-        logger.error('Missing API key, could not check article entitlement.')
-        return False
     if doi.lower().startswith('doi:'):
         doi = doi[4:]
     url = '%s/%s' % (elsevier_entitlement_url, doi)
@@ -89,12 +94,9 @@ def check_entitlement(doi):
         return False
 
 
-@ensure_api_keys
+@ensure_api_keys('could not download article')
 def download_article(id_val, id_type='doi', on_retry=False):
     """Low level function to get an XML article for a particular id."""
-    if ELSEVIER_KEYS is None:
-        logger.error('Missing API key, could not download article.')
-        return None
     if id_type == 'pmid':
         id_type = 'pubmed_id'
     url = '%s/%s' % (elsevier_article_url_fmt % id_type, id_val)
@@ -277,7 +279,7 @@ def _get_raw_text(full_text_elem):
 
 
 @lru_cache(maxsize=100)
-@ensure_api_keys
+@ensure_api_keys('could not perform search')
 def get_dois(query_str, count=100):
     """Search ScienceDirect through the API for articles.
 
@@ -286,10 +288,6 @@ def get_dois(query_str, count=100):
     cancer")'
     """
     url = '%s/%s' % (elsevier_search_url, query_str)
-    if ELSEVIER_KEYS is None:
-        logger.error('Missing API key at %s, could not perform search.' %
-                      API_KEY_FILE)
-        return None
     params = {'query': query_str,
               'count': count,
               'httpAccept': 'application/xml',

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -296,10 +296,10 @@ def get_environment():
 
     # Get the Elsevier keys from the Elsevier client
     environment_vars = [
-        {'name': ec.api_key_env_name,
-         'value': ec.elsevier_keys.get('X-ELS-APIKey', '')},
-        {'name': ec.inst_key_env_name,
-         'value': ec.elsevier_keys.get('X-ELS-Insttoken', '')},
+        {'name': ec.API_KEY_ENV_NAME,
+         'value': ec.ELSEVIER_KEYS.get('X-ELS-APIKey', '')},
+        {'name': ec.INST_KEY_ENV_NAME,
+         'value': ec.ELSEVIER_KEYS.get('X-ELS-Insttoken', '')},
         {'name': 'AWS_ACCESS_KEY_ID',
          'value': access_key},
         {'name': 'AWS_SECRET_ACCESS_KEY',


### PR DESCRIPTION
This PR should prevent unnecessary warning regarding missing elsevier api keys.