### PR TITLE
Refactor CWMS processor

### DIFF
--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -51,6 +51,7 @@ class CWMSProcessor(object):
     """
     _positive_ccs = {'ONT::CAUSE', 'ONT::INFLUENCE'}
     _positive_events = {'ONT::INCREASE'}
+    _neutral_events = {'ONT::MODULATE'}
     _negative_events = {'ONT::DECREASE', 'ONT::INHIBIT'}
 
     def __init__(self, xml_string):
@@ -91,13 +92,15 @@ class CWMSProcessor(object):
             polarity = 1
             subj = self._get_concept(event, "arg/[@role=':FACTOR']")
             obj = self._get_concept(event, "arg/[@role=':OUTCOME']")
-        elif ev_type in self._positive_events | self._negative_events:
+        elif ev_type in (self._positive_events
+                         | self._negative_events
+                         | self._neutral_events):
             subj = self._get_concept(event, "*[@role=':AGENT']")
             obj = self._get_concept(event, "*[@role=':AFFECTED']")
-            if ev_type in self._positive_events:
-                polarity = 1
+            if ev_type in self._negative_events:
+                polarity = -1
             else:
-                 polarity = -1
+                 polarity = 1
         else:
             logger.info("Unhandled event type: %s" % ev_type)
             return None, None, None

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -75,7 +75,7 @@ class CWMSProcessor(object):
         self.extract_noun_affect_relations()
         return
 
-    def _extract_statement(self, event):
+    def _get_subj_obj(self, event):
         ev_type = _get_type(event)
         positive_ccs = {'ONT::CAUSE', 'ONT::INFLUENCE'}
         positive_events = {'ONT::INCREASE'}
@@ -93,9 +93,8 @@ class CWMSProcessor(object):
                  polarity = -1
         else:
             logger.info("Unhandled event type: %s" % ev_type)
-            return Concept(ev_type)
-        return self.make_statement_noun_cause_effect(event, subj_arg, obj_arg,
-                                                     polarity)
+            return None, None, None
+        return subj_arg, obj_arg, polarity
 
     def extract_noun_causal_relations(self):
         """Extracts causal relationships between two nouns/terms (as opposed to
@@ -104,13 +103,15 @@ class CWMSProcessor(object):
         # Search for causal connectives of type ONT::CAUSE
         ccs = self.tree.findall("CC/[type]")
         for cc in ccs:
-            self._extract_statement(cc)
+            subj, obj, pol = self._get_subj_obj(cc)
+            self.make_statement_noun_cause_effect(cc, subj, obj, pol)
 
     def extract_noun_affect_relations(self):
         """Extract relationships where a term/noun affects another term/noun"""
         events = self.tree.findall("EVENT/[type]")
         for event in events:
-            self._extract_statement(event)
+            subj, obj, pol = self._get_subj_obj(event)
+            self.make_statement_noun_cause_effect(event, subj, obj, pol)
 
     def get_element_object(self, element):
         # Get the term with the given element id

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -1,16 +1,8 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
-import os
-import re
 import logging
-import operator
-import itertools
-import collections
 import xml.etree.ElementTree as ET
-from indra.util import read_unicode_csv
 from indra.statements import *
-import indra.databases.hgnc_client as hgnc_client
-import indra.databases.uniprot_client as up_client
 from indra.util import UnicodeXMLTreeBuilder as UTB
 
 logger = logging.getLogger('cwms')
@@ -150,10 +142,7 @@ class CWMSProcessor(object):
         ev.epistemics['direct'] = False
 
         # Make statement
-        if polarity == -1:
-            obj_delta = {'polarity': -1, 'adjectives': []}
-        else:
-            obj_delta = None
+        obj_delta = {'polarity': polarity, 'adjectives': []}
         st = Influence(cause_concept, affected_concept, obj_delta=obj_delta,
                        evidence=[ev])
         self.statements.append(st)

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -51,7 +51,6 @@ class CWMSProcessor(object):
     """
     def __init__(self, xml_string):
         self.statements = []
-        self.statement_dict = {}
         # Parse XML
         try:
             self.tree = ET.XML(xml_string, parser=UTB())
@@ -118,11 +117,6 @@ class CWMSProcessor(object):
         element_id = element.attrib.get('id')
         element_term = self.tree.find("*[@id='%s']" % element_id)
 
-        # Not sure this is the best way to check, but it will work. It is a
-        # HACKathon, afterall. Need to figure out how to propagate polarity...
-        if 'EVENT' in repr(element_term):
-            return self._extract_statement(element_term)
-
         if element_term is None:
             return
 
@@ -162,13 +156,7 @@ class CWMSProcessor(object):
             obj_delta = None
         st = Influence(cause_concept, affected_concept, obj_delta=obj_delta,
                        evidence=[ev])
-        if st.get_hash() not in self.statement_dict.keys():
-            self.statements.append(st)
-            self.statement_dict[st.get_hash()] = st
-        else:
-            # It's a shame we have to go this far before throwing away our work,
-            # but it will do for now.
-            st = self.statement_dict[st.get_hash()]
+        self.statements.append(st)
         return st
 
     def _get_evidence(self, event_tag):

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -86,7 +86,7 @@ class CWMSProcessor(object):
         and the polarity of the influence (see `_positive_ccs`,
         `_positive_events`, and `_negative_events` class attributes).
         """
-        ev_type = _get_type(event)
+        ev_type = event.find('type').text
         if ev_type in self._positive_ccs:
             polarity = 1
             subj = self._get_concept(event, "arg/[@role=':FACTOR']")
@@ -190,13 +190,3 @@ class CWMSProcessor(object):
         par_id = event_tag.attrib.get('paragraph')
         sec = self.par_to_sec.get(par_id)
         return sec
-
-
-def _get_type(event):
-    """Get the type of event."""
-    children = event.getchildren()
-    # What follows is another terrible hack.
-    type_text_list = [ch.text for ch in children if 'type' in repr(ch)]
-    if len(type_text_list) != 1:
-        raise CWMSError("Unexpected event structure.")
-    return type_text_list[0]

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -71,8 +71,8 @@ class CWMSProcessor(object):
                            for p in paragraph_tags}
 
         # Extract statements
