### PR TITLE
DRUM reading

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -263,11 +263,17 @@ the value in the configuration file. In other words, an environment variable,
 when set, takes precedence over the value set in the config file.
 
 Configuration values include:
-- REACHPATH: The location of the jar containing the REACH reader
+- REACHPATH: The location of the JAR file containing a local instance of the
+REACH reading system
 
-- EIDOSPATH: The location of the jar containing the Eidos reader
+- EIDOSPATH: The location of the JAR file containing a local instance of the
+Eidos reading system
 
-- SPARSERPATH: The location of the Sparser reading system (path to a folder)
+- SPARSERPATH: The location of a local instance of the Sparser
+reading system (path to a folder)
+
+- DRUMPATH: The location of a local installation of the DRUM reading system
+(path to a folder)
 
 - NDEX_USERNAME, NDEX_PASSWORD: Credentials for accessing the NDEx web service
 
@@ -278,7 +284,3 @@ Configuration values include:
 
 - INDRA_DEFAULT_JAVA_MEM_LIMIT: Maximum memory limit for Java virtual machines
   launched by INDRA
-
-- INDRA_DB_PRIMARY: Primary database address
-
-- INDRA_DB_TEST1, INDRA_DB_TEST2: Test database addresses

--- a/indra/resources/default_config.ini
+++ b/indra/resources/default_config.ini
@@ -12,6 +12,9 @@ EIDOSPATH =
 # Path to the Sparser reading system folder
 SPARSERPATH = 
 
+# Path to the DRUM reading system folder
+DRUMPATH = 
+
 # The default memory limit for the Java/Scala interface
 # (BioPAX, REACH, EIDOS)
 INDRA_DEFAULT_JAVA_MEM_LIMIT = 8g

--- a/indra/sources/trips/drum_reader.py
+++ b/indra/sources/trips/drum_reader.py
@@ -38,17 +38,38 @@ class DrumReader(KQMLModule):
     Once finished, the list of EKB XML extractions can be accessed via
     `dr.extractions`.
 
+    Parameters
+    ----------
+    run_drum : Optional[bool]
+        If True, the DRUM reading system is launched as a subprocess for
+        reading. If False, DRUM is expected to be running independently.
+        Default: False
+    drum_system : Optional[subproces.Popen]
+        A handle to the subprocess of a running DRUM system instance. This
+        can be passed in in case the instance is to be reused rather than
+        restarted. Default: None
+    **kwargs
+        All other keyword arguments are passed through to the DrumReader
+        KQML module's constructor.
+
     Attributes
     ----------
     extractions : list[str]
         A list of EKB XML extractions corresponding to the input text list.
