### PR TITLE
External belief prior scoring function

### DIFF
--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -194,7 +194,7 @@ class BeliefEngine(object):
     ----------
     scorer : object
         An object that computes the prior probability of a statement given its
-        its statment type and evidence. Must support type methods: 
+        its statment type and evidence. Must support type methods:
         * score_statement: takes indra.statements.Statement
             computes the belief score of a statement
         * check_prior_probs: takes list<indra.statements.Statement>

--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -201,7 +201,9 @@ class BeliefEngine(object):
             Verifies that the scorer has all the information it needs to score
             every statement in the list, and raises an exception if not
     """
-    def __init__(self, scorer=default_scorer):
+    def __init__(self, scorer=None):
+        if scorer is None:
+            scorer = default_scorer
         assert(isinstance(scorer, BeliefScorer))
         self.scorer = scorer
 

--- a/indra/explanation/model_checker.py
+++ b/indra/explanation/model_checker.py
@@ -361,6 +361,10 @@ class ModelChecker(object):
         # object, and the object may not have an "active" site of the
         # appropriate type
         obs_names = self.stmt_to_obs[stmt]
+        if not obs_names:
+            logger.debug("No observables for stmt %s, returning False" % stmt)
+            return PathResult(False, 'OBSERVABLES_NOT_FOUND',
+                              max_paths, max_path_length)
         for obs_name in obs_names:
             return self._find_im_paths(subj_mp, obs_name, target_polarity,
                                        max_paths, max_path_length)
@@ -376,6 +380,10 @@ class ModelChecker(object):
         else:
             target_polarity = 1 if isinstance(stmt, IncreaseAmount) else -1
         obs_names = self.stmt_to_obs[stmt]
+        if not obs_names:
+            logger.debug("No observables for stmt %s, returning False" % stmt)
+            return PathResult(False, 'OBSERVABLES_NOT_FOUND',
+                              max_paths, max_path_length)
         for obs_name in obs_names:
             return self._find_im_paths(subj_mp, obs_name, target_polarity,
                                        max_paths, max_path_length)
@@ -579,7 +587,7 @@ class ModelChecker(object):
             if not input_rule_set:
                 return PathResult(False, 'INPUT_RULES_NOT_FOUND',
                                   max_paths, max_path_length)
-        logger.info('Finding paths between %s and %s with polarity %s' %
+        logger.info('Checking path metrics between %s and %s with polarity %s' %
                     (subj_mp, obs_name, target_polarity))
 
         # -- Route to the path sampling function --

--- a/indra/sources/geneways/processor.py
+++ b/indra/sources/geneways/processor.py
@@ -105,7 +105,7 @@ class GenewaysProcessor(object):
         # listed by the Geneways action mention table and only includes
         # it in the evidence if there is exactly one such sentence
         text = None
-        if get_ft_mention:
+        if self.get_ft_mention:
             try:
                 content, content_type = get_full_text(mention.pmid, 'pmid')
                 if content is not None:

--- a/indra/tests/test_belief_engine.py
+++ b/indra/tests/test_belief_engine.py
@@ -191,6 +191,7 @@ def test_default_probs():
         for k, v in default_probs[err_type].items():
             assert default_probs[err_type][k] == v
 
+
 def test_default_probs_override():
     """Make sure default probs are overriden by constructor argument."""
     prior_probs={'rand': {'assertion': 0.5}}
@@ -203,6 +204,7 @@ def test_default_probs_override():
                 assert v == 0.5
             else:
                 assert default_probs[err_type][k] == v
+
 
 def test_default_probs_extend():
     """Make sure default probs are extended by constructor argument."""

--- a/indra/tests/test_belief_engine.py
+++ b/indra/tests/test_belief_engine.py
@@ -35,9 +35,9 @@ def test_prior_prob_two_same():
 def test_prior_prob_two_different():
     be = BeliefEngine()
     prob = 1 - (default_probs['rand']['reach'] +
-                 default_probs['syst']['reach']) * \
+                default_probs['syst']['reach']) * \
                (default_probs['rand']['trips'] +
-                 default_probs['syst']['trips'])
+                default_probs['syst']['trips'])
     st = Phosphorylation(None, Agent('a'), evidence=[ev1, ev2])
     assert(st.belief == 1)
     be.set_prior_probs([st])
@@ -47,9 +47,9 @@ def test_prior_prob_two_different():
 def test_prior_prob_one_two():
     be = BeliefEngine()
     prob = 1 - (default_probs['rand']['reach']**2 +
-                 default_probs['syst']['reach']) * \
+                default_probs['syst']['reach']) * \
                (default_probs['rand']['trips'] +
-                 default_probs['syst']['trips'])
+                default_probs['syst']['trips'])
     st = Phosphorylation(None, Agent('a'), evidence=[ev1, ev1, ev2])
     assert(st.belief == 1)
     be.set_prior_probs([st])
@@ -194,7 +194,7 @@ def test_default_probs():
 
 def test_default_probs_override():
     """Make sure default probs are overriden by constructor argument."""
-    prior_probs={'rand': {'assertion': 0.5}}
+    prior_probs = {'rand': {'assertion': 0.5}}
     scorer = SimpleScorer(prior_probs)
 
     be = BeliefEngine(scorer)
@@ -208,8 +208,8 @@ def test_default_probs_override():
 
 def test_default_probs_extend():
     """Make sure default probs are extended by constructor argument."""
-    prior_probs={'rand': {'new_source': 0.1},
-                                   'syst': {'new_source': 0.05}}
+    prior_probs = {'rand': {'new_source': 0.1},
+                   'syst': {'new_source': 0.05}}
     scorer = SimpleScorer(prior_probs)
 
     be = BeliefEngine(scorer)
@@ -282,50 +282,50 @@ def test_evidence_subtype_tagger():
     assert(stype == 'donald_duck')
     assert(subtype is None)
 
+
 def test_evidence_random_noise_prior():
     type_probs = {'biopax': 0.9, 'geneways': 0.2}
     biopax_subtype_probs = {
-            'reactome' : 0.4,
-            'biogrid' : 0.2}
+            'reactome': 0.4,
+            'biogrid': 0.2}
     geneways_subtype_probs = {
             'phosphorylate': 0.5,
-            'bind' : 0.7}
-    subtype_probs = {
-        'biopax' : biopax_subtype_probs,
-        'geneways' : geneways_subtype_probs }
+            'bind': 0.7}
+    subtype_probs = {'biopax': biopax_subtype_probs,
+                     'geneways': geneways_subtype_probs}
 
     ev_geneways_bind = Evidence(source_api='geneways', source_id=0,
-            pmid=0, text=None, epistemics={},
-            annotations={'actiontype': 'bind'})
+                                pmid=0, text=None, epistemics={},
+                                annotations={'actiontype': 'bind'})
     ev_biopax_reactome = Evidence(source_api='biopax', source_id=0,
-            pmid=0, text=None, epistemics={},
-            annotations={'source_sub_id': 'reactome'})
+                                  pmid=0, text=None, epistemics={},
+                                  annotations={'source_sub_id': 'reactome'})
     ev_biopax_pid = Evidence(source_api='biopax', source_id=0,
-            pmid=0, text=None, epistemics={},
-            annotations={'source_sub_id': 'pid'})
+                             pmid=0, text=None, epistemics={},
+                             annotations={'source_sub_id': 'pid'})
 
-    #Random noise prior for geneways bind evidence is the subtype prior,
-    #since we specified it
+    # Random noise prior for geneways bind evidence is the subtype prior,
+    # since we specified it
     assert(evidence_random_noise_prior(ev_geneways_bind,
-        type_probs, subtype_probs) == 0.7)
+           type_probs, subtype_probs) == 0.7)
 
-    #Random noise prior for reactome biopax evidence is the subtype prior,
-    #since we specified it
+    # Random noise prior for reactome biopax evidence is the subtype prior,
+    # since we specified it
     assert(evidence_random_noise_prior(ev_biopax_reactome,
-        type_probs, subtype_probs) == 0.4)
+           type_probs, subtype_probs) == 0.4)
 
-    #Random noise prior for pid evidence is the subtype prior,
-    #since we specified it
+    # Random noise prior for pid evidence is the subtype prior,
+    # since we specified it
     assert(evidence_random_noise_prior(ev_biopax_pid,
-        type_probs, subtype_probs) == 0.9)
+           type_probs, subtype_probs) == 0.9)
 
-    #Make sure this all still works when we go through the belief engine
+    # Make sure this all still works when we go through the belief engine
     statements = []
     members = [Agent('a'), Agent('b')]
-    statements.append( Complex(members, evidence=ev_geneways_bind) )
-    statements.append( Complex(members, evidence=ev_biopax_reactome) )
-    statements.append( Complex(members, evidence=ev_biopax_pid) )
-    p = {'rand': type_probs, 'syst': {'biopax':0, 'geneways':0}}
+    statements.append(Complex(members, evidence=ev_geneways_bind))
+    statements.append(Complex(members, evidence=ev_biopax_reactome))
+    statements.append(Complex(members, evidence=ev_biopax_pid))
+    p = {'rand': type_probs, 'syst': {'biopax': 0, 'geneways': 0}}
 
     scorer = SimpleScorer(p, subtype_probs)
     engine = BeliefEngine(scorer)

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -190,6 +190,10 @@ def run_preassembly(stmts_in, **kwargs):
         processes, while smaller groups are compared in the parent process.
         Default value is 100. Not relevant when parallelization is not
         used.
+    belief_scorer : instance of indra.belief.BeliefScorer
+        Instance of BeliefScorer class to use in calculating Statement
+        probabilities. If None is provided (default), then the default
+        scorer is used.
     save : Optional[str]
         The name of a pickle file to save the results (stmts_out) into.
     save_unique : Optional[str]
@@ -201,7 +205,8 @@ def run_preassembly(stmts_in, **kwargs):
         A list of preassembled top-level statements.
     """
     dump_pkl_unique = kwargs.get('save_unique')
-    be = BeliefEngine()
+    belief_scorer = kwargs.get('belief_scorer')
+    be = BeliefEngine(scorer=belief_scorer)
     pa = Preassembler(hierarchies, stmts_in)
     run_preassembly_duplicate(pa, be, save=dump_pkl_unique)
 
@@ -222,7 +227,7 @@ def run_preassembly_duplicate(preassembler, beliefengine, **kwargs):
     preassembler : indra.preassembler.Preassembler
         A Preassembler instance
     beliefengine : indra.belief.BeliefEngine
-        A BeliefEngine instance
+        A BeliefEngine instance.
     save : Optional[str]
         The name of a pickle file to save the results (stmts_out) into.
 
@@ -250,7 +255,7 @@ def run_preassembly_related(preassembler, beliefengine, **kwargs):
         A Preassembler instance which already has a set of unique statements
         internally.
     beliefengine : indra.belief.BeliefEngine
-        A BeliefEngine instance
+        A BeliefEngine instance.
     return_toplevel : Optional[bool]
         If True, only the top-level statements are returned. If False,
         all statements are returned irrespective of level of specificity.


### PR DESCRIPTION
With this PR, the belief engine accepts an external scoring function to determine the belief score of a statement given the statement type and evidence.