### PR TITLE
Update handling of BBN output

### DIFF
--- a/indra/sources/bbn/bbn_api.py
+++ b/indra/sources/bbn/bbn_api.py
@@ -21,11 +21,12 @@ def process_jsonld_file(fname):
         A BBNProcessor instance, which contains a list of INDRA Statements
         as its statements attribute.
     """
-    with open(fname, 'rb') as fh:
+    with open(fname, 'r') as fh:
         json_dict = json.load(fh)
     bp = processor.BBNJsonLdProcessor(json_dict)
     bp.get_events()
     return bp
+
 
 def process_json_file_old(fname):
     """Process a JSON-LD file in the old format to extract Statements.

--- a/indra/sources/bbn/processor.py
+++ b/indra/sources/bbn/processor.py
@@ -99,11 +99,16 @@ class BBNJsonLdProcessor(object):
         name = self._sanitize(entity['canonicalName'])
         # But if there is a trigger head text, we prefer that since
         # it almost always results in a cleaner name
+        # This is removed for now since the head word seems to be too
+        # minimal for some concepts, e.g. it gives us only "security"
+        # for "food security".
+        """
         trigger = entity.get('trigger')
         if trigger is not None:
             head_text = trigger.get('head text')
             if head_text is not None:
                 name = head_text
+        """
         # Save raw text and BBN scored groundings as db_refs
         db_refs = {'TEXT': entity['text'],
                    'BBN': _get_bbn_grounding(entity)}

--- a/indra/sources/bbn/processor.py
+++ b/indra/sources/bbn/processor.py
@@ -111,6 +111,7 @@ class BBNJsonLdProcessor(object):
         doc_id = provenance[0]['document']['@id']
         sent_id = provenance[0]['documentCharPositions']['sentence']
         text = self.document_dict[doc_id]['sentences'][sent_id]
+        text = self._sanitize(text)
         bounds = [provenance[0]['documentCharPositions'][k]
                   for k in ['start', 'end']]
 

--- a/indra/sources/bbn/processor.py
+++ b/indra/sources/bbn/processor.py
@@ -31,6 +31,8 @@ class BBNJsonLdProcessor(object):
         self.document_dict = {}
         self.entity_dict = {}
         self.event_dict = {}
+        self.eid_stmt_dict = {}
+        self.element_pair_stmt_dict = {}
 
     def get_documents(self):
         """Populate the sentences attribute with a dict keyed by document id."""
@@ -64,83 +66,109 @@ class BBNJsonLdProcessor(object):
 
         self.get_documents()
 
-        # The first state corresponds to increase/decrease
-        def get_polarity(event):
-            pol_map = {'Positive': 1, 'Negative': -1}
-            if 'states' in event:
-                for state_property in event['states']:
-                    if state_property['type'] == 'polarity':
-                        return pol_map[state_property['text']]
-            return None
-
-        def get_adjectives(event):
-            ret_list = []
-            if 'states' in event:
-                for state_property in event['states']:
-                    if state_property['type'] != 'polarity':
-                        ret_list.append(state_property['text'])
-            return ret_list
-
-        def _get_bbn_grounding(entity):
-            """Return BBN grounding."""
-            grounding = entity['type']
-            if grounding.startswith('/'):
-                grounding = grounding[1:]
-            return grounding
-
-        def _make_concept(entity):
-            """Return Concept from an BBN entity."""
-            # Use the canonical name as the name of the Concept
-            name = self._sanitize(entity['canonicalName'])
-            # Save raw text and BBN scored groundings as db_refs
-            db_refs = {'TEXT': entity['text'],
-                       'BBN': _get_bbn_grounding(entity)}
-            concept = Concept(name, db_refs=db_refs)
-            return concept
-
+        higher_order_events = []
+        annotation_events = []
         for event in events:
             etype = event.get('type')
-            if 'causal assertion' in etype:
-                agent_name = 'has_%s' % basename(etype).split('-')[0].lower()
-                args = event.get('arguments', {})
-                subj_tag = [arg for arg in args if arg['type'] == agent_name]
-                if subj_tag:
-                    subj_id = subj_tag[0]['value']['@id']
-                else:
-                    subj_id = None
-                obj_tag = [arg for arg in args if arg['type'] == 'has_effect']
-                if obj_tag:
-                    obj_id = obj_tag[0]['value']['@id']
-                else:
-                    obj_id = None
+            if 'causal assertion' in etype and 'Catalyst-Effect' not in etype:
+                subj_id = _get_subject_id(event, etype)
+                obj_id = _get_object_id(event)
 
                 # Skip event if either argument is missing
                 if not subj_id or not obj_id:
                     continue
 
