### PR TITLE
Optimize contradiction finding

### DIFF
--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -526,10 +526,12 @@ class Preassembler(object):
         contradicts : list(tuple(Statement, Statement))
             A list of Statement pairs that are contradicting.
         """
+        eh = self.hierarchies['entity']
+
         # Make a dict of Statement by type
         stmts_by_type = collections.defaultdict(lambda: [])
         for idx, stmt in enumerate(self.stmts):
-            stmts_by_type[type(stmt)].append(stmt)
+            stmts_by_type[type(stmt)].append((idx, stmt))
 
         # Handle Statements with polarity first
         pos_stmts = AddModification.__subclasses__()
@@ -542,15 +544,20 @@ class Preassembler(object):
         for pst, nst in zip(pos_stmts, neg_stmts):
             poss = stmts_by_type.get(pst, [])
             negs = stmts_by_type.get(nst, [])
-            for st1, st2 in itertools.product(poss, negs):
-                if st1.contradicts(st2, self.hierarchies):
-                    contradicts.append((st1, st2))
 
-        # HAndle neutral Statements next
+            pos_stmt_by_group = self._get_stmt_by_group(pst, poss, eh)
+            neg_stmt_by_group = self._get_stmt_by_group(nst, negs, eh)
+            for key, pg in pos_stmt_by_group.items():
+                ng = neg_stmt_by_group.get(key, [])
+                for (_, st1), (_, st2) in itertools.product(pg, ng):
+                    if st1.contradicts(st2, self.hierarchies):
+                        contradicts.append((st1, st2))
+
+        # Handle neutral Statements next
         neu_stmts = [Influence, ActiveForm]
         for stt in neu_stmts:
             stmts = stmts_by_type.get(stt, [])
-            for st1, st2 in itertools.combinations(stmts, 2):
+            for (_, st1), (_, st2) in itertools.combinations(stmts, 2):
                 if st1.contradicts(st2, self.hierarchies):
                     contradicts.append((st1, st2))
 

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -526,10 +526,25 @@ class Preassembler(object):
         contradicts : list(tuple(Statement, Statement))
             A list of Statement pairs that are contradicting.
         """
+        pos_stmts = AddModification.__subclasses__()
+        neg_stmts = [modclass_to_inverse[c] for c in pos_stmts]
+
+        pos_stmts += [Activation, IncreaseAmount, Influence]
+        neg_stmts += [Inhibition, DecreaseAmount, Influence]
+
+        # Make a list of Statement types
+        stmts_by_type = collections.defaultdict(lambda: [])
+        for idx, stmt in enumerate(self.stmts):
+            stmts_by_type[type(stmt)].append(stmt)
+
         contradicts = []
-        for st1, st2 in itertools.combinations(self.stmts, 2):
-            if st1.contradicts(st2, self.hierarchies):
-                contradicts.append((st1, st2))
+        for pst, nst in zip(pos_stmts, neg_stmts):
+            poss = stmts_by_type.get(pst, [])
+            negs = stmts_by_type.get(nst, [])
+            for st1, st2 in itertools.product(poss, negs):
+                if st1.contradicts(st2, self.hierarchies):
+                    contradicts.append((st1, st2))
+
         return contradicts
 
 

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -616,12 +616,19 @@ def test_find_contradicts():
     st2 = Activation(Agent('a'), Agent('b'))
     st3 = IncreaseAmount(Agent('a'), Agent('b'))
     st4 = DecreaseAmount(Agent('a'), Agent('b'))
-    pa = Preassembler(hierarchies, [st1, st2, st3, st4])
+    st5 = ActiveForm(Agent('a',
+            mods=[ModCondition('phosphorylation', None, None, True)]),
+            'kinase', True)
+    st6 = ActiveForm(Agent('a',
+            mods=[ModCondition('phosphorylation', None, None, True)]),
+            'kinase', False)
+    pa = Preassembler(hierarchies, [st1, st2, st3, st4, st5, st6])
     contradicts = pa.find_contradicts()
-    assert len(contradicts) == 2
+    assert len(contradicts) == 3
     for s1, s2 in contradicts:
         assert {s1.uuid, s2.uuid} in ({st1.uuid, st2.uuid},
-                                      {st3.uuid, st4.uuid})
+                                      {st3.uuid, st4.uuid},
+                                      {st5.uuid, st6.uuid})
 
 
 def test_preassemble_related_complex():

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -631,6 +631,21 @@ def test_find_contradicts():
                                       {st5.uuid, st6.uuid})
 
 
+def test_find_contradicts_refinement():
+    ras = Agent('RAS', db_refs={'FPLX': 'RAS'})
+    kras = Agent('KRAS', db_refs={'HGNC': '6407'})
+    hras = Agent('HRAS', db_refs={'HGNC': '5173'})
+    st1 = Phosphorylation(Agent('x'), ras)
+    st2 = Dephosphorylation(Agent('x'), kras)
+    st3 = Dephosphorylation(Agent('x'), hras)
+    pa = Preassembler(hierarchies, [st1, st2, st3])
+    contradicts = pa.find_contradicts()
+    assert len(contradicts) == 2
+    for s1, s2 in contradicts:
+        assert {s1.uuid, s2.uuid} in ({st1.uuid, st2.uuid},
+                                      {st1.uuid, st3.uuid})
+
+
 def test_preassemble_related_complex():
     ras = Agent('RAS', db_refs={'FPLX': 'RAS'})
     kras = Agent('KRAS', db_refs={'HGNC': '6407'})


### PR DESCRIPTION
This PR optimizes the previously naive implementation of contradiction finding to use the same kind of grouping optimization as `combine_related`. In addition, it constrains to find contradictions across Statement types where potential contradictions can occur, and simply ignores Statement types where contradictions are not defined.