### PR TITLE
Improve indra db REST client

### DIFF
--- a/indra/statements.py
+++ b/indra/statements.py
@@ -3195,14 +3195,16 @@ class NotAStatementName(Exception):
     pass
 
 
-def make_statement_camel(stmt_name):
-    """Makes a statement name match the case of the corresponding statement."""
+def get_statement_by_name(stmt_name):
+    """Get a statement class given the name of the statement class."""
     stmt_classes = get_all_descendants(Statement)
     for stmt_class in stmt_classes:
         if stmt_class.__name__.lower() == stmt_name.lower():
-            ret = stmt_class.__name__
-            break
-    else:
-        raise NotAStatementName('%s is not recognized as a statement.'
-                                % stmt_name)
-    return ret
+            return stmt_class
+    raise NotAStatementName('%s is not recognized as a statement type: %s'
+                            % stmt_name)
+
+
+def make_statement_camel(stmt_name):
+    """Makes a statement name match the case of the corresponding statement."""
+    return get_statement_by_name(stmt_name).__name__

--- a/indra/tests/test_indra_db_rest.py
+++ b/indra/tests/test_indra_db_rest.py
@@ -12,7 +12,7 @@ def __check_request(seconds, *args, **kwargs):
     stmts = dbr.get_statements(*args, **kwargs)
     assert stmts, "Got no statements."
     time_taken = datetime.now() - now
-    assert time_taken.seconds < seconds
+    assert time_taken.seconds < seconds, time_taken.seconds
 
 
 @attr('nonpublic')
@@ -43,15 +43,7 @@ def test_bigger_request():
 
 @attr('nonpublic')
 def test_too_big_request():
-    try:
-        dbr.get_statements(agents=['TP53'])
-    except dbr.IndraDBRestError as e:
-        if e.status_code == 413:
-            pass
-        else:
-            assert False, 'Unexpected error occurred: %s' % str(e)
-    except BaseException as e:
-        assert False, 'A very unexpected error occurred: %s' % str(e)
+    __check_request(60, agents=['TP53'])
 
 
 @attr('nonpublic')

--- a/indra/tests/test_indra_db_rest.py
+++ b/indra/tests/test_indra_db_rest.py
@@ -24,7 +24,7 @@ def test_simple_request():
 def test_null_request():
     try:
         dbr.get_statements()
-    except dbr.IndraDBRestError:
+    except ValueError:
         return
     except BaseException as e:
         assert False, "Raised wrong exception: " + str(e)
@@ -44,14 +44,14 @@ def test_bigger_request():
 @attr('nonpublic')
 def test_too_big_request():
     try:
-        __check_request(30, agents=['TP53'])
+        dbr.get_statements(agents=['TP53'])
     except dbr.IndraDBRestError as e:
-        if '502: Bad Gateway' in str(e):
-            pass  # This is the error that indicates the too much data.
+        if e.status_code == 413:
+            pass
         else:
-            assert False, 'Unexpected error occured: %s' % str(e)
+            assert False, 'Unexpected error occurred: %s' % str(e)
     except BaseException as e:
-        assert False, 'A very unexpected error occured: %s' % str(e)
+        assert False, 'A very unexpected error occurred: %s' % str(e)
 
 
 @attr('nonpublic')

--- a/indra/tests/test_indra_db_rest.py
+++ b/indra/tests/test_indra_db_rest.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from nose.plugins.attrib import attr
 from indra.sources import indra_db_rest as dbr
+from indra.sources.indra_db_rest import IndraDBRestError
 
 
 def __check_request(seconds, *args, **kwargs):
@@ -13,6 +14,7 @@ def __check_request(seconds, *args, **kwargs):
     assert stmts, "Got no statements."
     time_taken = datetime.now() - now
     assert time_taken.seconds < seconds, time_taken.seconds
+    return stmts
 
 
 @attr('nonpublic')
@@ -43,7 +45,21 @@ def test_bigger_request():
 
 @attr('nonpublic')
 def test_too_big_request():
-    __check_request(60, agents=['TP53'])
+    stmts_smpl = __check_request(30, agents=['TP53'])
+    try:
+        __check_request(30, agents=['TP53'], on_limit='error')
+        assert False, "Didn't raise error."
+    except IndraDBRestError as e:
+        assert e.status_code == 413, str(e)
+        assert len(e.resp.json()['statements'])
+    stmts_all = __check_request(60, agents=['TP53'], on_limit='persist')
+    assert len(stmts_all) > len(stmts_smpl)
+    smpl_uuids = {s.uuid for s in stmts_smpl}
+    all_uuids = {s.uuid for s in stmts_all}
+    assert smpl_uuids.issubset(all_uuids)
+    stmts_trnc = __check_request(30, agents=['TP53'], on_limit='truncate')
+    assert len(stmts_trnc) == len(stmts_smpl)
+    assert {s.uuid for s in stmts_trnc}.issubset(all_uuids)
 
 
 @attr('nonpublic')

--- a/indra/tests/test_indra_db_rest.py
+++ b/indra/tests/test_indra_db_rest.py
@@ -70,3 +70,12 @@ def test_paper_query():
     assert len(stmts_1)
     stmts_2 = dbr.get_statements_for_paper('8436299')
     assert len(stmts_2)
+
+
+@attr('nonpublic')
+def test_regulate_amount():
+    stmts = dbr.get_statements('FOS', stmt_type='RegulateAmount')
+    print(len(stmts))
+    stmt_types = {type(s).__name__ for s in stmts}
+    print(stmt_types)
+    assert {'IncreaseAmount', 'DecreaseAmount'}.issubset(stmt_types), stmt_types


### PR DESCRIPTION
This PR:
- allows the user to give a parent class of statement, and get the all the statements corresponding to it's children, e.g. given RegulateAmount, the `get_statements` function will now also return statements for `IncreaseAmount` and `DecreaseAmount`, and others.
- allows the client to break up queries that are too large into smaller chunks by statement type, thus circumventing the REST service's limit of 10,000 statements per request.