+    drum_system : subprocess.Popen
+        A subprocess handle that points to a running instance of the
+        DRUM reading system. In case the DRUM system is running independently,
+        this is None.
     """
     def __init__(self, **kwargs):
         if not have_kqml:
             raise ImportError('Install the `pykqml` package to use ' +
                               'the DrumReader')
         run_drum = kwargs.pop('run_drum', None)
-        if not run_drum:
+        drum_system = kwargs.pop('drum_system', None)
+        if drum_system:
+            self.drum_system = drum_system
+        elif not run_drum:
             self.drum_system = None
         else:
             host = kwargs.get('host', None)

--- a/indra/sources/trips/drum_reader.py
+++ b/indra/sources/trips/drum_reader.py
@@ -46,8 +46,7 @@ class DrumReader(KQMLModule):
             raise ImportError('Install the `pykqml` package to use ' +
                               'the DrumReader')
         self.to_read = kwargs.pop('to_read', None)
-        host = kwargs.pop('host', 'localhost')
-        super(DrumReader, self).__init__(name='DrumReader', host=host)
+        super(DrumReader, self).__init__(name='DrumReader', **kwargs)
         self.msg_counter = random.randint(1, 100000)
         self.ready()
         self.extractions = []
@@ -77,8 +76,13 @@ class DrumReader(KQMLModule):
 
     def receive_reply(self, msg, content):
         print('===RECEIVED REPLY===')
-        extractions = content.gets(':extractions')
-        self.extractions.append(extractions)
+        reply_head = content.head()
+        if reply_head == 'error':
+            comment = content.gets('comment')
+            logger.error('Got error reply: "%s"' % comment)
+        else:
+            extractions = content.gets('extractions')
+            self.extractions.append(extractions)
         self.reply_counter -= 1
         if self.reply_counter == 0:
             self.exit(0)

--- a/indra/sources/trips/drum_reader.py
+++ b/indra/sources/trips/drum_reader.py
@@ -46,7 +46,8 @@ class DrumReader(KQMLModule):
             raise ImportError('Install the `pykqml` package to use ' +
                               'the DrumReader')
         self.to_read = kwargs.pop('to_read', None)
-        super(DrumReader, self).__init__(name='DrumReader')
+        host = kwargs.pop('host', 'localhost')
+        super(DrumReader, self).__init__(name='DrumReader', host=host)
         self.msg_counter = random.randint(1, 100000)
         self.ready()
         self.extractions = []
@@ -55,7 +56,7 @@ class DrumReader(KQMLModule):
             self.read_text(text)
 
     def read_text(self, text):
-        print('Reading %s' % text)
+        print('Reading: "%s"' % text)
         msg_id = 'RT000%s' % self.msg_counter
         kqml_perf = _get_perf(text, msg_id)
         self.send(kqml_perf)

--- a/indra/sources/trips/drum_reader.py
+++ b/indra/sources/trips/drum_reader.py
@@ -70,7 +70,6 @@ class DrumReader(KQMLModule):
             self.exit(0)
 
 def _get_perf(text, msg_id):
-    text = text.encode('utf-8')
     msg = KQMLPerformative('REQUEST')
     msg.set('receiver', 'DRUM')
     content = KQMLList('run-text')

--- a/indra/sources/trips/drum_reader.py
+++ b/indra/sources/trips/drum_reader.py
@@ -55,14 +55,28 @@ class DrumReader(KQMLModule):
         for text in self.to_read:
             self.read_text(text)
 
+    def read_pmc(self, pmcid):
+        # '(request :receiver DRUM :content (run-pmcid :pmcid "5148607"' + \
+        #      ' :reply-when-done true) :reply-with P-5148607)'
+        msg = KQMLPerformative('REQUEST')
+        msg.set('receiver', 'DRUM')
+        content = KQMLList('run-pmcid')
+        content.sets('pmcid', pmcid)
+        content.set('reply-when-done', 'true')
+        msg.set('content', content)
+        msg.set('reply-with', 'P-%s' % pmcid)
+        self.send(msg)
+
     def read_text(self, text):
         print('Reading: "%s"' % text)
         msg_id = 'RT000%s' % self.msg_counter
         kqml_perf = _get_perf(text, msg_id)
         self.send(kqml_perf)
+        print('===SENT READING===')
         self.msg_counter += 1
 
     def receive_reply(self, msg, content):
+        print('===RECEIVED REPLY===')
         extractions = content.gets(':extractions')
         self.extractions.append(extractions)
         self.reply_counter -= 1

--- a/indra/sources/trips/trips_api.py
+++ b/indra/sources/trips/trips_api.py
@@ -49,7 +49,7 @@ def process_text(text, save_xml_name='trips_output.xml', save_xml_pretty=True,
     else:
         if offline_reading:
             try:
-                dr = DrumReader(to_read=[text])
+                dr = DrumReader()
                 if dr is None:
                     raise Exception('DrumReader could not be instantiated.')
             except BaseException as e:
@@ -58,6 +58,7 @@ def process_text(text, save_xml_name='trips_output.xml', save_xml_pretty=True,
                               ' a separate process')
                 return None
             try:
+                dr.read_text(text)
                 dr.start()
             except SystemExit:
                 pass

--- a/indra/tools/reading/run_drum_reading.py
+++ b/indra/tools/reading/run_drum_reading.py
@@ -1,0 +1,25 @@
+import sys
+import json
+from indra.sources.trips.drum_reader import DrumReader
+from indra.sources.trips import process_xml
+
+def read_content(content):
+    sentences = []
+    for k, v in content.items():
+        sentences += v
+    dr = DrumReader(to_read=sentences)
+    try:
+        dr.start()
+    except SystemExit:
+        pass
+    statements = []
+    for extraction in dr.extractions:
+        statements += process_xml(extraction).statements
+    return statements
+
+if __name__ == '__main__':
+    file_name = sys.argv[1]
+    with open(file_name, 'rt') as fh:
+        content = json.load(fh)
+    statements = read_content(content)
+    print(statements)

--- a/indra/tools/reading/run_drum_reading.py
+++ b/indra/tools/reading/run_drum_reading.py
@@ -40,6 +40,9 @@ def save_results(statements, out_fname):
         pickle.dump(statements, fh)
 
 
+# TODO: this currently assumes that a list of sentences is to be read
+# for a given PMID. Other usage modes to support are reading a full
+# NXML paper (from PMC), and reading the abstract for a given PMID.
 if __name__ == '__main__':
     host = sys.argv[1]
     file_name = sys.argv[2]

--- a/indra/tools/reading/run_drum_reading.py
+++ b/indra/tools/reading/run_drum_reading.py
@@ -1,25 +1,49 @@
 import sys
 import json
-from indra.sources.trips.drum_reader import DrumReader
+import time
+import pickle
 from indra.sources.trips import process_xml
+from indra.sources.trips.drum_reader import DrumReader
 
-def read_content(content):
-    sentences = []
-    for k, v in content.items():
-        sentences += v
-    dr = DrumReader(to_read=sentences)
-    try:
-        dr.start()
-    except SystemExit:
-        pass
-    statements = []
-    for extraction in dr.extractions:
-        statements += process_xml(extraction).statements
-    return statements
+
+def set_pmid(statements, pmid):
+    for stmt in statements:
+        for evidence in stmt.evidence:
+            evidence.pmid = pmid
+
+
+def read_content(content, host):
+    all_statements = []
+    for pmid, sentences in content.items():
+        print('================================')
+        print('Processing %d sentences for %s' % (len(sentences), pmid))
+        ts = time.time()
+        dr = DrumReader(to_read=sentences, host=host)
+        try:
+            dr.start()
+        except SystemExit:
+            pass
+        statements = []
+        for extraction in dr.extractions:
+            tp = process_xml(extraction)
+            statements += tp.statements
+        set_pmid(statements, pmid)
+        te = time.time()
+        print('Reading took %d seconds and produced %d Statements.' %
+              (te-ts, len(statements)))
+        all_statements += statements
+    return all_statements
+
+
+def save_results(statements, out_fname):
+    with open(out_fname, 'wb') as fh:
+        pickle.dump(statements, fh)
+
 
 if __name__ == '__main__':
-    file_name = sys.argv[1]
+    host = sys.argv[1]
+    file_name = sys.argv[2]
     with open(file_name, 'rt') as fh:
         content = json.load(fh)
-    statements = read_content(content)
-    print(statements)
+    statements = read_content(content, host)
+    save_results(statements, 'results.pkl')

--- a/indra/tools/reading/run_drum_reading.py
+++ b/indra/tools/reading/run_drum_reading.py
@@ -58,9 +58,8 @@ def read_text(text, **drum_args):
 
     Parameters
     ----------
-    pmid_sentences : dict[str, list[str]]
-        A dictonary where each key is a PMID pointing to a list of sentences
-        to be read.
+    text : str
+        A block of text to run DRUM on
 
     **drum_args
         Keyword arguments passed directly to the DrumReader. Typical
@@ -68,15 +67,15 @@ def read_text(text, **drum_args):
 
     Returns
     -------
-    all_statements : list[indra.statement.Statement]
+    statements : list[indra.statement.Statement]
         A list of INDRA Statements resulting from the reading
     """
