### PR TITLE
Implement simple client for INDRA's Database REST API

### DIFF
--- a/indra/config.py
+++ b/indra/config.py
@@ -82,7 +82,7 @@ class IndraConfigError(Exception):
 def get_config(key, failure_ok=True):
     """Get value by key from config file or environment.
 
-    Returns the configuration value, first checking the environemnt
+    Returns the configuration value, first checking the environment
     variables and then, if it's not present there, checking the configuration
     file.
 
@@ -96,7 +96,7 @@ def get_config(key, failure_ok=True):
     value: str
         The configuration value
     """
-    err_msg = "Key %s not in environemtn or config file." % key
+    err_msg = "Key %s not in environment or config file." % key
     if key in os.environ:
         return os.environ[key]
     elif key in CONFIG_DICT:

--- a/indra/config.py
+++ b/indra/config.py
@@ -74,8 +74,15 @@ if CONFIG_DICT is None:
 else:
     _check_config_dict()
 
-def get_config(key):
-    """Returns the configuration value, first checking the environemnt
+
+class IndraConfigError(Exception):
+    pass
+
+
+def get_config(key, failure_ok=True):
+    """Get value by key from config file or environment.
+
+    Returns the configuration value, first checking the environemnt
     variables and then, if it's not present there, checking the configuration
     file.
 
