### PR TITLE
Add agent activity to PySB rule name

### DIFF
--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -320,6 +320,11 @@ def get_agent_rule_str(agent):
                     rule_str_list.append('n' + _n(b.agent.name))
         if agent.location is not None:
             rule_str_list.append(_n(agent.location))
+        if agent.activity is not None:
+            if agent.activity.is_active:
+                rule_str_list.append(agent.activity.activity_type[:3])
+            else:
+                rule_str_list.append(agent.activity.activity_type[:3] + '_inact')
     rule_str = '_'.join(rule_str_list)
     return rule_str
 

--- a/indra/assemblers/pysb_assembler.py
+++ b/indra/assemblers/pysb_assembler.py
@@ -517,7 +517,12 @@ def get_monomer_pattern(model, agent, extra_fields=None):
     pattern = get_site_pattern(agent)
     if extra_fields is not None:
         for k, v in extra_fields.items():
-            pattern[k] = v
+            # This is an important assumption, it only sets the given pattern
+            # on the monomer if that site/key is not already specified at the
+            # Agent level. For instance, if the Agent is specified to have
+            # 'activity', that site will not be updated here.
+            if k not in pattern:
+                pattern[k] = v
     # If a model is given, return the Monomer with the generated pattern,
     # otherwise just return the pattern
     try:

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -776,11 +776,12 @@ def test_gef_activation():
 
 def test_gef_rasgtp():
     sos = Agent('SOS1', db_refs={'HGNC': '1'})
-    ras = Agent('KRAS', activity=ActivityCondition('gtpbound', True),
-                db_refs={'HGNC': '2'})
+    ras = Agent('KRAS', db_refs={'HGNC': '2'})
+    ras_gtp = Agent('KRAS', activity=ActivityCondition('gtpbound', True),
+                    db_refs={'HGNC': '2'})
     raf = Agent('BRAF', db_refs={'HGNC': '3'})
     gef_stmt = Gef(sos, ras)
-    rasgtp_stmt = GtpActivation(ras, raf, 'kinase')
+    rasgtp_stmt = GtpActivation(ras_gtp, raf, 'kinase')
     act_stmt = Activation(sos, raf, 'kinase')
     # Check that the activation is satisfied by the Gef
     pysba = PysbAssembler()
@@ -791,7 +792,7 @@ def test_gef_rasgtp():
     assert len(checks) == 1
     assert checks[0][0] == act_stmt
     assert checks[0][1].paths == [(('SOS1_activates_KRAS', 1),
-                                   ('KRAS_activates_BRAF_kinase', 1),
+                                   ('KRAS_gtp_activates_BRAF_kinase', 1),
                                    ('BRAF_kinase_active_obs', 1))], \
         checks[0][1].paths
 
@@ -884,12 +885,13 @@ def test_gap_rasgtp_phos():
     ras = Agent('KRAS', db_refs={'HGNC': '2'})
     ras_g = Agent('KRAS', activity=ActivityCondition('gtpbound', True),
                   db_refs={'HGNC': '2'})
-    raf = Agent('BRAF', activity=ActivityCondition('kinase', True),
-                db_refs={'HGNC': '3'})
+    raf = Agent('BRAF', db_refs={'HGNC': '3'})
+    raf_a = Agent('BRAF', activity=ActivityCondition('kinase', True),
+                  db_refs={'HGNC': '3'})
     mek = Agent('MEK', db_refs={'HGNC': '4'})
     gap_stmt = Gap(nf1, ras)
     rasgtp_stmt = GtpActivation(ras_g, raf, 'kinase')
-    phos = Phosphorylation(raf, mek)
+    phos = Phosphorylation(raf_a, mek)
     stmt_to_check = Dephosphorylation(nf1, mek)
     # Assemble and check
     pysba = PysbAssembler()
@@ -901,7 +903,7 @@ def test_gap_rasgtp_phos():
     assert checks[0][0] == stmt_to_check
     assert checks[0][1].paths == \
         [(('NF1_deactivates_KRAS', 1),
-          ('KRAS_gtp_activates_BRAF_kin_kinase', -1),
+          ('KRAS_gtp_activates_BRAF_kinase', -1),
           ('BRAF_kin_phosphorylation_MEK_phospho', -1),
           ('MEK_phospho_p_obs', -1))], checks[0][1].paths
 

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -657,8 +657,8 @@ def test_multitype_path():
         results = mc.check_model()
         assert len(results) == len(stmts_to_check)
         assert isinstance(results[0], tuple)
