### PR TITLE
Add CLI option to RAS Machine for setting number of days

### DIFF
--- a/indra/tools/machine/cli.py
+++ b/indra/tools/machine/cli.py
@@ -46,10 +46,11 @@ def make(directory):
 @click.argument('model_path')
 @click.option('--config', help='Specify configuration file path, otherwise '
                                'looks for config.yaml in model path')
-def run_with_search(model_path, config):
+@click.option('-d', '--num-days', type=int)
+def run_with_search(model_path, config, num_days):
     """Run with PubMed search for new papers."""
     from indra.tools.machine.machine import run_with_search_helper
-    run_with_search_helper(model_path, config)
+    run_with_search_helper(model_path, config, num_days=num_days)
 
 
 @main.command()

--- a/indra/tools/machine/machine.py
+++ b/indra/tools/machine/machine.py
@@ -518,7 +518,7 @@ def run_machine(model_path, pmids, belief_threshold, search_genes=None,
             twitter_client.update_status(msg_str, twitter_cred)
 
 
-def run_with_search_helper(model_path, config):
+def run_with_search_helper(model_path, config, num_days=None):
     logger.info('-------------------------')
     logger.info(time.strftime('%c'))
 
@@ -588,8 +588,11 @@ def run_with_search_helper(model_path, config):
         if search_genes is not None:
             search_terms += search_genes
         logger.info('Using search terms: %s' % ', '.join(search_terms))
-        num_days = int(config.get('search_terms_num_days', 5))
+
+        if num_days is None:
+            num_days = int(config.get('search_terms_num_days', 5))
         logger.info('Searching the last %d days', num_days)
+
         pmids_term = get_searchterm_pmids(search_terms, num_days=num_days)
         num_pmids = len(set(itt.chain.from_iterable(pmids_term.values())))
         logger.info('Collected %d PMIDs from PubMed search_terms.', num_pmids)


### PR DESCRIPTION
Sometimes, you just want to make that number bigger to get some more literature from even further back. 

This PR adds an option to the command line interface that lets the user override this number (even if it's explicitly set in the config.yaml, not to be confused with global configuration) when using the command line interface.

Example:

```sh
$ indra-machine run_with_search -d 40 /path/to/my/machine
``` 