### PR TITLE
Fix retrieval of abstracts.

### DIFF
--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -180,8 +180,9 @@ def _abstract_from_article_element(article, prepend_title=False):
     abstract = article.findall('Abstract/AbstractText')
     if abstract is None:
         return None
-    abstract_text = ' '.join([' ' if abst.text is None
-                                  else abst.text for abst in abstract])
+    abstract_text = ' '.join(['' if abst.text is None
+                              else ' '.join([text for text in abst.itertext()])
+                              for abst in abstract])
     title_tag = article.find('ArticleTitle')
     if title_tag is not None and prepend_title:
         title = title_tag.text

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -104,3 +104,9 @@ def test_get_metadata_for_ids():
 def test_send_request_invalid():
     res = pubmed_client.send_request('http://xxxxxxx', data={})
     assert res is None
+
+
+@attr('webservice')
+def test_abstract_with_html_embedded():
+    res = pubmed_client.get_abstract('25484845')
+    assert len(res) > 4, res


### PR DESCRIPTION
This fixes a bug wherein abstracts from pubmed which had html-style formatting internally, were truncated at the first instance of formatting. For example, "This is <i>not</i> really and abstract." would be returned by the pubmed client as "This is ".