### PR TITLE
Cleanse reach input

### DIFF
--- a/indra/db/reading_manager.py
+++ b/indra/db/reading_manager.py
@@ -82,7 +82,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
 from indra.tools.reading.db_reading import read_db as rdb
-from indra.tools.reading.readers import get_reader
+from indra.tools.reading.readers import get_reader_class
 
 logger = logging.getLogger('reading_manager')
 THIS_DIR = path.dirname(path.abspath(__file__))
@@ -94,7 +94,7 @@ class ReadingUpdateError(Exception):
 
 class ReadingManager(object):
     def __init__(self, reader_name, buffer_days=1, project_name=None):
-        self.reader = get_reader(reader_name)
+        self.reader = get_reader_class(reader_name)
         if self.reader is None:
             raise ReadingUpdateError('Name of reader was not matched to an '
                                      'available reader.')

--- a/indra/resources/default_config.ini
+++ b/indra/resources/default_config.ini
@@ -33,4 +33,3 @@ INDRA_DB_REST_API_KEY =
 
 # Default project name for aws resources
 DEFAULT_AWS_PROJECT =
-

--- a/indra/tools/reading/db_reading/read_db.py
+++ b/indra/tools/reading/db_reading/read_db.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
         )
     parser.add_argumet(
         '--max_reach_space_ratio',
-        type=int,
+        type=float,
         help='Set the maximum ratio of spaces to non-spaces for REACH input.',
         default=None
     )

--- a/indra/tools/reading/db_reading/read_db.py
+++ b/indra/tools/reading/db_reading/read_db.py
@@ -795,7 +795,7 @@ if __name__ == "__main__":
             for key_name, reach_arg in special_reach_args_dict.items():
                 if reach_arg is not None:
                     kwargs[key_name] = reach_arg
-        readers.append(get_reader(reader_name)(**kwargs))
+        readers.append(get_reader(reader_name, **kwargs))
 
     # Set the verbosity. The quiet argument overrides the verbose argument.
     verbose = args.verbose and not args.quiet

--- a/indra/tools/reading/db_reading/read_db.py
+++ b/indra/tools/reading/db_reading/read_db.py
@@ -799,7 +799,7 @@ if __name__ == "__main__":
                                    force_fulltext=args.force_fulltext,
                                    no_upload=args.no_reading_upload,
                                    pickle_file=reading_pickle,
-                                   prioritize=args.prioritize)
+                                   prioritize=args.use_best_fulltext)
 
         # Convert the outputs to statements ==================================
         produce_statements(outputs, no_upload=args.no_statement_upload,

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -192,15 +192,28 @@ class ReachReader(Reader):
         _, version = cls._check_reach_env()
         return version
 
-    def write_content(self, text_content):
+    def _check_content(self, content_str):
+        """Check if the content is likely to be successfully read."""
+        space_ratio = content_str.count(' ')/len(content_str)
+        max_space_ratio = float(get_config('REACH_MAX_SPACE_RATIO'))
+        if space_ratio > max_space_ratio:
+            return "space-ratio: %f > %f" % (space_ratio, max_space_ratio)
+        max_len = float(get_config('REACH_CHARACTER_LIMIT'))
+        if len(content_str) > max_len:
+            return "too long: %d > %d" % (len(content_str), max_len)
+        return None
+
+    def _write_content(self, text_content):
         def write_content_file(ext):
             fname = '%s.%s' % (text_content.id, ext)
+            cont_str = zlib.decompress(text_content.content, 16+zlib.MAX_WBITS)
+
+            quality_issue = self._check_content(cont_str)
+            if quality_issue is not None:
+                logger.warning("Skipping %d due to: %s"
+                                % (text_content.id, quality_issue))
             with open(path.join(self.input_dir, fname), 'wb') as f:
-                f.write(
-                    zlib.decompress(
-                        text_content.content, 16+zlib.MAX_WBITS
-                        )
-                    )
+                f.write(cont_str)
             logger.debug('%s saved for reading by reach.' % fname)
         if text_content.format == formats.XML:
             write_content_file('nxml')
@@ -208,19 +221,27 @@ class ReachReader(Reader):
             write_content_file('txt')
         else:
             raise ReachError("Unrecognized format %s." % text_content.format)
+        return
+
+    def _move_content(self, text_content):
+        fname = text_content.strip()
+        with open(fname) as f:
+            quality_issue = self._check_content(f.read())
+        if quality_issue is not None:
+            logger.warning("Skipping %s due to: %s"
+                           % (fname, quality_issue))
+        new_fname = path.join(self.input_dir, path.basename(fname))
+        shutil.copy(fname, new_fname)
+        return
 
     def prep_input(self, read_list):
         """Apply the readers to the content."""
         logger.info("Prepping input.")
         for text_content in read_list:
             if isinstance(text_content, str):
-                fname = text_content.strip()
-                shutil.copy(
-                    fname,
-                    path.join(self.input_dir, path.basename(fname))
-                    )
+                self._move_content(text_content)
             else:
-                self.write_content(text_content)
+                self._write_content(text_content)
         return
 
     def get_output(self):

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -204,7 +204,7 @@ class ReachReader(Reader):
     def _check_content(self, content_str):
         """Check if the content is likely to be successfully read."""
         if self.do_content_check:
-            space_ratio = content_str.count(' ')/len(content_str)
+            space_ratio = float(content_str.count(' '))/len(content_str)
             if space_ratio > self.max_space_ratio:
                 return "space-ratio: %f > %f" % (space_ratio,
                                                  self.max_space_ratio)

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -561,14 +561,19 @@ def get_readers():
     return children
 
 
-def get_reader(reader_name):
-    """Get a particular reader by name."""
+def get_reader_class(reader_name):
+    """Get a particular reader class by name."""
     for reader_class in get_readers():
         if reader_class.name.lower() == reader_name.lower():
             return reader_class
     else:
         logger.error("No such reader: %s" % reader_name)
         return None
+
+
+def get_reader(reader_name, *args, **kwargs):
+    """Get an instantiated reader by name."""
+    return get_reader_class(reader_name)(*args, **kwargs)
 
 
 class ReadingData(object):

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -563,7 +563,7 @@ if __name__ == '__main__':
         )
     parent_db_parser.add_argumet(
         '--max_reach_space_ratio',
-        type=int,
+        type=float,
         help='Set the maximum ratio of spaces to non-spaces for REACH input.',
         default=None
     )


### PR DESCRIPTION
This PR implements a couple of optional (but performed by default) checks on the content being read by REACH in the hopes of reducing the number of hang-ups. Specifically, the following types of content will be automatically skipped:
- Content that is long (> 5e5 by default). It is unclear whether such long content creates genuine stalls or is simply timed out before it can be read. In addition, from examining a few example cases, over-long text can often be a symptom of other anomalies.
- content that is more than 50% spaces. This targets a particular bug in some of the Elsevier content in which spaces are inserted between every character, but would also be an indicator of something odd in itself.

*Note that this PR adds two new config settings to the config file*