### PR TITLE
Handle log stashing better, and do post-reading analysis

### DIFF
--- a/indra/sources/sparser/processor.py
+++ b/indra/sources/sparser/processor.py
@@ -30,7 +30,7 @@ class SparserJSONProcessor(object):
                         else:
                             json_stmt['position'] = position[0]
                     if isinstance(residue, list):
-                        if len(residue) != 1:
+                        if len(residue) != 1 or not isinstance(residue[0], str):
                             logger.error('Invalid residue: %s' % residue)
                         else:
                             json_stmt['residue'] = residue[0]

--- a/indra/sources/sparser/processor.py
+++ b/indra/sources/sparser/processor.py
@@ -19,73 +19,83 @@ class SparserJSONProcessor(object):
     def get_statements(self):
         mod_class_names = [cls.__name__ for cls in modclass_to_modtype.keys()]
         for json_stmt in self.json_stmts:
-            # Step 1: fix JSON directly to eliminate errors when deserializing
-            if json_stmt.get('type') in mod_class_names:
-                position = json_stmt.get('position')
-                residue = json_stmt.get('residue')
-                if isinstance(position, list):
-                    if len(position) != 1:
-                        logger.error('Invalid position: %s' % position)
-                    else:
-                        json_stmt['position'] = position[0]
-                if isinstance(residue, list):
-                    if len(residue) != 1:
-                        logger.error('Invalid residue: %s' % residue)
-                    else:
-                        json_stmt['residue'] = residue[0]
-            elif json_stmt.get('type') in ('Activation', 'Inhibition'):
-                obj_activity = json_stmt.get('obj_activity')
-                if isinstance(obj_activity, list):
-                    if len(obj_activity) != 1:
-                        print('Invalid object activity: %s' % obj_activity)
-                    else:
-                        json_stmt['obj_activity'] = obj_activity[0]
-                obj = json_stmt.get('obj')
-                if isinstance(obj, (list, str)):
-                    continue
-            elif json_stmt.get('type') == 'Translocation':
-                # Fix locations if possible
-                for loc_param in ('from_location', 'to_location'):
-                    loc = json_stmt.get(loc_param)
-                    if loc:
-                        try:
-                            loc = get_valid_location(loc)
-                        except InvalidLocationError:
-                            logger.error('Invalid location: %s' % loc)
-                            loc = None
-                        json_stmt[loc_param] = loc
-                # Skip Translocation with both locations None
-                if (json_stmt.get('from_location') is None
-                   and json_stmt.get('to_location') is None):
-                    continue
-            elif json_stmt.get('type') == 'GeneTranscriptExpress':
-                continue
-
-            # Step 2: Deserialize into INDRA Statement
-            stmt = Statement._from_json(json_stmt)
-
-            # Step 3: Filter out invalid Statements
-            # Skip Statement if all agents are None
-            if not any(stmt.agent_list()):
-                continue
-            # Skip RegulateActivity if object is None
-            if isinstance(stmt, RegulateActivity):
-                if stmt.obj is None or stmt.subj is None:
-                    continue
-            if isinstance(stmt, Modification):
-                if stmt.sub is None:
-                    continue
-            # Skip Complexes with less than 2 members
-            if isinstance(stmt, Complex):
-                if len(stmt.members) < 2:
+            try:
+                # Step 1: fix JSON directly to reduce errors when deserializing
+                if json_stmt.get('type') in mod_class_names:
+                    position = json_stmt.get('position')
+                    residue = json_stmt.get('residue')
+                    if isinstance(position, list):
+                        if len(position) != 1:
+                            logger.error('Invalid position: %s' % position)
+                        else:
+                            json_stmt['position'] = position[0]
+                    if isinstance(residue, list):
+                        if len(residue) != 1:
+                            logger.error('Invalid residue: %s' % residue)
+                        else:
+                            json_stmt['residue'] = residue[0]
+                elif json_stmt.get('type') in ('Activation', 'Inhibition'):
+                    obj_activity = json_stmt.get('obj_activity')
+                    if isinstance(obj_activity, list):
+                        if len(obj_activity) != 1:
+                            print('Invalid object activity: %s' % obj_activity)
+                        else:
+                            json_stmt['obj_activity'] = obj_activity[0]
+                    obj = json_stmt.get('obj')
+                    if isinstance(obj, (list, str)):
+                        continue
+                elif json_stmt.get('type') == 'Translocation':
+                    # Fix locations if possible
+                    for loc_param in ('from_location', 'to_location'):
+                        loc = json_stmt.get(loc_param)
+                        if loc:
+                            try:
+                                loc = get_valid_location(loc)
+                            except InvalidLocationError:
+                                logger.error('Invalid location: %s' % loc)
+                                loc = None
+                            json_stmt[loc_param] = loc
+                    # Skip Translocation with both locations None
+                    if (json_stmt.get('from_location') is None
+                       and json_stmt.get('to_location') is None):
+                        continue
+                elif json_stmt.get('type') == 'GeneTranscriptExpress':
                     continue
 
