### PR TITLE
Fix handling of Elsevier and clean up content handling in general in new reading

### DIFF
--- a/indra/tests/pmc_cont_example.nxml
+++ b/indra/tests/pmc_cont_example.nxml
@@ -1,0 +1,129 @@
+<?xml version="1.0" ?>
+<!DOCTYPE article
+  PUBLIC '-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.0 20120330//EN'
+  'JATS-archivearticle1.dtd'>
+  <article article-type="review-article"
+      xmlns:mml="http://www.w3.org/1998/Math/MathML"
+      xmlns:xlink="http://www.w3.org/1999/xlink">
+  <?properties open_access?>
+  <front>
+    <journal-meta>
+      <journal-id journal-id-type="iso-abbrev">the pmc test</journal-id>
+      <journal-id journal-id-type="publisher-id">tptj</journal-id>
+      <journal-title-group>
+        <journal-title>ThePMCTestJournal</journal-title>
+      </journal-title-group>
+      <publisher>
+        <publisher-name>INDRA</publisher-name>
+      </publisher>
+    </journal-meta>
+    <article-meta>
+      <article-id pub-id-type="pmid">12345</article-id>
+      <article-id pub-id-type="pmc">246810</article-id>
+      <article-categories>
+        <subj-group subj-group-type="heading">
+          <subject>Test</subject>
+        </subj-group>
+      </article-categories>
+      <title-group>
+          <article-title>
+              This is a test, containing no meaningful content.
+          </article-title>
+      </title-group>
+      <contrib-group>
+        <contrib contrib-type="author">
+          <name>
+            <surname>Bar</surname>
+            <given-names>Foo</given-names>
+          </name>
+        </contrib>
+      </contrib-group>
+      <aff id="nowhere">
+          Harvard Medical School
+      </aff>
+      <pub-date pub-type="epub">
+        <day>15</day>
+        <month>5</month>
+        <year>2018</year>
+      </pub-date>
+      <pub-date pub-type="collection">
+        <month>5</month>
+        <year>2018</year>
+      </pub-date>
+      <volume>1</volume>
+      <issue>1</issue>
+      <fpage>1</fpage>
+      <lpage>314159</lpage>
+      <history>
+        <date date-type="received">
+          <day>15</day>
+          <month>5</month>
+          <year>2018</year>
+        </date>
+      </history>
+      <permissions>
+        <copyright-statement>It's a total free-for-all.</copyright-statement>
+      </permissions>
+      <abstract>
+        <p>
+            Finding a suitable test file is hard. So I made one, which says things
+            like MEK phoshporylates ERK, in the hopes of triggering our readers
+            and producing statements.
+        </p>
+      </abstract>
+      <kwd-group>
+        <kwd>testing</kwd>
+      </kwd-group>
+    </article-meta>
+  </front>
+  <body>
+    <sec>
+      <title>1. Introduction</title>
+      <p>
+          As I said, creating a test document is hard. But this really doesn't
+          need to be verbose. But again, saying that MAP2K1 phosphorylates
+          MAPK1 will generate some more statements, although the one in the
+          abstract was probably enough.
+      </p>
+    </sec>
+    <sec>
+      <title>2. Discussion</title>
+      <p>
+          This is not intended to test the readers themselves, but just the
+          architecture around them, hence it is not necessary, and would in fact
+          complicate things, by trying to trip up the readers with tables, or
+          anything like that.
+      </p>
+    </sec>
+    <sec>
+      <title>3. Conclusions</title>
+      <p>
+          This should be enough to stand in place of an entire article for the
+          sake of these tests.
+      </p>
+    </sec>
+  </body>
+  <back>
+    <ack>
+      <title>Acknowledgments</title>
+    </ack>
+    <ref-list>
+      <title>References</title>
+      <ref id="BS101">
+        <label>1.</label>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Baz</surname>
+              <given-names>F.B.</given-names>
+            </name>
+          </person-group>
+          <article-title>This is a reference.</article-title>
+          <source>NaN</source>
+          <year>2018</year>
+          <pub-id pub-id-type="pmid">222222222</pub-id>
+        </element-citation>
+      </ref>
+    </ref-list>
+  </back>
+</article>

