### PR TITLE
Provide feedback when too many statements found.

### DIFF
--- a/db_rest_api/api.py
+++ b/db_rest_api/api.py
@@ -210,15 +210,12 @@ def get_statements():
     # Check to make sure we didn't get too many statements
     if len(stmts) > MAX_STATEMENTS:
         # Divide the statements up by type, and get counts of each type.
-        stmts_dict = {}
         stmt_counts = {}
         for stmt in stmts:
             stmt_type = type(stmt).__name__
             if stmt_type not in stmt_counts:
                 stmt_counts[stmt_type] = {'count': 0}
-                stmts_dict[stmt_type] = []
             stmt_counts[stmt_type]['count'] += 1
-            stmts_dict[stmt_type].append(stmt)
 
         return jsonify(stmt_counts), 413
 

--- a/db_rest_api/test_api.py
+++ b/db_rest_api/test_api.py
@@ -113,6 +113,7 @@ class DbApiTestCase(unittest.TestCase):
         resp, dt, size = self.__time_get_query('statements', 'agent=TP53')
         assert resp.status_code == 413, "Unexpected status code: %s" % str(resp)
         assert dt < 30, "Query took too long: %d" % dt
+        assert 'Acetylation' in json.loads(resp.data.decode('utf-8'))
 
     def test_query_with_hgnc_ns(self):
         """Test specifying HGNC as a namespace."""


### PR DESCRIPTION
This PR alters the REST API service to provide more detailed feedback to the user if there are too many statements, specifically returning a count of each statement type.