-                subj = self.event_dict[subj_id]
-                obj = self.event_dict[obj_id]
-
-                subj_concept = _make_concept(subj)
-                obj_concept = _make_concept(obj)
-
-                # Adjectives are not extracted for now, in the case of BBN
-                # they are things like 'Asserted', 'Specific', 'Generic'
-                subj_delta = {'adjectives': get_adjectives(subj),
-                              'polarity': get_polarity(subj)}
-                obj_delta = {'adjectives': get_adjectives(obj),
-                             'polarity': get_polarity(obj)}
+                subj_concept, subj_delta = self._get_concept_from_eid(subj_id)
+                obj_concept, obj_delta = self._get_concept_from_eid(obj_id)
 
                 evidence = self._get_evidence(event, subj_concept, obj_concept,
-                                              get_adjectives(event))
+                                              get_states(event))
 
                 st = Influence(subj_concept, obj_concept, subj_delta, obj_delta,
                                evidence=evidence)
+                self.eid_stmt_dict[event['@id']] = st
+                self.element_pair_stmt_dict[subj_id, obj_id] = st
+                self.statements.append(st)
+            elif 'Catalyst-Effect' in etype:
+                higher_order_events.append(event)
             else:
-                print("Got: %s." % etype)
-                st = None
+                annotation_events.append(event)
 
+        for event in higher_order_events:
+            subj_id = _get_subject_id(event)
+            obj_id = _get_object_id(event)
+            if not subj_id and not obj_id:
+                logger.warning("Found incomplete Catalyst Event: %s"
+                               % str(event))
+                continue
+            subj, subj_delta = self._handle_high_level_event(subj_id)
+            obj, obj_delta = self._handle_high_level_event(obj_id)
+            evidence = self._get_evidence(event, subj, obj, get_states(event))
+            logger.info("Created Catalyst-Effect!")
+            st = Influence(subj, obj, subj_delta, obj_delta, evidence)
+            self.eid_stmt_dict[event['@id']] = st
+            self.element_pair_stmt_dict[subj_id, obj_id] = st
             self.statements.append(st)
+
+        for event in annotation_events:
+            etype = event.get('type')
+            if 'Before-After' in etype:
+                fore_id = _choose_id(event, 'before')
+                aft_id = _choose_id(event, 'after')
+                if not fore_id or not aft_id:
+                    logger.warning("Unexpected Before-After: does not have two "
+                                   "known arguments.")
+                    continue
+                fore, fore_delta = self._handle_high_level_event(fore_id)
+                aft, aft_delta = self._handle_high_level_event(aft_id)
+
+                # Align against sentence number
+                ev = self._get_evidence(event, fore, aft, get_states(event))
+                st = self.element_pair_stmt_dict.get((fore_id, aft_id))
+                if st is None:
+                    logger.info("Found Before-After relation with no causal "
+                                "relation: before=%s after=%s." % (fore, aft))
+                    continue
+                else:
+                    logger.info("Found Before-After relation with causal "
+                                "relation!")
+
+                # Note: the next step assumes no pre-assembly has been done,
+                # specifically that there is only one evidence in each
+                # statement.
+                st.evidence[0].annotations['time order'] = {'before': fore,
+                                                            'after': aft,
+                                                            'evidence': ev}
+
+        return
+
+    def _handle_high_level_event(self, eid):
+        if eid in self.eid_stmt_dict.keys():
+            ev = self.eid_stmt_dict[eid]
+            edelta = None
+        elif eid in self.event_dict.keys():
+            ev, edelta = self._get_concept_from_eid(eid)
+        else:
+            assert False, 'Subject eid unresolved.'
+        return ev, edelta
+
+    def _make_concept(self, entity):
+        """Return Concept from an BBN entity."""
+        # Use the canonical name as the name of the Concept
+        name = self._sanitize(entity['canonicalName'])
+        # Save raw text and BBN scored groundings as db_refs
+        db_refs = {'TEXT': entity['text'],
+                   'BBN': _get_bbn_grounding(entity)}
+        concept = Concept(name, db_refs=db_refs)
+        return concept
+
+    def _get_concept_from_eid(self, eid):
+        ev = self.event_dict[eid]
+        concept = self._make_concept(ev)
+        ev_delta = {'adjectives': [],
+                    'states': get_states(ev),
+                    'polarity': get_polarity(ev)}
+        return concept, ev_delta
 
     def _get_evidence(self, event, subj_concept, obj_concept, adjectives):
         """Return the Evidence object for the INDRA Statement."""
