### PR TITLE
Add db rest client to docs

### DIFF
--- a/doc/modules/db/index.rst
+++ b/doc/modules/db/index.rst
@@ -16,6 +16,12 @@ Content Manager (:py:mod:`indra.db.content_manager`)
 .. automodule:: indra.db.content_manager
     :members:
 
+Reading Manager (:py:mod:`indra.db.reading_manager`)
+----------------------------------------------------
+
+.. automodule:: indra.db.reading_manager
+    :members:
+
 Utilities (:py:mod:`indra.db.util`)
 -----------------------------------
 

--- a/doc/modules/sources/index.rst
+++ b/doc/modules/sources/index.rst
@@ -17,3 +17,4 @@ Processors for knowledge input (:py:mod:`indra.sources`)
    biogrid/index
    medscan/index
    sofia/index
+   indra_db_rest/index

--- a/doc/modules/sources/indra_db_rest/index.rst
+++ b/doc/modules/sources/indra_db_rest/index.rst
@@ -1,7 +1,8 @@
 INDRA Database REST Client (:py:mod:`indra.sources.indra_db_rest`)
 ==================================================================
 
-
+.. automodule:: indra.sources.indra_db_rest
+    :members:
 
 Client API (:py:mod:`indra.sources.indra_db_rest.client_api`)
 -------------------------------------------------------------

--- a/doc/modules/sources/indra_db_rest/index.rst
+++ b/doc/modules/sources/indra_db_rest/index.rst
@@ -1,0 +1,10 @@
+INDRA Database REST Client (:py:mod:`indra.sources.indra_db_rest`)
+==================================================================
+
+
+
+Client API (:py:mod:`indra.sources.indra_db_rest.client_api`)
+-------------------------------------------------------------
+
+.. automodule:: indra.sources.indra_db_rest.client_api
+    :members:

--- a/indra/sources/indra_db_rest/__init__.py
+++ b/indra/sources/indra_db_rest/__init__.py
@@ -1,1 +1,11 @@
+"""The INDRA database client allows querying a web service that serves
+content from a database of INDRA Statements collected and pre-assembled
+from various sources.
+
+Access to the webservice requires a URL (`INDRA_DB_REST_URL`) and
+possibly an API key (`INDRA_DB_REST_API_KEY`), both of which may be placed in
+your config file or as environment variables. If you do not have these
+but would like to access the database REST API, you may contact the developers
+to request a URL and API key.
+"""
 from .client_api import *

--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -35,7 +35,7 @@ def get_statements(subject=None, object=None, agents=None, stmt_type=None):
 
     Parameters
     ----------
-    subject, object : str
+    subject/object : str
         Optionally specify the subject and/or object of the statements in
         you wish to get from the database. By default, the namespace is assumed
         to be HGNC gene names, however you may specify another namespace by
@@ -52,7 +52,7 @@ def get_statements(subject=None, object=None, agents=None, stmt_type=None):
 
     Returns
     -------
-    stmts : list[:pyclass:`indra.statements.Statement`]
+    stmts : list[:py:class:`indra.statements.Statement`]
         A list of INDRA Statement instances. Note that if a supporting or
         supported Statement was not included in your query, it will simply be
         instantiated as an `Unresolved` statement, with `uuid` of the statement.
@@ -90,7 +90,7 @@ def get_statements_for_paper(id_val, id_type='pmid'):
 
     Returns
     -------
-    stmts : list[:pyclass:`indra.statements.Statement`]
+    stmts : list[:py:class:`indra.statements.Statement`]
         A list of INDRA Statement instances.
     """
     resp = _submit_request('papers', id=id_val, type=id_type)

--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -21,18 +21,6 @@ class IndraDBRestError(Exception):
 def get_statements(subject=None, object=None, agents=None, stmt_type=None):
     """Get statements from INDRA's database using the web api.
 
-    This tool is intended for those that wish to use the cumulative database
-    of pre-assembled INDRA Statements compiled from all our input databases and
-    from reading all of the available medical literature, but who do not have
-    direct access to the entire database.
-
-    Such access will require you have both a URL (`INDRA_DB_REST_URL`) and
-    possibly an API key (`INDRA_DB_REST_API_KEY`), both of which may be placed in
-    your config file or as environment variables.
-
-    If you do not have these, but would like to access the database rest api,
-    you may contact the developers to request a URL and key.
-
     Parameters
     ----------
     subject/object : str


### PR DESCRIPTION
This PR:
- Adds the rest client to the docs, and fixes some minor doc issues.
- Also adds the Reading Manager to the docs, and adds doc strings for the objects therein.