### PR TITLE
Reading reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - sudo update-java-alternatives -s java-8-oracle
   - sudo apt-get install oracle-java8-set-default
   - export JAVA_HOME="/usr/lib/jvm/java-8-oracle/"
-  - pip install pygraphviz pydot jsonschema coverage python-coveralls boto3 sqlalchemy psycopg2-binary pgcopy nose-timer flask nltk
+  - pip install pygraphviz pydot jsonschema coverage python-coveralls boto3 sqlalchemy psycopg2-binary pgcopy nose-timer flask nltk reportlab
   - pip install paths-graph
   - pip install doctest-ignore-unicode
   - pip install git+https://github.com/pybel/pybel.git@develop

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -314,7 +314,8 @@ MOCK_MODULES = [
     'sqlalchemy', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
     'sqlalchemy.orm', 'sqlalchemy.orm.attributes', 'sqlalchemy.dialects',
     'sqlalchemy.dialects.postgresql', 'sqlalchemy.schema', 'sqlalchemy.ext.compiler',
-    'sqlalchemy.sql', 'sqlalchemy.sql.expression', 'nltk', 'kappy', 'openpyxl'
+    'sqlalchemy.sql', 'sqlalchemy.sql.expression', 'nltk', 'kappy', 'openpyxl',
+    'reportlab'
     ]
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = mock.MagicMock()