@@ -181,6 +209,52 @@ class BBNJsonLdProcessor(object):
         text = text.replace('\n', ' ')
         return text
 
+
+def _choose_id(event, arg_type):
+    args = event.get('arguments', {})
+    obj_tag = [arg for arg in args if arg['type'] ==  'has_' + arg_type]
+    if obj_tag:
+        obj_id = obj_tag[0]['value']['@id']
+    else:
+        obj_id = None
+    return obj_id
+
+
+def _get_subject_id(event, event_type=None):
+    if event_type is None:
+        event_type = event.get('type')
+    agent_name = basename(event_type).split('-')[0].lower()
+    return _choose_id(event, agent_name)
+
+
+def _get_object_id(event):
+    return _choose_id(event, 'effect')
+
+
+def get_states(event):
+    ret_list = []
+    if 'states' in event:
+        for state_property in event['states']:
+            if state_property['type'] != 'polarity':
+                ret_list.append(state_property['text'])
+    return ret_list
+
+
+def _get_bbn_grounding(entity):
+    """Return BBN grounding."""
+    grounding = entity['type']
+    if grounding.startswith('/'):
+        grounding = grounding[1:]
+    return grounding
+
+
+def get_polarity(event):
+    pol_map = {'Positive': 1, 'Negative': -1}
+    if 'states' in event:
+        for state_property in event['states']:
+            if state_property['type'] == 'polarity':
+                return pol_map[state_property['text']]
+    return None
 
 # OLD BBN PROCESSOR
 

--- a/indra/sources/bbn/processor.py
+++ b/indra/sources/bbn/processor.py
@@ -95,8 +95,15 @@ class BBNJsonLdProcessor(object):
 
     def _make_concept(self, entity):
         """Return Concept from an BBN entity."""
-        # Use the canonical name as the name of the Concept
+        # Use the canonical name as the name of the Concept by default
         name = self._sanitize(entity['canonicalName'])
+        # But if there is a trigger head text, we prefer that since
+        # it almost always results in a cleaner name
+        trigger = entity.get('trigger')
+        if trigger is not None:
+            head_text = trigger.get('head text')
+            if head_text is not None:
+                name = head_text
         # Save raw text and BBN scored groundings as db_refs
         db_refs = {'TEXT': entity['text'],
                    'BBN': _get_bbn_grounding(entity)}

--- a/indra/sources/bbn/processor.py
+++ b/indra/sources/bbn/processor.py
@@ -72,9 +72,13 @@ class BBNJsonLdProcessor(object):
             subj_concept, subj_delta = self._get_concept(event, 'source')
             obj_concept, obj_delta = self._get_concept(event, 'destination')
 
-            # Apply the naive polarity from the type of statement.
+            # Apply the naive polarity from the type of statement. For the
+            # purpose of the multiplication here, if obj_delta['polarity'] is
+            # None to begin with, we assume it is positive
             obj_delta['polarity'] = \
-                event_polarities[event_type]*obj_delta['polarity']
+                event_polarities[event_type] * \
+                (obj_delta['polarity'] if obj_delta['polarity'] is not None
+                 else 1)
 
             if not subj_concept or not obj_concept:
                 continue

--- a/indra/sources/bbn/processor.py
+++ b/indra/sources/bbn/processor.py
@@ -50,14 +50,14 @@ class BBNJsonLdProcessor(object):
         self.event_dict = {ev['@id']: ev for ev in events}
 
         # List out event types and their default (implied) polarities.
-        extract_types = {'causation': 1, 'precondition': 1, 'catalyst': 1,
-                         'mitigation': -1, 'prevention': -1}
+        event_polarities = {'causation': 1, 'precondition': 1, 'catalyst': 1,
+                            'mitigation': -1, 'prevention': -1}
 
         # Restrict to known event types
         events = [e for e in events if any([et in e.get('type')
-                                            for et in extract_types.keys()])]
-        logger.info('%d events of types %s found' % (len(events),
-                                                     ', '.join(extract_types)))
+                                            for et in event_polarities.keys()])]
+        logger.info('%d events of types %s found'
+                    % (len(events), ', '.join(event_polarities.keys())))
 
         # Build a dictionary of entities and sentences by ID for convenient
         # lookup