@@ -89,13 +96,15 @@ def get_config(key):
     value: str
         The configuration value
     """
+    err_msg = "Key %s not in environemtn or config file." % key
     if key in os.environ:
         return os.environ[key]
     elif key in CONFIG_DICT:
         return CONFIG_DICT[key]
+    elif not failure_ok:
+        raise IndraConfigError(err_msg)
     else:
-        logger.warning('Could not find ' + str(key) +
-                       ' in environment variables or configuration file')
+        logger.warning(err_msg)
         return None
 
 

--- a/indra/resources/default_config.ini
+++ b/indra/resources/default_config.ini
@@ -25,7 +25,11 @@ BIOGRID_API_KEY =
 
 # Credentials for ndexbio.org
 NDEX_USERNAME = 
-NDEX_PASSWORD = 
+NDEX_PASSWORD =
+
+# Url and API Key for access to INDRA's Database Rest API
+INDRA_DB_REST_URL =
+INDRADB_REST_API_KEY =
 
 # Default project name for aws resources
 DEFAULT_AWS_PROJECT =

--- a/indra/resources/default_config.ini
+++ b/indra/resources/default_config.ini
@@ -29,7 +29,7 @@ NDEX_PASSWORD =
 
 # Url and API Key for access to INDRA's Database Rest API
 INDRA_DB_REST_URL =
-INDRADB_REST_API_KEY =
+INDRA_DB_REST_API_KEY =
 
 # Default project name for aws resources
 DEFAULT_AWS_PROJECT =

--- a/indra/sources/indra_db_rest/__init__.py
+++ b/indra/sources/indra_db_rest/__init__.py
@@ -1,0 +1,1 @@
+from .client_api import *

--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -1,0 +1,26 @@
+import requests
+
+from indra import get_config
+from indra.statements import stmts_from_json
+
+
+def get_statements(subject=None, object=None, agents=None, stmt_type=None):
+    agent_strs = ['agent=%s' % agent_str for agent_str in agents]
+    params = {}
+    for param_key, param_val in [('subject', subject), ('object', object),
+                                 ('type', stmt_type)]:
+        if param_val is not None:
+            params[param_key] = param_val
+    resp = submit_request(*agent_strs, **params)
+    stmts_json = resp.json()
+    return stmts_from_json(stmts_json)
+
+
+def submit_request(*args, **kwargs):
+    query_str = '?' + '&'.join(['%s=%s' % (k, v) for k, v in kwargs.items()]
+                               + list(args))
+    url = get_config('INDRA_DB_REST_URL', failure_ok=False)
+    api_key = get_config('INDRADB_REST_API_KEY', failure_ok=False)
+    resp = requests.get(url + '/statements/' + query_str,
+                        headers={'x-api-key': api_key})
+    return resp

--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -22,7 +22,7 @@ def get_statements(subject=None, object=None, agents=None, stmt_type=None):
     direct access to the entire database.
 
     Such access will require you have both a URL (`INDRA_DB_REST_URL`) and
-    possibly an API key (`INDRADB_REST_API_KEY`), both of which may be placed in
+    possibly an API key (`INDRA_DB_REST_API_KEY`), both of which may be placed in
     your config file or as environment variables.
 
     If you do not have these, but would like to access the database rest api,
@@ -74,7 +74,7 @@ def _submit_request(*args, **kwargs):
     query_str = '?' + '&'.join(['%s=%s' % (k, v) for k, v in kwargs.items()]
                                + list(args))
     url = get_config('INDRA_DB_REST_URL', failure_ok=False)
-    api_key = get_config('INDRADB_REST_API_KEY', failure_ok=False)
+    api_key = get_config('INDRA_DB_REST_API_KEY', failure_ok=False)
     resp = requests.get(url + '/statements/' + query_str,
                         headers={'x-api-key': api_key})
     if resp.status_code == 200:

--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import, print_function, unicode_literals
+from builtins import dict, str
+
+__all__ = ['get_statements']
+
 import requests
 
 from indra import get_config

--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -10,18 +10,57 @@ from indra.statements import stmts_from_json
 
 
 def get_statements(subject=None, object=None, agents=None, stmt_type=None):
+    """Get statements from INDRA's database using the web api.
+
+    This tool is intended for those that wish to use the cumulative database
+    of pre-assembled INDRA Statements compiled from all our input databases and
+    from reading all of the available medical literature, but who do not have
+    direct access to the entire database.
+
+    Such access will require you have both a URL (`INDRA_DB_REST_URL`) and
+    possibly an API key (`INDRADB_REST_API_KEY`), both of which may be placed in
+    your config file or as environment variables.
+
+    If you do not have these, but would like to access the database rest api,
+    you may contact the developers to request a URL and key.
+
+    Parameters
+    ----------
+    subject, object : str
+        Optionally specify the subject and/or object of the statements in
+        you wish to get from the database. By default, the namespace is assumed
+        to be HGNC gene names, however you may specify another namespace by
+        including `@<namespace>` at the end of the name string. For example, if
+        you want to specify an agent by chebi, you could use `CHEBI:6801@CHEBI`,
+        or if you wanted to use the HGNC id, you could use `6871@HGNC`.
+    agents : list[str]
+        A list of agents, specified in the same manner as subject and object,
+        but without specifying their grammatical position.
+    stmt_type : str
+        Specify the types of interactions you are interested in, as indicated
+        by the sub-classes of INDRA's Statements. This argument is *not* case
+        sensitive.
+
+    Returns
+    -------
+    stmts : list[:pyclass:`indra.statements.Statement`]
+        A list of INDRA Statement instances. Note that if a supporting or
+        supported Statement was not included in your query, it will simply be
+        instantiated as an `Unresolved` statement, with `uuid` of the statement.
+    """
     agent_strs = ['agent=%s' % agent_str for agent_str in agents]
     params = {}
     for param_key, param_val in [('subject', subject), ('object', object),
                                  ('type', stmt_type)]:
         if param_val is not None:
             params[param_key] = param_val
-    resp = submit_request(*agent_strs, **params)
+    resp = _submit_request(*agent_strs, **params)
     stmts_json = resp.json()
     return stmts_from_json(stmts_json)
 
 
-def submit_request(*args, **kwargs):
+def _submit_request(*args, **kwargs):
+    """Low level function to make the request to the rest API."""
     query_str = '?' + '&'.join(['%s=%s' % (k, v) for k, v in kwargs.items()]
                                + list(args))
     url = get_config('INDRA_DB_REST_URL', failure_ok=False)

--- a/indra/tests/test_indra_db_rest.py
+++ b/indra/tests/test_indra_db_rest.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import, print_function, unicode_literals
+from builtins import dict, str
+
+from datetime import datetime
+
+from nose.plugins.attrib import attr
+from indra.sources import indra_db_rest as dbr
+
+
+def __check_request(seconds, *args, **kwargs):
+    now = datetime.now()
+    stmts = dbr.get_statements(*args, **kwargs)
+    assert stmts, "Got no statements."
+    time_taken = datetime.now() - now
+    assert time_taken.seconds < seconds
+
+
+@attr('nonpublic')
+def test_simple_request():
+    __check_request(5, 'MAP2K1', 'MAPK1', stmt_type='Phosphorylation')
+
+
+@attr('nonpublic')
+def test_null_request():
+    try:
+        dbr.get_statements()
+    except dbr.IndraDBRestError:
+        return
+    except BaseException as e:
+        assert False, "Raised wrong exception: " + str(e)
+    assert False, "Null request did not raise any exception."
+
+
+@attr('nonpublic')
+def test_large_request():
+    __check_request(20, agents=['AKT1'])
+
+
+@attr('nonpublic')
+def test_bigger_request():
+    __check_request(30, agents=['MAPK1'])
+
+
+@attr('nonpublic')
+def test_too_big_request():
+    try:
+        __check_request(30, agents=['TP53'])
+    except dbr.IndraDBRestError as e:
+        if '502: Bad Gateway' in str(e):
+            pass  # This is the error that indicates the too much data.
+        else:
+            assert False, 'Unexpected error occured: %s' % str(e)
+    except BaseException as e:
+        assert False, 'A very unexpected error occured: %s' % str(e)


### PR DESCRIPTION
This PR adds a simple wrapper around the REST API for the database. A small change is also made to the `config.py` tool, which allows for an exception to be raise internally if a key is not resolved, depending on an keyword argument. The default behavior remains unchanged, so there should be no issue with backwards compatibility. Two new keys were also added to the config file.