### PR TITLE
Clean up some bugs found while applying changes made in the db_refactor branch.

### DIFF
--- a/db_rest_api/api.py
+++ b/db_rest_api/api.py
@@ -92,9 +92,6 @@ def _get_relevant_statements(stmts, ag_id, ns, stmt_type, role=None):
     """
     logger.debug("Checking agent %s in namespace %s." % (ag_id, ns))
     # TODO: This is a temporary measure, remove ASAP.
-    if ns == 'FPLX':
-        ns = 'BE'
-
     if role:
         role = role.upper()
 
@@ -229,14 +226,6 @@ def get_statements():
         elif limit_behavior == 'sample':
             from random import sample
             stmts = sample(stmts, MAX_STATEMENTS)
-
-    # TODO: This is a temporary patch. Remove ASAP.
-    # Fix the names from BE to FPLX
-    for s in stmts:
-        for ag in s.agent_list():
-            if ag is not None:
-                if 'BE' in ag.db_refs.keys():
-                    ag.db_refs['FPLX'] = ag.db_refs.pop('BE')
 
     # Create the json response, and send off.
     resp = jsonify({'limited': hit_limit,

--- a/db_rest_api/test_api.py
+++ b/db_rest_api/test_api.py
@@ -54,15 +54,21 @@ class DbApiTestCase(unittest.TestCase):
             ("Query took up %f MB. Must be less than %f MB."
              % (size/1e6, SIZELIMIT/1e6))
         stmts = stmts_from_json(json_stmts)
-        assert any([s.supports + s.supported_by for s in stmts]),\
-            ("Some statements lack support: %s."
-             % str([str(s) for s in stmts if not s.supports + s.supported_by]))
-        if check_stmts:
-            assert all([not s1.matches(s2)
-                        for s1, s2 in combinations(stmts, 2)]),\
-                ("Some statements match: %s."
-                 % str([(s1, s2) for s1, s2 in combinations(stmts, 2)
-                        if s1.matches(s2)]))
+        assert all([s.evidence for s in stmts]), \
+            "Some statements lack evidence."
+
+        # To allow for faster response-times, we currently do not include
+        # support links in the response.
+        # assert any([s.supports + s.supported_by for s in stmts]),\
+        #     ("Some statements lack support: %s."
+        #      % str([str(s) for s in stmts if not s.supports+s.supported_by]))
+        # if check_stmts:
+        #     assert all([not s1.matches(s2)
+        #                 for s1, s2 in combinations(stmts, 2)]),\
+        #         ("Some statements match: %s."
+        #          % str([(s1, s2) for s1, s2 in combinations(stmts, 2)
+        #                 if s1.matches(s2)]))
+
         assert dt <= time_limit, \
             ("Query took %f seconds. Must be less than %f seconds."
              % (dt, time_limit))

--- a/indra/db/util.py
+++ b/indra/db/util.py
@@ -541,7 +541,7 @@ def _get_filtered_rdg_statements(db, get_full_stmts, clauses=None,
                                           clauses)
 
     # Specify sources of fulltext content, and order priorities.
-    full_text_content = ['manuscripts', 'pmc_oa', 'elsevier']
+    full_text_content = ['manuscripts', 'pmc_oa', 'elsevier', 'pubmed']
 
     def better_func(element):
         print(element)
@@ -554,7 +554,7 @@ def _get_filtered_rdg_statements(db, get_full_stmts, clauses=None,
     for trid, src_dict in stmt_nd.items():
         bettered_duplicate_stmts = set()
         # Filter out unneeded fulltext.
-        while sum([k != 'pubmed' for k in src_dict.keys()]) > 1:
+        while len(src_dict) > 1:
             try:
                 worst_src = min(src_dict, key=better_func)
                 bettered_duplicate_stmts |= src_dict[worst_src].get_leaves()

--- a/indra/db/util.py
+++ b/indra/db/util.py
@@ -546,10 +546,10 @@ def _get_filtered_rdg_statements(db, get_full_stmts, clauses=None,
                                           clauses)
 
     # Specify sources of fulltext content, and order priorities.
-    full_text_content = ['manuscripts', 'pmc_oa', 'elsevier', 'pubmed']
+    text_content_sources = ['manuscripts', 'pmc_oa', 'elsevier', 'pubmed']
 
     def better_func(element):
-        return full_text_content.index(element)
+        return text_content_sources.index(element)
 
     # Now we filter and get the set of statements/statement ids.
     stmts = set()

--- a/indra/tests/test_db_preassembly.py
+++ b/indra/tests/test_db_preassembly.py
@@ -273,7 +273,8 @@ def _check_preassembly_with_database(num_stmts, batch_size):
     assert num_support_links
 
     # Try to get all the preassembled statements from the table.
-    pa_stmts = db_client.get_statements([], preassembled=True, db=db)
+    pa_stmts = db_client.get_statements([], preassembled=True, db=db,
+                                        with_support=True)
     assert len(pa_stmts) == len(pa_stmt_list), (len(pa_stmts),
                                                 len(pa_stmt_list))
 
@@ -294,8 +295,11 @@ def test_db_preassembly_large():
 
 
 @needs_py3
-def _check_incremental_preassembly_with_database(num_stmts, batch_size):
-    db = _get_loaded_db(num_stmts, batch_size=batch_size, split=0.8,
+def _check_db_pa_supplement(num_stmts, batch_size, init_batch_size=None,
+                            split=0.8):
+    if not init_batch_size:
+        init_batch_size = batch_size
+    db = _get_loaded_db(num_stmts, batch_size=init_batch_size, split=split,
                         with_init_corpus=True)
     start = datetime.now()
     pa_manager = pm.PreassemblyManager(batch_size=batch_size)
@@ -305,15 +309,16 @@ def _check_incremental_preassembly_with_database(num_stmts, batch_size):
     print("Duration of incremental update:", end-start)
 
     raw_stmts = db_util.distill_stmts(db, get_full_stmts=True)
-    pa_stmts = db_client.get_statements([], preassembled=True, db=db)
+    pa_stmts = db_client.get_statements([], preassembled=True, db=db,
+                                        with_support=True)
     _check_against_opa_stmts(raw_stmts, pa_stmts)
 
 
 @attr('nonpublic')
 def test_db_incremental_preassembly_small():
-    _check_incremental_preassembly_with_database(200, 40)
+    _check_db_pa_supplement(200, 40)
 
 
 @attr('nonpublic', 'slow')
 def test_db_incremental_preassembly_large():
-    _check_incremental_preassembly_with_database(11721, 2017)
+    _check_db_pa_supplement(11721, 2017)

--- a/indra/tests/test_db_preassembly.py
+++ b/indra/tests/test_db_preassembly.py
@@ -297,9 +297,12 @@ def test_db_preassembly_large():
 def _check_incremental_preassembly_with_database(num_stmts, batch_size):
     db = _get_loaded_db(num_stmts, batch_size=batch_size, split=0.8,
                         with_init_corpus=True)
+    start = datetime.now()
     pa_manager = pm.PreassemblyManager(batch_size=batch_size)
     print("Beginning supplement...")
     pa_manager.supplement_corpus(db)
+    end = datetime.now()
+    print("Duration of incremental update:", end-start)
 
     raw_stmts = db_util.distill_stmts(db, get_full_stmts=True)
     pa_stmts = db_client.get_statements([], preassembled=True, db=db)

--- a/indra/util/__init__.py
+++ b/indra/util/__init__.py
@@ -210,7 +210,7 @@ def flatMap(f, xs):
     return flatten(lmap(f, xs))
 
 
-def batch_iter(iterator, batch_size, padding=None, return_func=None):
+def batch_iter(iterator, batch_size, return_func=None, padding=None):
     """Break an iterable into batches of size batch_size
 
     Note that `padding` should be set to something (anything) which is NOT a
@@ -223,12 +223,12 @@ def batch_iter(iterator, batch_size, padding=None, return_func=None):
         A python object which is iterable.
     batch_size : int
         The size of batches you wish to produce from the iterator.
-    padding : anything
-        This is used internally to ensure that the remainder of the list is
-        included. This MUST NOT be a valid element of the iterator.
     return_func : executable or None
         Pass a function that takes a generator and returns an iterable (e.g.
         `list` or `set`). If None, a generator will be returned.
+    padding : anything
+        This is used internally to ensure that the remainder of the list is
+        included. This MUST NOT be a valid element of the iterator.
 
     Returns
     -------


### PR DESCRIPTION
This PR applies various small fixes and improvements found in the wake of the db_refactor branch. Key among them:
- Special handling of Famplex in the web client is no longer needed
- Support is no longer retrieved by default in the web client. Future development will likely involve special calls to get support links for a statement or statements.
- Deletes of duplicate statements in the db preassembly pipeline are now done in batches.
- Various improvements to logging.