### PR TITLE
Add function to pubmed_client to get citation count

### DIFF
--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -108,6 +108,30 @@ def get_ids(search_term, **kwargs):
     return ids
 
 
+def get_id_count(search_term):
+    """Get the number of citations in Pubmed for a search query.
+
+    Parameters
+    ----------
+    search_term : str
+        A term for which the PubMed search should be performed.
+
+    Returns
+    -------
+    int or None
+        The number of citations for the query, or None if the query fails.
+    """
+    params = {'term': search_term,
+              'rettype': 'count',
+              'db': 'pubmed'}
+    tree = send_request(pubmed_search, params)
+    if tree is None:
+        return None
+    else:
+        count = tree.getchildren()[0].text
+        return int(count)
+
+
 @lru_cache(maxsize=100)
 def get_ids_for_gene(hgnc_name, **kwargs):
     """Get the curated set of articles for a gene in the Entrez database.

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -28,6 +28,14 @@ def test_get_ids():
 
 
 @attr('webservice')
+def test_get_id_count():
+    id_count = pubmed_client.get_id_count('SDLFKJSLDKJH')
+    assert id_count == 0
+    id_count = pubmed_client.get_id_count('KRAS')
+    assert id_count > 0
+
+
+@attr('webservice')
 def test_get_pmc_ids():
     ids = pubmed_client.get_ids('braf', retmax=10, db='pmc')
     assert(len(ids) == 10)


### PR DESCRIPTION
If you only want a citation count (and not the list of citations) there is a specific arg that can be passed: https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch 

Since the XML object returned is completely different than the case for the regular PMID ID search, it seemed cleaner to implement this in its own function rather than as an option to `get_ids`.