@@ -68,8 +68,13 @@ class BBNJsonLdProcessor(object):
         self.get_documents()
 
         for event in events:
+            event_type = event.get('type')
             subj_concept, subj_delta = self._get_concept(event, 'source')
             obj_concept, obj_delta = self._get_concept(event, 'destination')
+
+            # Apply the naive polarity from the type of statement.
+            obj_delta['polarity'] = \
+                event_polarities[event_type]*obj_delta['polarity']
 
             if not subj_concept or not obj_concept:
                 continue

--- a/indra/sources/bbn/processor.py
+++ b/indra/sources/bbn/processor.py
@@ -71,7 +71,10 @@ class BBNJsonLdProcessor(object):
         for event in events:
             etype = event.get('type')
             if 'causal assertion' in etype and 'Catalyst-Effect' not in etype:
-                subj_id = _get_subject_id(event, etype)
+                if 'MitigatingFactor' in etype:
+                    subj_id = _get_subject_id(event, 'mitigating_factor')
+                else:
+                    subj_id = _get_subject_id(event, etype)
                 obj_id = _get_object_id(event)
 
                 # Skip event if either argument is missing
@@ -212,7 +215,7 @@ class BBNJsonLdProcessor(object):
 
 def _choose_id(event, arg_type):
     args = event.get('arguments', {})
-    obj_tag = [arg for arg in args if arg['type'] ==  'has_' + arg_type]
+    obj_tag = [arg for arg in args if arg['type'] == 'has_' + arg_type]
     if obj_tag:
         obj_id = obj_tag[0]['value']['@id']
     else:

