### PR TITLE
TEES refactored for batch processing

### DIFF
--- a/indra/resources/default_config.ini
+++ b/indra/resources/default_config.ini
@@ -15,6 +15,9 @@ SPARSERPATH =
 # Path to the DRUM reading system folder
 DRUMPATH = 
 
+# Path to TEES
+TEES_PATH =
+
 # The default memory limit for the Java/Scala interface
 # (BioPAX, REACH, EIDOS)
 INDRA_DEFAULT_JAVA_MEM_LIMIT = 8g

--- a/indra/sources/tees/__init__.py
+++ b/indra/sources/tees/__init__.py
@@ -1,0 +1,1 @@
+from .api import *

--- a/indra/sources/tees/api.py
+++ b/indra/sources/tees/api.py
@@ -30,6 +30,8 @@ import re
 from indra.sources.tees.parse_tees import tees_parse_networkx_to_dot
 import networkx.algorithms.dag as dag
 
+__all__ = ['run_on_text', 'process_text', 'extract_output']
+
 logger = logging.getLogger('tees')
 
 # If TEES isn't specified, we will check to see if any of these directories
@@ -224,7 +226,7 @@ def extract_output(output_dir):
 
     # Locate the file of sentences segmented by the TEES system, described
     # in a compressed xml document
-    sentences_glob = os.path.join(output_dir, '*-sentences.xml.gz')
+    sentences_glob = os.path.join(output_dir, '*-preprocessed.xml.gz')
     sentences_filename_candidates = glob.glob(sentences_glob)
 
     # Make sure there is exactly one such file

--- a/indra/sources/tees/api.py
+++ b/indra/sources/tees/api.py
@@ -83,17 +83,20 @@ def process_text(text, pmid=None, python2_path=None):
                         'Need python2 to run TEES.')
 
     # Run TEES