--- a/indra/tests/test_reading_scripts.py
+++ b/indra/tests/test_reading_scripts.py
@@ -263,8 +263,30 @@ def test_read_files():
             example_files.append(test_file_fmt.format(fmt=fmt))
 
     # Get txt content
-    tc_text = db.select_one(db.TextContent, db.TextContent.source == 'pubmed')
-    add_content(tc_text, 'txt')
+    abstract_txt = \
+        ("Bleaching gravid <i>C. elegans</i> followed by a short period of "
+         "starvation of the L1 larvae is a routine method performed by worm "
+         "researchers for generating synchronous populations for experiments. "
+         "During the process of investigating dietary effects on gene "
+         "regulation in L1 stage worms by single-worm RNA-Seq, we found that "
+         "the density of resuspended L1 larvae affects expression of many "
+         "mRNAs. Specifically, a number of genes related to metabolism and "
+         "signalling are highly expressed in worms arrested at low density, "
+         "but are repressed at higher arrest densities. We generated a GFP "
+         "reporter strain based on one of the most density-dependent genes in "
+         "our dataset - <i>lips-15</i> - and confirmed that this reporter was "
+         "expressed specifically in worms arrested at relatively low density. "
+         "Finally, we show that conditioned media from high density L1 "
+         "cultures was able to downregulate <i>lips-15</i> even in L1 animals "
+         "arrested at low density, and experiments using <i>daf-22</i> mutant "
+         "animals demonstrated that this effect is not mediated by the "
+         "ascaroside family of signalling pheromones. Together, our data "
+         "implicate a soluble signalling molecule in density sensing by L1 "
+         "stage <i>C. elegans</i>, and provide guidance for design of "
+         "experiments focused on early developmental gene regulation.")
+    with open(test_file_fmt.format(fmt='text'), 'w') as f:
+        f.write(abstract_txt)
+    example_files.append(test_file_fmt.format(fmt='text'))
 
     # Get nxml content
     tc_nxml = db.select_one(db.TextContent,

--- a/indra/tests/test_reading_scripts.py
+++ b/indra/tests/test_reading_scripts.py
@@ -247,50 +247,20 @@ def test_produce_readings():
 @attr('slow', 'nonpublic')
 def test_read_files():
     "Test that the system can read files."
-    db = get_db_with_pubmed_content()
-
     # Create the test files.
-    test_file_fmt = 'test_reading_{fmt}_file.{fmt}'
+    test_file_fmt = 'test_.{fmt}'
     example_files = []
 
-    def add_content(tc, fmt):
-        if tc is None:
-            print("Could not find %s content for testing." % fmt)
-        else:
-            with open(test_file_fmt.format(fmt=fmt), 'wb') as f:
-                f.write(zlib.decompress(tc.content, zlib.MAX_WBITS+16))
-            example_files.append(test_file_fmt.format(fmt=fmt))
-
     # Get txt content
-    abstract_txt = \
-        ("Bleaching gravid <i>C. elegans</i> followed by a short period of "
-         "starvation of the L1 larvae is a routine method performed by worm "
-         "researchers for generating synchronous populations for experiments. "
-         "During the process of investigating dietary effects on gene "
-         "regulation in L1 stage worms by single-worm RNA-Seq, we found that "
-         "the density of resuspended L1 larvae affects expression of many "
-         "mRNAs. Specifically, a number of genes related to metabolism and "
-         "signalling are highly expressed in worms arrested at low density, "
-         "but are repressed at higher arrest densities. We generated a GFP "
-         "reporter strain based on one of the most density-dependent genes in "
-         "our dataset - <i>lips-15</i> - and confirmed that this reporter was "
-         "expressed specifically in worms arrested at relatively low density. "
-         "Finally, we show that conditioned media from high density L1 "
-         "cultures was able to downregulate <i>lips-15</i> even in L1 animals "
-         "arrested at low density, and experiments using <i>daf-22</i> mutant "
-         "animals demonstrated that this effect is not mediated by the "
-         "ascaroside family of signalling pheromones. Together, our data "
-         "implicate a soluble signalling molecule in density sensing by L1 "
-         "stage <i>C. elegans</i>, and provide guidance for design of "
-         "experiments focused on early developmental gene regulation.")
-    with open(test_file_fmt.format(fmt='text'), 'w') as f:
+    abstract_txt = ("This is a paper that contains the phrase: MEK "
+                    "phosphorylates ERK.")
+    with open('test_abstract.txt', 'w') as f:
         f.write(abstract_txt)
-    example_files.append(test_file_fmt.format(fmt='text'))
+    example_files.append('test_abstract.txt')
 
     # Get nxml content
-    tc_nxml = db.select_one(db.TextContent,
-                            db.TextContent.source.in_(['pmc_oa', 'manuscripts']))
-    add_content(tc_nxml, 'nxml')
+    if path.exists('pmc_cont_example.nxml'):
+        example_files.append('pmc_cont_example.nxml')
 
     assert len(example_files), "No content available to test."
 

--- a/indra/tests/test_reading_scripts.py
+++ b/indra/tests/test_reading_scripts.py
@@ -248,7 +248,6 @@ def test_produce_readings():
 def test_read_files():
     "Test that the system can read files."
     # Create the test files.
-    test_file_fmt = 'test_.{fmt}'
     example_files = []
 
     # Get txt content
@@ -259,8 +258,10 @@ def test_read_files():
     example_files.append('test_abstract.txt')
 
     # Get nxml content
-    if path.exists('pmc_cont_example.nxml'):
-        example_files.append('pmc_cont_example.nxml')
+    pmc_test_fpath = path.join(path.dirname(path.abspath(__file__)),
+                               'pmc_cont_example.nxml')
+    if path.exists(pmc_test_fpath):
+        example_files.append(pmc_test_fpath)
 
     assert len(example_files), "No content available to test."
 
@@ -268,7 +269,7 @@ def test_read_files():
     readers = get_readers()
     outputs = read_files(example_files, readers)
     N_out = len(outputs)
-    N_exp = len(example_files)
+    N_exp = 2*len(example_files)
     assert N_out == N_exp, "Expected %d outputs, got %d." % (N_exp, N_out)
 
 

--- a/indra/tests/test_reading_scripts.py
+++ b/indra/tests/test_reading_scripts.py
@@ -14,7 +14,6 @@ from indra.tools.reading.util.script_tools import make_statements
 from indra.tools.reading.readers import SparserReader
 from indra.tools.reading.readers import get_readers as get_all_readers
 
-from indra.db import formats
 from indra.tests.test_db import get_db as get_test_db
 from indra.tests.test_db import get_db_with_pubmed_content
 

--- a/indra/tools/reading/db_reading/read_db.py
+++ b/indra/tools/reading/db_reading/read_db.py
@@ -457,7 +457,7 @@ def process_content(text_content):
         cont_fmt = 'nxml'
     else:
         cont_fmt = text_content.format
-    content = Content.from_string(str(text_content.id), cont_fmt,
+    content = Content.from_string(text_content.id, cont_fmt,
                                   text_content.content, compressed=True,
                                   encoded=True)
     if text_content.source == 'elsevier':

--- a/indra/tools/reading/db_reading/read_db.py
+++ b/indra/tools/reading/db_reading/read_db.py
@@ -520,8 +520,15 @@ def make_db_readings(id_dict, readers, batch_size=1000, force_fulltext=False,
                             )
                         if reading is not None:
                             continue
+                if text_content.format == formats.TEXT:
+                    cont_fmt = 'txt'
+                elif (text_content.source in ['pmc_oa', 'manuscripts']
+                      and text_content.format == formats.XML):
+                    cont_fmt = 'nxml'
+                else:
+                    cont_fmt = text_content.format
                 content = ContentText(text_content.id,
-                                      text_content.format,
+                                      cont_fmt,
                                       text_content.content,
                                       compressed=True, encoded=True)
                 if text_content.source == 'elsevier':

--- a/indra/tools/reading/db_reading/read_db.py
+++ b/indra/tools/reading/db_reading/read_db.py
@@ -104,8 +104,8 @@ from indra.literature.elsevier_client import extract_text as process_elsevier
 from indra.db import get_primary_db, formats, texttypes
 from indra.db import sql_expressions as sql
 from indra.db.util import insert_agents
-from indra.tools.reading.readers import ReadingData, _get_dir, get_reader,\
-    ContentText
+from indra.tools.reading.readers import ReadingData, _get_dir, get_reader, \
+    Content
 
 
 class ReadDBError(Exception):
@@ -457,13 +457,12 @@ def process_content(text_content):
         cont_fmt = 'nxml'
     else:
         cont_fmt = text_content.format
-    content = ContentText(text_content.id,
-                          cont_fmt,
-                          text_content.content,
-                          compressed=True, encoded=True)
+    content = Content.from_string(text_content.id, cont_fmt,
+                                  text_content.content, compressed=True,
+                                  encoded=True)
     if text_content.source == 'elsevier':
-        content = ContentText(content.id, 'txt',
-                              process_elsevier(content.get_text()))
+        content = Content.from_string(content.id, 'text',
+                                      process_elsevier(content.get_text()))
     return content
 
 

--- a/indra/tools/reading/db_reading/read_db.py
+++ b/indra/tools/reading/db_reading/read_db.py
@@ -524,6 +524,9 @@ def make_db_readings(id_dict, readers, batch_size=1000, force_fulltext=False,
                                       text_content.format,
                                       text_content.content,
                                       compressed=True, encoded=True)
+                if text_content.source == 'elsevier':
+                    content = ContentText(content.id, 'txt',
+                                          process_elsevier(content.get_text()))
                 batch_list_dict[r.name].append(content)
 
                 if (len(batch_list_dict[r.name])+1) % batch_size is 0:

--- a/indra/tools/reading/read_files.py
+++ b/indra/tools/reading/read_files.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     if args.debug and not args.quiet:
         logger.setLevel(logging.DEBUG)
 
-from indra.tools.reading.readers import _get_dir, get_readers
+from indra.tools.reading.readers import _get_dir, get_readers, ContentFile
 
 
 def read_files(files, readers, **kwargs):
@@ -48,7 +48,8 @@ def read_files(files, readers, **kwargs):
     """
     output_list = []
     for reader in readers:
-        res_list = reader.read(files, **kwargs)
+        res_list = reader.read([ContentFile(fpath) for fpath in files],
+                               **kwargs)
         if res_list is None:
             logger.info("Nothing read by %s." % reader.name)
         else:

--- a/indra/tools/reading/read_files.py
+++ b/indra/tools/reading/read_files.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     if args.debug and not args.quiet:
         logger.setLevel(logging.DEBUG)
 
-from indra.tools.reading.readers import _get_dir, get_readers, ContentFile
+from indra.tools.reading.readers import _get_dir, get_readers, Content
 
 
 def read_files(files, readers, **kwargs):
@@ -46,10 +46,10 @@ def read_files(files, readers, **kwargs):
     output_list : list [ReadingData]
         A list of ReadingData objects with the contents of the readings.
     """
+    reading_content = [Content.from_file(filepath) for filepath in files]
     output_list = []
     for reader in readers:
-        res_list = reader.read([ContentFile(fpath) for fpath in files],
-                               **kwargs)
+        res_list = reader.read(reading_content, **kwargs)
         if res_list is None:
             logger.info("Nothing read by %s." % reader.name)
         else:

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -154,7 +154,7 @@ class Content(object):
         return any([self._format == fmt for fmt in formats])
 
     def get_id(self):
-        return str(self._id)
+        return self._id
 
     def get_format(self):
         return self._format
@@ -362,10 +362,12 @@ class ReachReader(Reader):
                                % (content.get_id(), quality_issue))
                 continue
 
-            if re.match('^\w+?\d+$', content.get_id()) is None:
+            # Look for things that are more like file names, rather than ids.
+            cid = content.get_id()
+            if isinstance(cid, str) and re.match('^\w*?\d+$', cid) is None:
                 new_id = 'FILE%06d' % i
                 i += 1
-                self.id_maps[new_id] = content.get_id()
+                self.id_maps[new_id] = cid
                 content.change_id(new_id)
                 new_fpath = content.copy_to(self.input_dir)
             else:

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -303,6 +303,7 @@ class ReachReader(Reader):
             if quality_issue is not None:
                 logger.warning("Skipping %d due to: %s"
                                % (content.id, quality_issue))
+                continue
             new_fpath = content.copy_to(self.input_dir)
             logger.debug('%s saved for reading by reach.'
                          % new_fpath)

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -154,7 +154,7 @@ class Content(object):
         return any([self._format == fmt for fmt in formats])
 
     def get_id(self):
-        return self._id
+        return str(self._id)
 
     def get_format(self):
         return self._format
@@ -163,12 +163,14 @@ class Content(object):
         """Get the loaded, decompressed, and decoded text of this content."""
         self._load_raw_content()
         if self._text is None:
+            assert self._raw_content is not None
             ret_cont = self._raw_content
             if self.compressed:
                 ret_cont = zlib.decompress(ret_cont, zlib.MAX_WBITS+16)
             if self.encoded:
                 ret_cont = ret_cont.decode('utf-8')
             self._text = ret_cont
+        assert self._text is not None
         return self._text
 
     def get_filename(self, renew=False):

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -433,7 +433,7 @@ class SparserReader(Reader):
                         content.id = 'PMC' + str(content.id)
                     fpath = content.copy_to(self.tmp_dir)
                     self.file_list.append(fpath)
-            elif content.format == 'txt':
+            elif content.format in ['txt', 'text']:
                 # Otherwise we need to frame the content in xml and put it
                 # in a new file with the appropriate name.
                 nxml_str = sparser.make_nxml_from_text(content.get_text())

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -89,7 +89,7 @@ class Content(object):
     def get_filepath(self):
         if self._location is None:
             self._location = '.'
-        return path.join(self._location, self._fname)
+        return path.join(self._location, self.get_filename())
 
     def copy_to(self, location, fname=None):
         if fname is None:
@@ -106,12 +106,12 @@ class Content(object):
 
 
 class ContentFile(Content):
-    def __init__(self, file_name):
-        file_id = '.'.join(path.basename(file_name).split('.')[:-1])
-        file_format = file_name.split('.')[-1]
+    def __init__(self, file_path):
+        file_id = '.'.join(path.basename(file_path).split('.')[:-1])
+        file_format = file_path.split('.')[-1]
         super(ContentFile, self).__init__(file_id, file_format)
         self.file_exists = True
-        self._location = path.dirname(file_name)
+        self._location = path.dirname(file_path)
         return
 
     def get_text(self):


### PR DESCRIPTION
This PR's primary purpose is to fix the handling of Elsevier content, by extracting the text from Elsevier XML before reading. However, to enable this, and also to pull database dependencies out of the reading architecture, this PR also introduces a new Content object (`indra.tools.reading.readers.Content`), which is now the standard class used for content read by all the readers, whether the content is already loaded, e.g. from the database.

In addition, various small fixes were made.