-        assert results[0][1].paths == paths[0]
-        assert results[1][1].paths == paths[1]
+        assert results[0][1].paths == paths[0], results[0][1].paths
+        assert results[1][1].paths == paths[1], results[1][1].paths
     # Check with the ActiveForm
     stmts1 = [
         Complex([egfr, grb2]),
@@ -672,7 +672,7 @@ def test_multitype_path():
                            ('KRAS_gtpbound_active_obs', 1))],
                          [(('EGFR_GRB2_bind', 1), ('SOS1_GRB2_EGFR_bind', 1),
                            ('SOS1_GRB2_activates_KRAS_gtpbound', 1),
-                           ('KRAS_activates_BRAF_kinase', 1),
+                           ('KRAS_gtp_activates_BRAF_kinase', 1),
                            ('BRAF_kinase_active_obs', 1))]))
     # Check without the ActiveForm
     stmts2 = [
@@ -686,7 +686,7 @@ def test_multitype_path():
                            ('KRAS_gtpbound_active_obs', 1))],
                          [(('EGFR_GRB2_bind', 1), ('SOS1_GRB2_EGFR_bind', 1),
                            ('SOS1_GRB2_activates_KRAS', 1),
-                           ('KRAS_activates_BRAF_kinase', 1),
+                           ('KRAS_gtp_activates_BRAF_kinase', 1),
                            ('BRAF_kinase_active_obs', 1))]))
 
 
@@ -792,7 +792,9 @@ def test_gef_rasgtp():
     assert checks[0][0] == act_stmt
     assert checks[0][1].paths == [(('SOS1_activates_KRAS', 1),
                                    ('KRAS_activates_BRAF_kinase', 1),
-                                   ('BRAF_kinase_active_obs', 1))]
+                                   ('BRAF_kinase_active_obs', 1))], \
+        checks[0][1].paths
+
 
 
 def test_gef_rasgtp_phos():
@@ -817,9 +819,10 @@ def test_gef_rasgtp_phos():
     assert len(checks) == 1
     assert checks[0][0] == stmt_to_check
     assert checks[0][1].paths == [(('SOS1_activates_KRAS', 1),
-                                   ('KRAS_activates_BRAF_kinase', 1),
-                                   ('BRAF_phosphorylation_MEK_phospho', 1),
-                                   ('MEK_phospho_p_obs', 1))]
+                                   ('KRAS_gtp_activates_BRAF_kinase', 1),
+                                   ('BRAF_kin_phosphorylation_MEK_phospho', 1),
+                                   ('MEK_phospho_p_obs', 1))], \
+        checks[0][1].paths
 
 
 def test_gap_activation():
@@ -871,8 +874,9 @@ def test_gap_rasgtp():
     assert len(checks) == 1
     assert checks[0][0] == act_stmt
     assert checks[0][1].paths == [(('NF1_deactivates_KRAS', 1),
-                                   ('KRAS_activates_BRAF_kinase', -1),
-                                   ('BRAF_kinase_active_obs', -1))]
+                                   ('KRAS_gtp_activates_BRAF_kinase', -1),
+                                   ('BRAF_kinase_active_obs', -1))], \
+        checks[0][1].paths
 
 
 def test_gap_rasgtp_phos():
@@ -895,10 +899,11 @@ def test_gap_rasgtp_phos():
     checks = mc.check_model()
     assert len(checks) == 1
     assert checks[0][0] == stmt_to_check
-    assert checks[0][1].paths == [(('NF1_deactivates_KRAS', 1),
-                                   ('KRAS_activates_BRAF_kinase', -1),
-                                   ('BRAF_phosphorylation_MEK_phospho', -1),
-                                   ('MEK_phospho_p_obs', -1))]
+    assert checks[0][1].paths == \
+        [(('NF1_deactivates_KRAS', 1),
+          ('KRAS_gtp_activates_BRAF_kin_kinase', -1),
+          ('BRAF_kin_phosphorylation_MEK_phospho', -1),
+          ('MEK_phospho_p_obs', -1))], checks[0][1].paths
 
 
 def test_increase_amount():

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -1155,3 +1155,17 @@ def test_convert_subj():
     assert(len(pa.model.rules) == 1)
     assert(len(pa.model.monomers) == 3)
 
+
+def test_activity_agent_rule_name():
+    stmt = Phosphorylation(Agent('BRAF',
+                                 activity=ActivityCondition('kinase',
+                                                            True)),
+                           Agent('MAP2K1',
+                                 activity=ActivityCondition('activity',
+                                                            False)))
+    pa = PysbAssembler()
+    pa.add_statements([stmt])
+    pa.make_model()
+    assert pa.model.rules[0].name == \
+        'BRAF_kin_phosphorylation_MAP2K1_act_inact_phospho', \
+        pa.model.rules[0].name


### PR DESCRIPTION
For some reason agent activities were not made part of the rule name yet which could have resulted in inadvertent rule name collisions and made influence maps confusing.