-            # Step 4: Fix Agent names and grounding
-            for agent in stmt.agent_list():
-                _fix_agent(agent)
+                # Step 2: Deserialize into INDRA Statement
+                stmt = Statement._from_json(json_stmt)
 
-            # Step 5: Append to list of Statements
-            self.statements.append(stmt)
+                # Step 3: Filter out invalid Statements
+                # Skip Statement if all agents are None
+                if not any(stmt.agent_list()):
+                    continue
+                # Skip RegulateActivity if object is None
+                if isinstance(stmt, RegulateActivity):
+                    if stmt.obj is None or stmt.subj is None:
+                        continue
+                if isinstance(stmt, Modification):
+                    if stmt.sub is None:
+                        continue
+                # Skip Complexes with less than 2 members
+                if isinstance(stmt, Complex):
+                    if len(stmt.members) < 2:
+                        continue
+
+                # Step 4: Fix Agent names and grounding
+                for agent in stmt.agent_list():
+                    _fix_agent(agent)
+
+                # Step 5: Append to list of Statements
+                self.statements.append(stmt)
+            except Exception as e:
+                # Keep an eye on these and try to fix them as they come up, but
+                # at least a reading job won't fail because of a couple
+                # glitches. The logs should be processed, and processing errors
+                # should be extracted and reported.
+                logger.error("PROCESSING ERROR: Could not process json:\n%s"
+                             % str(json_stmt))
+                logger.exception(e)
+                logger.error("END PROCESSING ERROR --------")
 
     def set_statements_pmid(self, pmid):
         """Set the evidence PMID of Statements that have been extracted.

--- a/indra/tests/test_reading_scripts_aws.py
+++ b/indra/tests/test_reading_scripts_aws.py
@@ -1,0 +1,47 @@
+
+import boto3
+from os import path
+from subprocess import check_call
+from indra.db import util as dbu
+from indra.util import zip_string
+
+
+s3 = boto3.client('s3')
+
+
+HERE = path.dirname(path.abspath(__file__))
+
+
+def test_db_reading_help():
+    check_call(['python', '-m', 'indra.tools.reading.db_reading.read_db_aws',
+                '--help'])
+
+
+def test_db_reading_noraml_querty():
+    # Put some basic stuff in the test databsae
+    N = 6
+    db = dbu.get_test_db()
+    db._clear(force=True)
+    db.copy('text_ref', [(i, 'PMID80945%d' % i) for i in range(N)],
+            cols=('id', 'pmid'))
+    text_content = [
+        (i, i, 'pubmed', 'text', 'abstract',
+         zip_string('MEK phosphorylates ERK in test %d.' % i))
+        for i in range(N)
+        ]
+    db.copy('text_content', text_content,
+            cols=('id', 'text_ref_id', 'source', 'format', 'text_type',
+                  'content'))
+
+    # Put an id file on s3
+    basename = 'local_test_run'
+    s3_inp_prefix = 'reading_inputs/%s/' % basename
+    s3_out_prefix = 'reading_results/%s/' % basename
+    local_dir = path.join(HERE, 'local_test')
+    s3.put_object(Bucket='bigmech', Key=s3_inp_prefix + 'id_list',
+                  Body='\n'.join(['tcid: %d' % i for i in range(5)]))
+
+    # Call the reading tool
+    check_call(['python', '-m', 'indra.tools.reading.db_reading.read_db_aws',
+                basename, local_dir, 'unread', 'all', '4', '0', '2', '-r',
+                'sparser', '--test'])

--- a/indra/tests/test_reading_scripts_aws.py
+++ b/indra/tests/test_reading_scripts_aws.py
@@ -36,9 +36,8 @@ def test_normal_db_reading_call():
 
     # Put an id file on s3
     basename = 'local_db_test_run'
-    s3_inp_prefix = 'reading_inputs/%s/' % basename
-    s3_out_prefix = 'reading_results/%s/' % basename
-    s3.put_object(Bucket='bigmech', Key=s3_inp_prefix + 'id_list',
+    s3_prefix = 'reading_results/%s/' % basename
+    s3.put_object(Bucket='bigmech', Key=s3_prefix + 'id_list',
                   Body='\n'.join(['tcid: %d' % i for i in range(5)]))
 
     # Call the reading tool
@@ -48,20 +47,18 @@ def test_normal_db_reading_call():
     check_call(cmd)
 
     # Remove garbage on s3
-    for pref in [s3_inp_prefix, s3_out_prefix]:
-        res = s3.list_objects(Bucket='bigmech', Prefix=pref)
-        for entry in res['Contents']:
-            print("Removing %s..." % entry['Key'])
-            s3.delete_object(Bucket='bigmech', Key=entry['Key'])
+    res = s3.list_objects(Bucket='bigmech', Prefix=s3_prefix)
+    for entry in res['Contents']:
+        print("Removing %s..." % entry['Key'])
+        s3.delete_object(Bucket='bigmech', Key=entry['Key'])
     return
 
 
 def test_normal_pmid_reading_call():
     # Put an id file on s3
     basename = 'local_pmid_test_run'
-    s3_inp_prefix = 'reading_inputs/%s/' % basename
-    s3_out_prefix = 'reading_results/%s/' % basename
-    s3.put_object(Bucket='bigmech', Key=s3_inp_prefix + 'pmids',
+    s3_prefix = 'reading_results/%s/' % basename
+    s3.put_object(Bucket='bigmech', Key=s3_prefix + 'pmids',
                   Body='\n'.join(['PMID000test%d' % n for n in range(4)]))
 
     # Call the reading tool
@@ -70,9 +67,8 @@ def test_normal_pmid_reading_call():
     check_call(cmd)
 
     # Remove garbage on s3
-    for pref in [s3_inp_prefix, s3_out_prefix]:
-        res = s3.list_objects(Bucket='bigmech', Prefix=pref)
-        for entry in res['Contents']:
-            print("Removing %s..." % entry['Key'])
-            s3.delete_object(Bucket='bigmech', Key=entry['Key'])
+    res = s3.list_objects(Bucket='bigmech', Prefix=s3_prefix)
+    for entry in res['Contents']:
+        print("Removing %s..." % entry['Key'])
+        s3.delete_object(Bucket='bigmech', Key=entry['Key'])
     return

--- a/indra/tests/test_reading_scripts_aws.py
+++ b/indra/tests/test_reading_scripts_aws.py
@@ -2,6 +2,9 @@
 import boto3
 from os import path
 from subprocess import check_call
+
+from nose.plugins.attrib import attr
+
 from indra.db import util as dbu
 from indra.util import zip_string
 from indra.tools.reading import submit_reading_pipeline as srp
@@ -13,11 +16,13 @@ s3 = boto3.client('s3')
 HERE = path.dirname(path.abspath(__file__))
 
 
+@attr('nonpublic')
 def test_db_reading_help():
     check_call(['python', '-m', 'indra.tools.reading.db_reading.read_db_aws',
                 '--help'])
 
 
+@attr('nonpublic')
 def test_normal_db_reading_call():
     # Put some basic stuff in the test databsae
     N = 6
@@ -54,6 +59,7 @@ def test_normal_db_reading_call():
     return
 
 
+@attr('nonpublic')
 def test_normal_pmid_reading_call():
     # Put an id file on s3
     basename = 'local_pmid_test_run'

--- a/indra/tests/test_reading_scripts_aws.py
+++ b/indra/tests/test_reading_scripts_aws.py
@@ -35,7 +35,7 @@ def test_normal_db_reading_call():
                   'content'))
 
     # Put an id file on s3
-    basename = 'local_test_run'
+    basename = 'local_db_test_run'
     s3_inp_prefix = 'reading_inputs/%s/' % basename
     s3_out_prefix = 'reading_results/%s/' % basename
     s3.put_object(Bucket='bigmech', Key=s3_inp_prefix + 'id_list',
@@ -53,3 +53,26 @@ def test_normal_db_reading_call():
         for entry in res['Contents']:
             print("Removing %s..." % entry['Key'])
             s3.delete_object(Bucket='bigmech', Key=entry['Key'])
+    return
+
+
+def test_normal_pmid_reading_call():
+    # Put an id file on s3
+    basename = 'local_pmid_test_run'
+    s3_inp_prefix = 'reading_inputs/%s/' % basename
+    s3_out_prefix = 'reading_results/%s/' % basename
+    s3.put_object(Bucket='bigmech', Key=s3_inp_prefix + 'pmids',
+                  Body='\n'.join(['PMID000test%d' % n for n in range(4)]))
+
+    # Call the reading tool
+    sub = srp.PmidSubmitter(basename, ['sparser'])
+    job_name, cmd = sub._make_command(0, 2)
+    check_call(cmd)
+
+    # Remove garbage on s3
+    for pref in [s3_inp_prefix, s3_out_prefix]:
+        res = s3.list_objects(Bucket='bigmech', Prefix=pref)
+        for entry in res['Contents']:
+            print("Removing %s..." % entry['Key'])
+            s3.delete_object(Bucket='bigmech', Key=entry['Key'])
+    return

--- a/indra/tests/test_reading_scripts_aws.py
+++ b/indra/tests/test_reading_scripts_aws.py
@@ -45,3 +45,10 @@ def test_db_reading_noraml_querty():
     check_call(['python', '-m', 'indra.tools.reading.db_reading.read_db_aws',
                 basename, local_dir, 'unread', 'all', '4', '0', '2', '-r',
                 'sparser', '--test'])
+
+    # Remove garbage on s3
+    for pref in [s3_inp_prefix, s3_out_prefix]:
+        res = s3.list_objects(Bucket='bigmech', Prefix=pref)
+        for entry in res['Contents']:
+            print("Removing %s..." % entry['Key'])
+            s3.delete_object(Bucket='bigmech', Key=entry['Key'])

--- a/indra/tools/reading/db_reading/read_db.py
+++ b/indra/tools/reading/db_reading/read_db.py
@@ -23,13 +23,23 @@ if __name__ == '__main__':
          'and should thus be used with care.')
         )
     parser.add_argument(
-        '-m', '--mode',
-        choices=['all', 'unread-all', 'unread-unread', 'none'],
+        '-m', '--reading_mode',
+        choices=['all', 'unread', 'none'],
         default='unread',
-        help=('Set the reading mode. If \'all\', read everything, if '
-              '\'unread\', only read content that does not have pre-existing '
-              'readings of the same reader and version, if \'none\', only '
-              'use pre-existing readings. Default is \'unread\'.')
+        help=("Set the reading mode. If 'all', read everything, if "
+              "'unread', only read content that does not have pre-existing "
+              "readings of the same reader and version, if 'none', only "
+              "use pre-existing readings. Default is 'unread'.")
+        )
+    parser.add_argument(
+        '-s', '--stmt_mode',
+        choices=['all', 'unread', 'none'],
+        default='all',
+        help=("Choose which readings should produce statements. If 'all', all "
+              "readings that are produced or retrieved will be used to produce "
+              "statements. If 'unread', only produce statements from "
+              "previously unread content. If 'none', do not produce any "
+              "statements (only readings will be produced).")
         )
     parser.add_argument(
         '-t', '--temp',
@@ -232,7 +242,7 @@ def get_clauses(id_dict, db):
         `db.filter_query(<table>, <other clauses>, *clause_list)`.
         If the id_dict has no ids, an effectively empty condition is returned.
     """
