### PR TITLE
Complex refinement

### DIFF
--- a/indra/statements.py
+++ b/indra/statements.py
@@ -2328,18 +2328,22 @@ class Complex(Statement):
         if len(self.members) != len(other.members):
             return False
         # Check that every member in other is refined in self, but only once!
-        self_match_indices = set([])
-        for other_agent in other.members:
-            for self_agent_ix, self_agent in enumerate(self.members):
-                if self_agent_ix in self_match_indices:
-                    continue
-                if self_agent.refinement_of(other_agent, hierarchies):
-                    self_match_indices.add(self_agent_ix)
-                    break
-        if len(self_match_indices) != len(other.members):
-            return False
-        else:
+
+        def match_members(self_members, other_members):
+            self_match_indices = set([])
+            for other_agent in other_members:
+                for self_agent_ix, self_agent in enumerate(self_members):
+                    if self_agent_ix in self_match_indices:
+                        continue
+                    if self_agent.refinement_of(other_agent, hierarchies):
+                        self_match_indices.add(self_agent_ix)
+                        break
+            print(self_match_indices)
+            if len(self_match_indices) != len(other_members):
+                return False
             return True
+
+        return match_members(self.members, other.members)
 
     def equals(self, other):
         matches = super(Complex, self).equals(other)

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -159,6 +159,7 @@ import sys
 import uuid
 import rdflib
 import logging
+import itertools
 from copy import deepcopy
 from collections import OrderedDict as _o
 from indra.util import unicode_strs
@@ -2330,18 +2331,20 @@ class Complex(Statement):
         # Check that every member in other is refined in self, but only once!
 
         def match_members(self_members, other_members):
-            self_match_indices = set([])
-            for other_agent in other_members:
-                for self_agent_ix, self_agent in enumerate(self_members):
-                    if self_agent_ix in self_match_indices:
-                        continue
-                    if self_agent.refinement_of(other_agent, hierarchies):
-                        self_match_indices.add(self_agent_ix)
-                        break
-            print(self_match_indices)
-            if len(self_match_indices) != len(other_members):
-                return False
-            return True
+            other_member_perms = \
+                itertools.permutations(other_members, len(other_members))
+            for other_member_perm in other_member_perms:
+                self_match_indices = set([])
+                for other_agent in other_member_perm:
+                    for self_agent_ix, self_agent in enumerate(self_members):
+                        if self_agent_ix in self_match_indices:
+                            continue
+                        if self_agent.refinement_of(other_agent, hierarchies):
+                            self_match_indices.add(self_agent_ix)
+                            break
+                if len(self_match_indices) == len(other_members):
+                    return True
+            return False
 
         return match_members(self.members, other.members)
 

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -2331,19 +2331,32 @@ class Complex(Statement):
         # Check that every member in other is refined in self, but only once!
 
         def match_members(self_members, other_members):
+            # Build all the permutations of the other complex's members
             other_member_perms = \
                 itertools.permutations(other_members, len(other_members))
+            # Compare self with all orders of other
             for other_member_perm in other_member_perms:
                 self_match_indices = set([])
+                # See if each of the members in other has a corresponding
+                # member in self
                 for other_agent in other_member_perm:
                     for self_agent_ix, self_agent in enumerate(self_members):
+                        # This is when the agent is already matched so we
+                        # don't want to match it (use it) again
                         if self_agent_ix in self_match_indices:
                             continue
+                        # If self member is a refinement of other, record
+                        # self's index to make sure we know it's matched
+                        # and don't match it again
                         if self_agent.refinement_of(other_agent, hierarchies):
                             self_match_indices.add(self_agent_ix)
                             break
+                # If we matches all self members to other members, this is
+                # a refinement and we can return
                 if len(self_match_indices) == len(other_members):
                     return True
+            # If none of the orderings resulted in refinement then this
+            # is not a refinement
             return False
 
         return match_members(self.members, other.members)

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -623,3 +623,18 @@ def test_find_contradicts():
         assert {s1.uuid, s2.uuid} in ({st1.uuid, st2.uuid},
                                       {st3.uuid, st4.uuid})
 
+
+def test_preassemble_related_complex():
+    ras = Agent('RAS', db_refs={'FPLX': 'RAS'})
+    kras = Agent('KRAS', db_refs={'HGNC': '6407'})
+    hras = Agent('HRAS', db_refs={'HGNC': '5173'})
+    st1 = Complex([kras, hras])
+    st2 = Complex([kras, ras])
+    st3 = Complex([hras, kras])
+    st4 = Complex([ras, kras])
+    pa = Preassembler(hierarchies, [st1, st2, st3, st4])
+    uniq = pa.combine_duplicates()
+    assert len(uniq) == 2
+    top = pa.combine_related()
+    assert len(top) == 1
+

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1149,9 +1149,11 @@ def test_related_complex_refinement():
     st2 = Complex([kras, ras])
     st3 = Complex([hras, kras])
     st4 = Complex([ras, kras])
-    #assert st1.refinement_of(st2, hierarchies)
-    #assert st3.refinement_of(st4, hierarchies)
+    assert st1.refinement_of(st2, hierarchies)
+    assert st3.refinement_of(st4, hierarchies)
     assert st1.refinement_of(st4, hierarchies)
+    assert not st2.refinement_of(st1, hierarchies)
+    assert not st4.refinement_of(st1, hierarchies)
 
 
 @raises(InvalidResidueError)

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1141,6 +1141,19 @@ def test_mismatched_complex_refinement():
     assert not st2.refinement_of(st1, hierarchies)
 
 
+def test_related_complex_refinement():
+    ras = Agent('RAS', db_refs={'FPLX': 'RAS'})
+    kras = Agent('KRAS', db_refs={'HGNC': '6407'})
+    hras = Agent('HRAS', db_refs={'HGNC': '5173'})
+    st1 = Complex([kras, hras])
+    st2 = Complex([kras, ras])
+    st3 = Complex([hras, kras])
+    st4 = Complex([ras, kras])
+    #assert st1.refinement_of(st2, hierarchies)
+    #assert st3.refinement_of(st4, hierarchies)
+    assert st1.refinement_of(st4, hierarchies)
+
+
 @raises(InvalidResidueError)
 def test_residue_mod_condition():
     ModCondition('phosphorylation', 'xyz')


### PR DESCRIPTION
This PR fixes #558 by taking into account multiple orderings of complexes to handle the case when members of the complex are cross-related (this is a very special case to be honest). This solves the issue but can in some cases result in slower pre-assembly (for instance when encountering such complexes with many members) - the effect on speed in practice is not clear yet.