-        self.extract_noun_causal_relations()
-        self.extract_noun_affect_relations()
+        self.extract_noun_relations('CC')
+        self.extract_noun_relations('EVENT')
         return
 
     def _get_subj_obj(self, event):
@@ -94,21 +94,12 @@ class CWMSProcessor(object):
         else:
             logger.info("Unhandled event type: %s" % ev_type)
             return None, None, None
+
         return subj_arg, obj_arg, polarity
 
-    def extract_noun_causal_relations(self):
-        """Extracts causal relationships between two nouns/terms (as opposed to
-        events)
-        """
-        # Search for causal connectives of type ONT::CAUSE
-        ccs = self.tree.findall("CC/[type]")
-        for cc in ccs:
-            subj, obj, pol = self._get_subj_obj(cc)
-            self.make_statement_noun_cause_effect(cc, subj, obj, pol)
-
-    def extract_noun_affect_relations(self):
+    def extract_noun_relations(self, key):
         """Extract relationships where a term/noun affects another term/noun"""
-        events = self.tree.findall("EVENT/[type]")
+        events = self.tree.findall("%s/[type]" % key)
         for event in events:
             subj, obj, pol = self._get_subj_obj(event)
             self.make_statement_noun_cause_effect(event, subj, obj, pol)

--- a/indra/tests/test_cwms.py
+++ b/indra/tests/test_cwms.py
@@ -158,3 +158,22 @@ def test_cwms_two_sentences():
     cp = process_text(text)
     assert cp is not None
     assert len(cp.statements) == 2
+
+
+@attr('slow', 'webservice')
+def test_second_order_statements():
+    text = 'Drought increases the decrease of crops by army worms'
+    cp = process_text(text)
+    assert cp is not None
+    print(cp.statements)  # Check to make sure str/repr work.
+    assert len(cp.statements) == 2, len(cp.statements)
+
+
+@attr('slow', 'webservice')
+def test_three_sentences():
+    text = 'Floods cause displacement. Displacement reduces access to food. ' \
+           'Rainfall causes floods.'
+    cp = process_text(text)
+    assert cp is not None
+    print(cp.statements)
+    assert len(cp.statements) == 3, len(cp.statements)

--- a/indra/tests/test_cwms.py
+++ b/indra/tests/test_cwms.py
@@ -162,6 +162,8 @@ def test_cwms_two_sentences():
 
 @attr('slow', 'webservice')
 def test_second_order_statements():
+    # NOTE: the second order statement feature is being developed elsewhere,
+    # however this test should still pass as is.
     text = 'Drought increases the decrease of crops by army worms'
     cp = process_text(text)
     assert cp is not None
@@ -171,6 +173,9 @@ def test_second_order_statements():
 
 @attr('slow', 'webservice')
 def test_three_sentences():
+    # These sentences were used in the June 2018 WM East and West coast
+    # hackathons for creating a simple test model constructed from all the
+    # readers, and utilizing other components.
     text = 'Floods cause displacement. Displacement reduces access to food. ' \
            'Rainfall causes floods.'
     cp = process_text(text)


### PR DESCRIPTION
This PR refactors the CWMS processor to handle more types of statements, prepares the way for handling more general 2nd order statement extractions, and generally cleans up the structure of the code. All tests passing locally.