-    # Handle all id types besides text ref ids (trid) and text content ids (tcid).
+    # Handle all id types but text ref ids (trid) and text content ids (tcid).
     id_condition_list = [getattr(db.TextRef, id_type).in_(id_list)
                          for id_type, id_list in id_dict.items()
                          if len(id_list) and id_type not in ['tcid', 'trid']]
@@ -622,8 +632,8 @@ def upload_readings(output_list, db=None):
     return
 
 
-def produce_readings(id_dict, reader_list, verbose=False,
-                     read_mode='unread-all', force_fulltext=False,
+def produce_readings(id_dict, reader_list, verbose=False, read_mode='unread',
+                     get_preexisting=True, force_fulltext=False,
                      batch_size=1000, no_upload=False, pickle_file=None,
                      db=None, log_readers=True, prioritize=False):
     """Produce the reading output for the given ids, and upload them to db.
@@ -640,13 +650,14 @@ def produce_readings(id_dict, reader_list, verbose=False,
     verbose : bool
         Optional, default False - If True, log and print the output of the
         commandline reader utilities, if False, don't.
-    read_mode : str : 'all', 'unread-all', 'unread-unread', or 'none'
-        Optional, default 'undread-all' - If 'all', read everything (generally
-        slow); if 'unread-all', only read things that were unread, but use the
-        cache of old readings to get everything (as fast as you can be while
-        still getting everything); if 'unread-unread', just like 'unread-all',
-        but only return the unread content; if 'none', don't read, and only get
-        existing readings.
+    read_mode : str : 'all', 'unread', or 'none'
+        Optional, default 'undread' - If 'all', read everything (generally
+        slow); if 'unread', only read things that were unread, (the cache of old
+        readings may still be used if `stmt_mode='all'` to get everything); if
+        'none', don't read, and only retrieve existing readings.
+    get_preexisting : bool
+        Optional, default True. If True, retrieve old readings where available
+        (if `read_mode` is not 'all'). If False, don't retrieve old readings.
     force_fulltext : bool
         Optional, default False - If True, only read fulltext article, ignoring
         abstracts.
@@ -666,6 +677,10 @@ def produce_readings(id_dict, reader_list, verbose=False,
         Optional, default is None, in which case the primary database provided
         by `get_primary_db` function is used. Used to interface with a
         different databse.
+    log_readers : bool
+        Default True. If True, stash the logs of the readers in a file.
+    prioritize : bool
+        Default False. If True, choose only the best content to read.
 
     Returns
     -------
@@ -673,6 +688,7 @@ def produce_readings(id_dict, reader_list, verbose=False,
         A list of the outputs of the readings in the form of ReadingData
         instances.
     """
+    # Get a database instance.
     logger.debug("Producing readings in %s mode." % read_mode)
     if db is None:
         db = get_primary_db()
@@ -685,9 +701,10 @@ def produce_readings(id_dict, reader_list, verbose=False,
                                    always_add=['pubmed'], db=db)
         id_dict = {'tcid': list(tcids)}
 
+    # Handle the cases where I need to retrieve old readings.
     prev_readings = []
     skip_reader_tcid_dict = None
-    if read_mode not in ['all', 'unread-unread']:
+    if get_preexisting and read_mode != 'all':
         prev_readings = get_db_readings(id_dict, reader_list, force_fulltext,
                                         batch_size, db=db)
         skip_reader_tcid_dict = {r.name: [] for r in reader_list}
@@ -695,6 +712,8 @@ def produce_readings(id_dict, reader_list, verbose=False,
         if read_mode != 'none':
             for rd in prev_readings:
                 skip_reader_tcid_dict[rd.reader].append(rd.tcid)
+
+    # Now produce any new readings that need to be produced.
     outputs = []
     if read_mode != 'none':
         outputs = make_db_readings(id_dict, reader_list, verbose=verbose,
@@ -829,6 +848,12 @@ if __name__ == "__main__":
     # Set the verbosity. The quiet argument overrides the verbose argument.
     verbose = args.verbose and not args.quiet
 
+    # Some combinations of options don't make sense:
+    forbidden_combos = [('all', 'unread'), ('none', 'unread'), ('none', 'none')]
+    assert (args.reading_mode, args.stmt_mode) not in forbidden_combos, \
+        ("The combination of reading mode %s and statement mode %s is not "
+         "allowed." % (args.reading_mode, args.stmt_mode))
+
     for n in range(n_max):
         logger.info("Beginning outer batch %d/%d. ------------" % (n+1, n_max))
 
@@ -845,12 +870,15 @@ if __name__ == "__main__":
 
         # Read everything ====================================================
         outputs = produce_readings(id_dict, readers, verbose=verbose,
-                                   read_mode=args.mode, batch_size=args.b_in,
+                                   read_mode=args.reading_mode,
+                                   get_preexisting=(args.stmt_mode == 'all'),
+                                   batch_size=args.b_in,
                                    force_fulltext=args.force_fulltext,
                                    no_upload=args.no_reading_upload,
                                    pickle_file=reading_pickle,
                                    prioritize=args.use_best_fulltext)
 
         # Convert the outputs to statements ==================================
-        produce_statements(outputs, no_upload=args.no_statement_upload,
-                           pickle_file=stmts_pickle, n_proc=args.n_proc)
+        if args.stmt_mode != 'none':
+            produce_statements(outputs, no_upload=args.no_statement_upload,
+                               pickle_file=stmts_pickle, n_proc=args.n_proc)

--- a/indra/tools/reading/db_reading/read_db_aws.py
+++ b/indra/tools/reading/db_reading/read_db_aws.py
@@ -239,7 +239,7 @@ if __name__ == '__main__':
 
     client = boto3.client('s3')
     bucket_name = 'bigmech'
-    id_list_key = 'reading_inputs/%s/id_list' % args.basename
+    id_list_key = 'reading_results/%s/id_list' % args.basename
     readers = [reader_class(args.basename, args.num_cores)
                for reader_class in get_readers()
                if reader_class.name.lower() in args.readers]

--- a/indra/tools/reading/db_reading/read_db_aws.py
+++ b/indra/tools/reading/db_reading/read_db_aws.py
@@ -3,6 +3,8 @@ for the job either needs to be provided in environment variables (e.g., the
 REACH version and path) or loaded from S3 (e.g., the list of PMIDs).
 """
 from __future__ import absolute_import, print_function, unicode_literals
+
+import pickle
 from builtins import dict, str
 import boto3
 import botocore
@@ -141,6 +143,10 @@ def report_statistics(reading_outputs, stmt_outputs, starts, ends,
             text_report_str += '%s: %d\n' % (label, data)
 
     s3.put_object(Key=s3_prefix + 'summary.txt', Body=text_report_str,
+                  Bucket=bucket_name)
+    s3.put_object(Key=s3_prefix + 'hist_data.pkl', Body=pickle.dumps(hist_dict),
+                  Bucket=bucket_name)
+    s3.put_object(Key=s3_prefix + 'sum_data.pkl', Body=pickle.dumps(data_dict),
                   Bucket=bucket_name)
     ends['stats'] = datetime.now()
 

--- a/indra/tools/reading/db_reading/read_db_aws.py
+++ b/indra/tools/reading/db_reading/read_db_aws.py
@@ -224,7 +224,7 @@ if __name__ == '__main__':
 
     # Some combinations of options don't make sense:
     forbidden_combos = [('all', 'unread'), ('none', 'unread'), ('none', 'none')]
-    assert (args.reading_mode, args.stmt_mode) not in forbidden_combos, \
+    assert (args.read_mode, args.stmt_mode) not in forbidden_combos, \
         ("The combination of reading mode %s and statement mode %s is not "
          "allowed." % (args.reading_mode, args.stmt_mode))
 

--- a/indra/tools/reading/db_reading/read_db_aws.py
+++ b/indra/tools/reading/db_reading/read_db_aws.py
@@ -11,6 +11,8 @@ import sys
 import os
 import random
 import numpy as np
+import matplotlib as mpl
+mpl.use('Agg')
 from matplotlib import pyplot as plt
 from datetime import datetime
 from indra.tools.reading.db_reading.read_db import produce_readings, \

--- a/indra/tools/reading/db_reading/read_db_aws.py
+++ b/indra/tools/reading/db_reading/read_db_aws.py
@@ -45,6 +45,16 @@ def report_statistics(reading_outputs, stmt_outputs, starts, ends,
     data_dict['Content processed'] = len({t[1] for t in reading_stmts})
     data_dict['Statements produced'] = len(stmt_outputs)
 
+    readings_with_stmts = []
+    readings_with_no_stmts = []
+    for t in reading_stmts:
+        if t[-1]:
+            readings_with_stmts.append(t)
+        else:
+            readings_with_no_stmts.append(t)
+
+    data_dict['Readings with 0 statements'] = len(readings_with_no_stmts)
+
     # Do a bunch of aggregation
     tc_rd_dict = {}
     tc_stmt_dict = {}
@@ -52,7 +62,7 @@ def report_statistics(reading_outputs, stmt_outputs, starts, ends,
     reader_stmts = {}
     reader_tcids = {}
     reader_rids = {}
-    for rid, tcid, reader, stmts in reading_stmts:
+    for rid, tcid, reader, stmts in readings_with_stmts:
         # Handle things keyed by tcid
         if tcid not in tc_rd_dict.keys():
             tc_rd_dict[tcid] = {rid}
@@ -74,6 +84,21 @@ def report_statistics(reading_outputs, stmt_outputs, starts, ends,
             reader_rids[reader] = {rid}
         else:
             reader_stmts[reader] |= set(stmts)
+            reader_tcids[reader].add(tcid)
+            reader_rids[reader].add(rid)
+
+    for rid, tcid, reader, _ in readings_with_no_stmts:
+        # Handle things keyed by tcid
+        if tcid not in tc_rd_dict.keys():
+            tc_rd_dict[tcid] = {rid}
+        else:
+            tc_rd_dict[tcid].add(rid)
+
+        # Handle things keyed by reader
+        if reader not in reader_stmts.keys():
+            reader_tcids[reader] = {tcid}
+            reader_rids[reader] = {rid}
+        else:
             reader_tcids[reader].add(tcid)
             reader_rids[reader].add(rid)
 

--- a/indra/tools/reading/db_reading/read_db_aws.py
+++ b/indra/tools/reading/db_reading/read_db_aws.py
@@ -24,7 +24,7 @@ from indra.tools.reading.readers import get_readers
 
 def plot_hist(agged, agg_over, data, s3, s3_base, bucket_name):
     fig = plt.figure()
-    plt.hist(data)
+    plt.hist(data, bins=np.arange(len(data)))
     plt.xlabel('Number of %s for %s' % (agged, agg_over))
     plt.ylabel('Number of %s with a given number of %s' % (agg_over, agged))
     fname = '%s_per_%s.png' % (agged, agg_over)

--- a/indra/tools/reading/db_reading/read_db_aws.py
+++ b/indra/tools/reading/db_reading/read_db_aws.py
@@ -31,7 +31,8 @@ def plot_hist(agged, agg_over, data, s3, s3_base, bucket_name):
     return
 
 
-def report_statistics(reading_outputs, stmt_outputs, basename, s3, bucket_name):
+def report_statistics(reading_outputs, stmt_outputs, starts, ends, basename, s3,
+                      bucket_name):
     s3_base = 'reading_results/%s/logs/run_db_reading/statisics/' % basename
     starts['stats'] = datetime.now()
     data_dict = {}
@@ -265,5 +266,6 @@ if __name__ == '__main__':
     else:
         stmt_data = []
 
-    report_statistics(outputs, stmt_data, starts, ends, args.basename, client, bucket_name)
+    report_statistics(outputs, stmt_data, starts, ends, args.basename, client,
+                      bucket_name)
 

--- a/indra/tools/reading/pmid_reading/read_pmids_aws.py
+++ b/indra/tools/reading/pmid_reading/read_pmids_aws.py
@@ -75,11 +75,12 @@ if __name__ == '__main__':
     client = boto3.client('s3')
     bucket_name = 'bigmech'
     pmid_list_key = 'reading_results/%s/pmids' % args.basename
-    path_to_reach = get_config('REACHPATH')
-    reach_version = get_config('REACH_VERSION')
-    if path_to_reach is None or reach_version is None:
-        print('REACHPATH and/or REACH_VERSION not defined, exiting.')
-        sys.exit(1)
+    if 'reach' in [rdr.lower() for rdr in args.readers]:
+        path_to_reach = get_config('REACHPATH')
+        reach_version = get_config('REACH_VERSION')
+        if path_to_reach is None or reach_version is None:
+            print('REACHPATH and/or REACH_VERSION not defined, exiting.')
+            sys.exit(1)
 
     try:
         pmid_list_obj = client.get_object(

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -501,6 +501,34 @@ class PmidSubmitter(Submitter):
         return
 
 
+def submit_reading(basename, pmid_list_filename, readers, start_ix=None,
+                   end_ix=None, pmids_per_job=3000, num_tries=2,
+                   force_read=False, force_fulltext=False, project_name=None):
+    """Submit an old-style pmid-centered no-database s3 only reading job.
+
+    This function is provided for the sake of backward compatibility. It is
+    preferred that you use the object-oriented PmidSubmitter and the
+    submit_reading job going forward.
+    """
+    sub = PmidSubmitter(basename, readers, project_name)
+    sub.set_options(force_read, force_fulltext)
+    sub.submit_reading(pmid_list_filename, start_ix, end_ix, pmids_per_job,
+                       num_tries)
+    return sub.job_list
+
+
+def submit_combine(basename, readers, job_ids=None, project_name=None):
+    """Submit a batch job to combine the outputs of a reading job.
+
+    This function is provided for backwards compatibility. You should use the
+    PmidSubmitter and submit_combine methods.
+    """
+    sub = PmidSubmitter(basename, readers, project_name)
+    sub.job_list = job_ids
+    sub.submit_combine()
+    return sub
+
+
 class DbReadingSubmitter(Submitter):
     _s3_input_name = 'id_list'
     _purpose = 'db_reading'
@@ -540,6 +568,25 @@ class DbReadingSubmitter(Submitter):
         self.options['max_reach_input_len'] = max_reach_input_len
         self.options['max_reach_space_ratio'] = max_reach_space_ratio
         return
+
+
+def submit_db_reading(basename, id_list_filename, readers, start_ix=None,
+                      end_ix=None, pmids_per_job=3000, num_tries=2,
+                      force_read=False, force_fulltext=False,
+                      read_all_fulltext=False, project_name=None,
+                      max_reach_input_len=None, max_reach_space_ratio=None,
+                      no_stmts=False):
+    """Submit batch reading jobs that uses the database for content and results.
+
+    This function is provided for backwards compatibility, use DbReadingSubmitter
+    and its submit_reading method instead.
+    """
+    sub = DbReadingSubmitter(basename, readers, project_name)
+    sub.set_options(force_read, no_stmts, force_fulltext, read_all_fulltext,
+                    max_reach_input_len, max_reach_space_ratio)
+    sub.submit_reading(id_list_filename, start_ix, end_ix, pmids_per_job,
+                       num_tries)
+    return sub
 
 
 if __name__ == '__main__':

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -187,6 +187,14 @@ def wait_for_complete(queue_name, job_list=None, job_name_prefix=None,
                        start_time.strftime('%Y%m%d_%H%M%S'))
         sleep(poll_interval)
 
+    # Pick up any stragglers
+    if stash_log_method:
+        success_ids = [job_def['jobId'] for job_def in done]
+        failure_ids = [job_def['jobId'] for job_def in failed]
+        stash_logs(observed_job_def_dict, success_ids, failure_ids,
+                   queue_name, stash_log_method, job_name_prefix,
+                   start_time.strftime('%Y%m%d_%H%M%S'))
+
     return ret
 
 

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -205,7 +205,6 @@ def stash_logs(job_defs, success_ids, failure_ids, queue_name, method='local',
                     name),
                 Body=log_str
                 )
-
     elif method == 'local':
         if job_name_prefix is None:
             job_name_prefix = 'batch_%s' % tag
@@ -215,8 +214,12 @@ def stash_logs(job_defs, success_ids, failure_ids, queue_name, method='local',
         def stash_log(log_str, name_base):
             with open(os.path.join(dirname, name_base + '.log'), 'w') as f:
                 f.write(log_str)
+    else:
+        raise ValueError('Invalid method: %s' % method)
 
-    for job_def_tpl in job_defs:
+    for jobId, job_def_tpl in job_defs.items():
+        if jobId not in success_ids and jobId not in failure_ids:
+            continue  # Logs aren't done and ready to be loaded.
         try:
             job_def = dict(job_def_tpl)
             lines = get_job_log(job_def, write_file=False)

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -432,6 +432,18 @@ class Submitter(object):
         self.job_list = job_list
         return job_list
 
+    def watch_and_wait(self, poll_interval=10, idle_log_timeout=None,
+                       kill_on_timeout=False, stash_log_method=None,
+                       tag_instances=False):
+        """This provides shortcut access to the wait_for_complete_function."""
+        return wait_for_complete(self._job_queue, job_list=self.job_list,
+                                 job_name_prefix=self.basename,
+                                 poll_interval=poll_interval,
+                                 idle_log_timeout=idle_log_timeout,
+                                 kill_on_log_timeout=kill_on_timeout,
+                                 stash_log_method=stash_log_method,
+                                 tag_instances=tag_instances)
+
 
 class PmidSubmitter(Submitter):
     _s3_input_name = 'pmids'

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -213,7 +213,7 @@ def stash_logs(job_defs, success_jobs, failure_jobs, queue_name, method='local',
         s3_client = boto3.client('s3')
 
         def stash_log(log_str, name_base):
-            name = '%s_%s.log' % (name_base, tag)
+            name = '%s/%s.log' % (name_base, tag)
             s3_client.put_object(
                 Bucket=bucket_name,
                 Key='reading_results/%s/logs/%s/%s' % (

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -424,8 +424,8 @@ class Submitter(object):
             logger.info('Command list: %s' % str(command_list))
             job_info = batch_client.submit_job(
                 jobName=job_name,
-                jobQueue=self._job_def,
-                jobDefinition=self._job_queue,
+                jobQueue=self._job_queue,
+                jobDefinition=self._job_def,
                 containerOverrides={
                     'environment': environment_vars,
                     'command': command_list},

--- a/indra/tools/reading/util/log_analysis_tools.py
+++ b/indra/tools/reading/util/log_analysis_tools.py
@@ -136,13 +136,20 @@ def get_reading_stats(log_str):
     ret_dict = {}
     ret_dict['num_prex_readings'] = \
         re_get_nums('Found (\d+) pre-existing readings', 0)[0]
-    ret_dict['num_new_readings'] = re_get_nums('Made (\d+) new readings')[0]
+    try:
+        ret_dict['num_new_readings'] = re_get_nums('Made (\d+) new readings')[0]
+    except:
+        ret_dict['num_new_readings'] = None
     ret_dict['num_succeeded'] = \
         re_get_nums('Adding (\d+)/\d+ reading entries')[0]
     ret_dict['num_stmts'], ret_dict['num_readings'] = \
         re_get_nums('Found (\d+) statements from (\d+) readings')
     ret_dict['num_agents'] = \
-        re_get_nums('Received request to copy (\d+) entries into agents')[0]
+        re_get_nums('Received request to copy (\d+) entries '
+                    'into .{3,4}agents')[0]
+    ret_dict['num_statements'] = \
+        re_get_nums('Received request to copy (\d+) entries into '
+                    '.{3,4}statements')[0]
     return ret_dict
 
 

--- a/indra/tools/reading/util/log_analysis_tools.py
+++ b/indra/tools/reading/util/log_analysis_tools.py
@@ -21,10 +21,11 @@ def analyze_reach_log(log_fname=None, log_str=None):
         with open(log_fname, 'r') as fh:
             log_str = fh.read()
     # has_content, total = get_content_nums(log_str)  # unused
-    pmids_started = started_patt.findall(log_str)
-    pmids_finished = finished_patt.findall(log_str)
-    pmids_not_done = set(pmids_started) - set(pmids_finished)
-    return pmids_not_done
+    pmids = {}
+    pmids['started'] = started_patt.findall(log_str)
+    pmids['finished'] = finished_patt.findall(log_str)
+    pmids['not_done'] = set(pmids['started']) - set(pmids['finished'])
+    return pmids
 
 
 #==============================================================================
@@ -151,15 +152,37 @@ def analyze_db_reading(job_prefix, reading_queue='run_db_reading_queue'):
     log_strs = get_logs_from_db_reading(job_prefix, reading_queue)
     indra_log_strs = []
     all_reach_logs = []
+    log_stats = []
     for log_str in log_strs:
         log_str, reach_logs = separate_reach_logs(log_str)
         all_reach_logs.extend(reach_logs)
         indra_log_strs.append(log_str)
+        log_stats.append(get_reading_stats(log_str))
+
+    # Analayze the reach failures.
     failed_reach_logs = [reach_log_str
                          for result, reach_log_str in all_reach_logs
                          if result == 'FAILURE']
-    tcids_unfinished = {tcid for reach_log in failed_reach_logs
-                        if bool(reach_log)
-                        for tcid in analyze_reach_log(log_str=reach_log)}
+    failed_id_dicts = [analyze_reach_log(log_str=reach_log)
+                       for reach_log in failed_reach_logs if bool(reach_log)]
+    tcids_unfinished = {id_dict['not_done'] for id_dict in failed_id_dicts}
     print("Found %d unfinished tcids." % len(tcids_unfinished))
-    return tcids_unfinished
+
+    # Summarize the global stats
+    if log_stats:
+        sum_dict = dict.fromkeys(log_stats[0].keys())
+        for log_stat in log_stats:
+            for k in log_stat.keys():
+                if isinstance(log_stat[k], list):
+                    if k not in sum_dict.keys():
+                        sum_dict[k] = [0]*len(log_stat[k])
+                    sum_dict[k] = [sum_dict[k][i] + log_stat[k][i]
+                                   for i in range(len(log_stat[k]))]
+                else:
+                    if k not in sum_dict.keys():
+                        sum_dict[k] = 0
+                    sum_dict[k] += log_stat[k]
+    else:
+        sum_dict = {}
+
+    return tcids_unfinished, sum_dict, log_stats


### PR DESCRIPTION
This PR does two things for the reading pipeline:
- when using `wait_for_complete`, job logs will be stored as jobs complete, rather than only being stored at the end of all the jobs. This prevents logs from being lost simply because `wait_for_complete` was restarted.
- When a _database_ reading job is done, some easily derived statistics are calculated and posted on s3, along with the logs. This should help us more easily identify potential failures of the reading system.

As of this posting, this has not yet been tested on batch.

-----------------------
UPDATE: This has now been tested on batch, and it works. I have also added new sanity tests which run locally to ensure there are no silly errors or disagreements between the function call in the batch submission code and the actual aws batch scripts. This included an extensive but backwards-compatible rewrite of the submission functions into an object-oriented framework.