### PR TITLE
Eidos CLI

### DIFF
--- a/doc/modules/sources/eidos/index.rst
+++ b/doc/modules/sources/eidos/index.rst
@@ -21,3 +21,9 @@ Eidos Reader (:py:mod:`indra.sources.eidos.eidos_reader`)
 
 .. automodule:: indra.sources.eidos.eidos_reader
     :members:
+
+Eidos CLI (:py:mod:`indra.sources.eidos.eidos_cli`)
+---------------------------------------------------
+
+.. automodule:: indra.sources.eidos.eidos_cli
+    :members:

--- a/indra/sources/eidos/eidos_cli.py
+++ b/indra/sources/eidos/eidos_cli.py
@@ -1,0 +1,87 @@
+"""
+This is a Python based command line interface to Eidos
+to complement the Python-Java bridge based interface.
+EIDOSPATH (in the INDRA config.ini or as an environmental variable)
+needs to be pointing to a fat JAR of the Eidos system.
+"""
+import os
+import glob
+import logging
+import subprocess
+from indra import get_config
+from .eidos_api import process_json_ld_file
+
+
+eip = get_config('EIDOSPATH')
+eidos_package = 'org.clulab.wm.eidos'
+logger = logging.getLogger('eidos_cli')
+
+
+def run_eidos(endpoint, *args):
+    """Run a given enpoint of Eidos through the command line.
+
+    Parameters
+    ----------
+    endpoint : str
+        The class within the Eidos package to run, for instance
+        'apps.ExtractFromDirectory' will run
+        'org.clulab.wm.eidos.apps.ExtractFromDirectory'
+    *args
+        Any further arguments to be passed as inputs to the class
+        being run.
+    """
+    # Make the full path to the class that should be used
+    call_class = '%s.%s' % (eidos_package, endpoint)
+    # Assemble the command line command and append optonal args
+    cmd = ['java', '-Xmx12G', '-cp', eip, call_class] + list(args)
+    logger.info('Running Eidos with command "%s"' % (' '.join(cmd)))
+    subprocess.call(cmd)
+
+
+def run_extract_from_directory(path_in, path_out):
+    """Run Eidos on a set of text files in a folder.
+
+    The output is produced in the specified output folder but
+    the output files aren't processed by this function.
+
+    Parameters
+    ----------
+    path_in : str
+        Path to an input folder with some text files
+    path_out : str
+        Path to an output folder in which Eidos places the output
+        JSON-LD files
+    """
+    logger.info('Running Eidos on input folder %s' % path_in)
+    run_eidos('apps.ExtractFromDirectory', path_in, path_out)
+
+
+def run_extract_and_process(path_in, path_out):
+    """Run Eidos on a set of text files and process output with INDRA.
+
+    The output is produced in the specified output folder but
+    the output files aren't processed by this function.
+
+    Parameters
+    ----------
+    path_in : str
+        Path to an input folder with some text files
+    path_out : str
+        Path to an output folder in which Eidos places the output
+        JSON-LD files
+
+    Returns
+    -------
+    stmts : list[indra.statements.Statements]
+        A list of INDRA Statements
+    """
+    run_extract_from_directory(path_in, path_out)
+    jsons = glob.glob(os.path.join(path_out, '*.jsonld'))
+    logger.info('Found %d JSON-LD files to process in %s' %
+                (len(jsons), path_out))
+    stmts = []
+    for json in jsons:
+        ep = process_json_ld_file(json)
+        if ep:
+            stmts += ep.statements
+    return stmts

--- a/indra/sources/eidos/eidos_cli.py
+++ b/indra/sources/eidos/eidos_cli.py
@@ -38,7 +38,7 @@ def run_eidos(endpoint, *args):
     subprocess.call(cmd)
 
 
-def run_extract_from_directory(path_in, path_out):
+def extract_from_directory(path_in, path_out):
     """Run Eidos on a set of text files in a folder.
 
     The output is produced in the specified output folder but
@@ -56,7 +56,7 @@ def run_extract_from_directory(path_in, path_out):
     run_eidos('apps.ExtractFromDirectory', path_in, path_out)
 
 
-def run_extract_and_process(path_in, path_out):
+def extract_and_process(path_in, path_out):
     """Run Eidos on a set of text files and process output with INDRA.
 
     The output is produced in the specified output folder but
@@ -75,7 +75,7 @@ def run_extract_and_process(path_in, path_out):
     stmts : list[indra.statements.Statements]
         A list of INDRA Statements
     """
-    run_extract_from_directory(path_in, path_out)
+    extract_from_directory(path_in, path_out)
     jsons = glob.glob(os.path.join(path_out, '*.jsonld'))
     logger.info('Found %d JSON-LD files to process in %s' %
                 (len(jsons), path_out))


### PR DESCRIPTION
This PR adds a Python CLI wrapper around Eidos to allow running it from within Python via the command line. This is complementary to using the Python-Java bridge and is meant to facilitate batch processing of large numbers of files with Eidos from a Python environment. Example usage:

```python
from indra.sources.eidos import eidos_cli
stmts = eidos_cli.extract_and_process('input_folder', 'output_folder')
```
runs `ExtractFromDirectory` on the `input_folder`, produces JSON-LDs in the `output_folder` and then processes those to return a list of INDRA Statements.

In addition, 
```eidos_cli.extract_from_directory```
 just runs reading without subsequent processing, and 
```eidos_cli.run_eidos``` 
is a generic interface allowing running any other endpoint of Eidos other than `ExtractFromDirectory`.

Could be useful for @adarshp 