### PR TITLE
Fix minor bug in reading modes for aws batch.

### DIFF
--- a/indra/tools/reading/db_reading/read_db_aws.py
+++ b/indra/tools/reading/db_reading/read_db_aws.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
         )
     parser.add_argument(
         dest='mode',
-        choices=['all', 'unread_all', 'none'],
+        choices=['all', 'unread-all', 'unread-unread', 'none'],
         help=('Set the reading mode. If \'all\', read everything, if '
               '\'unread\', only read content that does not have pre-existing '
               'readings of the same reader and version, if \'none\', only '

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -402,7 +402,7 @@ def submit_db_reading(basename, id_list_filename, readers, start_ix=None,
     if force_read:
         mode = 'all'
     else:
-        mode = 'unread'
+        mode = 'unread-all'
 
     # Iterate over the list of PMIDs and submit the job in chunks
     batch_client = boto3.client('batch', region_name='us-east-1')


### PR DESCRIPTION
The terminology changed a while back, and by a fluke this worked despite the update. However, in the refactor the loophole that let it work was closed. This PR just makes the update.