--- a/indra/db/util.py
+++ b/indra/db/util.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from datetime import datetime
-from os.path import abspath
 
 __all__ = ['get_defaults', 'get_primary_db', 'get_db', 'insert_agents',
            'insert_pa_stmts', 'insert_db_stmts', 'get_raw_stmts_frm_db_list',
@@ -16,6 +15,7 @@ from functools import partial, wraps
 from multiprocessing.pool import Pool
 
 from indra.util import batch_iter
+from indra.util.nested_dict import NestedDict
 from indra.util.get_version import get_version
 from indra.statements import Complex, SelfModification, ActiveForm,\
     stmts_from_json, Conversion, Translocation, Statement
@@ -483,114 +483,6 @@ def get_raw_stmts_frm_db_list(db, db_stmt_objs, fix_refs=True, with_sids=True):
         return [(sid, stmt) for _, sid, stmt in rid_stmt_sid_trios]
     else:
         return [stmt for _, _, stmt in rid_stmt_sid_trios]
-
-
-class NestedDict(dict):
-    """A dict-like object that recursively populates elements of a dict."""
-
-    def __getitem__(self, key):
-        if key not in self.keys():
-            val = self.__class__()
-            self.__setitem__(key, val)
-        else:
-            val = dict.__getitem__(self, key)
-        return val
-
-    def __repr__(self):
-        sub_str = dict.__repr__(self)[1:-1]
-        if not sub_str:
-            return self.__class__.__name__ + '()'
-        # This does not completely generalize, but it works for most cases.
-        for old, new in [('), ', '),\n'), ('\n', '\n  ')]:
-            sub_str = sub_str.replace(old, new)
-        return'%s(\n  %s\n)' % (self.__class__.__name__, sub_str)
-
-    def __str__(self):
-        return self.__repr__()
-
-    def export_dict(self):
-        "Convert this into an ordinary dict (of dicts)."
-        return {k: v.export_dict() if isinstance(v, self.__class__) else v
-                for k, v in self.items()}
-
-    def get(self, key):
-        "Find the first value within the tree which has the key."
-        if key in self.keys():
-            return self[key]
-        else:
-            res = None
-            for v in self.values():
-                # This could get weird if the actual expected returned value
-                # is None, especially in teh case of overlap. Any ambiguity
-                # would be resolved by get_path(s).
-                if hasattr(v, 'get'):
-                    res = v.get(key)
-                if res is not None:
-                    break
-            return res
-
-    def get_path(self, key):
-        "Like `get`, but also return the path taken to the value."
-        if key in self.keys():
-            return (key,), self[key]
-        else:
-            key_path, res = (None, None)
-            for sub_key, v in self.items():
-                if isinstance(v, self.__class__):
-                    key_path, res = v.get_path(key)
-                elif hasattr(v, 'get'):
-                    res = v.get(key)
-                    key_path = (key,) if res is not None else None
-                if res is not None and key_path is not None:
-                    key_path = (sub_key,) + key_path
-                    break
-            return key_path, res
-
-    def gets(self, key):
-        "Like `get`, but return all matches, not just the first."
-        result_list = []
-        if key in self.keys():
-            result_list.append(self[key])
-        for v in self.values():
-            if isinstance(v, self.__class__):
-                sub_res_list = v.gets(key)
-                for res in sub_res_list:
-                    result_list.append(res)
-            elif isinstance(v, dict):
-                if key in v.keys():
-                    result_list.append(v[key])
-        return result_list
-
-    def get_paths(self, key):
-        "Like `gets`, but include the paths, like `get_path` for all matches."
-        result_list = []
-        if key in self.keys():
-            result_list.append(((key,), self[key]))
-        for sub_key, v in self.items():
-            if isinstance(v, self.__class__):
-                sub_res_list = v.get_paths(key)
-                for key_path, res in sub_res_list:
-                    result_list.append(((sub_key,) + key_path, res))
-            elif isinstance(v, dict):
-                if key in v.keys():
-                    result_list.append(((sub_key, key), v[key]))
-        return result_list
-
-    def get_leaves(self):
-        """Get the deepest entries as a flat set."""
-        ret_set = set()
-        for val in self.values():
-            if isinstance(val, self.__class__):
-                ret_set |= val.get_leaves()
-            elif isinstance(val, dict):
-                ret_set |= set(val.values())
-            elif isinstance(val, list):
-                ret_set |= set(val)
-            elif isinstance(val, set):
-                ret_set |= val
-            else:
-                ret_set.add(val)
-        return ret_set
 
 
 def _get_reading_statement_dict(db, clauses=None, get_full_stmts=True):

--- a/indra/sources/sparser/sparser_api.py
+++ b/indra/sources/sparser/sparser_api.py
@@ -207,7 +207,7 @@ def process_xml(xml_str):
     return sp
 
 
-def run_sparser(fname, output_fmt, outbuf=None):
+def run_sparser(fname, output_fmt, outbuf=None, timeout=600):
     """Return the path to reading output after running Sparser reading.
 
     Parameters
@@ -221,6 +221,10 @@ def run_sparser(fname, output_fmt, outbuf=None):
         'json' or 'xml'.
     outbuf : Optional[file]
         A file like object that the Sparser output is written to.
+    timeout : int
+        The number of seconds to wait until giving up on this one reading. The
+        default is 600 seconds (i.e. 10 minutes). Sparcer is a fast reader and
+        the typical type to read a single full text is a matter of seconds.
 
     Returns
     -------
@@ -245,7 +249,8 @@ def run_sparser(fname, output_fmt, outbuf=None):
         if not os.path.exists(fpath):
             raise Exception("'%s' is not a valid path." % fpath)
 
-    out_bts = subprocess.check_output([sparser_exec_path, format_flag, fname])
+    out_bts = subprocess.check_output([sparser_exec_path, format_flag, fname],
+                                      timeout=timeout)
     if outbuf is not None:
         outbuf.write(out_bts)
         outbuf.flush()

--- a/indra/tests/test_reading_scripts_aws.py
+++ b/indra/tests/test_reading_scripts_aws.py
@@ -56,6 +56,7 @@ def test_normal_db_reading_call():
     job_name, cmd = sub._make_command(0, len(text_content))
     cmd += ['--test']
     check_call(cmd)
+    sub.produce_report()
 
     # Remove garbage on s3
     res = s3.list_objects(Bucket='bigmech', Prefix=s3_prefix)

--- a/indra/tests/test_reading_scripts_aws.py
+++ b/indra/tests/test_reading_scripts_aws.py
@@ -36,6 +36,10 @@ def test_normal_db_reading_call():
          zip_string('MEK phosphorylates ERK in test %d.' % i))
         for i in range(N)
         ]
+    text_content += [
+        (N, N-1, 'pmc_oa', 'text', 'fulltext',
+         zip_string('MEK phosphorylates ERK. EGFR activates SHC.'))
+        ]
     db.copy('text_content', text_content,
             cols=('id', 'text_ref_id', 'source', 'format', 'text_type',
                   'content'))
@@ -44,11 +48,12 @@ def test_normal_db_reading_call():
     basename = 'local_db_test_run'
     s3_prefix = 'reading_results/%s/' % basename
     s3.put_object(Bucket='bigmech', Key=s3_prefix + 'id_list',
-                  Body='\n'.join(['tcid: %d' % i for i in range(5)]))
+                  Body='\n'.join(['tcid: %d' % i
+                                  for i in range(len(text_content))]))
 
     # Call the reading tool
     sub = srp.DbReadingSubmitter(basename, ['sparser'])
-    job_name, cmd = sub._make_command(0, 2)
+    job_name, cmd = sub._make_command(0, len(text_content))
     cmd += ['--test']
     check_call(cmd)
 

--- a/indra/tests/test_reading_scripts_aws.py
+++ b/indra/tests/test_reading_scripts_aws.py
@@ -1,8 +1,7 @@
 
 import boto3
-from os import path
+from os import path, chdir
 from subprocess import check_call
-
 from nose.plugins.attrib import attr
 
 from indra.db import util as dbu
@@ -18,12 +17,14 @@ HERE = path.dirname(path.abspath(__file__))
 
 @attr('nonpublic')
 def test_db_reading_help():
+    chdir(path.expanduser('~'))
     check_call(['python', '-m', 'indra.tools.reading.db_reading.read_db_aws',
                 '--help'])
 
 
 @attr('nonpublic')
 def test_normal_db_reading_call():
+    chdir(path.expanduser('~'))
     # Put some basic stuff in the test databsae
     N = 6
     db = dbu.get_test_db()
@@ -61,6 +62,7 @@ def test_normal_db_reading_call():
 
 @attr('nonpublic')
 def test_normal_pmid_reading_call():
+    chdir(path.expanduser('~'))
     # Put an id file on s3
     basename = 'local_pmid_test_run'
     s3_prefix = 'reading_results/%s/' % basename

--- a/indra/tools/reading/db_reading/read_db_aws.py
+++ b/indra/tools/reading/db_reading/read_db_aws.py
@@ -144,11 +144,11 @@ class StatReporter(Reporter):
         # Produce some numpy count arrays.
         self.hist_dict[('readings', 'text content')] = \
             np.array([len(rid_set) for rid_set in tc_rd_dict.values()])
-        self.hist_dict[('statements', 'text_content')] = \
+        self.hist_dict[('stmts', 'text content')] = \
             np.array([len(stmts) for stmts in tc_stmt_dict.values()])
-        self.hist_dict[('statements', 'readings')] = \
+        self.hist_dict[('stmts', 'readings')] = \
             np.array([len(stmts) for stmts in rd_stmt_dict.values()])
-        self.hist_dict[('statements', 'readers')] = \
+        self.hist_dict[('stmts', 'readers')] = \
             np.array([len(stmts) for stmts in reader_stmts.values()])
         self.hist_dict[('text content', 'reader')] = \
             np.array([len(tcid_set) for tcid_set in reader_tcids.values()])
@@ -211,6 +211,10 @@ class StatReporter(Reporter):
         self.summary_dict['Content processed'] = \
             len({t[1] for t in reading_stmts})
         self.summary_dict['Statements produced'] = len(stmt_outputs)
+        self.s3.put_object(Key=self.s3_prefix + 'raw_tuples.pkl',
+                           Body=pickle.dumps([t[:-1] + (len(t[-1]),)
+                                              for t in reading_stmts]),
+                           Bucket=self.bucket_name)
 
         readings_with_stmts = []
         readings_with_no_stmts = []
@@ -220,7 +224,7 @@ class StatReporter(Reporter):
             else:
                 readings_with_no_stmts.append(t)
 
-        self.summary_dict['Readings with 0 statements'] = \
+        self.summary_dict['Readings with no statements'] = \
             len(readings_with_no_stmts)
 
         self._populate_hist_data(readings_with_stmts, readings_with_no_stmts)

--- a/indra/tools/reading/db_reading/read_db_aws.py
+++ b/indra/tools/reading/db_reading/read_db_aws.py
@@ -47,9 +47,13 @@ class StatReporter(Reporter):
 
     def _get_git_info(self):
         git_info_dict = get_git_info()
+        text_file_content = ''
         for key, val in git_info_dict.items():
             label = key.replace('_', ' ').capitalize()
+            text_file_content += '%s: %s\n' % (label, val)
             self.add_story_text('%s: %s' % (label, val), section='Git Info')
+        self.s3.put_object(Key=self.s3_prefix + 'git_info.txt',
+                           Body=text_file_content, Bucket=self.bucket_name)
         return
 
     def _plot_hist(self, agged, agg_over, data):

--- a/indra/tools/reading/db_reading/read_db_aws.py
+++ b/indra/tools/reading/db_reading/read_db_aws.py
@@ -222,7 +222,10 @@ class StatReporter(Reporter):
         self._make_text_summary()
         ends['stats'] = datetime.now()
 
-        doc = self.make_report()
+        fname = self.make_report()
+        with open(fname, 'rb') as f:
+            self.s3.put_object(Key=self.s3_prefix + fname, Body=f.read(),
+                               Bucket=self.bucket_name)
 
         self._make_timing_report(starts, ends)
         self._stash_data()

--- a/indra/tools/reading/db_reading/read_db_aws.py
+++ b/indra/tools/reading/db_reading/read_db_aws.py
@@ -41,6 +41,8 @@ class StatReporter(Reporter):
         self._make_job_line('Job Name', job_name)
         self._make_job_line('Job s3 prefix', s3_log_prefix)
         self._get_git_info()
+        self.set_section_order(['Job Info', 'Git Info', 'Summary Statistics',
+                                'Plots'])
         return
 
     def _get_git_info(self):

--- a/indra/tools/reading/db_reading/read_db_aws.py
+++ b/indra/tools/reading/db_reading/read_db_aws.py
@@ -3,243 +3,19 @@ for the job either needs to be provided in environment variables (e.g., the
 REACH version and path) or loaded from S3 (e.g., the list of PMIDs).
 """
 from __future__ import absolute_import, print_function, unicode_literals
-
-import pickle
 from builtins import dict, str
+
+import os
+import sys
 import boto3
 import botocore
 import logging
-import sys
-import os
 import random
-import numpy as np
-import matplotlib as mpl
-
-
-mpl.use('Agg')
-from matplotlib import pyplot as plt
 from datetime import datetime
-from indra.util.get_version import get_git_info
-from indra.tools.reading.util.reporter import Reporter
 from indra.tools.reading.db_reading.read_db import produce_readings, \
     produce_statements, get_id_dict
 from indra.tools.reading.readers import get_readers
-
-
-class StatReporter(Reporter):
-    """A class to handle generating the reports made at the end of a job."""
-    def __init__(self, job_name, s3_log_prefix, s3, bucket_name):
-        super(StatReporter, self).__init__('%s_summary' % job_name)
-        self.s3_prefix = s3_log_prefix + 'statistics/'
-        self.bucket_name = bucket_name
-        self.s3 = s3
-        self.summary_dict = {}
-        self.hist_dict = {}
-        self.set_title("Report of Database Reading Batch Job")
-        self.sections = {'Summary Statistics': [], 'Plots': [], 'Git Info': [],
-                         'Job Info': []}
-        self._make_job_line('Job Name', job_name)
-        self._make_job_line('Job s3 prefix', s3_log_prefix)
-        self._get_git_info()
-        self.set_section_order(['Job Info', 'Git Info', 'Summary Statistics',
-                                'Plots'])
-        return
-
-    def _get_git_info(self):
-        git_info_dict = get_git_info()
-        text_file_content = ''
-        for key, val in git_info_dict.items():
-            label = key.replace('_', ' ').capitalize()
-            text_file_content += '%s: %s\n' % (label, val)
-            self.add_story_text('%s: %s' % (label, val), section='Git Info')
-        self.s3.put_object(Key=self.s3_prefix + 'git_info.txt',
-                           Body=text_file_content, Bucket=self.bucket_name)
-        return
-
-    def _plot_hist(self, agged, agg_over, data):
-        fig = plt.figure()
-        plt.hist(data, bins=np.arange(len(data)))
-        plt.xlabel('Number of %s for %s' % (agged, agg_over))
-        plt.ylabel('Number of %s with a given number of %s' % (agg_over, agged))
-        fname = '%s_per_%s.png' % (agged, agg_over)
-        fig.set_size_inches(6, 4)
-        fig.savefig(fname)
-        with open(fname, 'rb') as f:
-            s3_key = self.s3_prefix + fname
-            self.s3.put_object(Key=s3_key, Body=f.read(),
-                               Bucket=self.bucket_name)
-        self.add_story_image(fname, width=6, height=4, section='Plots')
-        return
-
-    def _make_timing_report(self, starts, ends):
-        # Report on the timing
-        timing_str = ''
-        for step in ['reading', 'statement production', 'stats']:
-            time_taken = ends[step] - starts[step]
-            timing_str += ('%22s: start: %s, end: %s, duration: %s\n'
-                           % (step, starts[step], ends[step], time_taken))
-
-        self.s3.put_object(Key=self.s3_prefix + 'timing.txt', Body=timing_str,
-                           Bucket=self.bucket_name)
-        return
-
-    def _stash_data(self):
-        """Store the data in pickle files. This should be done last."""
-        self.s3.put_object(Key=self.s3_prefix + 'hist_data.pkl',
-                           Body=pickle.dumps(self.hist_dict),
-                           Bucket=self.bucket_name)
-        self.s3.put_object(Key=self.s3_prefix + 'sum_data.pkl',
-                           Bucket=self.bucket_name,
-                           Body=pickle.dumps(self.summary_dict))
-        return
-
-    def _populate_hist_data(self, readings_with_stmts, readings_with_no_stmts):
-        # Do a bunch of aggregation
-        tc_rd_dict = {}
-        tc_stmt_dict = {}
-        rd_stmt_dict = {}
-        reader_stmts = {}
-        reader_tcids = {}
-        reader_rids = {}
-        for rid, tcid, reader, stmts in readings_with_stmts:
-            # Handle things keyed by tcid
-            if tcid not in tc_rd_dict.keys():
-                tc_rd_dict[tcid] = {rid}
-                tc_stmt_dict[tcid] = set(stmts)
-            else:
-                tc_rd_dict[tcid].add(rid)
-                tc_stmt_dict[tcid] |= set(stmts)
-
-            # Handle things keyed by rid
-            if rid not in rd_stmt_dict.keys():
-                rd_stmt_dict[rid] = set(stmts)
-            else:
-                rd_stmt_dict[rid] |= set(stmts)  # this shouldn't really happen.
-
-            # Handle things keyed by reader
-            if reader not in reader_stmts.keys():
-                reader_stmts[reader] = set(stmts)
-                reader_tcids[reader] = {tcid}
-                reader_rids[reader] = {rid}
-            else:
-                reader_stmts[reader] |= set(stmts)
-                reader_tcids[reader].add(tcid)
-                reader_rids[reader].add(rid)
-
-        for rid, tcid, reader, _ in readings_with_no_stmts:
-            # Handle things keyed by tcid
-            if tcid not in tc_rd_dict.keys():
-                tc_rd_dict[tcid] = {rid}
-            else:
-                tc_rd_dict[tcid].add(rid)
-
-            # Handle things keyed by reader
-            if reader not in reader_stmts.keys():
-                reader_tcids[reader] = {tcid}
-                reader_rids[reader] = {rid}
-            else:
-                reader_tcids[reader].add(tcid)
-                reader_rids[reader].add(rid)
-
-        # Produce some numpy count arrays.
-        self.hist_dict[('readings', 'text content')] = \
-            np.array([len(rid_set) for rid_set in tc_rd_dict.values()])
-        self.hist_dict[('stmts', 'text content')] = \
-            np.array([len(stmts) for stmts in tc_stmt_dict.values()])
-        self.hist_dict[('stmts', 'readings')] = \
-            np.array([len(stmts) for stmts in rd_stmt_dict.values()])
-        self.hist_dict[('stmts', 'readers')] = \
-            np.array([len(stmts) for stmts in reader_stmts.values()])
-        self.hist_dict[('text content', 'reader')] = \
-            np.array([len(tcid_set) for tcid_set in reader_tcids.values()])
-        self.hist_dict[('readings', 'reader')] = \
-            np.array([len(rid_set) for rid_set in reader_rids.values()])
-        return
-
-    def _make_histograms(self):
-        # Produce the histograms
-        for (agged, agg_over), data in self.hist_dict.items():
-            self._plot_hist(agged, agg_over, data)
-            label = '%s per %s' % (agged, agg_over)
-            stat_dict = {'mean': data.mean(), 'std': data.std(),
-                         'median': np.median(data)}
-            self.add_story_text(str(stat_dict), style='Code', section='Plots')
-            self.summary_dict[label.capitalize()] = {'mean': data.mean(),
-                                                     'std': data.std(),
-                                                     'median': np.median(data)}
-        return
-
-    def _make_text_summary(self):
-        text_report_str = ''
-        top_labels = ['Total readings', 'Content processed',
-                      'Statements produced']
-        for label in top_labels:
-            text_str = '%s: %d\n' % (label, self.summary_dict[label])
-            self.add_story_text(text_str, section='Summary Statistics')
-            text_report_str += '%s: %d\n' % (label, self.summary_dict[label])
-
-        for label, data in self.summary_dict.items():
-            if label in top_labels:
-                continue
-            if isinstance(data, dict):
-                text_report_str += '%s:\n' % label
-                text_report_str += '\n'.join(['\t%s: %d' % (k, v)
-                                              for k, v in data.items()])
-                text_report_str += '\n'
-            else:
-                text_str = '%s: %d\n' % (label, data)
-                self.add_story_text(text_str, section='Summary Statistics')
-                text_report_str += text_str
-        self.s3.put_object(Key=self.s3_prefix + 'summary.txt',
-                           Body=text_report_str, Bucket=self.bucket_name)
-        return
-
-    def _make_job_line(self, key, value):
-        self.add_story_text(key, section='Job Info', space=(1, 6))
-        self.add_story_text(value, section='Job Info', style='Code')
-
-    def report_statistics(self, reading_outputs, stmt_outputs, starts, ends):
-        starts['stats'] = datetime.now()
-        for k, end in ends.items():
-            self._make_job_line(k + ' start', str(starts[k]))
-            self._make_job_line(k + ' end', str(end))
-            self._make_job_line(k + ' duration', str(end-starts[k]))
-
-        self.summary_dict['Total readings'] = len(reading_outputs)
-        reading_stmts = [(rd.reading_id, rd.tcid, rd.reader, rd.get_statements())
-                         for rd in reading_outputs]
-        self.summary_dict['Content processed'] = \
-            len({t[1] for t in reading_stmts})
-        self.summary_dict['Statements produced'] = len(stmt_outputs)
-        self.s3.put_object(Key=self.s3_prefix + 'raw_tuples.pkl',
-                           Body=pickle.dumps([t[:-1] + (len(t[-1]),)
-                                              for t in reading_stmts]),
-                           Bucket=self.bucket_name)
-
-        readings_with_stmts = []
-        readings_with_no_stmts = []
-        for t in reading_stmts:
-            if t[-1]:
-                readings_with_stmts.append(t)
-            else:
-                readings_with_no_stmts.append(t)
-
-        self.summary_dict['Readings with no statements'] = \
-            len(readings_with_no_stmts)
-
-        self._populate_hist_data(readings_with_stmts, readings_with_no_stmts)
-        self._make_histograms()
-        self._make_text_summary()
-        ends['stats'] = datetime.now()
-
-        fname = self.make_report()
-        with open(fname, 'rb') as f:
-            self.s3.put_object(Key=self.s3_prefix + fname, Body=f.read(),
-                               Bucket=self.bucket_name)
-
-        self._make_timing_report(starts, ends)
-        self._stash_data()
-        return
+from indra.tools.reading.db_reading.report_db_aws import DbAwsStatReporter
 
 
 if __name__ == '__main__':
@@ -395,5 +171,5 @@ if __name__ == '__main__':
     else:
         stmt_data = []
 
-    rep = StatReporter(args.job_name, s3_log_prefix, client, bucket_name)
+    rep = DbAwsStatReporter(args.job_name, s3_log_prefix, client, bucket_name)
     rep.report_statistics(outputs, stmt_data, starts, ends)

--- a/indra/tools/reading/db_reading/report_db_aws.py
+++ b/indra/tools/reading/db_reading/report_db_aws.py
@@ -1,0 +1,228 @@
+from __future__ import absolute_import, print_function, unicode_literals
+from builtins import dict, str
+
+import pickle
+import numpy as np
+import matplotlib as mpl
+mpl.use('Agg')
+from matplotlib import pyplot as plt
+from datetime import datetime
+
+from indra.util.get_version import get_git_info
+from indra.tools.reading.util.reporter import Reporter
+
+
+class DbAwsStatReporter(Reporter):
+    """A class to handle generating the reports made at the end of a job."""
+    def __init__(self, job_name, s3_log_prefix, s3, bucket_name):
+        super(DbAwsStatReporter, self).__init__('%s_summary' % job_name)
+        self.s3_prefix = s3_log_prefix + 'statistics/'
+        self.bucket_name = bucket_name
+        self.s3 = s3
+        self.summary_dict = {}
+        self.hist_dict = {}
+        self.set_title("Report of Database Reading Batch Job")
+        self.sections = {'Summary Statistics': [], 'Plots': [], 'Git Info': [],
+                         'Job Info': []}
+        self._make_job_line('Job Name', job_name)
+        self._make_job_line('Job s3 prefix', s3_log_prefix)
+        self._get_git_info()
+        self.set_section_order(['Job Info', 'Git Info', 'Summary Statistics',
+                                'Plots'])
+        return
+
+    def _get_git_info(self):
+        git_info_dict = get_git_info()
+        text_file_content = ''
+        for key, val in git_info_dict.items():
+            label = key.replace('_', ' ').capitalize()
+            text_file_content += '%s: %s\n' % (label, val)
+            self.add_story_text('%s: %s' % (label, val), section='Git Info')
+        self.s3.put_object(Key=self.s3_prefix + 'git_info.txt',
+                           Body=text_file_content, Bucket=self.bucket_name)
+        return
+
+    def _plot_hist(self, agged, agg_over, data):
+        fig = plt.figure()
+        plt.hist(data, bins=np.arange(len(data)))
+        plt.xlabel('Number of %s for %s' % (agged, agg_over))
+        plt.ylabel('Number of %s with a given number of %s' % (agg_over, agged))
+        fname = '%s_per_%s.png' % (agged, agg_over)
+        fig.set_size_inches(6, 4)
+        fig.savefig(fname)
+        with open(fname, 'rb') as f:
+            s3_key = self.s3_prefix + fname
+            self.s3.put_object(Key=s3_key, Body=f.read(),
+                               Bucket=self.bucket_name)
+        self.add_story_image(fname, width=6, height=4, section='Plots')
+        return
+
+    def _make_timing_report(self, starts, ends):
+        # Report on the timing
+        timing_str = ''
+        for step in ['reading', 'statement production', 'stats']:
+            time_taken = ends[step] - starts[step]
+            timing_str += ('%22s: start: %s, end: %s, duration: %s\n'
+                           % (step, starts[step], ends[step], time_taken))
+
+        self.s3.put_object(Key=self.s3_prefix + 'timing.txt', Body=timing_str,
+                           Bucket=self.bucket_name)
+        return
+
+    def _stash_data(self):
+        """Store the data in pickle files. This should be done last."""
+        self.s3.put_object(Key=self.s3_prefix + 'hist_data.pkl',
+                           Body=pickle.dumps(self.hist_dict),
+                           Bucket=self.bucket_name)
+        self.s3.put_object(Key=self.s3_prefix + 'sum_data.pkl',
+                           Bucket=self.bucket_name,
+                           Body=pickle.dumps(self.summary_dict))
+        return
+
+    def _populate_hist_data(self, readings_with_stmts, readings_with_no_stmts):
+        # Do a bunch of aggregation
+        tc_rd_dict = {}
+        tc_stmt_dict = {}
+        rd_stmt_dict = {}
+        reader_stmts = {}
+        reader_tcids = {}
+        reader_rids = {}
+        for rid, tcid, reader, stmts in readings_with_stmts:
+            # Handle things keyed by tcid
+            if tcid not in tc_rd_dict.keys():
+                tc_rd_dict[tcid] = {rid}
+                tc_stmt_dict[tcid] = set(stmts)
+            else:
+                tc_rd_dict[tcid].add(rid)
+                tc_stmt_dict[tcid] |= set(stmts)
+
+            # Handle things keyed by rid
+            if rid not in rd_stmt_dict.keys():
+                rd_stmt_dict[rid] = set(stmts)
+            else:
+                rd_stmt_dict[rid] |= set(stmts)  # this shouldn't really happen.
+
+            # Handle things keyed by reader
+            if reader not in reader_stmts.keys():
+                reader_stmts[reader] = set(stmts)
+                reader_tcids[reader] = {tcid}
+                reader_rids[reader] = {rid}
+            else:
+                reader_stmts[reader] |= set(stmts)
+                reader_tcids[reader].add(tcid)
+                reader_rids[reader].add(rid)
+
+        for rid, tcid, reader, _ in readings_with_no_stmts:
+            # Handle things keyed by tcid
+            if tcid not in tc_rd_dict.keys():
+                tc_rd_dict[tcid] = {rid}
+            else:
+                tc_rd_dict[tcid].add(rid)
+
+            # Handle things keyed by reader
+            if reader not in reader_stmts.keys():
+                reader_tcids[reader] = {tcid}
+                reader_rids[reader] = {rid}
+            else:
+                reader_tcids[reader].add(tcid)
+                reader_rids[reader].add(rid)
+
+        # Produce some numpy count arrays.
+        self.hist_dict[('readings', 'text content')] = \
+            np.array([len(rid_set) for rid_set in tc_rd_dict.values()])
+        self.hist_dict[('stmts', 'text content')] = \
+            np.array([len(stmts) for stmts in tc_stmt_dict.values()])
+        self.hist_dict[('stmts', 'readings')] = \
+            np.array([len(stmts) for stmts in rd_stmt_dict.values()])
+        self.hist_dict[('stmts', 'readers')] = \
+            np.array([len(stmts) for stmts in reader_stmts.values()])
+        self.hist_dict[('text content', 'reader')] = \
+            np.array([len(tcid_set) for tcid_set in reader_tcids.values()])
+        self.hist_dict[('readings', 'reader')] = \
+            np.array([len(rid_set) for rid_set in reader_rids.values()])
+        return
+
+    def _make_histograms(self):
+        # Produce the histograms
+        for (agged, agg_over), data in self.hist_dict.items():
+            self._plot_hist(agged, agg_over, data)
+            label = '%s per %s' % (agged, agg_over)
+            stat_dict = {'mean': data.mean(), 'std': data.std(),
+                         'median': np.median(data)}
+            self.add_story_text(str(stat_dict), style='Code', section='Plots')
+            self.summary_dict[label.capitalize()] = {'mean': data.mean(),
+                                                     'std': data.std(),
+                                                     'median': np.median(data)}
+        return
+
+    def _make_text_summary(self):
+        text_report_str = ''
+        top_labels = ['Total readings', 'Content processed',
+                      'Statements produced']
+        for label in top_labels:
+            text_str = '%s: %d\n' % (label, self.summary_dict[label])
+            self.add_story_text(text_str, section='Summary Statistics')
+            text_report_str += '%s: %d\n' % (label, self.summary_dict[label])
+
+        for label, data in self.summary_dict.items():
+            if label in top_labels:
+                continue
+            if isinstance(data, dict):
+                text_report_str += '%s:\n' % label
+                text_report_str += '\n'.join(['\t%s: %d' % (k, v)
+                                              for k, v in data.items()])
+                text_report_str += '\n'
+            else:
+                text_str = '%s: %d\n' % (label, data)
+                self.add_story_text(text_str, section='Summary Statistics')
+                text_report_str += text_str
+        self.s3.put_object(Key=self.s3_prefix + 'summary.txt',
+                           Body=text_report_str, Bucket=self.bucket_name)
+        return
+
+    def _make_job_line(self, key, value):
+        self.add_story_text(key, section='Job Info', space=(1, 6))
+        self.add_story_text(value, section='Job Info', style='Code')
+
+    def report_statistics(self, reading_outputs, stmt_outputs, starts, ends):
+        starts['stats'] = datetime.now()
+        for k, end in ends.items():
+            self._make_job_line(k + ' start', str(starts[k]))
+            self._make_job_line(k + ' end', str(end))
+            self._make_job_line(k + ' duration', str(end-starts[k]))
+
+        self.summary_dict['Total readings'] = len(reading_outputs)
+        reading_stmts = [(rd.reading_id, rd.tcid, rd.reader, rd.get_statements())
+                         for rd in reading_outputs]
+        self.summary_dict['Content processed'] = \
+            len({t[1] for t in reading_stmts})
+        self.summary_dict['Statements produced'] = len(stmt_outputs)
+        self.s3.put_object(Key=self.s3_prefix + 'raw_tuples.pkl',
+                           Body=pickle.dumps([t[:-1] + (len(t[-1]),)
+                                              for t in reading_stmts]),
+                           Bucket=self.bucket_name)
+
+        readings_with_stmts = []
+        readings_with_no_stmts = []
+        for t in reading_stmts:
+            if t[-1]:
+                readings_with_stmts.append(t)
+            else:
+                readings_with_no_stmts.append(t)
+
+        self.summary_dict['Readings with no statements'] = \
+            len(readings_with_no_stmts)
+
+        self._populate_hist_data(readings_with_stmts, readings_with_no_stmts)
+        self._make_histograms()
+        self._make_text_summary()
+        ends['stats'] = datetime.now()
+
+        fname = self.make_report()
+        with open(fname, 'rb') as f:
+            self.s3.put_object(Key=self.s3_prefix + fname, Body=f.read(),
+                               Bucket=self.bucket_name)
+
+        self._make_timing_report(starts, ends)
+        self._stash_data()
+        return

--- a/indra/tools/reading/db_reading/report_db_aws.py
+++ b/indra/tools/reading/db_reading/report_db_aws.py
@@ -59,7 +59,19 @@ class DbAwsStatReporter(Reporter):
     def _plot_hist(self, agged, agg_over, data):
         """Make and stash a figure for histogram-like data."""
         fig = plt.figure()
-        plt.hist(data, bins=np.arange(len(data)))
+
+        # Check if it's worth actually making a histogram...
+        if not data:
+            self.add_text('No data for %s per %s.' % (agged, agg_over),
+                          section='Plots')
+            return
+        if len(set(data)) == 1:
+            self.add_text('%s per %s: %d' % (agged, agg_over, data[0]),
+                          section='Plots')
+            return
+
+        # Make the histogram.
+        plt.hist(data, bins=np.arange(len(data)), log=True)
         plt.xlabel('Number of %s for %s' % (agged, agg_over))
         plt.ylabel('Number of %s with a given number of %s' % (agg_over, agged))
         fname = '%s_per_%s.png' % (agged, agg_over)

--- a/indra/tools/reading/db_reading/report_db_aws.py
+++ b/indra/tools/reading/db_reading/report_db_aws.py
@@ -84,7 +84,7 @@ class DbAwsStatReporter(Reporter):
                      align='center')
             plt.xticks(xtick_locs, key_list)
         else:
