### PR TITLE
Bump Cython version and use original pyjnius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - sudo apt-get update
   - echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
   - echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
-  - pip install numpy scipy sympy cython==0.23.5 nose lxml matplotlib==1.5.0 pandas
+  - pip install numpy scipy sympy cython==0.26.1 nose lxml matplotlib==1.5.0 pandas
   - sudo pip2 install numpy
 install:
   # INDRA dependencies
@@ -42,7 +42,7 @@ install:
   - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
   - pip install git+https://github.com/pysb/pysb.git
   # Biopax/Paxtools dependencies
-  - pip install jnius-indra
+  - pip install pyjnius
   # Download a number of useful resource files for testing purposes
   - pip install .[all]
   - cd indra/benchmarks/assembly_eval/batch4

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - sudo apt-get update
   - echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
   - echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
-  - pip install numpy scipy sympy cython==0.26.1 nose lxml matplotlib==1.5.0 pandas
+  - pip install numpy scipy sympy cython nose lxml matplotlib==1.5.0 pandas
   - sudo pip2 install numpy
 install:
   # INDRA dependencies
@@ -42,7 +42,7 @@ install:
   - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
   - pip install git+https://github.com/pysb/pysb.git
   # Biopax/Paxtools dependencies
-  - pip install pyjnius
+  - pip install git+https://github.com/kivy/pyjnius.git@1cbfef
   # Download a number of useful resource files for testing purposes
   - pip install .[all]
   - cd indra/benchmarks/assembly_eval/batch4

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ extracted from the neighborhood query.
 
 Next, we look at an example of querying the [Pathway Commons
 database](http://pathwaycommons.org) for paths between two lists of proteins.
-Note: see installation notes above for installing jnius, which is required for
-using the BioPAX API of INDRA.
+Note: see installation notes above for installing pyjnius, which is required
+for using the BioPAX API of INDRA.
 
 ```python
 from indra.sources import biopax

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -144,13 +144,15 @@ and add `JNI` to `JVMCapabilities` as
 
     export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_74.jdk/Contents/Home
 
-4. Then first install cython (tested with version 0.23.5) followed by jnius-indra. These need to be
-   broken up into two sequential calls to pip install.
+4. Then first install cython (tested with version 0.26.1; note that cython
+   versions 0.27 and above do NOT work with pyjnius and indra) followed by
+   pyjnius. These need to be broken up into two sequential calls to pip
+   install.
 
 .. code-block:: bash
 
-    pip install cython==0.23.5
-    pip install jnius-indra
+    pip install cython==0.26.1
+    pip install pyjnius
 
 Graphviz
 ````````

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -144,15 +144,16 @@ and add `JNI` to `JVMCapabilities` as
 
     export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_74.jdk/Contents/Home
 
-4. Then first install cython (tested with version 0.26.1; note that cython
-   versions 0.27 and above do NOT work with pyjnius and indra) followed by
-   pyjnius. These need to be broken up into two sequential calls to pip
+4. Then first install Cython (tested with version 0.28.1) followed by
+   pyjnius (note that the released version of pyjnius does _not_ work with
+   recent Cython versions, hence installation from Github is required).
+   These need to be broken up into two sequential calls to pip
    install.
 
 .. code-block:: bash
 
-    pip install cython==0.26.1
-    pip install pyjnius
+    pip install cython
+    pip install git+https://github.com/kivy/pyjnius.git@1cbfef
 
 Graphviz
 ````````

--- a/doc/tutorials/machine_reading.rst
+++ b/doc/tutorials/machine_reading.rst
@@ -75,7 +75,7 @@ Install other dependencies
 ::
 
     pip install jsonpickle # Necessary to process JSON from S3
-    pip install --upgrade jnius-indra # Necessary for REACH
+    pip install --upgrade pyjnius # Necessary for REACH
     export JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64
 
 Assemble a Corpus of PMIDs

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ def main():
 
     extras_require = {
                       # Inputs and outputs
-                      'biopax': ['jnius-indra'],
+                      'biopax': ['cython', 'pyjnius'],
                       'trips_offline': ['pykqml'],
-                      'reach_offline': ['jnius-indra'],
-                      'eidos_offline': ['pyyaml', 'jnius-indra'],
+                      'reach_offline': ['cython', 'pyjnius'],
+                      'eidos_offline': ['pyyaml', 'cython', 'pyjnius'],
                       'geneways': ['stemming', 'nltk'],
                       'sofia': ['openpyxl'],
                       'hume': ['rdflib-jsonld'],
@@ -72,7 +72,6 @@ def main():
                     'indra.tools.reading.util',
                     'indra.tools.machine', 'indra.util'],
           install_requires=install_list,
-          tests_require=['jnius-indra', 'jsonschema', 'coverage', 'matplotlib'],
           extras_require=extras_require,
           include_package_data=True,
           keywords=['systems', 'biology', 'model', 'pathway', 'assembler',


### PR DESCRIPTION
This PR changes requirements and setup instructions as follows:
- we now point to the original repo of `pyjnius` (latest tests reveal that the custom patches added in `jnius-indra` are not required anymore), _but_ the actual PyPI release of `pyjnius` is broken, therefore we use a Github-based installation link until either `pyjnius` releases a new version or we can update `jnius-indra`.
- use the latest version of Cython