### PR TITLE
Api evidence

### DIFF
--- a/indra/assemblers/cx_assembler.py
+++ b/indra/assemblers/cx_assembler.py
@@ -168,7 +168,7 @@ class CxAssembler(object):
             cx_str = self.print_cx()
             fh.write(cx_str)
 
-    def upload_model(self, ndex_cred):
+    def upload_model(self, ndex_cred=None):
         """Creates a new NDEx network of the assembled CX model.
 
         To upload the assembled CX model to NDEx, you need to have
@@ -190,6 +190,10 @@ class CxAssembler(object):
             the assembled CX model.
         """
         cx_str = self.print_cx()
+        if not ndex_cred:
+            username, password = ndex_client.get_default_ndex_cred({})
+            ndex_cred = {'user': username,
+                         'password': password}
         network_id = ndex_client.create_network(cx_str, ndex_cred)
         return network_id
 

--- a/indra/assemblers/cx_assembler.py
+++ b/indra/assemblers/cx_assembler.py
@@ -168,7 +168,7 @@ class CxAssembler(object):
             cx_str = self.print_cx()
             fh.write(cx_str)
 
-    def upload_model(self, ndex_cred=None):
+    def upload_model(self, ndex_cred=None, private=True):
         """Creates a new NDEx network of the assembled CX model.
 
         To upload the assembled CX model to NDEx, you need to have
@@ -178,10 +178,13 @@ class CxAssembler(object):
 
         Parameters
         ----------
-        ndex_cred : dict
+        ndex_cred : Optional[dict]
             A dictionary with the following entries:
             'user': NDEx user name
             'password': NDEx password
+        
+        private : Optional[bool]
+            Whether or not the created network will be private on NDEX.
 
         Returns
         -------
@@ -194,7 +197,7 @@ class CxAssembler(object):
             username, password = ndex_client.get_default_ndex_cred({})
             ndex_cred = {'user': username,
                          'password': password}
-        network_id = ndex_client.create_network(cx_str, ndex_cred)
+        network_id = ndex_client.create_network(cx_str, ndex_cred, private)
         return network_id
 
     def set_context(self, cell_type):

--- a/indra/databases/ndex_client.py
+++ b/indra/databases/ndex_client.py
@@ -88,7 +88,7 @@ def send_request(ndex_service_url, params, is_json=True, use_get=False):
         return res.text
 
 
-def create_network(cx_str, ndex_cred):
+def create_network(cx_str, ndex_cred, private=True):
     """Creates a new NDEx network of the assembled CX model.
 
     To upload the assembled CX model to NDEx, you need to have
@@ -123,6 +123,8 @@ def create_network(cx_str, ndex_cred):
         return
 
     network_id = network_uri.rsplit('/')[-1]
+    if not private:
+        nd.make_network_public(network_id)
     logger.info('The UUID for the uploaded network is: %s' % network_id)
     logger.info('View at: http://ndexbio.org/#/network/%s' % network_id)
     return network_id

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -289,7 +289,7 @@ def share_model():
                                        'v': cyjs_model_str,
                                        'd': 'string'})
     ca.make_model()
-    network_id = ca.upload_model()
+    network_id = ca.upload_model(private=False)
     return {'network_id': network_id}
 
 

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -509,11 +509,12 @@ def filter_grounded_only():
 def get_evidence_for_stmts():
     if request.method == 'OPTIONS':
         return {}
-    response = request.body.read().decode('utf-8')
-    body = json.loads(response)
+    req = request.body.read().decode('utf-8')
+    body = json.loads(req)
     stmt_json = body.get('statement')
-    stmt = stmts_from_json([stmt_json])
+    stmt = Statement._from_json(stmt_json)
     from indra.sources.indra_db_rest import get_statements
+
     def _get_agent_ref(agent):
         """Get the preferred ref for an agent for db web api."""
         if agent is None:

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -554,6 +554,8 @@ def get_evidence_for_stmts():
         return stmts
 
     stmts_out = _get_matching_stmts(stmt)
