### PR TITLE
Some cleanup of db changes

### DIFF
--- a/db_rest_api/api.py
+++ b/db_rest_api/api.py
@@ -233,7 +233,7 @@ def get_statements():
     logger.info("Getting evidence for the %d resulting statements."
                 % len(stmts))
     if stmts:
-        get_evidence(stmts)
+        get_evidence(stmts, fix_refs=False)
 
     # Create the json response, and send off.
     resp = jsonify({'limited': hit_limit,

--- a/indra/db/client.py
+++ b/indra/db/client.py
@@ -330,7 +330,7 @@ def get_statements(clauses, count=1000, do_stmt_count=False, db=None,
             logger.info("Total of %d statements" % num_stmts)
         db_stmts = q.yield_per(count)
         for subset in batch_iter(db_stmts, count):
-            stmts.extend(get_raw_stmts_frm_db_list(db, subset, with_sids=False))
+            stmts.extend(get_raw_stmts_frm_db_list(db, subset, with_sids=False, fix_refs=fix_refs))
             if do_stmt_count:
                 logger.info("%d of %d statements" % (len(stmts), num_stmts))
             else:

--- a/indra/db/client.py
+++ b/indra/db/client.py
@@ -180,9 +180,11 @@ def get_statements_by_gene_role_type(agent_id=None, agent_ns='HGNC-SYMBOL',
         longer.
     fix_refs : bool
         The paper refs within the evidence objects are not populated in the
-        database, and thus must be filled using the relations in the datbase.
-        If True (default), the Text Ref IDs from the database are normalized
-        to PMIDs, or None if no PMID is available.
+        database, and thus must be filled using the relations in the database.
+        If True (default), the `pmid` field of each Statement Evidence object
+        is set to the correct PMIDs, or None if no PMID is available. If False,
+        the `pmid` field defaults to the value populated by the reading
+        system.
 
     Returns
     -------
@@ -308,9 +310,11 @@ def get_statements(clauses, count=1000, do_stmt_count=False, db=None,
         longer.
     fix_refs : bool
         The paper refs within the evidence objects are not populated in the
-        database, and thus must be filled using the relations in the datbase.
-        If True (default), the Text Ref IDs from the database are normalized
-        to PMIDs, or None if no PMID is available.
+        database, and thus must be filled using the relations in the database.
+        If True (default), the `pmid` field of each Statement Evidence object
+        is set to the correct PMIDs, or None if no PMID is available. If False,
+        the `pmid` field defaults to the value populated by the reading
+        system.
 
     Returns
     -------
@@ -432,9 +436,11 @@ def get_evidence(pa_stmt_list, db=None, fix_refs=True):
         database, as defined in the db_config.ini file in .config/indra.
     fix_refs : bool
         The paper refs within the evidence objects are not populated in the
-        database, and thus must be filled using the relations in the datbase.
-        If True (default), the Text Ref IDs from the database are normalized
-        to PMIDs, or None if no PMID is available.
+        database, and thus must be filled using the relations in the database.
+        If True (default), the `pmid` field of each Statement Evidence object
+        is set to the correct PMIDs, or None if no PMID is available. If False,
+        the `pmid` field defaults to the value populated by the reading
+        system.
 
     Returns
     -------

--- a/indra/db/client.py
+++ b/indra/db/client.py
@@ -13,7 +13,7 @@ logger = logging.getLogger('db_client')
 from indra.util import batch_iter
 from indra.databases import hgnc_client
 from .util import get_primary_db, make_raw_stmts_from_db_list, \
-    unpack, _get_statement_object
+    unpack, _get_statement_object, _clockit
 
 
 def get_reader_output(db, ref_id, ref_type='tcid', reader=None,
@@ -134,6 +134,7 @@ def get_content_by_refs(db, pmid_list=None, trid_list=None, sources=None,
     return content_dict
 
 
+@_clockit
 def get_statements_by_gene_role_type(agent_id=None, agent_ns='HGNC-SYMBOL',
                                      role=None, stmt_type=None, count=1000,
                                      db=None, do_stmt_count=True,
@@ -273,6 +274,7 @@ def get_statements_by_paper(id_val, id_type='pmid', count=1000, db=None,
     return stmts
 
 
+@_clockit
 def get_statements(clauses, count=1000, do_stmt_count=True, db=None,
                    preassembled=True, with_support=False, fix_refs=True,
                    with_evidence=True):
@@ -410,6 +412,7 @@ def get_statements(clauses, count=1000, do_stmt_count=True, db=None,
     return stmts
 
 
+@_clockit
 def get_evidence(pa_stmt_list, db=None, fix_refs=True):
     """Fill in the evidence for a list of pre-assembled statements.
 

--- a/indra/db/database_manager.py
+++ b/indra/db/database_manager.py
@@ -276,8 +276,9 @@ class DatabaseManager(object):
 
         class RawStatements(self.Base):
             __tablename__ = 'raw_statements'
-            uuid = Column(String(40), primary_key=True)
-            mk_hash = Column(String, nullable=False)
+            id = Column(Integer, primary_key=True)
+            uuid = Column(String(40))
+            mk_hash = Column(BigInteger, nullable=False)
             db_info_id = Column(Integer, ForeignKey('db_info.id'))
             db_info = relationship(DBInfo)
             reading_id = Column(Integer, ForeignKey('reading.id'))
@@ -292,9 +293,9 @@ class DatabaseManager(object):
         class RawAgents(self.Base):
             __tablename__ = 'raw_agents'
             id = Column(Integer, primary_key=True)
-            stmt_uuid = Column(String(40),
-                               ForeignKey('raw_statements.uuid'),
-                               nullable=False)
+            stmt_id = Column(Integer,
+                             ForeignKey('raw_statements.id'),
+                             nullable=False)
             statements = relationship(RawStatements)
             db_name = Column(String(40), nullable=False)
             db_id = Column(String, nullable=False)
@@ -305,9 +306,9 @@ class DatabaseManager(object):
         class RawUniqueLinks(self.Base):
             __tablename__ = 'raw_unique_links'
             id = Column(Integer, primary_key=True)
-            raw_stmt_uuid = Column(String(40), ForeignKey('raw_statements.uuid'),
-                                   nullable=False)
-            pa_stmt_mk_hash = Column(String, ForeignKey('pa_statements.mk_hash'),
+            raw_stmt_id = Column(Integer, ForeignKey('raw_statements.id'),
+                                 nullable=False)
+            pa_stmt_mk_hash = Column(BigInteger, ForeignKey('pa_statements.mk_hash'),
                                      nullable=False)
         self.RawUniqueLinks = RawUniqueLinks
         self.tables[RawUniqueLinks.__tablename__] = RawUniqueLinks
@@ -322,7 +323,7 @@ class DatabaseManager(object):
 
         class PAStatements(self.Base):
             __tablename__ = 'pa_statements'
-            mk_hash = Column(String, primary_key=True)
+            mk_hash = Column(BigInteger, primary_key=True)
             uuid = Column(String(40), unique=True, nullable=False)
             type = Column(String(100), nullable=False)
             indra_version = Column(String(100), nullable=False)
@@ -334,7 +335,7 @@ class DatabaseManager(object):
         class PAAgents(self.Base):
             __tablename__ = 'pa_agents'
             id = Column(Integer, primary_key=True)
-            stmt_mk_hash = Column(String,
+            stmt_mk_hash = Column(BigInteger,
                                   ForeignKey('pa_statements.mk_hash'),
                                   nullable=False)
             statements = relationship(PAStatements)
@@ -347,10 +348,10 @@ class DatabaseManager(object):
         class PASupportLinks(self.Base):
             __tablename__ = 'pa_support_links'
             id = Column(Integer, primary_key=True)
-            supporting_mk_hash = Column(String,
+            supporting_mk_hash = Column(BigInteger,
                                         ForeignKey('pa_statements.mk_hash'),
                                         nullable=False)
-            supported_mk_hash = Column(String,
+            supported_mk_hash = Column(BigInteger,
                                        ForeignKey('pa_statements.mk_hash'),
                                        nullable=False)
         self.PASupportLinks = PASupportLinks

--- a/indra/db/preassembly_manager.py
+++ b/indra/db/preassembly_manager.py
@@ -137,25 +137,31 @@ class PreassemblyManager(object):
         if in_mks is None and ex_mks is None:
             db_stmt_iter = db.select_all(db.PAStatements.json,
                                          yield_per=self.batch_size)
-        elif ex_mks is None:
+        elif ex_mks is None and in_mks:
             db_stmt_iter = db.select_all(
                 db.PAStatements.json,
                 db.PAStatements.mk_hash.in_(in_mks),
                 yield_per=self.batch_size
                 )
-        elif in_mks is None:
+        elif in_mks is None and ex_mks:
             db_stmt_iter = db.select_all(
                 db.PAStatements.json,
                 db.PAStatements.mk_hash.notin_(ex_mks),
+                yield_per=self.batch_size
+                )
+        elif in_mks and ex_mks:
+            db_stmt_iter = db.select_all(
+                db.PAStatements.json,
+                db.PAStatements.mk_hash.notin_(ex_mks),
+                db.PAStatements.mk_hash.in_(in_mks),
                 yield_per=self.batch_size
                 )
         else:
             db_stmt_iter = db.select_all(
                 db.PAStatements.json,
-                db.PAStatements.mk_hash.notin_(ex_mks),
-                db.PAStatements.mk_hash.in_(in_mks),
                 yield_per=self.batch_size
                 )
+
         pa_stmts = (_stmt_from_json(s_json) for s_json, in db_stmt_iter)
         return batch_iter(pa_stmts, self.batch_size, return_func=list)
 

--- a/indra/db/util.py
+++ b/indra/db/util.py
@@ -358,11 +358,12 @@ def _fix_evidence_refs(db, rid_stmt_pairs):
     return
 
 
-def make_raw_stmts_from_db_list(db, db_stmt_objs):
+def make_raw_stmts_from_db_list(db, db_stmt_objs, fix_refs=True):
     """Convert table objects of raw statements into INDRA Statement objects."""
     rid_stmt_pairs = [(db_stmt.reading_id, _get_statement_object(db_stmt))
                       for db_stmt in db_stmt_objs]
-    _fix_evidence_refs(db, rid_stmt_pairs)
+    if fix_refs:
+        _fix_evidence_refs(db, rid_stmt_pairs)
     return [stmt for _, stmt in rid_stmt_pairs]
 
 

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1102,11 +1102,12 @@ class Statement(object):
         if not shallow:
             if self.hash is None or refresh:
                 ev_matches_key_list = sorted([ev.matches_key() for ev in self.evidence])
-                self.hash = clean(self.matches_key() + str(ev_matches_key_list))
+                self.hash = hash(clean(self.matches_key()
+                                       + str(ev_matches_key_list)))
             ret = self.hash
         else:
             if self.shallow_hash is None or refresh:
-                self.shallow_hash = clean(self.matches_key())
+                self.shallow_hash = hash(clean(self.matches_key()))
             ret = self.shallow_hash
         return ret
 

--- a/indra/tests/make_raw_statement_test_set.py
+++ b/indra/tests/make_raw_statement_test_set.py
@@ -1,0 +1,126 @@
+from indra.statements import Phosphorylation, Agent, Evidence
+from indra.db.util import NestedDict
+
+
+def add_stmts_to_target_set(stmts, target_sets):
+    if not target_sets:
+        for stmt in stmts:
+            target_sets.append(({stmt},
+                                {s.uuid for s in stmts if s is not stmt}))
+    else:
+        old_target_sets = target_sets[:]
+        target_sets = []
+        for stmt_set, dup_set in old_target_sets:
+            for stmt in stmts:
+                new_set = stmt_set.copy()
+                new_set.add(stmt)
+                new_dups = dup_set.copy()
+                new_dups |= {s.uuid for s in stmts if s != stmt}
+                target_sets.append((new_set, new_dups))
+    return target_sets
+
+
+def make_raw_statement_test_set():
+    d = NestedDict()
+    stmts = []
+    target_sets = []
+    bettered_uuids = set()
+
+    # We produced statements a coupld of times with and old reader version
+    stmts.append(make_test_statement('A1', 'B1', 'Evidence 1 for A1 phosphorylates B1', 'reach'))
+    stmts.append(make_test_statement('A1', 'B1', 'Evidence 1 for A1 phosphorylates B1', 'reach'))
+    assert stmts[-1].get_hash() == stmts[-2].get_hash()
+    d[1]['pubmed'][1]['reach']['61059a-biores-e9ee36'][1][stmts[-1].get_hash()] = set(stmts[-2:])
+
+    stmts.append(make_test_statement('A1', 'B1', 'Evidence 2 for A1 phosphorylates B1', 'reach'))
+    assert stmts[-2].get_hash() != stmts[-1].get_hash()
+    d[1]['pubmed'][1]['reach']['61059a-biores-e9ee36'][1][stmts[-1].get_hash()] = {stmts[-1]}
+
+    stmts.append(make_test_statement('A2', 'B2', 'Evience 1 for A2 phosphorylates B2', 'reach'))
+    d[1]['pubmed'][1]['reach']['61059a-biores-e9ee36'][1][stmts[-1].get_hash()] = {stmts[-1]}
+
+    # Then we did it again for a new reader version.
+    stmts.append(make_test_statement('A1', 'B1', 'Evidence 1 for A1 phosphorylates B1', 'reach'))
+    stmts.append(make_test_statement('A1', 'B1', 'Evidence 1 for A1 phosphorylates B1', 'reach'))
+    assert stmts[-1].get_hash() == stmts[-2].get_hash()
+    d[1]['pubmed'][1]['reach']['1.3.3-61059a-biores-'][2][stmts[-1].get_hash()] = set(stmts[-2:])
+    stmts.append(make_test_statement('A1', 'B1', 'Evidence 2 for A1 phosphorylates B1', 'reach'))
+    assert stmts[-2].get_hash() != stmts[-1].get_hash()
+    d[1]['pubmed'][1]['reach']['1.3.3-61059a-biores-'][2][stmts[-1].get_hash()] = {stmts[-1]}
+
+    # Add some results from sparser
+    stmts.append(make_test_statement(None, 'B1', 'Evidence 1 for A1 phosphorylates B1', 'sparser'))
+    stmts.append(make_test_statement(None, 'B1', 'Evidence 1 for A1 phosphorylates B1', 'sparser'))
+    assert stmts[-1].get_hash() == stmts[-2].get_hash()
+    d[1]['pubmed'][1]['sparser']['sept14-linux'][3][stmts[-1].get_hash()] = set(stmts[-2:])
+
+    stmts.append(make_test_statement(None, 'B2', 'Evidence 1 for A2 phosphoryates B2', 'sparser'))
+    assert stmts[-1].get_hash() != stmts[-2].get_hash()
+    d[1]['pubmed'][1]['sparser']['sept14-linux'][3][stmts[-1].get_hash()] = {stmts[-1]}
+
+    # Now add statements from another source.
+    stmts.append(make_test_statement('A1', 'B1', 'Evidence 1 for A1 phosphorylates B1', 'reach'))
+    stmts.append(make_test_statement('A1', 'B1', 'Evidence 1 for A1 phosphorylates B1', 'reach'))
+    assert stmts[-1].get_hash() == stmts[-2].get_hash()
+    d[1]['pmc_oa'][2]['reach']['61059a-biores-e9ee36'][4][stmts[-1].get_hash()] = set(stmts[-2:])
+
+    stmts.append(make_test_statement('A1', 'B1', 'Evidence 2 for A1 phosphorylates B1', 'reach'))
+    assert stmts[-2].get_hash() != stmts[-1].get_hash()
+    d[1]['pmc_oa'][2]['reach']['61059a-biores-e9ee36'][4][stmts[-1].get_hash()] = {stmts[-1]}
+
+    stmts.append(make_test_statement('A2', 'B2', 'Evience 1 for A2 phosphorylates B2', 'reach'))
+    d[1]['pmc_oa'][2]['reach']['61059a-biores-e9ee36'][4][stmts[-1].get_hash()] = {stmts[-1]}
+
+    stmts.append(make_test_statement('A2', 'B2', 'Evidence 2 for A2 phosphorylates B2', 'reach'))
+    d[1]['pmc_oa'][2]['reach']['61059a-biores-e9ee36'][4][stmts[-1].get_hash()] = {stmts[-1]}
+
+    stmts.append(make_test_statement('A3', 'B3', 'Evidence 1 for A3 phosphorylates B3', 'reach'))
+    d[1]['pmc_oa'][2]['reach']['61059a-biores-e9ee36'][4][stmts[-1].get_hash()] = {stmts[-1]}
+    bettered_uuids |= {s.uuid for s in stmts}
+
+    # Then we did it again for a new reader version.
+    stmts.append(make_test_statement('A1', 'B1', 'Evidence 1 for A1 phosphorylates B1', 'reach'))
+    stmts.append(make_test_statement('A1', 'B1', 'Evidence 1 for A1 phosphorylates B1', 'reach'))
+    assert stmts[-1].get_hash() == stmts[-2].get_hash()
+    d[1]['pmc_oa'][2]['reach']['1.3.3-61059a-biores-'][5][stmts[-1].get_hash()] = set(stmts[-2:])
+    target_sets = add_stmts_to_target_set(stmts[-2:], target_sets)
+
+    stmts.append(make_test_statement('A1', 'B1', 'Evidence 2 for A1 phosphorylates B1', 'reach'))
+    assert stmts[-2].get_hash() != stmts[-1].get_hash()
+    d[1]['pmc_oa'][2]['reach']['1.3.3-61059a-biores-'][5][stmts[-1].get_hash()] = {stmts[-1]}
+    target_sets = add_stmts_to_target_set(stmts[-1:], target_sets)
+
+    stmts.append(make_test_statement('A2', 'B2', 'Evidence 2 for A2 phosphorylates B2', 'reach'))
+    d[1]['pmc_oa'][2]['reach']['1.3.3-61059a-biores-'][4][stmts[-1].get_hash()] = {stmts[-1]}
+    target_sets = add_stmts_to_target_set(stmts[-1:], target_sets)
+
+    stmts.append(make_test_statement('A3', 'B3', 'Evidence 1 for A3 phosphorylates B3', 'reach'))
+    d[1]['pmc_oa'][2]['reach']['1.3.3-61059a-biores-'][4][stmts[-1].get_hash()] = {stmts[-1]}
+    target_sets = add_stmts_to_target_set(stmts[-1:], target_sets)
+
+    # Add some results from sparser
+    stmts.append(make_test_statement(None, 'B1', 'Evidence 1 for A1 phosphorylates B1', 'sparser'))
+    stmts.append(make_test_statement(None, 'B1', 'Evidence 1 for A1 phosphorylates B1', 'sparser'))
+    assert stmts[-1].get_hash() == stmts[-2].get_hash()
+    d[1]['pmc_oa'][2]['sparser']['sept14-linux'][6][stmts[-1].get_hash()] = set(stmts[-2:])
+    target_sets = add_stmts_to_target_set(stmts[-2:], target_sets)
+
+    stmts.append(make_test_statement(None, 'B2', 'Evidence 1 for A2 phosphoryates B2', 'sparser'))
+    assert stmts[-1].get_hash() != stmts[-2].get_hash()
+    d[1]['pmc_oa'][2]['sparser']['sept14-linux'][6][stmts[-1].get_hash()] = {stmts[-1]}
+    target_sets = add_stmts_to_target_set(stmts[-1:], target_sets)
+
+    stmts.append(make_test_statement('A3', 'B3', 'Evidence 1 for A3 phosphorylates B3', 'sparser'))
+    d[2]['manuscripts'][3]['sparser']['sept14-linux'][7][stmts[-1].get_hash()] = {stmts[-1]}
+    target_sets = add_stmts_to_target_set(stmts[-1:], target_sets)
+
+    stmts.append(make_test_statement('A3', 'B3', 'Evidence 1 for A3 phosphorylates B3', 'sparser'))
+    d[2]['pmc_oa'][4]['sparser']['sept14-linux'][8][stmts[-1].get_hash()] = {stmts[-1]}
+    bettered_uuids.add(stmts[-1].uuid)
+
+    return d, stmts, target_sets, bettered_uuids
+
+
+def make_test_statement(A, B, text, source_api):
+    return Phosphorylation(Agent(A), Agent(B),
+                           evidence=[Evidence(text=text, source_api=source_api)])

--- a/indra/tests/test_db_preassembly.py
+++ b/indra/tests/test_db_preassembly.py
@@ -257,7 +257,7 @@ def test_statement_distillation_large():
 
 
 @attr('nonpublic', 'slow')
-def test_statement_distillation_large():
+def test_statement_distillation_extra_large():
     _check_statement_distillation(1001721)
 
 

--- a/indra/tests/test_db_preassembly.py
+++ b/indra/tests/test_db_preassembly.py
@@ -349,3 +349,7 @@ def test_db_incremental_preassembly_small():
 @attr('nonpublic', 'slow')
 def test_db_incremental_preassembly_large():
     _check_db_pa_supplement(11721, 2017)
+
+
+def test_db_incremental_preassembly_very_large():
+    _check_db_pa_supplement(100000, 20000)

--- a/indra/tests/test_db_preassembly.py
+++ b/indra/tests/test_db_preassembly.py
@@ -427,5 +427,6 @@ def test_db_incremental_preassembly_large():
     _check_db_pa_supplement(11721, 2017)
 
 
+@attr('nonpublic', 'slow')
 def test_db_incremental_preassembly_very_large():
     _check_db_pa_supplement(100000, 20000)

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -229,7 +229,7 @@ def run_preassembly_duplicate(preassembler, beliefengine, **kwargs):
                 len(preassembler.stmts))
     dump_pkl = kwargs.get('save')
     stmts_out = preassembler.combine_duplicates()
-    #beliefengine.set_prior_probs(stmts_out)
+    beliefengine.set_prior_probs(stmts_out)
     logger.info('%d unique statements' % len(stmts_out))
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -229,7 +229,7 @@ def run_preassembly_duplicate(preassembler, beliefengine, **kwargs):
                 len(preassembler.stmts))
     dump_pkl = kwargs.get('save')
     stmts_out = preassembler.combine_duplicates()
-    beliefengine.set_prior_probs(stmts_out)
+    #beliefengine.set_prior_probs(stmts_out)
     logger.info('%d unique statements' % len(stmts_out))
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)

--- a/indra/tools/reading/db_reading/read_db.py
+++ b/indra/tools/reading/db_reading/read_db.py
@@ -743,9 +743,11 @@ def upload_statements(stmt_data_list, db=None):
     logger.info("Uploading agents to the database.")
     reading_id_set = set([sd.reading_id for sd in stmt_data_list])
     if len(reading_id_set):
-        uuid_set = {s.statement.uuid for s in stmt_data_list}
-        insert_agents(db, 'raw', db.RawStatements.uuid.in_(uuid_set),
-                      verbose=True, override_default_query=True)
+        db_stmts = (
+            db.select_one(db.RawStatements, db.RawStatements.uuid.like(s.uuid))
+            for s in stmt_data_list
+            )
+        insert_agents(db, 'raw', db_stmts, verbose=True)
     return
 
 

--- a/indra/tools/reading/util/reading_results_stats.py
+++ b/indra/tools/reading/util/reading_results_stats.py
@@ -273,7 +273,7 @@ if __name__ == '__main__':
     if args.source == 'from-db':
         logger.info("Getting statements from the database.")
         from indra.db import get_primary_db
-        from indra.db.util import make_raw_stmts_from_db_list, \
+        from indra.db.util import get_raw_stmts_frm_db_list, \
             _get_statement_object, _set_evidence_text_ref
 
         db = get_primary_db()


### PR DESCRIPTION
This PR addresses some of the issues that came up after the previous db PR, aiming to:
- Speed up queries for pa statements
- Improve checks on the quality of the products the preassembly pipeline.

This branch will allow access to the RawStatements table (broken by remote changes) but not the PAStatements table.