-            plt.hist(data, bins=np.arange(len(data)), log=True, align='left')
+            plt.hist(data, bins=np.arange(max(data)), log=True, align='left')
         plt.xlabel(agged)
         plt.ylabel(agg_over)
         fname = '%s_per_%s.png' % (agged, agg_over)

--- a/indra/tools/reading/db_reading/report_db_aws.py
+++ b/indra/tools/reading/db_reading/report_db_aws.py
@@ -83,10 +83,14 @@ class DbAwsStatReporter(Reporter):
             plt.bar(xtick_locs, [data[k] for k in key_list],
                      align='center')
             plt.xticks(xtick_locs, key_list)
+            plt.xlabel(agg_over)
+            plt.ylabel(agged)
         else:
-            plt.hist(data, bins=np.arange(max(data)), log=True, align='left')
-        plt.xlabel(agged)
-        plt.ylabel(agg_over)
+            plt.hist(data, bins=np.arange(min(data), max(data)), log=True,
+                     align='left', edgecolor='none')
+            plt.xlim(min(data), max(data))
+            plt.xlabel(agged)
+            plt.ylabel(agg_over)
         fname = '%s_per_%s.png' % (agged, agg_over)
         fig.set_size_inches(6, 4)
         fig.tight_layout()

--- a/indra/tools/reading/db_reading/report_db_aws.py
+++ b/indra/tools/reading/db_reading/report_db_aws.py
@@ -51,7 +51,7 @@ class DbAwsStatReporter(Reporter):
         for key, val in git_info_dict.items():
             label = key.replace('_', ' ').capitalize()
             text_file_content += '%s: %s\n' % (label, val)
