### PR TITLE
Add a couple more ontologies to cwms.

### DIFF
--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -17,7 +17,9 @@ POLARITY_DICT = {'CC': {'ONT::CAUSE': 1,
                  'EVENT': {'ONT::INCREASE': 1,
                            'ONT::MODULATE': None,
                            'ONT::DECREASE': -1,
-                           'ONT::INHIBIT': -1}}
+                           'ONT::INHIBIT': -1,
+                           'ONT::TRANSFORM': None,
+                           'ONT::STIMULATE': 1}}
 
 
 class CWMSProcessor(object):


### PR DESCRIPTION
These came up when running the paragraph: "Education improves thinking. Thinking increases doubt. Doubt destabilizes the totalitarian government."

Words like "improves" and "destabilizes" don't strike me as exceptionally odd, or worth omitting, and the ontologies they are mapped to seem relevant.