-    a1_text, a2_text, sentence_segmentations = run_tees_on_text(text,
+    a1_text, a2_text, sentence_segmentations = run_on_text(text,
                                                                 python2_path)
 
     # Run the TEES processor
     tp = TEESProcessor(a1_text, a2_text, sentence_segmentations, pmid)
     return tp
 
-def run_tees_on_text(text, python2_path):
+def run_on_text(text, python2_path):
     """Runs TEES on the given text in a temporary directory and returns a
-    temporary directory with TEES output. The caller should delete this
-    directory when done with it.
+    temporary directory with TEES output.
+    
+    The caller should delete this directory when done with it. This function
+    runs TEES and produces TEES output files but does not process TEES output
+    into INDRA statements.
 
     Parameters
     ----------
@@ -196,11 +199,11 @@ def run_tees_on_text(text, python2_path):
         shutil.rmtree(tmp_dir)
         raise e
     # Return the temporary directory with the TEES output
-    output_tuple = extract_relevant_tees_output(tmp_dir)
+    output_tuple = extract_output(tmp_dir)
     shutil.rmtree(tmp_dir)
     return output_tuple
 
-def extract_relevant_tees_output(output_dir):
+def extract_output(output_dir):
     """Extract the text of the a1, a2, and sentence segmentation files from the
     TEES output directory. These files are located within a compressed archive.
 
@@ -284,11 +287,13 @@ def extract_relevant_tees_output(output_dir):
         tar_file.extractall(path=tmp_dir, members=extract_these)
 
         # Read the text of the a1 (entities) file
-        with open(os.path.join(tmp_dir, a1_file), 'r') as f:
+        with codecs.open(os.path.join(tmp_dir, a1_file), 'r',
+                         encoding='utf-8') as f:
             a1_text = f.read()
 
         # Read the text of the a2 (events) file
-        with open(os.path.join(tmp_dir, a2_file), 'r') as f:
+        with codecs.open(os.path.join(tmp_dir, a2_file), 'r',
+                         encoding='utf-8') as f:
             a2_text = f.read()
 
         # Now that we're done, remove the temporary directory

--- a/indra/sources/tees/api.py
+++ b/indra/sources/tees/api.py
@@ -50,12 +50,12 @@ def process_text(text, pmid=None, python2_path=None):
 
     Parameters
     ----------
-    text: str
+    text : str
         Plain text to process with TEES
-    pmid: str
+    pmid : str
         The PMID from which the paper comes from, to be stored in the Evidence
         object of statements. Set to None if this is unspecified.
-    python2_path: str
+    python2_path : str
         TEES is only compatible with python 2. This processor invokes this
         external python 2 interpreter so that the processor can be run in
         either python 2 or python 3. If None, searches for an executible named
@@ -63,7 +63,7 @@ def process_text(text, pmid=None, python2_path=None):
 
     Returns
     -------
-    tp: TEESProcessor
+    tp : TEESProcessor
         A TEESProcessor object which contains a list of INDRA statements
         extracted from TEES extractions
     """
@@ -132,16 +132,16 @@ def run_tees_on_text(text, tees_path, python2_path):
 
     Parameters
     ----------
-    text: str
+    text : str
         Text from which to extract relationships
-    tees_path: str
+    tees_path : str
         Path to the TEES directory
-    python2_path: str
+    python2_path : str
         The path to the python 2 interpreter
 
     Returns
     -------
-    output_dir: str
+    output_dir : str
         Temporary directory with TEES output. The caller should delete this
         directgory when done with it.
     """
@@ -213,16 +213,16 @@ def extract_relevant_tees_output(output_dir):
 
     Parameters
     ----------
-    output_dir: str
+    output_dir : str
         Directory containing the output of the TEES system
 
     Returns
     -------
-    a1_text: str
+    a1_text : str
         The text of the TEES a1 file (specifying the entities)
-    a2_text: str
+    a2_text : str
         The text of the TEES a2 file (specifying the event graph)
-    sentence_segmentations: str
+    sentence_segmentations : str
         The text of the XML file specifying the sentence segmentation
     """
 

--- a/indra/sources/tees/api.py
+++ b/indra/sources/tees/api.py
@@ -18,6 +18,13 @@ from indra.sources.tees.processor import TEESProcessor
 import os.path
 import logging
 import codecs
+import tempfile
+import shutil
+import subprocess
+import glob
+import gzip
+import tarfile
+import re
 
 from indra.sources.tees.parse_tees import tees_parse_networkx_to_dot
 import networkx.algorithms.dag as dag
@@ -104,6 +111,197 @@ def process_text(text, pmid=None, tees_path=None, python2_path=None):
                         'listed in the PATH environment variable. ' +
                         'Need python2 to run TEES.')
 
+    # Run TEES
+    a1_text, a2_text, sentence_segmentations = run_tees_on_text(text,
+                                                                tees_path,
+                                                                python2_path)
+
     # Run the TEES processor
-    tp = TEESProcessor(text, pmid, tees_path, python2_path)
+    tp = TEESProcessor(a1_text, a2_text, sentence_segmentations, pmid)
     return tp
+
+def run_tees_on_text(text, tees_path, python2_path):
+    """Runs TEES on the given text in a temporary directory and returns a
+    temporary directory with TEES output. The caller should delete this
+    directory when done with it.
+
+    Parameters
+    ----------
+    text: str
+        Text from which to extract relationships
+    tees_path: str
+        Path to the TEES directory
+    python2_path: str
+        The path to the python 2 interpreter
+
+    Returns
+    -------
+    output_dir: str
+        Temporary directory with TEES output. The caller should delete this
+        directgory when done with it.
+    """
+    # Make sure the provided TEES directory exists
+    if not os.path.isdir(tees_path):
+        raise Exception('Provided TEES directory does not exist.')
+
+    # Make sure the classify.py script exists within this directory
+    classify_path = 'classify.py'
+    # if not os.path.isfile(classify_path):
+    #    raise Exception('classify.py does not exist in provided TEES path.')
+
+    # Create a temporary directory to tag the shared-task files
+    tmp_dir = tempfile.mkdtemp(suffix='indra_tees_processor')
+
+    pwd = os.path.abspath(os.getcwd())
+
+    try:
+        # Write text to a file in the temporary directory
+        text_path = os.path.join(tmp_dir, 'text.txt')
+        # Had some trouble with non-ascii characters. A possible TODO item in
+        # the future is to look into resolving this, for now just ignoring
+        # non-latin-1 characters
+        with codecs.open(text_path, 'w', encoding='latin-1', errors='ignore') \
+                as f:
+            f.write(text)
+
+        # Run TEES
+        output_path = os.path.join(tmp_dir, 'output')
+        model_path = os.path.join(tees_path, 'tees_data/models/GE11-test/')
+        command = [python2_path, classify_path, '-m', model_path,
+                   '-i', text_path,
+                   '-o', output_path]
+        try:
+            pwd = os.path.abspath(os.getcwd())
+            os.chdir(tees_path)  # Change to TEES directory
+            # print('cwd is:', os.getcwd())
+            # out = subprocess.check_output(command, stderr=subprocess.STDOUT)
+            p = subprocess.Popen(command, stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE, cwd=tees_path)
+            p.wait()
+            (so, se) = p.communicate()
+            print(so)
+            print(se)
+            os.chdir(pwd)  # Change back to previous directory
+            # print('cwd is:', os.getcwd())
+            # print(out.decode('utf-8'))
+
+        except BaseException as e:
+            # If there's an error, print it out and then propagate the
+            # exception
+            os.chdir(pwd)  # Change back to previous directory
+            # print (e.output.decode('utf-8'))
+            raise e
+
+    except BaseException as e:
+        # If there was an exception, delete the temporary directory and
+        # pass on the exception
+        shutil.rmtree(tmp_dir)
+        raise e
+    # Return the temporary directory with the TEES output
+    output_tuple = extract_relevant_tees_output(tmp_dir)
+    shutil.rmtree(tmp_dir)
+    return output_tuple
+
+def extract_relevant_tees_output(output_dir):
+    """Extract the text of the a1, a2, and sentence segmentation files from the
+    TEES output directory. These files are located within a compressed archive.
+
+    Parameters
+    ----------
+    output_dir: str
+        Directory containing the output of the TEES system
+
+    Returns
+    -------
+    a1_text: str
+        The text of the TEES a1 file (specifying the entities)
+    a2_text: str
+        The text of the TEES a2 file (specifying the event graph)
+    sentence_segmentations: str
+        The text of the XML file specifying the sentence segmentation
+    """
+
+    # Locate the file of sentences segmented by the TEES system, described
+    # in a compressed xml document
+    sentences_glob = os.path.join(output_dir, '*-sentences.xml.gz')
+    sentences_filename_candidates = glob.glob(sentences_glob)
+
+    # Make sure there is exactly one such file
+    if len(sentences_filename_candidates) != 1:
+        m = 'Looking for exactly one file matching %s but found %d matches'
+        raise Exception(m % (
+            sentences_glob, len(sentences_filename_candidates)))
+        return None, None, None
+
+    # Read in the sentence segmentation XML
+    sentence_segmentation_filename = sentences_filename_candidates[0]
+    with gzip.GzipFile(sentences_filename_candidates[0], 'r') as f:
+        sentence_segmentations = f.read().decode('utf-8')
+
+    # Create a temporary directory to which to extract the a1 and a2 files from
+    # the tarball
+    tmp_dir = tempfile.mkdtemp(suffix='indra_tees_processor')
+
+    try:
+        # Make sure the tarfile with the extracted events is in shared task
+        # format is in the output directory
+        tarfile_glob = os.path.join(output_dir, '*-events.tar.gz')
+        candidate_tarfiles = glob.glob(tarfile_glob)
+        if len(candidate_tarfiles) != 1:
+            raise Exception('Expected exactly one match for glob %s' %
+                            tarfile_glob)
+            return None, None, None
+
+        # Decide what tar files to extract
+        # (We're not blindly extracting all files because of the security
+        # warning in the documentation for TarFile.extractall
+        # In particular, we want to make sure that the filename doesn't
+        # try to specify a relative or absolute path other than the current
+        # directory by making sure the filename starts with an alphanumeric
+        # character.
+        # We're also only interested in files with the .a1 or .a2 extension
+        tar_file = tarfile.open(candidate_tarfiles[0])
+        a1_file = None
+        a2_file = None
+        extract_these = []
+        for m in tar_file.getmembers():
+            if re.match('[a-zA-Z0-9].*.a[12]', m.name):
+                extract_these.append(m)
+
+                if m.name.endswith('.a1'):
+                    a1_file = m.name
+                elif m.name.endswith('.a2'):
+                    a2_file = m.name
+                else:
+                    assert(False)
+
+        # There should be exactly two files that match these criteria
+        if len(extract_these) != 2 or a1_file is None or a2_file is None:
+            raise Exception('We thought there would be one .a1 and one .a2' +
+                            ' file in the tarball, but we got %d files total' %
+                            len(extract_these))
+            return None, None, None
+
+        # Extract the files that we decided to extract
+        tar_file.extractall(path=tmp_dir, members=extract_these)
+
+        # Read the text of the a1 (entities) file
+        with open(os.path.join(tmp_dir, a1_file), 'r') as f:
+            a1_text = f.read()
+
+        # Read the text of the a2 (events) file
+        with open(os.path.join(tmp_dir, a2_file), 'r') as f:
+            a2_text = f.read()
+
+        # Now that we're done, remove the temporary directory
+        shutil.rmtree(tmp_dir)
+
+        # Return the extracted text
+        return a1_text, a2_text, sentence_segmentations
+    except BaseException as e:
+        # If there was an exception, delete the temporary directory and
+        # pass on the exception
+        print('Not removing temporary directory: ' + tmp_dir)
+        shutil.rmtree(tmp_dir)
+        raise e
+        return None, None, None

--- a/indra/sources/tees/parse_tees.py
+++ b/indra/sources/tees/parse_tees.py
@@ -89,14 +89,18 @@ def parse_a1(a1_text):
         if len(line) == 0:
             continue
         tokens = line.rstrip().split('\t')
-        assert(len(tokens) == 3)
+        if len(tokens) != 3:
+            raise Exception('Expected three tab-seperated tokens per line ' +
+                            'in the a1 file output from TEES.')
 
         identifier = tokens[0]
         entity_info = tokens[1]
         entity_name = tokens[2]
 
         info_tokens = entity_info.split()
-        assert(len(info_tokens) == 3)
+        if len(info_tokens) != 3:
+            raise Exception('Expected three space-seperated tokens in the ' + 
+                            'second column of the a2 file output from TEES.')
         entity_type = info_tokens[0]
         first_offset = int(info_tokens[1])
         second_offset = int(info_tokens[2])
@@ -154,7 +158,9 @@ def parse_a2(a2_text, entities, tees_sentences):
 
         elif line[0] == 'E':  # New event
             tokens = line.rstrip().split('\t')
-            assert(len(tokens) == 2)
+            if len(tokens) != 2:
+                raise Exception('Expected two tab-separated tokens per line ' +
+                                'in TEES a2 file.')
 
             event_identifier = tokens[0]
 
@@ -165,7 +171,10 @@ def parse_a2(a2_text, entities, tees_sentences):
             properties = dict()
             for pair in key_value_pairs:
                 key_and_value = pair.split(':')
-                assert(len(key_and_value) == 2)
+                if len(key_and_value) != 2:
+                    raise Exception('Expected two colon-separated tokens ' + 
+                                    'in the second column of the a2 file ' + 
+                                    'output from TEES.')
                 properties[key_and_value[0]] = key_and_value[1]
 
             # Add event to the graph if we haven't added it yet
@@ -188,10 +197,14 @@ def parse_a2(a2_text, entities, tees_sentences):
 
         elif line[0] == 'M':  # Event modification
             tokens = line.split('\t')
-            assert(len(tokens) == 2)
+            if len(tokens) == 2:
+                raise Exception('Expected two tab-separated tokens per line ' +
+                                'in the a2 file output from TEES.')
 
             tokens2 = tokens[1].split()
-            assert(len(tokens2) == 2)
+            if len(tokens2) == 2:
+                raise Exception('Expected two space-separated tokens per ' + 
+                                'line in the a2 file output from TEES.')
             modification_type = tokens2[0]
             modified = tokens2[1]
 
@@ -256,7 +269,7 @@ class TEESSentences:
             return None
 
 
-def parse_tees_output_files(a1_text, a2_text, sentence_segmentations):
+def parse_output(a1_text, a2_text, sentence_segmentations):
     """Parses the output of the TEES reader and returns a networkx graph
     with the event information.
 

--- a/indra/sources/tees/parse_tees.py
+++ b/indra/sources/tees/parse_tees.py
@@ -44,13 +44,13 @@ class TEESEntity:
 
     Attributes
     ----------
-    identifier: str
+    identifier : str
         The unique tag for each entity, starting with T (ex. T28)
-    entity_type: str
+    entity_type : str
         The type of entity (ex. Protein)
-    entity_name: str
+    entity_name : str
         The name of the entity, as listed in the text
-    offsets: list[int]
+    offsets : list[int]
         The lower and upper offsets where the entity was mentioned in the text
     """
     def __init__(self, identifier, entity_type, entity_name, offsets):
@@ -74,12 +74,12 @@ def parse_a1(a1_text):
 
     Parameters
     ----------
-    a1_text: str
+    a1_text : str
         Text of the TEES a1 output file, specifying the entities
 
     Returns
     -------
-    entities: Dictionary mapping TEES identifiers to TEESEntity objects
+    entities : Dictionary mapping TEES identifiers to TEESEntity objects
         describing each entity. Each row of the .a1 file corresponds to one
         TEESEntity object.
     """
@@ -116,14 +116,14 @@ def parse_a2(a2_text, entities, tees_sentences):
 
     Parameters
     ----------
-    a2_text: str
+    a2_text : str
         Text of the TEES a2 file output, specifying the event graph
-    sentences_xml_gz: str
+    sentences_xml_gz : str
         Filename with the TEES sentence segmentation in a gzipped xml format
 
     Returns
     -------
-    events:
+    events :
         A networkx graph of events. Node names are entity and event labels
         in the original A2 file (such as "E2" or "T1") and edges between nodes
         are the various properties. Text nodes (ex. "T1") have a text node
@@ -241,12 +241,12 @@ class TEESSentences:
 
         Parameters
         ----------
-        index: int
+        index : int
             Looks up a sentence with this index
 
         Returns
         -------
-        text: str
+        text : str
             A sentence corresponding to the given document index, or None
             if none can be found
         """
@@ -262,16 +262,16 @@ def parse_tees_output_files(a1_text, a2_text, sentence_segmentations):
 
     Parameters
     ----------
-    a1_text: str
+    a1_text : str
         Contents of the TEES a1 output, specifying the entities
-    a1_text: str
+    a1_text : str
         Contents of the TEES a2 output, specifying the event graph
-    sentence_segmentations: str
+    sentence_segmentations : str
         Concents of the TEES sentence segmentation output XML
 
     Returns
     -------
-    events: networkx.DiGraph
+    events : networkx.DiGraph
         networkx graph with the entities, events, and relationship between
         extracted by TEES
     """
@@ -293,11 +293,11 @@ def tees_parse_networkx_to_dot(G, output_file, subgraph_nodes):
 
     Parameters
     ----------
-    G: networkx.DiGraph
+    G : networkx.DiGraph
         Graph with TEES extractions returned by run_and_parse_tees
-    output_file: str
+    output_file : str
         Output file to which to write .dot file
-    subgraph_nodes: list[str]
+    subgraph_nodes : list[str]
         Only convert the connected graph that includes these ndoes
     """
 

--- a/indra/sources/tees/parse_tees.py
+++ b/indra/sources/tees/parse_tees.py
@@ -74,8 +74,8 @@ def parse_a1(a1_text):
 
     Parameters
     ----------
-    a1_filename: str
-        File with the list of entities.
+    a1_text: str
+        Text of the TEES a1 output file, specifying the entities
 
     Returns
     -------
@@ -112,12 +112,12 @@ def parse_a1(a1_text):
 
 
 def parse_a2(a2_text, entities, tees_sentences):
-    """Extracts events from a TEES a2 files into a networkx directed graph.
+    """Extracts events from a TEES a2 output into a networkx directed graph.
 
     Parameters
     ----------
-    a2_file: str
-        Filename with the list of entities.
+    a2_text: str
+        Text of the TEES a2 file output, specifying the event graph
     sentences_xml_gz: str
         Filename with the TEES sentence segmentation in a gzipped xml format
 
@@ -257,13 +257,17 @@ class TEESSentences:
 
 
 def parse_tees_output_files(a1_text, a2_text, sentence_segmentations):
-    """Parses the files in the TEES output directory. And returns a networkx
-    graph.
+    """Parses the output of the TEES reader and returns a networkx graph
+    with the event information.
 
     Parameters
     ----------
-    output_dir: str
-        Directory containing the output of the TEES system
+    a1_text: str
+        Contents of the TEES a1 output, specifying the entities
+    a1_text: str
+        Contents of the TEES a2 output, specifying the event graph
+    sentence_segmentations: str
+        Concents of the TEES sentence segmentation output XML
 
     Returns
     -------

--- a/indra/sources/tees/processor.py
+++ b/indra/sources/tees/processor.py
@@ -36,19 +36,19 @@ class TEESProcessor(object):
 
     Parameters
     ----------
-    a1_text: str
+    a1_text : str
         The TEES a1 output file, with entity information
-    a2_test: str
+    a2_test : str
         The TEES a2 output file, with the event graph
-    sentence_segmentations: str
+    sentence_segmentations : str
         The TEES sentence segmentation XML output
-    pmid: int
+    pmid : int
         The pmid which the text comes from, or None if we don't want to specify
         at the moment. Stored in the Evidence object for each statement.
 
     Attributes
     ----------
-    statements: list[indra.statements.Statement]
+    statements : list[indra.statements.Statement]
         A list of INDRA statements extracted from the provided text via TEES
     """
 
@@ -88,11 +88,11 @@ class TEESProcessor(object):
 
         Parameters
         ----------
-        G:
+        G :
             The graph object
-        node_name:
+        node_name :
             Node that the edge starts at
-        edge_label:
+        edge_label :
             The text in the relation property of the edge
         """
         G = self.G
@@ -158,15 +158,15 @@ class TEESProcessor(object):
 
         Parameters
         ----------
-        event_name: str
+        event_name : str
             Look for event nodes with this name
-        desired_relations: list[str]
+        desired_relations : list[str]
             Look for event nodes with outgoing edges annotated with each of
             these relations
 
         Returns
         -------
-        event_nodes: list[str]
+        event_nodes : list[str]
             Event nodes that fit the desired criteria
         """
 
@@ -187,8 +187,8 @@ class TEESProcessor(object):
         return desired_event_nodes
 
     def get_related_node(self, node, relation):
-        """Looks for an edge from node to some other node, such that the edge is
-        annotated with the given relation. If there exists such an edge,
+        """Looks for an edge from node to some other node, such that the edge
+        is annotated with the given relation. If there exists such an edge,
         returns the name of the node it points to. Otherwise, returns None."""
         G = self.G
         for edge in G.edges(node):
@@ -381,12 +381,12 @@ class TEESProcessor(object):
 
         Parameters
         ----------
-        node: str
+        node : str
             We want to create the subgraph containing this node.
 
         Returns
         -------
-        subgraph: networkx.DiGraph
+        subgraph : networkx.DiGraph
             The subgraph containing the specified node.
         """
         G = self.G

--- a/indra/sources/tees/processor.py
+++ b/indra/sources/tees/processor.py
@@ -16,7 +16,7 @@ from future.utils import python_2_unicode_compatible
 
 from indra.statements import Phosphorylation, Dephosphorylation, Complex, \
         IncreaseAmount, DecreaseAmount, Agent, Evidence
-from indra.sources.tees.parse_tees import run_and_parse_tees
+from indra.sources.tees.parse_tees import parse_tees_output_files
 from indra.preassembler.grounding_mapper import load_grounding_map,\
         GroundingMapper
 from networkx.algorithms import dag
@@ -24,27 +24,27 @@ import os.path
 
 
 class TEESProcessor(object):
-    """Converts the specified text into a series of INDRA statmenets.
+    """Converts the output of the TEES reader to INDRA statements.
 
     Only extracts a subset of INDRA statements. Currently supported
     statements are:
     * Phosphorylation
+    * Dephosphorylation
+    * Binding
+    * IncreaseAmount
+    * DecreaseAmount
 
     Parameters
     ----------
-    text: str
-        Plain text from biomedical publications from which to extract
-        INDRA statements.
+    a1_text: str
+        The TEES a1 output file, with entity information
+    a2_test: str
+        The TEES a2 output file, with the event graph
+    sentence_segmentations: str
+        The TEES sentence segmentation XML output
     pmid: int
         The pmid which the text comes from, or None if we don't want to specify
         at the moment. Stored in the Evidence object for each statement.
-    tees_path: str
-        Path to the directory containing the TEES installation, in
-        particular containing TEES' classify.py.
-    python2_path: str
-        Absolute path to a python 2 interpreter. This is needed to run
-        TEES because TEES is only compatabile with python 2. If None then
-        searches for an executable named python2 in the path.
 
     Attributes
     ----------
@@ -52,7 +52,7 @@ class TEESProcessor(object):
         A list of INDRA statements extracted from the provided text via TEES
     """
 
-    def __init__(self, text, pmid, tees_path, python2_path):
+    def __init__(self, a1_text, a2_text, sentence_segmentations, pmid):
         # Store pmid
         self.pmid = pmid
 
@@ -68,7 +68,8 @@ class TEESProcessor(object):
         mapper = GroundingMapper(gm)
 
         # Run TEES and parse into networkx graph
-        self.G = run_and_parse_tees(text, tees_path, python2_path)
+        self.G = parse_tees_output_files(a1_text, a2_text,
+                                         sentence_segmentations)
 
         # Extract statements from the TEES graph
         self.statements = []

--- a/indra/sources/tees/processor.py
+++ b/indra/sources/tees/processor.py
@@ -16,7 +16,7 @@ from future.utils import python_2_unicode_compatible
 
 from indra.statements import Phosphorylation, Dephosphorylation, Complex, \
         IncreaseAmount, DecreaseAmount, Agent, Evidence
-from indra.sources.tees.parse_tees import parse_tees_output_files
+from indra.sources.tees.parse_tees import parse_output
 from indra.preassembler.grounding_mapper import load_grounding_map,\
         GroundingMapper
 from networkx.algorithms import dag
@@ -38,7 +38,7 @@ class TEESProcessor(object):
     ----------
     a1_text : str
         The TEES a1 output file, with entity information
-    a2_test : str
+    a2_text : str
         The TEES a2 output file, with the event graph
     sentence_segmentations : str
         The TEES sentence segmentation XML output
@@ -68,8 +68,7 @@ class TEESProcessor(object):
         mapper = GroundingMapper(gm)
 
         # Run TEES and parse into networkx graph
-        self.G = parse_tees_output_files(a1_text, a2_text,
-                                         sentence_segmentations)
+        self.G = parse_output(a1_text, a2_text, sentence_segmentations)
 
         # Extract statements from the TEES graph
         self.statements = []


### PR DESCRIPTION
Refactor the previously monolithic TEES reader and processor to separate these steps:
1) Invoking the TEES reader
2) Extracting the relevant TEES output as strings from the output directory containing much relevant and irrelevant TEES output
3) Processing strings containing the relevant TEES output extracted in step 2) into INDRA statements

This lays the groundwork to running TEES on AWS with the database, in particular facilitating storing the TEES output as strings in the database before processing.