-            self.add_story_text('%s: %s' % (label, val), section='Git Info')
+            self.add_text('%s: %s' % (label, val), section='Git Info')
         self.s3.put_object(Key=self.s3_prefix + 'git_info.txt',
                            Body=text_file_content, Bucket=self.bucket_name)
         return
@@ -69,7 +69,7 @@ class DbAwsStatReporter(Reporter):
             s3_key = self.s3_prefix + fname
             self.s3.put_object(Key=s3_key, Body=f.read(),
                                Bucket=self.bucket_name)
-        self.add_story_image(fname, width=6, height=4, section='Plots')
+        self.add_image(fname, width=6, height=4, section='Plots')
         return
 
     def _make_timing_report(self, starts, ends):
@@ -167,7 +167,7 @@ class DbAwsStatReporter(Reporter):
             label = '%s per %s' % (agged, agg_over)
             stat_dict = {'mean': data.mean(), 'std': data.std(),
                          'median': np.median(data)}
-            self.add_story_text(str(stat_dict), style='Code', section='Plots')
+            self.add_text(str(stat_dict), style='Code', section='Plots')
             self.summary_dict[label.capitalize()] = {'mean': data.mean(),
                                                      'std': data.std(),
                                                      'median': np.median(data)}
@@ -180,7 +180,7 @@ class DbAwsStatReporter(Reporter):
                       'Statements produced']
         for label in top_labels:
             text_str = '%s: %d\n' % (label, self.summary_dict[label])