+    agent_name_list = [ag.name for ag in stmt.agent_list()]
+    stmts_out = stmts = ac.filter_concept_names(stmts_out, agent_name_list, 'all')
     if stmts_out:
         stmts_json = stmts_to_json(stmts_out)
         res = {'statements': stmts_json}

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -272,6 +272,27 @@ def assemble_cx():
     return res
 
 
+#   SHARE CX   #
+@route('/share_model', method=['POST', 'OPTIONS'])
+@allow_cors
+def share_model():
+    """Upload the model to NDEX"""
+    if request.method == 'OPTIONS':
+        return {}
+    response = request.body.read().decode('utf-8')
+    body = json.loads(response)
+    stmts_json = body.get('statements')
+    cyjs_model_str = body.get('cyjs_model')
+    stmts = stmts_from_json(stmts_json)
+    ca = CxAssembler(stmts)
+    ca.cx['networkAttributes'].append({'n': 'cyjs_model',
+                                       'v': cyjs_model_str,
+                                       'd': 'string'})
+    ca.make_model()
+    network_id = ca.upload_model()
+    return {'network_id': network_id}
+
+
 #  GRAPH   #
 @route('/assemblers/graph', method=['POST', 'OPTIONS'])
 @allow_cors

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -9,6 +9,7 @@ from indra.assemblers import PysbAssembler, CxAssembler, GraphAssembler,\
     CyJSAssembler, SifAssembler
 import indra.tools.assemble_corpus as ac
 from indra.databases import cbio_client
+from indra.sources.indra_db_rest import get_statements
 
 logger = logging.getLogger('rest_api')
 logger.setLevel(logging.DEBUG)
@@ -513,7 +514,6 @@ def get_evidence_for_stmts():
     body = json.loads(req)
     stmt_json = body.get('statement')
     stmt = Statement._from_json(stmt_json)
-    from indra.sources.indra_db_rest import get_statements
 
     def _get_agent_ref(agent):
         """Get the preferred ref for an agent for db web api."""

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -6,7 +6,7 @@ from indra.sources import trips, reach, bel, biopax
 from indra.databases import hgnc_client
 from indra.statements import *
 from indra.assemblers import PysbAssembler, CxAssembler, GraphAssembler,\
-    CyJSAssembler, SifAssembler
+    CyJSAssembler, SifAssembler, EnglishAssembler
 import indra.tools.assemble_corpus as ac
 from indra.databases import cbio_client
 from indra.sources.indra_db_rest import get_statements
@@ -328,6 +328,27 @@ def assemble_cyjs():
     cja.make_model(grouping=True)
     model_str = cja.print_cyjs_graph()
     return model_str
+
+
+#   English   #
+@route('/assemblers/english', method=['POST', 'OPTIONS'])
+@allow_cors
+def assemble_english():
+    """Assemble each statement into """
+    if request.method == 'OPTIONS':
+        return {}
+    response = request.body.read().decode('utf-8')
+    body = json.loads(response)
+    stmts_json = body.get('statements')
+    stmts = stmts_from_json(stmts_json)
+    sentences = {}
+    for st in stmts:
+        enga = EnglishAssembler()
+        enga.add_statements([st])
+        model_str = enga.make_model()
+        sentences[st.uuid] = model_str
+    res = {'sentences': sentences}
+    return res
 
 
 @route('/assemblers/sif/loopy', method=['POST', 'OPTIONS'])


### PR DESCRIPTION
- Changes to REST API
  - New assembler endpoints
    - assemble English sentences from model
    - assemble CX and share it to NDEX

  - Get evidence from INDRA database
    - filter evidence to agent names in request

- Changes to CX Assembler
  - the `ndex_cred` param in `upload_model` is now optional. if not supplied, an attempt is made to retrieve it from the config file

- Changes to NDEX client
  - `create_network` now has an optional param `private` which is `True` by default. If set to false, the model will be uploaded to NDEX as a public network.