### PR TITLE
Fix issue with CAG nodes not being grounded properly in viz

### DIFF
--- a/indra/assemblers/cag_assembler.py
+++ b/indra/assemblers/cag_assembler.py
@@ -57,7 +57,8 @@ class CAGAssembler(object):
         nx.MultiDiGraph
             The assembled CAG.
         """
-        self.grounding_threshold = grounding_threshold
+        if grounding_threshold is not None:
+            self.grounding_threshold = grounding_threshold
 
         # Filter to Influence Statements which are currently supported
         statements = [stmt for stmt in self.statements if


### PR DESCRIPTION
The grounding threshold was automatically being set to `None` in the `make_model` class method, even if it was specified during instantiation.