-            self.add_story_text(text_str, section='Summary Statistics')
+            self.add_text(text_str, section='Summary Statistics')
             text_report_str += '%s: %d\n' % (label, self.summary_dict[label])
 
         for label, data in self.summary_dict.items():
@@ -193,7 +193,7 @@ class DbAwsStatReporter(Reporter):
                 text_report_str += '\n'
             else:
                 text_str = '%s: %d\n' % (label, data)
-                self.add_story_text(text_str, section='Summary Statistics')
+                self.add_text(text_str, section='Summary Statistics')
                 text_report_str += text_str
         self.s3.put_object(Key=self.s3_prefix + 'summary.txt',
                            Body=text_report_str, Bucket=self.bucket_name)
@@ -201,8 +201,8 @@ class DbAwsStatReporter(Reporter):
 
     def _make_job_line(self, key, value):
         """For job info section, produce one line."""
-        self.add_story_text(key, section='Job Info', space=(1, 6))
-        self.add_story_text(value, section='Job Info', style='Code')
+        self.add_text(key, section='Job Info', space=(1, 6))
+        self.add_text(value, section='Job Info', style='Code')
 
     def report_statistics(self, reading_outputs, stmt_outputs, starts, ends):
         """Grab low-hanging-statistics and produce a pdf report.

--- a/indra/tools/reading/db_reading/report_db_aws.py
+++ b/indra/tools/reading/db_reading/report_db_aws.py
@@ -80,7 +80,7 @@ class DbAwsStatReporter(Reporter):
         if isinstance(data, dict):
             key_list = list(data.keys())
             xtick_locs = np.arange(len(data))
-            plt.plot(xtick_locs, [data[k] for k in key_list],
+            plt.bar(xtick_locs, [data[k] for k in key_list],
                      align='center')
             plt.xticks(xtick_locs, key_list)
         else:

--- a/indra/tools/reading/db_reading/report_db_aws.py
+++ b/indra/tools/reading/db_reading/report_db_aws.py
@@ -149,7 +149,7 @@ class DbAwsStatReporter(Reporter):
                 tc_rd_dict[tcid].add(rid)
 
             # Handle things keyed by reader
-            if reader not in reader_stmts.keys():
+            if reader not in reader_tcids.keys():
                 reader_tcids[reader] = {tcid}
                 reader_rids[reader] = {rid}
             else:

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -563,7 +563,7 @@ class SparserReader(Reader):
             logger.info('Reading %s.' % fpath)
         outpath = None
         try:
-            outpath = sparser.run_sparser(fpath, 'json', outbuf)
+            outpath = sparser.run_sparser(fpath, 'json', outbuf, timeout=60)
         except Exception as e:
             if verbose:
                 logger.error('Failed to run sparser on %s.' %

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -829,15 +829,21 @@ class DbReadingSubmitter(Submitter):
     def _report_sum_data(self, summary_info):
         # Two kind of things to handle:
         for k, job_dict in summary_info.items():
+            if isinstance(list(job_dict.values())[0], dict):
+                continue
+
             # Overall totals
             self.reporter.add_text('total %s: %d' % (k, sum(job_dict.values())),
                                    section='Totals')
 
             # Hists of totals.
+            if len(job_dict) <= 1:
+                continue
+
             w = 6.5
             h = 4
             fig = plt.figure(figsize=(w, h))
-            plt.hist(job_dict.values(), bins=range(max(job_dict.values())),
+            plt.hist(list(job_dict.values()), bins=range(max(job_dict.values())),
                      align='left')
             plt.xlabel(k)
             plt.ylabel('Number of Jobs')

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -574,6 +574,17 @@ class DbReadingSubmitter(Submitter):
         self.options['max_reach_space_ratio'] = max_reach_space_ratio
         return
 
+    def watch_and_wait(self, *args, **kwargs):
+        super(DbReadingSubmitter, self).watch_and_wait(*args, **kwargs)
+        self.produce_report()
+
+    def produce_report(self):
+        """Produce a report of the batch jobs."""
+        s3_prefix = 'reading_results/%s/logs/%s/' % (self.basename,
+                                                     self._job_queue)
+        s3 = boto3.client('s3')
+        relevant_files = s3.list_objects(Bucket=bucket_name, Prefix=s3_prefix)
+
 
 def submit_db_reading(basename, id_list_filename, readers, start_ix=None,
                       end_ix=None, pmids_per_job=3000, num_tries=2,

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -213,7 +213,7 @@ def stash_logs(job_defs, success_jobs, failure_jobs, queue_name, method='local',
         s3_client = boto3.client('s3')
 
         def stash_log(log_str, name_base):
-            name = '%s/%s.log' % (name_base, tag)
+            name = '%s_%s.log' % (name_base, tag)
             s3_client.put_object(
                 Bucket=bucket_name,
                 Key='reading_results/%s/logs/%s/%s' % (
@@ -246,9 +246,12 @@ def stash_logs(job_defs, success_jobs, failure_jobs, queue_name, method='local',
             log_str = ''.join(lines)
             base_name = job_def['jobName']
             if job_def['jobId'] in success_ids:
-                base_name += '_SUCCESS'
+                base_name += '/SUCCESS'
             elif job_def['jobId'] in failure_ids:
-                base_name += '_FAILED'
+                base_name += '/FAILED'
+            else:
+                logger.error("Job cannot be logged unless completed.")
+                continue
             logger.info('Stashing ' + base_name)
             stash_log(log_str, base_name)
         except Exception as e:

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -827,6 +827,24 @@ class DbReadingSubmitter(Submitter):
         return
 
     def _report_sum_data(self, summary_info):
+        # Two kind of things to handle:
+        for k, job_dict in summary_info.items():
+            # Overall totals
+            self.reporter.add_text('total %s: %d' % (k, sum(job_dict.values())),
+                                   section='Totals')
+
+            # Hists of totals.
+            w = 6.5
+            h = 4
+            fig = plt.figure(figsize=(w, h))
+            plt.hist(job_dict.values(), bins=range(max(job_dict.values())),
+                     align='left')
+            plt.xlabel(k)
+            plt.ylabel('Number of Jobs')
+            fig.tight_layout()
+            fname = k + '_hist.png'
+            fig.savefig(fname)
+            self.reporter.add_image(fname, width=w, height=h, section='Plots')
         return
 
     def _handle_hist_data(self, job_ref, hist_dict, file_bytes):
@@ -847,8 +865,8 @@ class DbReadingSubmitter(Submitter):
             'git_info.txt': (self._handle_git_info, self._report_git_info),
             'timing.txt': (self._handle_timing, self._report_timing),
             'raw_tuples.pkl': (None, None),
-            'hist_data.pkl': (None, None),
-            'sum_data.pkl': (None, None)
+            'hist_data.pkl': (self._handle_hist_data, None),
+            'sum_data.pkl': (self._handle_sum_data, self._report_sum_data)
             }
         stat_aggs = {}
         for stat_file, (handle_stats, report_stats) in stat_files.items():

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -878,9 +878,7 @@ class DbReadingSubmitter(Submitter):
         for stat_file, (handle_stats, report_stats) in stat_files.items():
             logger.info("Aggregating %s..." % stat_file)
             # Prep the data storage.
-            if stat_file not in stat_aggs.keys():
-                stat_aggs[stat_file] = {}
-            my_agg = stat_aggs[stat_file]
+            my_agg = {}
 
             # Get a list of the relevant files (one per job).
             file_paths = file_tree.get_paths(stat_file)
@@ -895,8 +893,10 @@ class DbReadingSubmitter(Submitter):
                 if handle_stats is not None:
                     handle_stats(ref, my_agg, file_bytes)
 
-            if report_stats is not None:
-                report_stats(stat_aggs[stat_file])
+            if report_stats is not None and len(my_agg):
+                report_stats(my_agg)
+
+            stat_aggs[stat_file] = my_agg
 
         fname = self.reporter.make_report()
         with open(fname, 'rb') as f:

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
+
+import pickle
 from builtins import dict, str
 
 import os
@@ -814,6 +816,22 @@ class DbReadingSubmitter(Submitter):
         img_path = 'time_figure.png'
         fig.savefig(img_path)
         self.reporter.add_image(img_path, width=w, height=h, section='Plots')
+        return
+
+    def _handle_sum_data(self, job_ref, summary_info, file_bytes):
+        one_sum_data_dict = pickle.loads(file_bytes)
+        for k, v in one_sum_data_dict.items():
+            if k not in summary_info.keys():
+                summary_info[k] = {}
+            summary_info[k][job_ref] = v
+        return
+
+    def _report_sum_data(self, summary_info):
+        return
+
+    def _handle_hist_data(self, job_ref, hist_dict, file_bytes):
+        a_hist_data_dict = pickle.loads(file_bytes)
+        hist_dict[job_ref] = a_hist_data_dict
         return
 
     def produce_report(self):

--- a/indra/tools/reading/util/reporter.py
+++ b/indra/tools/reading/util/reporter.py
@@ -6,6 +6,13 @@ from reportlab.lib.units import inch
 
 
 class Reporter(object):
+    """A class to produce a simple pdf report using the reportlab package.
+
+    Parameters
+    ----------
+    name : str
+        A name that will be the name of this file, and the title by default.
+    """
     def __init__(self, name):
         self.styles = getSampleStyleSheet()
         self.styles.add(ParagraphStyle(name="Justify", alignment=TA_JUSTIFY))
@@ -17,23 +24,129 @@ class Reporter(object):
         return
 
     def set_title(self, title):
+        """Overwrite the default title with a string title of your choosing."""
         self.title = title
         return
 
-    def set_section_order(self, section_name_list):
-        self.section_headings = section_name_list[:]
-        for section_name in self.sections.keys():
-            if section_name not in section_name_list:
-                section_name_list.append(section_name)
-        return
-
     def add_section(self, section_name):
+        """Create a section of the report, to be headed by section_name
+
+        Text and images can be added by using the `section` argument of the
+        `add_text` and `add_image` methods. Sections can also be ordered by
+        using the `set_section_order` method.
+
+        By default, text and images that have no section will be placed after
+        all the sections, in the order they were added. This behavior may be
+        altered using the `sections_first` attribute of the `make_report`
+        method.
+        """
         self.section_headings.append(section_name)
         if section_name in self.sections:
             raise ValueError("Section %s already exists." % section_name)
         self.sections[section_name] = []
+        return
+
+    def set_section_order(self, section_name_list):
+        """Set the order of the sections, which are by default unorderd.
+
+        Any unlisted sections that exist will be placed at the end of the
+        document in no particular order.
+        """
+        self.section_headings = section_name_list[:]
+        for section_name in self.sections.keys():
+            if section_name not in section_name_list:
+                self.section_headings.append(section_name)
+        return
+
+    def add_text(self, text, *args, **kwargs):
+        """Add text to the document.
+
+        Text is shown on the final document in the order it is added, either
+        within the given section or as part of the un-sectioned list of content.
+
+        Parameters
+        ----------
+        text : str
+            The text to be added.
+        style : str
+            Choose the style of the text. Options include 'Normal', 'Code',
+            'Title', 'h1'. For others, see `getSampleStyleSheet` from
+            `reportlab.lib.styles`.
+        space : tuple (num spaces, font size)
+            The number and size of spaces to follow this section of text.
+            Default is (1, 12).
+        fontsize : int
+            The integer font size of the text (e.g. 12 for 12 point font).
+            Default is 12.
+        alignment : str
+            The alignment of the text. Options include 'left', 'right', and
+            'center'. Default is 'left'.
+        section : str
+            (This must be a keyword) Select a section in which to place this
+            text. Default is None, in which case the text will be simply be
+            added to a default list of text and images.
+        """
+        # Pull down some kwargs.
+        section_name = kwargs.pop('section', None)
+
+        # Actually do the formatting.
+        para, sp = self._preformat_text(text, *args, **kwargs)
+
+        # Select the appropriate list to update
+        if section_name is None:
+            relevant_list = self.story
+        else:
+            relevant_list = self.sections[section_name]
+
+        # Add the new content to list.
+        relevant_list.append(para)
+        relevant_list.append(sp)
+        return
+
+    def add_image(self, image_path, width=None, height=None, section=None):
+        """Add an image to the document.
+
+        Images are shown on the final document in the order they are added,
+        either within the given section or as part of the un-sectioned list of
+        content.
+
+        Parameters
+        ----------
+        image_path : str
+            A path to the image on the local file system.
+        width : int or float
+            The width of the image in the document in inches.
+        height : int or float
+            The height of the image in the document in incehs.
+        section : str
+            (This must be a keyword) Select a section in which to place this
+            image. Default is None, in which case the image will be simply be
+            added to a default list of text and images.
+        """
+        if width is not None:
+            width = width*inch
+        if height is not None:
+            height = height*inch
+        im = Image(image_path, width, height)
+        if section is None:
+            self.story.append(im)
+        else:
+            self.sections[section].append(im)
+        return
 
     def make_report(self, sections_first=True, section_header_params=None):
+        """Create the pdf document with name `self.name + '.pdf'`.
+
+        Parameters
+        ----------
+        sections_first : bool
+            If True (default), text and images with sections are presented first
+            and un-sectioned content is appended afterword. If False, sectioned
+            text and images will be placed before the sections.
+        section_header_params : dict or None
+            Optionally overwrite/extend the default formatting for the section
+            headers. Default is None.
+        """
         full_story = list(self._preformat_text(self.title, style='Title',
                                                fontsize=18, alignment='center'))
 
@@ -58,6 +171,7 @@ class Reporter(object):
         return fname
 
     def _make_sections(self, **section_hdr_params):
+        """Flatten the sections into a single story list."""
         sect_story = []
         for section_name in self.section_headings:
             section_story = self.sections[section_name]
@@ -70,6 +184,7 @@ class Reporter(object):
 
     def _preformat_text(self, text, style='Normal', space=None, fontsize=12,
                         alignment='left'):
+        """Format the text for addition to a story list."""
         if space is None:
             space=(1,12)
         ptext = ('<para alignment=\"%s\"><font size=%d>%s</font></para>'
@@ -77,33 +192,3 @@ class Reporter(object):
         para = Paragraph(ptext, self.styles[style])
         sp = Spacer(*space)
         return para, sp
-
-    def add_story_text(self, text, *args, **kwargs):
-        # Pull down some kwargs.
-        section_name = kwargs.pop('section', None)
-
-        # Actually do the formatting.
-        para, sp = self._preformat_text(text, *args, **kwargs)
-
-        # Select the appropriate list to update
-        if section_name is None:
-            relevant_list = self.story
-        else:
-            relevant_list = self.sections[section_name]
-
-        # Add the new content to list.
-        relevant_list.append(para)
-        relevant_list.append(sp)
-        return
-
-    def add_story_image(self, image_path, width=None, height=None,
-                        section=None):
-        if width is not None:
-            width = width*inch
-        if height is not None:
-            height = height*inch
-        im = Image(image_path, width, height)
-        if section is None:
-            self.story.append(im)
-        else:
-            self.sections[section].append(im)

--- a/indra/tools/reading/util/reporter.py
+++ b/indra/tools/reading/util/reporter.py
@@ -23,7 +23,7 @@ class Reporter(object):
     def add_story_text(self, text, style='Normal', space=None, fontsize=12):
         if space is None:
             space=(1,12)
-        ptext = '<fond size=%d>%s</font>' % (fontsize, text)
+        ptext = '<font size=%d>%s</font>' % (fontsize, text)
         self.story.append(Paragraph(ptext, self.styles[style]))
         self.story.append(Spacer(*space))
         return

--- a/indra/tools/reading/util/reporter.py
+++ b/indra/tools/reading/util/reporter.py
@@ -1,0 +1,37 @@
+from reportlab.lib.enums import TA_JUSTIFY
+from reportlab.lib.pagesizes import letter
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Image
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.units import inch
+
+
+class Reporter(object):
+    def __init__(self, name):
+        self.styles = getSampleStyleSheet()
+        self.styles.add(ParagraphStyle(name="Justify", alignment=TA_JUSTIFY))
+        self.story = []
+        self.name = name
+        return
+
+    def make_report(self):
+        doc = SimpleDocTemplate(self.name + '.pdf', pagesize=letter,
+                                rightMargin=72, leftMargin=72,
+                                topMargin=72, bottomMargin=18)
+        doc.build(self.story)
+        return doc
+
+    def add_story_text(self, text, style='Normal', space=None, fontsize=12):
+        if space is None:
+            space=(1,12)
+        ptext = '<fond size=%d>%s</font>' % (fontsize, text)
+        self.story.append(Paragraph(ptext, self.styles[style]))
+        self.story.append(Spacer(*space))
+        return
+
+    def add_story_image(self, image_path, width=None, height=None):
+        if width is not None:
+            width = width*inch
+        if height is not None:
+            height = height*inch
+        im = Image(image_path, width, height)
+        self.story.append(im)

--- a/indra/tools/reading/util/reporter.py
+++ b/indra/tools/reading/util/reporter.py
@@ -41,11 +41,12 @@ class Reporter(object):
             full_story += self.story
             full_story += self._make_sections(**section_header_params)
 
-        doc = SimpleDocTemplate(self.name + '.pdf', pagesize=letter,
+        fname = self.name + '.pdf'
+        doc = SimpleDocTemplate(fname, pagesize=letter,
                                 rightMargin=72, leftMargin=72,
                                 topMargin=72, bottomMargin=18)
         doc.build(full_story)
-        return doc
+        return fname
 
     def _make_sections(self, **section_hdr_params):
         sect_story = []

--- a/indra/tools/reading/util/reporter.py
+++ b/indra/tools/reading/util/reporter.py
@@ -13,13 +13,22 @@ class Reporter(object):
         self.name = name
         self.title = name
         self.sections = {}
+        self.section_headings = []
         return
 
     def set_title(self, title):
         self.title = title
         return
 
+    def set_section_order(self, section_name_list):
+        self.section_headings = section_name_list[:]
+        for section_name in self.sections.keys():
+            if section_name not in section_name_list:
+                section_name_list.append(section_name)
+        return
+
     def add_section(self, section_name):
+        self.section_headings.append(section_name)
         if section_name in self.sections:
             raise ValueError("Section %s already exists." % section_name)
         self.sections[section_name] = []

--- a/indra/tools/reading/util/reporter.py
+++ b/indra/tools/reading/util/reporter.py
@@ -11,7 +11,12 @@ class Reporter(object):
         self.styles.add(ParagraphStyle(name="Justify", alignment=TA_JUSTIFY))
         self.story = []
         self.name = name
+        self.title = name
         self.sections = {}
+        return
+
+    def set_title(self, title):
+        self.title = title
         return
 
     def add_section(self, section_name):
@@ -20,11 +25,13 @@ class Reporter(object):
         self.sections[section_name] = []
 
     def make_report(self, sections_first=True, section_header_params=None):
-        full_story = []
+        full_story = list(self._preformat_text(self.title, style='Title',
+                                               fontsize=18, alignment='center'))
 
         # Set the default section header parameters
         if section_header_params is None:
-            section_header_params = {'style': 'h1', 'fontsize': 14}
+            section_header_params = {'style': 'h1', 'fontsize': 14,
+                                     'alignment': 'center'}
 
         # Merge the sections and the rest of the story.
         if sections_first:
@@ -43,15 +50,19 @@ class Reporter(object):
     def _make_sections(self, **section_hdr_params):
         sect_story = []
         for section_name, section_story in self.sections.items():
-            title, title_sp = self._preformat_text(section_name + '-'*40,
+            line = '-'*20
+            section_head_text = '%s %s %s' % (line, section_name, line)
+            title, title_sp = self._preformat_text(section_head_text,
                                                    **section_hdr_params)
             sect_story += [title, title_sp] + section_story
         return sect_story
 
-    def _preformat_text(self, text, style='Normal', space=None, fontsize=12):
+    def _preformat_text(self, text, style='Normal', space=None, fontsize=12,
+                        alignment='left'):
         if space is None:
             space=(1,12)
-        ptext = '<font size=%d>%s</font>' % (fontsize, text)
+        ptext = ('<para alignment=\"%s\"><font size=%d>%s</font></para>'
+                 % (alignment, fontsize, text))
         para = Paragraph(ptext, self.styles[style])
         sp = Spacer(*space)
         return para, sp

--- a/indra/tools/reading/util/reporter.py
+++ b/indra/tools/reading/util/reporter.py
@@ -11,27 +11,77 @@ class Reporter(object):
         self.styles.add(ParagraphStyle(name="Justify", alignment=TA_JUSTIFY))
         self.story = []
         self.name = name
+        self.sections = {}
         return
 
-    def make_report(self):
+    def add_section(self, section_name):
+        if section_name in self.sections:
+            raise ValueError("Section %s already exists." % section_name)
+        self.sections[section_name] = []
+
+    def make_report(self, sections_first=True, section_header_params=None):
+        full_story = []
+
+        # Set the default section header parameters
+        if section_header_params is None:
+            section_header_params = {'style': 'h1', 'fontsize': 14}
+
+        # Merge the sections and the rest of the story.
+        if sections_first:
+            full_story += self._make_sections(**section_header_params)
+            full_story += self.story
+        else:
+            full_story += self.story
+            full_story += self._make_sections(**section_header_params)
+
         doc = SimpleDocTemplate(self.name + '.pdf', pagesize=letter,
                                 rightMargin=72, leftMargin=72,
                                 topMargin=72, bottomMargin=18)
-        doc.build(self.story)
+        doc.build(full_story)
         return doc
 
-    def add_story_text(self, text, style='Normal', space=None, fontsize=12):
+    def _make_sections(self, **section_hdr_params):
+        sect_story = []
+        for section_name, section_story in self.sections.items():
+            title, title_sp = self._preformat_text(section_name + '-'*40,
+                                                   **section_hdr_params)
+            sect_story += [title, title_sp] + section_story
+        return sect_story
+
+    def _preformat_text(self, text, style='Normal', space=None, fontsize=12):
         if space is None:
             space=(1,12)
         ptext = '<font size=%d>%s</font>' % (fontsize, text)
-        self.story.append(Paragraph(ptext, self.styles[style]))
-        self.story.append(Spacer(*space))
+        para = Paragraph(ptext, self.styles[style])
+        sp = Spacer(*space)
+        return para, sp
+
+    def add_story_text(self, text, *args, **kwargs):
+        # Pull down some kwargs.
+        section_name = kwargs.pop('section', None)
+
+        # Actually do the formatting.
+        para, sp = self._preformat_text(text, *args, **kwargs)
+
+        # Select the appropriate list to update
+        if section_name is None:
+            relevant_list = self.story
+        else:
+            relevant_list = self.sections[section_name]
+
+        # Add the new content to list.
+        relevant_list.append(para)
+        relevant_list.append(sp)
         return
 
-    def add_story_image(self, image_path, width=None, height=None):
+    def add_story_image(self, image_path, width=None, height=None,
+                        section=None):
         if width is not None:
             width = width*inch
         if height is not None:
             height = height*inch
         im = Image(image_path, width, height)
-        self.story.append(im)
+        if section is None:
+            self.story.append(im)
+        else:
+            self.sections[section].append(im)

--- a/indra/tools/reading/util/reporter.py
+++ b/indra/tools/reading/util/reporter.py
@@ -59,7 +59,8 @@ class Reporter(object):
 
     def _make_sections(self, **section_hdr_params):
         sect_story = []
-        for section_name, section_story in self.sections.items():
+        for section_name in self.section_headings:
+            section_story = self.sections[section_name]
             line = '-'*20
             section_head_text = '%s %s %s' % (line, section_name, line)
             title, title_sp = self._preformat_text(section_head_text,

--- a/indra/tools/reading/util/reporter.py
+++ b/indra/tools/reading/util/reporter.py
@@ -173,6 +173,9 @@ class Reporter(object):
     def _make_sections(self, **section_hdr_params):
         """Flatten the sections into a single story list."""
         sect_story = []
+        if not self.section_headings and len(self.sections):
+            self.section_headings = self.sections.keys()
+
         for section_name in self.section_headings:
             section_story = self.sections[section_name]
             line = '-'*20

--- a/indra/util/get_version.py
+++ b/indra/util/get_version.py
@@ -4,14 +4,30 @@ will include the git commit hash. Otherwise, the version will be marked with
 'UNHASHED'.
 """
 