--- a/indra/tests/hackathon_test_paragraph.json-ld
+++ b/indra/tests/hackathon_test_paragraph.json-ld
@@ -1,0 +1,756 @@
+{
+    "@context": {
+        "Argument": "https://w3id.org/wm/cag/Argument", 
+        "Corpus": "https://w3id.org/wm/cag/Corpus", 
+        "Dependency": "https://w3id.org/wm/cag/Dependency", 
+        "Document": "https://w3id.org/wm/cag/Document", 
+        "Entity": "https://w3id.org/wm/cag/Entity", 
+        "Event": "https://w3id.org/wm/cag/Event", 
+        "Interval": "https://w3id.org/wm/cag/Interval", 
+        "Modifier": "https://w3id.org/wm/cag/Modifier", 
+        "Provenance": "https://w3id.org/wm/cag/Provenance", 
+        "Sentence": "https://w3id.org/wm/cag/Sentence", 
+        "State": "https://w3id.org/wm/cag/State", 
+        "Trigger": "https://w3id.org/wm/cag/Trigger", 
+        "Word": "https://w3id.org/wm/cag/Word"
+    }, 
+    "@type": "Corpus", 
+    "documents": [
+        {
+            "@id": "ENG_NW_WM_HACK_BEN_PARAS", 
+            "@type": "Document", 
+            "location": "ENG_NW_WM_HACK_BEN_PARAS", 
+            "sentences": [
+                {
+                    "@id": "SEN-ENG_NW_WM_HACK_BEN_PARAS-0", 
+                    "@type": "Sentence", 
+                    "text": "Floods cause displacement."
+                }, 
+                {
+                    "@id": "SEN-ENG_NW_WM_HACK_BEN_PARAS-1", 
+                    "@type": "Sentence", 
+                    "text": "Displacement reduces access to food."
+                }, 
+                {
+                    "@id": "SEN-ENG_NW_WM_HACK_BEN_PARAS-2", 
+                    "@type": "Sentence", 
+                    "text": "Rainfall causes floods."
+                }
+            ]
+        }
+    ], 
+    "extractions": [
+        {
+            "@id": "EventGroup-0", 
+            "@type": "Event", 
+            "canonicalName": "rainfall", 
+            "text": "rainfall", 
+            "type": "/event/event group"
+        }, 
+        {
+            "@id": "unification-1", 
+            "@type": "Event", 
+            "arguments": [
+                {
+                    "@type": "Argument", 
+                    "type": "group", 
+                    "value": {
+                        "@id": "EventGroup-0"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "member", 
+                    "value": {
+                        "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-11"
+                    }
+                }
+            ], 
+            "labels": [
+                "DirectedRelation"
+            ], 
+            "type": "unification"
+        }, 
+        {
+            "@id": "EventGroup-1", 
+            "@type": "Event", 
+            "canonicalName": "floods", 
+            "text": "floods", 
+            "type": "/event/event group"
+        }, 
+        {
+            "@id": "unification-2", 
+            "@type": "Event", 
+            "arguments": [
+                {
+                    "@type": "Argument", 
+                    "type": "group", 
+                    "value": {
+                        "@id": "EventGroup-1"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "member", 
+                    "value": {
+                        "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-0"
+                    }
+                }
+            ], 
+            "labels": [
+                "DirectedRelation"
+            ], 
+            "type": "unification"
+        }, 
+        {
+            "@id": "unification-3", 
+            "@type": "Event", 
+            "arguments": [
+                {
+                    "@type": "Argument", 
+                    "type": "group", 
+                    "value": {
+                        "@id": "EventGroup-1"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "member", 
+                    "value": {
+                        "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-10"
+                    }
+                }
+            ], 
+            "labels": [
+                "DirectedRelation"
+            ], 
+            "type": "unification"
+        }, 
+        {
+            "@id": "EventGroup-2", 
+            "@type": "Event", 
+            "canonicalName": "displacement", 
+            "text": "displacement", 
+            "type": "/event/event group"
+        }, 
+        {
+            "@id": "unification-4", 
+            "@type": "Event", 
+            "arguments": [
+                {
+                    "@type": "Argument", 
+                    "type": "group", 
+                    "value": {
+                        "@id": "EventGroup-2"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "member", 
+                    "value": {
+                        "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-5"
+                    }
+                }
+            ], 
+            "labels": [
+                "DirectedRelation"
+            ], 
+            "type": "unification"
+        }, 
+        {
+            "@id": "unification-5", 
+            "@type": "Event", 
+            "arguments": [
+                {
+                    "@type": "Argument", 
+                    "type": "group", 
+                    "value": {
+                        "@id": "EventGroup-2"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "member", 
+                    "value": {
+                        "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-4"
+                    }
+                }
+            ], 
+            "labels": [
+                "DirectedRelation"
+            ], 
+            "type": "unification"
+        }, 
+        {
+            "@id": "EventGroup-3", 
+            "@type": "Event", 
+            "canonicalName": "access", 
+            "text": "access", 
+            "type": "/event/event group"
+        }, 
+        {
+            "@id": "unification-6", 
+            "@type": "Event", 
+            "arguments": [
+                {
+                    "@type": "Argument", 
+                    "type": "group", 
+                    "value": {
+                        "@id": "EventGroup-3"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "member", 
+                    "value": {
+                        "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-6"
+                    }
+                }
+            ], 
+            "labels": [
+                "DirectedRelation"
+            ], 
+            "type": "unification"
+        }, 
+        {
+            "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-6", 
+            "@type": "Event", 
+            "arguments": [], 
+            "canonicalName": "access", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/event/factor", 
+                    "value": 0.28738973585570116
+                }
+            ], 
+            "labels": [
+                "Event"
+            ], 
+            "provenance": [
+                {
+                    "@type": "Provenance", 
+                    "document": {
+                        "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                    }, 
+                    "documentCharPositions": {
+                        "@type": "Interval", 
+                        "end": 126, 
+                        "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-1", 
+                        "start": 121
+                    }
+                }
+            ], 
+            "states": [
+                {
+                    "@type": "State", 
+                    "text": "Asserted", 
+                    "type": "modality"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Generic", 
+                    "type": "genericity"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Positive", 
+                    "type": "polarity"
+                }
+            ], 
+            "text": "access", 
+            "trigger": {
+                "@type": "Trigger", 
+                "head text": "access", 
+                "provenance": [
+                    {
+                        "@type": "Provenance", 
+                        "document": {
+                            "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                        }, 
+                        "documentCharPositions": {
+                            "@type": "Interval", 
+                            "end": 126, 
+                            "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-1", 
+                            "start": 121
+                        }
+                    }
+                ], 
+                "text": "access"
+            }, 
+            "type": "/event/factor"
+        }, 
+        {
+            "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-5", 
+            "@type": "Event", 
+            "arguments": [], 
+            "canonicalName": "Displacement", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/event/factor", 
+                    "value": 0.24066585870573057
+                }
+            ], 
+            "labels": [
+                "Event"
+            ], 
+            "provenance": [
+                {
+                    "@type": "Provenance", 
+                    "document": {
+                        "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                    }, 
+                    "documentCharPositions": {
+                        "@type": "Interval", 
+                        "end": 111, 
+                        "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-1", 
+                        "start": 100
+                    }
+                }
+            ], 
+            "states": [
+                {
+                    "@type": "State", 
+                    "text": "Asserted", 
+                    "type": "modality"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Generic", 
+                    "type": "genericity"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Positive", 
+                    "type": "polarity"
+                }
+            ], 
+            "text": "Displacement", 
+            "trigger": {
+                "@type": "Trigger", 
+                "head text": "Displacement", 
+                "provenance": [
+                    {
+                        "@type": "Provenance", 
+                        "document": {
+                            "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                        }, 
+                        "documentCharPositions": {
+                            "@type": "Interval", 
+                            "end": 111, 
+                            "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-1", 
+                            "start": 100
+                        }
+                    }
+                ], 
+                "text": "Displacement"
+            }, 
+            "type": "/event/factor"
+        }, 
+        {
+            "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-4", 
+            "@type": "Event", 
+            "arguments": [], 
+            "canonicalName": "displacement", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/event/factor", 
+                    "value": 0.24066585870573057
+                }
+            ], 
+            "labels": [
+                "Event"
+            ], 
+            "provenance": [
+                {
+                    "@type": "Provenance", 
+                    "document": {
+                        "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                    }, 
+                    "documentCharPositions": {
+                        "@type": "Interval", 
+                        "end": 97, 
+                        "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-0", 
+                        "start": 86
+                    }
+                }
+            ], 
+            "states": [
+                {
+                    "@type": "State", 
+                    "text": "Asserted", 
+                    "type": "modality"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Generic", 
+                    "type": "genericity"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Positive", 
+                    "type": "polarity"
+                }
+            ], 
+            "text": "displacement", 
+            "trigger": {
+                "@type": "Trigger", 
+                "head text": "displacement", 
+                "provenance": [
+                    {
+                        "@type": "Provenance", 
+                        "document": {
+                            "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                        }, 
+                        "documentCharPositions": {
+                            "@type": "Interval", 
+                            "end": 97, 
+                            "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-0", 
+                            "start": 86
+                        }
+                    }
+                ], 
+                "text": "displacement"
+            }, 
+            "type": "/event/factor"
+        }, 
+        {
+            "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-11", 
+            "@type": "Event", 
+            "arguments": [], 
+            "canonicalName": "Rainfall", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/event/factor", 
+                    "value": 0.25770933167862553
+                }
+            ], 
+            "labels": [
+                "Event"
+            ], 
+            "provenance": [
+                {
+                    "@type": "Provenance", 
+                    "document": {
+                        "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                    }, 
+                    "documentCharPositions": {
+                        "@type": "Interval", 
+                        "end": 144, 
+                        "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-2", 
+                        "start": 137
+                    }
+                }
+            ], 
+            "states": [
+                {
+                    "@type": "State", 
+                    "text": "Asserted", 
+                    "type": "modality"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Generic", 
+                    "type": "genericity"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Positive", 
+                    "type": "polarity"
+                }
+            ], 
+            "text": "Rainfall", 
+            "trigger": {
+                "@type": "Trigger", 
+                "head text": "Rainfall", 
+                "provenance": [
+                    {
+                        "@type": "Provenance", 
+                        "document": {
+                            "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                        }, 
+                        "documentCharPositions": {
+                            "@type": "Interval", 
+                            "end": 144, 
+                            "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-2", 
+                            "start": 137
+                        }
+                    }
+                ], 
+                "text": "Rainfall"
+            }, 
+            "type": "/event/factor"
+        }, 
+        {
+            "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-10", 
+            "@type": "Event", 
+            "arguments": [], 
+            "canonicalName": "floods", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/event/weather/precipitation", 
+                    "value": 0.12665498751708462
+                }, 
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/entity/indicator/Flood Potential Index", 
+                    "value": 0.12665498751708462
+                }
+            ], 
+            "labels": [
+                "Event"
+            ], 
+            "provenance": [
+                {
+                    "@type": "Provenance", 
+                    "document": {
+                        "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                    }, 
+                    "documentCharPositions": {
+                        "@type": "Interval", 
+                        "end": 158, 
+                        "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-2", 
+                        "start": 153
+                    }
+                }
+            ], 
+            "states": [
+                {
+                    "@type": "State", 
+                    "text": "Asserted", 
+                    "type": "modality"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Specific", 
+                    "type": "genericity"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Positive", 
+                    "type": "polarity"
+                }
+            ], 
+            "text": "floods", 
+            "trigger": {
+                "@type": "Trigger", 
+                "head text": "floods", 
+                "provenance": [
+                    {
+                        "@type": "Provenance", 
+                        "document": {
+                            "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                        }, 
+                        "documentCharPositions": {
+                            "@type": "Interval", 
+                            "end": 158, 
+                            "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-2", 
+                            "start": 153
+                        }
+                    }
+                ], 
+                "text": "floods"
+            }, 
+            "type": "/event/weather/precipitation"
+        }, 
+        {
+            "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-0", 
+            "@type": "Event", 
+            "arguments": [], 
+            "canonicalName": "Floods", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/event/weather", 
+                    "value": 0.12665498751708462
+                }, 
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/entity/indicator/Flood Potential Index", 
+                    "value": 0.12665498751708462
+                }
+            ], 
+            "labels": [
+                "Event"
+            ], 
+            "provenance": [
+                {
+                    "@type": "Provenance", 
+                    "document": {
+                        "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                    }, 
+                    "documentCharPositions": {
+                        "@type": "Interval", 
+                        "end": 78, 
+                        "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-0", 
+                        "start": 73
+                    }
+                }
+            ], 
+            "states": [
+                {
+                    "@type": "State", 
+                    "text": "Asserted", 
+                    "type": "modality"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Specific", 
+                    "type": "genericity"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Positive", 
+                    "type": "polarity"
+                }
+            ], 
+            "text": "Floods", 
+            "trigger": {
+                "@type": "Trigger", 
+                "head text": "Floods", 
+                "provenance": [
+                    {
+                        "@type": "Provenance", 
+                        "document": {
+                            "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                        }, 
+                        "documentCharPositions": {
+                            "@type": "Interval", 
+                            "end": 78, 
+                            "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-0", 
+                            "start": 73
+                        }
+                    }
+                ], 
+                "text": "Floods"
+            }, 
+            "type": "/event/weather"
+        }, 
+        {
+            "@id": "REL-ENG_NW_WM_HACK_BEN_PARAS-18", 
+            "@type": "Event", 
+            "arguments": [
+                {
+                    "@type": "Argument", 
+                    "type": "source", 
+                    "value": {
+                        "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-5"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "destination", 
+                    "value": {
+                        "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-6"
+                    }
+                }
+            ], 
+            "labels": [
+                "DirectedRelation"
+            ], 
+            "provenance": [
+                {
+                    "@type": "Provenance", 
+                    "document": {
+                        "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                    }, 
+                    "documentCharPositions": {
+                        "@type": "Interval", 
+                        "end": 126, 
+                        "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-1", 
+                        "start": 100
+                    }
+                }
+            ], 
+            "type": "mitigation"
+        }, 
+        {
+            "@id": "REL-ENG_NW_WM_HACK_BEN_PARAS-17", 
+            "@type": "Event", 
+            "arguments": [
+                {
+                    "@type": "Argument", 
+                    "type": "source", 
+                    "value": {
+                        "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-0"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "destination", 
+                    "value": {
+                        "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-4"
+                    }
+                }
+            ], 
+            "labels": [
+                "DirectedRelation"
+            ], 
+            "provenance": [
+                {
+                    "@type": "Provenance", 
+                    "document": {
+                        "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                    }, 
+                    "documentCharPositions": {
+                        "@type": "Interval", 
+                        "end": 97, 
+                        "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-0", 
+                        "start": 73
+                    }
+                }
+            ], 
+            "type": "causation"
+        }, 
+        {
+            "@id": "REL-ENG_NW_WM_HACK_BEN_PARAS-10", 
+            "@type": "Event", 
+            "arguments": [
+                {
+                    "@type": "Argument", 
+                    "type": "source", 
+                    "value": {
+                        "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-11"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "destination", 
+                    "value": {
+                        "@id": "EVE-ENG_NW_WM_HACK_BEN_PARAS-10"
+                    }
+                }
+            ], 
+            "labels": [
+                "DirectedRelation"
+            ], 
+            "provenance": [
+                {
+                    "@type": "Provenance", 
+                    "document": {
+                        "@id": "ENG_NW_WM_HACK_BEN_PARAS"
+                    }, 
+                    "documentCharPositions": {
+                        "@type": "Interval", 
+                        "end": 158, 
+                        "sentence": "SEN-ENG_NW_WM_HACK_BEN_PARAS-2", 
+                        "start": 137
+                    }
+                }
+            ], 
+            "type": "causation"
+        }
+    ]
+}

--- a/indra/tests/test_bbn.py
+++ b/indra/tests/test_bbn.py
@@ -57,7 +57,8 @@ def test_on_ten_doc_file():
 
 
 def test_bbn_on_ben_paragraph():
-    bp = process_jsonld_file(join(path_this, 'hackathon_ben_paras.json-ld'))
+    bp = process_jsonld_file(join(path_this, 'hackathon_test_paragraph.json-ld'))
     assert bp is not None
+    print(bp.statements)
     stmt_dict = {hash(s.get_hash()): s for s in bp.statements}
     assert len(stmt_dict) == 3, len(stmt_dict)

--- a/indra/tests/test_bbn.py
+++ b/indra/tests/test_bbn.py
@@ -54,3 +54,10 @@ def test_on_ten_doc_file():
     bp = process_jsonld_file(join(path_this, 'wm_10_doc.json-ld'))
     assert bp is not None
     assert bp.statements
+
+
+def test_bbn_on_ben_paragraph():
+    bp = process_jsonld_file(join(path_this, 'hackathon_ben_paras.json-ld'))
+    assert bp is not None
+    stmt_dict = {hash(s.get_hash()): s for s in bp.statements}
+    assert len(stmt_dict) == 3, len(stmt_dict)

--- a/indra/tests/test_bbn.py
+++ b/indra/tests/test_bbn.py
@@ -49,15 +49,9 @@ def test_negated_effect():
     assert(len(bp.statements) == 0)
 
 
-def test_on_ten_doc_file():
-    """Test on the extraction from the WM 10 documents."""
-    bp = process_jsonld_file(join(path_this, 'wm_10_doc.json-ld'))
-    assert bp is not None
-    assert bp.statements
-
-
 def test_bbn_on_ben_paragraph():
-    bp = process_jsonld_file(join(path_this, 'hackathon_test_paragraph.json-ld'))
+    bp = process_jsonld_file(join(path_this,
+                                  'hackathon_test_paragraph.json-ld'))
     assert bp is not None
     print(bp.statements)
     stmt_dict = {hash(s.get_hash()): s for s in bp.statements}

--- a/indra/tests/test_bbn.py
+++ b/indra/tests/test_bbn.py
@@ -9,9 +9,9 @@ from indra.statements import *
 path_this = os.path.dirname(os.path.abspath(__file__))
 test_file_simple = os.path.join(path_this, 'bbn_test_simple.json-ld')
 test_file_negatedCause = os.path.join(path_this,
-        'bbn_test_negatedCause.json-ld')
+                                      'bbn_test_negatedCause.json-ld')
 test_file_negatedEffect = os.path.join(path_this,
-        'bbn_test_negatedEffect.json-ld')
+                                       'bbn_test_negatedEffect.json-ld')
 
 
 def test_simple_extraction():
@@ -47,3 +47,10 @@ def test_negated_effect():
     The processor should give no statements for a negated effect."""
     bp = process_json_file_old(test_file_negatedEffect)
     assert(len(bp.statements) == 0)
+
+
+def test_on_ten_doc_file():
+    """Test on the extraction from the WM 10 documents."""
+    bp = process_jsonld_file(join(path_this, 'wm_10_doc.json-ld'))
+    assert bp is not None
+    assert bp.statements


### PR DESCRIPTION
This PR handles many of the new influence-type relations now present in the BBN json. There are several relation types that are currently not handled because they require deeper consideration in the INDRA architecture: Catalysts that could apply to relations (no confirmed examples), temporallyPrecedes, and unifications. Some work related to this may be found in the commit history but not in the final product.