-
+    return read_pmid_sentences({'PMID': text}, **drum_args)
 
 
 def read_pmc(pmcid, **drum_args):
-    
-
+    # TODO: run DRUM in PMC reading mode here
+    return
 
 def save_results(statements, out_fname):
     with open(out_fname, 'wb') as fh:

--- a/indra/tools/reading/run_drum_reading.py
+++ b/indra/tools/reading/run_drum_reading.py
@@ -60,6 +60,8 @@ def read_pmid_sentences(pmid_sentences, **drum_args):
         logger.info('Reading took %d seconds and produced %d Statements.' %
                     (te-ts, len(statements)))
         all_statements[pmid] = statements
+    if dr.drum_system:
+        dt._kill_drum()
     return all_statements
 
 

--- a/indra/tools/reading/run_drum_reading.py
+++ b/indra/tools/reading/run_drum_reading.py
@@ -33,12 +33,18 @@ def read_pmid_sentences(pmid_sentences, **drum_args):
             for evidence in stmt.evidence:
                 evidence.pmid = pmid
 
+    run_drum = drum_args.get('run_drum', False)
+    drum_process = None
     all_statements = {}
     for pmid, sentences in pmid_sentences.items():
         logger.info('================================')
         logger.info('Processing %d sentences for %s' % (len(sentences), pmid))
         ts = time.time()
         dr = DrumReader(**drum_args)