-from subprocess import check_output, CalledProcessError
-from os.path import dirname
+import re
 from os import devnull
+from os.path import dirname
+from subprocess import check_output, CalledProcessError
 
 from indra import __version__
 
 
 INDRA_GITHASH = None
+
+
+def get_git_info():
+    """Get a dict with useful git info."""
+    re_patt_str = (r'commit\s+(?P<commit_hash>\w+)\s+Author:\s+'
+                   r'(?P<author_name>.*?)\s+<(?P<author_email>.*?)>\s+Date:\s+'
+                   r'(?P<date>.*?)\n\s+(?P<commit_msg>.*?)\s+diff')
+    show_out = check_output(['git', 'show']).decode('ascii')
+    revp_out = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
+    revp_out = revp_out.decode('ascii').strip()
+    m = re.match(re_patt_str, show_out)
+    assert m is not None, "Regex failed."
+    ret_dict = m.groupdict()
+    ret_dict['branch_name'] = revp_out
+    return ret_dict
 
 
 def get_version(with_git_hash=True, refresh_hash=False):

--- a/indra/util/get_version.py
+++ b/indra/util/get_version.py
@@ -5,8 +5,8 @@ will include the git commit hash. Otherwise, the version will be marked with
 """
 
 import re
-from os import devnull
-from os.path import dirname
+from os import devnull, chdir, curdir
+from os.path import dirname, abspath
 from subprocess import check_output, CalledProcessError
 
 from indra import __version__
@@ -17,16 +17,21 @@ INDRA_GITHASH = None
 
 def get_git_info():
     """Get a dict with useful git info."""
-    re_patt_str = (r'commit\s+(?P<commit_hash>\w+)\s+Author:\s+'
-                   r'(?P<author_name>.*?)\s+<(?P<author_email>.*?)>\s+Date:\s+'
-                   r'(?P<date>.*?)\n\s+(?P<commit_msg>.*?)\s+diff')
-    show_out = check_output(['git', 'show']).decode('ascii')
-    revp_out = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
-    revp_out = revp_out.decode('ascii').strip()
-    m = re.match(re_patt_str, show_out)
-    assert m is not None, "Regex failed."
-    ret_dict = m.groupdict()
-    ret_dict['branch_name'] = revp_out
+    start_dir = abspath(curdir)
+    try:
+        chdir(dirname(abspath(__file__)))
+        re_patt_str = (r'commit\s+(?P<commit_hash>\w+)\s+Author:\s+'
+                       r'(?P<author_name>.*?)\s+<(?P<author_email>.*?)>\s+Date:\s+'
+                       r'(?P<date>.*?)\n\s+(?P<commit_msg>.*?)\s+diff')
+        show_out = check_output(['git', 'show']).decode('ascii')
+        revp_out = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
+        revp_out = revp_out.decode('ascii').strip()
+        m = re.match(re_patt_str, show_out)
+        assert m is not None, "Regex failed."
+        ret_dict = m.groupdict()
+        ret_dict['branch_name'] = revp_out
+    finally:
+        chdir(start_dir)
     return ret_dict
 
 

--- a/indra/util/nested_dict.py
+++ b/indra/util/nested_dict.py
@@ -1,0 +1,110 @@
+from __future__ import absolute_import, print_function, unicode_literals
+from builtins import dict, str
+
+
+class NestedDict(dict):
+    """A dict-like object that recursively populates elements of a dict."""
+
+    def __getitem__(self, key):
+        if key not in self.keys():
+            val = self.__class__()
+            self.__setitem__(key, val)
+        else:
+            val = dict.__getitem__(self, key)
+        return val
+
+    def __repr__(self):
+        sub_str = dict.__repr__(self)[1:-1]
+        if not sub_str:
+            return self.__class__.__name__ + '()'
+        # This does not completely generalize, but it works for most cases.
+        for old, new in [('), ', '),\n'), ('\n', '\n  ')]:
+            sub_str = sub_str.replace(old, new)
+        return'%s(\n  %s\n)' % (self.__class__.__name__, sub_str)
+
+    def __str__(self):
+        return self.__repr__()
+
+    def export_dict(self):
+        "Convert this into an ordinary dict (of dicts)."
+        return {k: v.export_dict() if isinstance(v, self.__class__) else v
+                for k, v in self.items()}
+
+    def get(self, key):
+        "Find the first value within the tree which has the key."
+        if key in self.keys():
+            return self[key]
+        else:
+            res = None
+            for v in self.values():
+                # This could get weird if the actual expected returned value
+                # is None, especially in teh case of overlap. Any ambiguity
+                # would be resolved by get_path(s).
+                if hasattr(v, 'get'):
+                    res = v.get(key)
+                if res is not None:
+                    break
+            return res
+
+    def get_path(self, key):
+        "Like `get`, but also return the path taken to the value."
+        if key in self.keys():
+            return (key,), self[key]
+        else:
+            key_path, res = (None, None)
+            for sub_key, v in self.items():
+                if isinstance(v, self.__class__):
+                    key_path, res = v.get_path(key)
+                elif hasattr(v, 'get'):
+                    res = v.get(key)
+                    key_path = (key,) if res is not None else None
+                if res is not None and key_path is not None:
+                    key_path = (sub_key,) + key_path
+                    break
+            return key_path, res
+
+    def gets(self, key):
+        "Like `get`, but return all matches, not just the first."
+        result_list = []
+        if key in self.keys():
+            result_list.append(self[key])
+        for v in self.values():
+            if isinstance(v, self.__class__):
+                sub_res_list = v.gets(key)
+                for res in sub_res_list:
+                    result_list.append(res)
+            elif isinstance(v, dict):
+                if key in v.keys():
+                    result_list.append(v[key])
+        return result_list
+
+    def get_paths(self, key):
+        "Like `gets`, but include the paths, like `get_path` for all matches."
+        result_list = []
+        if key in self.keys():
+            result_list.append(((key,), self[key]))
+        for sub_key, v in self.items():
+            if isinstance(v, self.__class__):
+                sub_res_list = v.get_paths(key)
+                for key_path, res in sub_res_list:
+                    result_list.append(((sub_key,) + key_path, res))
+            elif isinstance(v, dict):
+                if key in v.keys():
+                    result_list.append(((sub_key, key), v[key]))
+        return result_list
+
+    def get_leaves(self):
+        """Get the deepest entries as a flat set."""
+        ret_set = set()
+        for val in self.values():
+            if isinstance(val, self.__class__):
+                ret_set |= val.get_leaves()
+            elif isinstance(val, dict):
+                ret_set |= set(val.values())
+            elif isinstance(val, list):
+                ret_set |= set(val)
+            elif isinstance(val, set):
+                ret_set |= val
+            else:
+                ret_set.add(val)
+        return ret_set


### PR DESCRIPTION
This PR primarily implements a scheme for reporting on batch reading jobs, both at the level of individual jobs and for an entire batch. The goal is to better allow us to catch and diagnose bugs in the reading system. Overall, the work is preliminary. There are many features that could be added with fairly little difficulty, but there is currently sufficient detail to get a sense of the success or failure of a batch and or job. The organization of the s3 records was also improved.

Currently shown in the pdf summaries are things such as:
- Git info for both the submitter and then batch jobs
- Graphs of the number of statements produced per reading, per content, and per reader.
- Sum total of the number of statements produced, the readings processed, and the number of readings that actually produced statements.
- A chart of the time taken by the different jobs and the overall load over time.
- Statistics on the jobs that succeeded and failed (gathered while running `wait_for_complete`).
- Text and pickle files with the raw data above, to enable further aggregation in the future.

Some things that would be good to add and would not be very difficult:
- Basic log analysis, such as a set of errors seen, and how common they were, extracting any tracebacks, extracting the number of readings performed vs. the number of stashed readings retrieved
- Dump a pickle file with text content ids that were not read when a job failed
- Record the times at which different jobs were running in wait_for_complete, and incorporate this into the timing chart (Currently failed jobs are missing because the method must rely on self-reporting by the jobs).
- In general, better handling of failed jobs (a failed job should still produce a report on what progress it did make).
- It would also be good to have a bot post the reports to Slack.

Some more challenging things to add (because the reading management system would need to be refactored to be object-oriented):
- The statistics on reading times (per source)
- A break-down by content type (e.g. fulltext vs. abstract, pmc_oa vs elsevier).

A simple class, `indra.tools.reading.util.reporter.Reporter` was developed to easy the creation of simple PDF's. This may be useful in other applications. It is a simplification of the much richer and more general `reportlab` module, designed for a simple and specific purpose.

Further development in this direction will hopefully come in later PR's.