### PR TITLE
Skip some slow tests

### DIFF
--- a/indra/tests/test_bel.py
+++ b/indra/tests/test_bel.py
@@ -21,14 +21,15 @@ def assert_pmids(stmts):
             if ev.pmid is not None:
                 assert ev.pmid.isdigit(), ev.pmid 
 
-@attr('webservice')
+
+@attr('webservice', 'slow')
 def test_bel_ndex_query():
     bp = bel.process_ndex_neighborhood(['NFKB1'])
     assert_pmids(bp.statements)
     unicode_strs(bp.statements)
 
 
-@attr('webservice')
+@attr('slow')
 def test_pybel_neighborhood_query():
     corpus = path_this + '/../../data/small_corpus.bel'
     bp = bel.process_pybel_neighborhood(['TP63'], corpus)

--- a/indra/tests/test_biopax.py
+++ b/indra/tests/test_biopax.py
@@ -156,7 +156,7 @@ def test_get_entity_mods():
     assert(mod_pos == set(['1035', '1056', '1128', '1188', '1242']))
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_pathsfromto():
     bp = biopax.process_pc_pathsfromto(['MAP2K1'], ['MAPK1'])
     assert_pmids(bp.statements)

--- a/indra/tests/test_chembl_client.py
+++ b/indra/tests/test_chembl_client.py
@@ -20,7 +20,7 @@ query_dict_BRAF_target = {'query': 'target',
                                      'limit': 1}}
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_get_inhibitions():
     stmt = chembl_client.get_inhibition(vem, braf)
     assert(stmt is not None)

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -3,6 +3,7 @@ from builtins import dict, str
 
 from os.path import join, dirname
 from nose.tools import raises
+from nose.plugins.attrib import attr
 
 from indra.statements import *
 from indra.databases import hgnc_client
@@ -48,6 +49,7 @@ def test_parse_csv_from_file():
     assert sp.complex_map == {}
 
 
+@attr('webservice', 'slow') 
 def test_parse_csv_from_web():
     sp = process_from_web()
     assert isinstance(sp._data, list)

--- a/indra/tests/test_sparser.py
+++ b/indra/tests/test_sparser.py
@@ -2,6 +2,7 @@ import json
 from indra.sources import sparser
 from indra.sources.sparser.processor import _fix_agent
 from indra.statements import Agent, Phosphorylation
+from nose.plugins.attrib import attr
 
 # ############################
 # XML processing tests
@@ -24,6 +25,8 @@ def test_phosphorylation():
     assert(ev.source_api == 'sparser')
 
 
+# This test uses some slow UniPtot web queries to standardize agent names
+@attr('webservice', 'slow')
 def test_phosphorylation2():
     sp = sparser.process_xml(xml_str2)
     assert(len(sp.statements) == 1)

--- a/indra/tests/test_trips.py
+++ b/indra/tests/test_trips.py
@@ -29,7 +29,7 @@ def assert_grounding_value_or_none(st):
                 if not v:
                     assert(v is None)
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_phosphorylation():
     tp = trips.process_text('BRAF phosphorylates MEK1 at Ser222.')
     assert(len(tp.statements) == 1)
@@ -44,7 +44,7 @@ def test_phosphorylation():
     assert unicode_strs((tp, st))
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_mod_cond():
     tp = trips.process_text('Phosphorylated BRAF binds ubiquitinated MAP2K1.')
     assert(len(tp.statements) == 1)
@@ -62,7 +62,7 @@ def test_mod_cond():
     assert(st.evidence)
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_ubiquitination():
     tp = trips.process_text('MDM2 ubiquitinates TP53.')
     assert(len(tp.statements) == 1)
@@ -74,7 +74,7 @@ def test_ubiquitination():
     assert(st.evidence)
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_phosphorylation_noresidue():
     tp = trips.process_text('BRAF phosphorylates MEK1.')
     assert(len(tp.statements) == 1)
@@ -88,7 +88,7 @@ def test_phosphorylation_noresidue():
     assert(st.evidence)
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_phosphorylation_nosite():
     tp = trips.process_text('BRAF phosphorylates MEK1 at Serine.')
     assert(len(tp.statements) == 1)
@@ -102,7 +102,7 @@ def test_phosphorylation_nosite():
     assert(st.evidence)
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_actmod():
     tp = trips.process_text('MEK1 phosphorylated at Ser222 is activated.')
     assert(len(tp.statements) == 1)
@@ -118,7 +118,7 @@ def test_actmod():
     assert(st.evidence)
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_actmods():
     tp = trips.process_text('MEK1 phosphorylated at Ser 218 and Ser222 is activated.')
     assert(len(tp.statements) == 1)
@@ -135,7 +135,7 @@ def test_actmods():
     assert(st.evidence)
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_actform_bound():
     tp = trips.process_text('HRAS bound to GTP is activated.')
     assert(len(tp.statements) == 1)
@@ -150,7 +150,7 @@ def test_actform_bound():
     assert(st.evidence)
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_actform_muts():
     tp = trips.process_text('BRAF V600E is activated.')
     assert(len(tp.statements) == 1)
@@ -166,7 +166,7 @@ def test_actform_muts():
     assert(st.evidence)
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_actmods2():
     tp = trips.process_text('BRAF phosphorylated at Ser536 binds MEK1.')
     assert(len(tp.statements) == 1)
@@ -182,7 +182,7 @@ def test_actmods2():
     assert(st.evidence)
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_synthesis():
     tp = trips.process_text('NFKB transcribes IKB.')
     assert(len(tp.statements) == 1)
@@ -196,7 +196,7 @@ def test_synthesis():
     assert(st.evidence)
 
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_degradation():
     tp = trips.process_text('MDM2 degrades TP53.')
     assert(len(tp.statements) == 1)
@@ -209,7 +209,7 @@ def test_degradation():
     assert_grounding_value_or_none(st)
     assert(st.evidence)
 
-@attr('webservice')
+@attr('webservice', 'slow')
 def test_simple_decrease():
     tp = trips.process_text('Selumetinib decreases FOS.')
     assert len(tp.statements) == 1


### PR DESCRIPTION
This PR adds `slow` tags to a few tests to prevent them from being run on every single push. Note, however, that the daily Cron builds will still run these tests.