+        if run_drum and drum_process is None:
+            drum_args.pop('run_drum', None)
+            drum_process = dr.drum_system
+            drum_args['drum_system'] = drum_process
         for sentence in sentences:
             dr.read_text(sentence)
         try:

--- a/indra/tools/reading/run_drum_reading.py
+++ b/indra/tools/reading/run_drum_reading.py
@@ -6,19 +6,37 @@ from indra.sources.trips import process_xml
 from indra.sources.trips.drum_reader import DrumReader
 
 
-def set_pmid(statements, pmid):
-    for stmt in statements:
-        for evidence in stmt.evidence:
-            evidence.pmid = pmid
+def read_pmid_sentences(pmid_sentences, **drum_args):
+    """Read sentences from a PMID-keyed dictonary and return all Statements
 
+    Parameters
+    ----------
+    pmid_sentences : dict[str, list[str]]
+        A dictonary where each key is a PMID pointing to a list of sentences
+        to be read.
 
-def read_content(content, host):
+    **drum_args
+        Keyword arguments passed directly to the DrumReader. Typical
+        things to specify are 'host' and 'port'.
+
+    Returns
+    -------
+    all_statements : list[indra.statement.Statement]
+        A list of INDRA Statements resulting from the reading
+    """
+    def _set_pmid(statements, pmid):
+        for stmt in statements:
+            for evidence in stmt.evidence:
+                evidence.pmid = pmid
+
     all_statements = []
-    for pmid, sentences in content.items():
+    for pmid, sentences in pmid_sentences.items():
         print('================================')
         print('Processing %d sentences for %s' % (len(sentences), pmid))
         ts = time.time()
-        dr = DrumReader(to_read=sentences, host=host)
+        dr = DrumReader(**drum_args)
+        for sentence in sentences:
+            dr.read_text(sentence)
         try:
             dr.start()
         except SystemExit:
@@ -27,7 +45,7 @@ def read_content(content, host):
         for extraction in dr.extractions:
             tp = process_xml(extraction)
             statements += tp.statements
-        set_pmid(statements, pmid)
+        _set_pmid(statements, pmid)
         te = time.time()
         print('Reading took %d seconds and produced %d Statements.' %
               (te-ts, len(statements)))
@@ -35,18 +53,40 @@ def read_content(content, host):
     return all_statements
 
 
+def read_text(text, **drum_args):
+    """Read sentences from a PMID-keyed dictonary and return all Statements
+
+    Parameters
+    ----------
+    pmid_sentences : dict[str, list[str]]
+        A dictonary where each key is a PMID pointing to a list of sentences
+        to be read.
+
+    **drum_args
+        Keyword arguments passed directly to the DrumReader. Typical
+        things to specify are 'host' and 'port'.
+
+    Returns
+    -------
+    all_statements : list[indra.statement.Statement]
+        A list of INDRA Statements resulting from the reading
+    """
+
+
+
+def read_pmc(pmcid, **drum_args):
+    
+
+
 def save_results(statements, out_fname):
     with open(out_fname, 'wb') as fh:
         pickle.dump(statements, fh)
 
 
-# TODO: this currently assumes that a list of sentences is to be read
-# for a given PMID. Other usage modes to support are reading a full
-# NXML paper (from PMC), and reading the abstract for a given PMID.
 if __name__ == '__main__':
     host = sys.argv[1]
     file_name = sys.argv[2]
     with open(file_name, 'rt') as fh:
         content = json.load(fh)
-    statements = read_content(content, host)
+    statements = read_content(content, host=host, port=port)
     save_results(statements, 'results.pkl')


### PR DESCRIPTION
This PR makes improvements in the way reading with DRUM is done locally. It adds support for PMC reading, allows the reading system to be started and stopped when reading finishes, and adds a wrapper for the reader in `indra.tools.reading`. There are still many things to add and potential improvements but those can be added on separate branches later.