### PR TITLE
Fix db api handling of FPLX and fruitless roles

### DIFF
--- a/db_rest_api/test_api.py
+++ b/db_rest_api/test_api.py
@@ -127,6 +127,19 @@ class DbApiTestCase(unittest.TestCase):
         assert dt <= TIMELIMIT, dt
         assert size <= SIZELIMIT, size
 
+    def test_famplex_query(self):
+        resp, dt, size = self.__time_get_query('statements',
+                                               ('subject=PDGF@FPLX'
+                                                '&object=FOS'
+                                                '&type=Phosphorylation'))
+        stmts = stmts_from_json(json.loads(resp.data.decode('utf-8')))
+        assert len(stmts)
+        assert all([s.agent_list()[0].db_refs.get('FPLX') == 'PDGF'
+                    for s in stmts]),\
+            'Not all subjects match.'
+        assert dt <= TIMELIMIT, dt
+        assert size <= SIZELIMIT, size
+
     def __test_basic_paper_query(self, id_val, id_type, min_num_results=1):
         query_str = 'id=%s&type=%s' % (id_val, id_type)
         resp, dt, size = self.__time_get_query('papers', query_str)

--- a/indra/tests/test_indra_db_rest.py
+++ b/indra/tests/test_indra_db_rest.py
@@ -54,6 +54,14 @@ def test_too_big_request():
         assert False, 'A very unexpected error occured: %s' % str(e)
 
 
+def test_famplex_namespace():
+    stmts = dbr.get_statements('PDGF@FPLX', 'FOS', stmt_type='IncreaseAmount')
+    assert all([s.agent_list()[0].db_refs['FPLX'] == 'PDGF' for s in stmts]),\
+        'Not all subjects match.'
+    assert all([s.agent_list()[1].name == 'FOS' for s in stmts]),\
+        'Not all objects match.'
+
+
 @attr('nonpublic')
 def test_paper_query():
     stmts_1 = dbr.get_statements_for_paper('PMC5770457', 'pmcid')

--- a/indra/tests/test_indra_db_rest.py
+++ b/indra/tests/test_indra_db_rest.py
@@ -54,6 +54,7 @@ def test_too_big_request():
         assert False, 'A very unexpected error occured: %s' % str(e)
 
 
+@attr('nonpublic')
 def test_famplex_namespace():
     stmts = dbr.get_statements('PDGF@FPLX', 'FOS', stmt_type='IncreaseAmount')
     print(len(stmts))

--- a/indra/tests/test_indra_db_rest.py
+++ b/indra/tests/test_indra_db_rest.py
@@ -56,7 +56,8 @@ def test_too_big_request():
 
 def test_famplex_namespace():
     stmts = dbr.get_statements('PDGF@FPLX', 'FOS', stmt_type='IncreaseAmount')
-    assert all([s.agent_list()[0].db_refs['FPLX'] == 'PDGF' for s in stmts]),\
+    print(len(stmts))
+    assert all([s.agent_list()[0].db_refs.get('FPLX') == 'PDGF' for s in stmts]),\
         'Not all subjects match.'
     assert all([s.agent_list()[1].name == 'FOS' for s in stmts]),\
         'Not all objects match.'


### PR DESCRIPTION
This PR:
- Handles the FPLX->BE rift that currently exists in the database (this will be remedied in the near future, but must be patched for now).
- Correctly handles the case were no statements remain at the end of a check.