### PR TITLE
Rawtext preserve

### DIFF
--- a/indra/benchmarks/assembly_eval/batch4/run_combined.py
+++ b/indra/benchmarks/assembly_eval/batch4/run_combined.py
@@ -35,8 +35,6 @@ if __name__ == '__main__':
         rasmodel_stmts = rasmodel.get_statements()
         # Combine all statements
         all_statements = tp.statements + reach_stmts_for_pmcid
-        for stmt in all_statements:
-            stmt.uuid = str(uuid.uuid4())
         # Run assembly
         run_assembly(all_statements, 'combined', pmcid,
                      background_assertions=rasmodel_stmts)

--- a/indra/db/client.py
+++ b/indra/db/client.py
@@ -684,8 +684,10 @@ def _get_pa_stmt_jsons_w_mkhash_subquery(db, mk_hashes_q, best_first=True,
             else:
                 for ag in ag_value:
                     raw_text.append(ag['db_refs'].get('TEXT'))
+        if 'annotations' not in ev_json.keys():
+            ev_json['annotations'] = {}
         ev_json['annotations']['agents'] = {'raw_text': raw_text}
-        if 'prior_uuids' in ev_json['annotations'].keys():
+        if 'prior_uuids' not in ev_json['annotations'].keys():
             ev_json['annotations']['prior_uuids'] = []
         ev_json['annotations']['prior_uuids'].append(raw_json['id'])
 

--- a/indra/db/client.py
+++ b/indra/db/client.py
@@ -685,6 +685,9 @@ def _get_pa_stmt_jsons_w_mkhash_subquery(db, mk_hashes_q, best_first=True,
                 for ag in ag_value:
                     raw_text.append(ag['db_refs'].get('TEXT'))
         ev_json['annotations']['agents'] = {'raw_text': raw_text}
+        if 'prior_uuids' in ev_json['annotations'].keys():
+            ev_json['annotations']['prior_uuids'] = []
+        ev_json['annotations']['prior_uuids'].append(raw_json['id'])
 
         stmts_dict[mk_hash]['evidence'].append(ev_json)
 

--- a/indra/db/client.py
+++ b/indra/db/client.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from itertools import groupby, permutations, product
 from sqlalchemy import or_, desc, func, true, select, distinct
 
-from indra.statements import Unresolved, Evidence
+from indra.statements import Unresolved, Evidence, get_statement_by_name
 
 logger = logging.getLogger('db_client')
 
@@ -663,13 +663,30 @@ def _get_pa_stmt_jsons_w_mkhash_subquery(db, mk_hashes_q, best_first=True,
     for mk_hash, ev_count, raw_json_bts, pa_json_bts, pmid in res:
         returned_evidence += 1
         raw_json = json.loads(raw_json_bts.decode('utf-8'))
+        ev_json = raw_json['evidence'][0]
+
+        # Add a new statements if the hash is new
         if mk_hash not in stmts_dict.keys():
             total_evidence += ev_count
             stmts_dict[mk_hash] = json.loads(pa_json_bts.decode('utf-8'))
             stmts_dict[mk_hash]['evidence'] = []
+
+        # Fix the pmid
         if pmid:
-            raw_json['evidence'][0]['pmid'] = pmid
-        stmts_dict[mk_hash]['evidence'].append(raw_json['evidence'][0])
+            ev_json['pmid'] = pmid
+
+        # Add agents' raw text to annotations.
+        raw_text = []
+        for ag_name in get_statement_by_name(raw_json['type'])._agent_order:
+            ag_value = raw_json[ag_name]
+            if isinstance(ag_value, dict):
+                raw_text.append(ag_value['db_refs'].get('TEXT'))
+            else:
+                for ag in ag_value:
+                    raw_text.append(ag['db_refs'].get('TEXT'))
+        ev_json['annotations']['agents'] = {'raw_text': raw_text}
+
+        stmts_dict[mk_hash]['evidence'].append(ev_json)
 
     ret = {'statements': stmts_dict,
            'total_evidence': total_evidence,

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -137,7 +137,7 @@ class Preassembler(object):
                 if stmt_ix is 0:
                     new_stmt = stmt.make_generic_copy()
                 raw_text = [None if ag is None else ag.db_refs.get('TEXT')
-                            for ag in stmt.agent_list()]
+                            for ag in stmt.agent_list(deep_sorted=True)]
                 for ev in stmt.evidence:
                     ev_key = ev.matches_key()
                     if ev_key not in ev_keys:

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -135,9 +135,11 @@ class Preassembler(object):
             # Statements to it
             new_stmt = duplicates[0].make_generic_copy()
             for stmt_ix, stmt in enumerate(duplicates):
+                raw_text = [ag.db_refs.get('TEXT') for ag in stmt.agent_list()]
                 for ev in stmt.evidence:
                     ev_key = ev.matches_key()
                     if ev_key not in ev_keys:
+                        ev.annotations['agents'] = {'raw_text': raw_text}
                         new_stmt.evidence.append(ev)
                         ev_keys.add(ev_key)
             # This should never be None or anything else

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -129,22 +129,20 @@ class Preassembler(object):
         ['evidence 1', 'evidence 2']
         """
         unique_stmts = []
+        ev_keys = set()
         for _, duplicates in Preassembler._get_stmt_matching_groups(stmts):
             # Get the first statement and add the evidence of all subsequent
             # Statements to it
+            new_stmt = duplicates[0].make_generic_copy()
             for stmt_ix, stmt in enumerate(duplicates):
-                if stmt_ix == 0:
-                    ev_keys = [ev.matches_key() for ev in stmt.evidence]
-                    first_stmt = stmt
-                else:
-                    for ev in stmt.evidence:
-                        key = ev.matches_key()
-                        if key not in ev_keys:
-                            first_stmt.evidence.append(ev)
-                            ev_keys.append(key)
+                for ev in stmt.evidence:
+                    ev_key = ev.matches_key()
+                    if ev_key not in ev_keys:
+                        new_stmt.evidence.append(ev)
+                        ev_keys.add(ev_key)
             # This should never be None or anything else
-            assert isinstance(first_stmt, Statement)
-            unique_stmts.append(first_stmt)
+            assert isinstance(new_stmt, Statement)
+            unique_stmts.append(new_stmt)
         return unique_stmts
 
     def _get_entities(self, stmt, stmt_type, eh):

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -133,9 +133,11 @@ class Preassembler(object):
         for _, duplicates in Preassembler._get_stmt_matching_groups(stmts):
             # Get the first statement and add the evidence of all subsequent
             # Statements to it
-            new_stmt = duplicates[0].make_generic_copy()
             for stmt_ix, stmt in enumerate(duplicates):
-                raw_text = [ag.db_refs.get('TEXT') for ag in stmt.agent_list()]
+                if stmt_ix is 0:
+                    new_stmt = stmt.make_generic_copy()
+                raw_text = [None if ag is None else ag.db_refs.get('TEXT')
+                            for ag in stmt.agent_list()]
                 for ev in stmt.evidence:
                     ev_key = ev.matches_key()
                     if ev_key not in ev_keys:

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -129,8 +129,8 @@ class Preassembler(object):
         ['evidence 1', 'evidence 2']
         """
         unique_stmts = []
-        ev_keys = set()
         for _, duplicates in Preassembler._get_stmt_matching_groups(stmts):
+            ev_keys = set()
             # Get the first statement and add the evidence of all subsequent
             # Statements to it
             for stmt_ix, stmt in enumerate(duplicates):

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -140,6 +140,9 @@ class Preassembler(object):
                     ev_key = ev.matches_key()
                     if ev_key not in ev_keys:
                         ev.annotations['agents'] = {'raw_text': raw_text}
+                        if 'prior_uuids' not in ev.annotations.keys():
+                            ev.annotations['prior_uuids'] = []
+                        ev.annotations['prior_uuids'].append(stmt.uuid)
                         new_stmt.evidence.append(ev)
                         ev_keys.add(ev_key)
             # This should never be None or anything else

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1216,17 +1216,17 @@ class Statement(object):
         ag_list = []
         for ag_name in self._agent_order:
             ag_attr = getattr(self, ag_name)
-            if isinstance(ag_attr, Agent):
+            if isinstance(ag_attr, Concept):
                 ag_list.append(ag_attr)
             elif isinstance(ag_attr, list):
-                ag_types = {type(ag) for ag in ag_attr}
-                if ag_types == {Agent}:
-                    raise TypeError("Expected all elements of list to be Agent,"
-                                    "but got: %s" % ag_types)
+                if not all([isinstance(ag, Concept) for ag in ag_attr]):
+                    raise TypeError("Expected all elements of list to be Agent "
+                                    "and/or Concept, but got: %s"
+                                    % {type(ag) for ag in ag_attr})
                 ag_list.extend(sorted(ag_attr))
             else:
-                raise TypeError("Expected type Agent or list, got type %s."
-                                % type(ag_attr))
+                raise TypeError("Expected type Agent, Concept, or list, got "
+                                "type %s." % type(ag_attr))
         return ag_list
 
     def entities_match(self, other):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1198,11 +1198,13 @@ class Statement(object):
             A long integer hash.
         """
         if shallow:
-            if self._shallow_hash is None or refresh:
+            if not hasattr(self, '_shallow_hash') or self._shallow_hash is None\
+                    or refresh:
                 self._shallow_hash = self._make_hash(self.matches_key(), 14)
             ret = self._shallow_hash
         else:
-            if self._full_hash is None or refresh:
+            if not hasattr(self, '_full_hash') or self._full_hash is None \
+                    or refresh:
                 ev_mk_list = sorted([ev.matches_key() for ev in self.evidence])
                 self._full_hash =\
                     self._make_hash(self.matches_key() + str(ev_mk_list), 16)

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -2949,8 +2949,8 @@ class Conversion(Statement):
     def matches_key(self):
         keys = [type(self)]
         keys += [self.subj.matches_key() if self.subj else None]
-        keys += [agent.matches_key() for agent in self.obj_to]
-        keys += [agent.matches_key() for agent in self.obj_from]
+        keys += [agent.matches_key() for agent in sorted_agents(self.obj_to)]
+        keys += [agent.matches_key() for agent in sorted_agents(self.obj_from)]
         return str(keys)
 
     def set_agent_list(self, agent_list):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1223,7 +1223,7 @@ class Statement(object):
                     raise TypeError("Expected all elements of list to be Agent "
                                     "and/or Concept, but got: %s"
                                     % {type(ag) for ag in ag_attr})
-                ag_list.extend(sorted(ag_attr))
+                ag_list.extend(sorted(ag_attr, key=lambda ag: ag.matches_key()))
             else:
                 raise TypeError("Expected type Agent, Concept, or list, got "
                                 "type %s." % type(ag_attr))

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1216,7 +1216,7 @@ class Statement(object):
         ag_list = []
         for ag_name in self._agent_order:
             ag_attr = getattr(self, ag_name)
-            if isinstance(ag_attr, Concept):
+            if isinstance(ag_attr, Concept) or ag_attr is None:
                 ag_list.append(ag_attr)
             elif isinstance(ag_attr, list):
                 if not all([isinstance(ag, Concept) for ag in ag_attr]):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1224,7 +1224,7 @@ class Statement(object):
                                     "and/or Concept, but got: %s"
                                     % {type(ag) for ag in ag_attr})
                 if deep_sorted:
-                    ag_attr = sorted(ag_attr, key=lambda ag: ag.matches_key())
+                    ag_attr = sorted_agents(ag_attr)
                 ag_list.extend(ag_attr)
             else:
                 raise TypeError("Expected type Agent, Concept, or list, got "
@@ -1397,6 +1397,10 @@ class Statement(object):
         for attr in ['_full_hash', '_shallow_hash']:
             my_hash = kwargs.pop(attr, None)
             my_shallow_hash = kwargs.pop(attr, None)
+        for attr in self._agent_order:
+            attr_value = kwargs.get(attr)
+            if isinstance(attr_value, list):
+                kwargs[attr] = sorted_agents(attr_value)
         new_instance = self.__class__(**kwargs)
         new_instance._full_hash = my_hash
         new_instance._shallow_hash = my_shallow_hash
@@ -3380,6 +3384,10 @@ def draw_stmt_graph(stmts):
     ax.get_xaxis().set_visible(False)
     ax.get_yaxis().set_visible(False)
     plt.show()
+
+
+def sorted_agents(agent_list):
+    return sorted(agent_list, key=lambda ag: ag.matches_key())
 
 
 def get_all_descendants(parent):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1147,8 +1147,16 @@ class Statement(object):
         # Make it a signed int.
         return 16**n_bytes//2 - raw_h
 
-    def matches_key(self):
+    def _make_matches_key(self):
         raise NotImplementedError("Method must be implemented in child class.")
+
+    def matches_key(self):
+        key = self._make_matches_key()
+        rep_chars = '\'\"\\<>'
+        for c in rep_chars:
+            key = key.replace(c, '')
+        key = key.replace('class indra.statements.', '')[1:-1]
+        return key
 
     def matches(self, other):
         return self.matches_key() == other.matches_key()
@@ -1438,7 +1446,7 @@ class Modification(Statement):
         else:
             self.position = position
 
-    def matches_key(self):
+    def _make_matches_key(self):
         if self.enz is None:
             enz_key = None
         else:
@@ -1602,7 +1610,7 @@ class SelfModification(Statement):
              (type(self).__name__, self.enz, res_str, pos_str))
         return s
 
-    def matches_key(self):
+    def _make_matches_key(self):
         key = (type(self), self.enz.matches_key(),
                str(self.residue), str(self.position))
         return str(key)
@@ -1855,7 +1863,7 @@ class RegulateActivity(Statement):
         state.pop('subj_activity', None)
         self.__dict__.update(state)
 
-    def matches_key(self):
+    def _make_matches_key(self):
         key = (type(self), self.subj.matches_key(),
                self.obj.matches_key(), str(self.obj_activity),
                str(self.is_activation))
@@ -2077,7 +2085,7 @@ class ActiveForm(Statement):
         self.activity = activity
         self.is_active = is_active
 
-    def matches_key(self):
+    def _make_matches_key(self):
         key = (type(self), self.agent.matches_key(),
                str(self.activity), str(self.is_active))
         return str(key)
@@ -2210,7 +2218,7 @@ class HasActivity(Statement):
         self.activity = activity
         self.has_activity = has_activity
 
-    def matches_key(self):
+    def _make_matches_key(self):
         key = (type(self), self.agent.matches_key(),
                str(self.activity), str(self.has_activity))
         return str(key)
@@ -2278,7 +2286,7 @@ class Gef(Statement):
         self.gef = gef
         self.ras = ras
 
-    def matches_key(self):
+    def _make_matches_key(self):
         key = (type(self), self.gef.matches_key(),
                self.ras.matches_key())
         return str(key)
@@ -2363,7 +2371,7 @@ class Gap(Statement):
         self.gap = gap
         self.ras = ras
 
-    def matches_key(self):
+    def _make_matches_key(self):
         key = (type(self), self.gap.matches_key(),
                self.ras.matches_key())
         return str(key)
@@ -2442,7 +2450,7 @@ class Complex(Statement):
         super(Complex, self).__init__(evidence)
         self.members = members
 
-    def matches_key(self):
+    def _make_matches_key(self):
         members = sorted(self.members, key=lambda x: x.matches_key())
         key = (type(self), tuple(m.matches_key() for m in members))
         return str(key)
@@ -2580,7 +2588,7 @@ class Translocation(Statement):
         matches = matches and (self.to_location == other.to_location)
         return matches
 
-    def matches_key(self):
+    def _make_matches_key(self):
         key = (type(self), self.agent.matches_key(), str(self.from_location),
                str(self.to_location))
         return str(key)
@@ -2623,7 +2631,7 @@ class RegulateAmount(Statement):
                              type(self).__name__)
         self.obj = obj
 
-    def matches_key(self):
+    def _make_matches_key(self):
         if self.subj is None:
             subj_key = None
         else:
@@ -2821,7 +2829,7 @@ class Influence(IncreaseAmount):
             delta_equals(self.obj_delta, other.obj_delta)
         return matches
 
-    def matches_key(self):
+    def _make_matches_key(self):
         key = (type(self), self.subj.matches_key(),
                self.obj.matches_key(),
                self.subj_delta['polarity'],
@@ -2946,7 +2954,7 @@ class Conversion(Statement):
         if isinstance(obj_to, Agent):
             self.obj_to = [obj_to]
 
-    def matches_key(self):
+    def _make_matches_key(self):
         keys = [type(self)]
         keys += [self.subj.matches_key() if self.subj else None]
         keys += [agent.matches_key() for agent in sorted_agents(self.obj_to)]

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1211,7 +1211,7 @@ class Statement(object):
                 l.extend(bc_agents)
         return l
 
-    def agent_list(self):
+    def agent_list(self, deep_sorted=False):
         """Get the canonicallized agent list."""
         ag_list = []
         for ag_name in self._agent_order:
@@ -1223,7 +1223,9 @@ class Statement(object):
                     raise TypeError("Expected all elements of list to be Agent "
                                     "and/or Concept, but got: %s"
                                     % {type(ag) for ag in ag_attr})
-                ag_list.extend(sorted(ag_attr, key=lambda ag: ag.matches_key()))
+                if deep_sorted:
+                    ag_attr = sorted(ag_attr, key=lambda ag: ag.matches_key())
+                ag_list.extend(ag_attr)
             else:
                 raise TypeError("Expected type Agent, Concept, or list, got "
                                 "type %s." % type(ag_attr))

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -13,6 +13,7 @@ from indra.statements import Agent, Phosphorylation, BoundCondition, \
                              IncreaseAmount, DecreaseAmount
 from indra.preassembler.hierarchy_manager import hierarchies
 
+
 def test_duplicates():
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
     ras = Agent('RAS', db_refs = {'FA': '03663'})
@@ -21,6 +22,7 @@ def test_duplicates():
     pa = Preassembler(hierarchies, stmts=[st1, st2])
     pa.combine_duplicates()
     assert(len(pa.unique_stmts) == 1)
+
 
 def test_duplicates_copy():
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
@@ -34,6 +36,7 @@ def test_duplicates_copy():
     assert(len(stmts) == 2)
     assert(len(stmts[0].evidence) == 1)
     assert(len(stmts[1].evidence) == 1)
+
 
 def test_duplicates_sorting():
     mc = ModCondition('phosphorylation')
@@ -52,6 +55,7 @@ def test_duplicates_sorting():
     pa = Preassembler(hierarchies, stmts=stmts)
     pa.combine_duplicates()
     assert(len(pa.unique_stmts) == 2)
+
 
 def test_combine_duplicates():
     raf = Agent('RAF1')
@@ -90,6 +94,7 @@ def test_combine_duplicates():
     assert pa.unique_stmts[3].matches(p1) # RAF phos MEK
     assert num_evs[3] == 4, num_evs[3]
 
+
 def test_combine_evidence_exact_duplicates():
     raf = Agent('RAF1')
     mek = Agent('MEK1')
@@ -107,6 +112,7 @@ def test_combine_evidence_exact_duplicates():
     assert(len(pa.unique_stmts[0].evidence) == 2)
     assert(set(ev.text for ev in pa.unique_stmts[0].evidence) ==
            set(['foo', 'bar']))
+
 
 def test_superfamily_refinement():
     """A gene-level statement should be supported by a family-level
@@ -158,6 +164,7 @@ def test_modification_refinement():
     assert (len(stmts[0].supported_by) == 1)
     assert (stmts[0].supported_by[0].equals(st2))
 
+
 def test_modification_refinement_residue_noenz():
     erbb3 = Agent('Erbb3')
     st1 = Phosphorylation(None, erbb3)
@@ -165,6 +172,7 @@ def test_modification_refinement_residue_noenz():
     pa = Preassembler(hierarchies, stmts=[st1, st2])
     pa.combine_related()
     assert(len(pa.related_stmts) == 1)
+
 
 def test_modification_refinement_noenz():
     """A more specific modification statement should be supported by a more
@@ -182,6 +190,7 @@ def test_modification_refinement_noenz():
     assert (len(stmts[0].supported_by) == 1)
     assert (stmts[0].supported_by[0].equals(st2))
     assert (stmts[0].supported_by[0].supports[0].equals(st1))
+
 
 def test_modification_refinement_noenz2():
     """A more specific modification statement should be supported by a more
@@ -207,6 +216,7 @@ def test_modification_refinement_noenz2():
     assert (stmts[0].supported_by[0].equals(st2))
     assert (stmts[0].supported_by[0].supports[0].equals(st1))
 
+
 def test_modification_norefinement_noenz():
     """A more specific modification statement should be supported by a more
     generic modification statement."""
@@ -221,6 +231,7 @@ def test_modification_norefinement_noenz():
     # these statements shouldn't be combined. 
     assert(len(stmts) == 2)
     assert(len(stmts[1].evidence)==1)
+
 
 def test_modification_norefinement_subsfamily():
     """A more specific modification statement should be supported by a more
@@ -238,6 +249,7 @@ def test_modification_norefinement_subsfamily():
     assert(len(stmts) == 2)
     assert(len(stmts[1].evidence)==1)
 
+
 def test_modification_norefinement_enzfamily():
     """A more specific modification statement should be supported by a more
     generic modification statement."""
@@ -253,6 +265,7 @@ def test_modification_norefinement_enzfamily():
     # these statements shouldn't be combined. 
     assert(len(stmts) == 2)
     assert(len(stmts[1].evidence)==1)
+
 
 def test_bound_condition_refinement():
     """A statement with more specific bound context should be supported by a
@@ -273,6 +286,7 @@ def test_bound_condition_refinement():
     assert (len(stmts[0].supported_by) == 1)
     assert (stmts[0].supported_by[0].equals(st1))
 
+
 def test_bound_condition_norefinement():
     """A statement with more specific bound context should be supported by a
     less specific statement."""
@@ -288,6 +302,7 @@ def test_bound_condition_norefinement():
     # The bound condition is more specific in st2 but the modification is less
     # specific. Therefore these statements should not be combined.
     assert(len(stmts) == 2)
+
 
 def test_bound_condition_deep_refinement():
     """A statement with more specific bound context should be supported by a
@@ -311,6 +326,7 @@ def test_bound_condition_deep_refinement():
     assert (len(stmts[0].supported_by) == 1)
     assert (stmts[0].supported_by[0].equals(st1))
 
+
 def test_complex_refinement():
     ras = Agent('RAS')
     raf = Agent('RAF')
@@ -321,6 +337,7 @@ def test_complex_refinement():
     pa.combine_related()
     assert(len(pa.unique_stmts) == 2)
     assert(len(pa.related_stmts) == 2)
+
 
 def test_complex_agent_refinement():
     ras = Agent('RAS')
@@ -333,11 +350,13 @@ def test_complex_agent_refinement():
     assert(len(pa.unique_stmts) == 2)
     assert(len(pa.related_stmts) == 2)
 
+
 def test_mod_sites_refinement():
     """A statement with more specific modification context should be supported
     by a less-specific statement."""
     # TODO
     assert True
+
 
 def test_binding_site_refinement():
     """A statement with information about a binding site for an interaction
@@ -345,6 +364,7 @@ def test_binding_site_refinement():
     information."""
     # TODO
     assert True
+
 
 def test_activating_substitution_refinement():
     """Should only be refinement if entities are a refinement and all
@@ -389,6 +409,7 @@ def test_activating_substitution_refinement():
     assert(not st3.refinement_of(st5, hierarchies))
     assert(not st4.refinement_of(st5, hierarchies))
 
+
 def test_translocation():
     st1 = Translocation(Agent('AKT'), None, None)
     st2 = Translocation(Agent('AKT'), None, 'plasma membrane')
@@ -396,6 +417,7 @@ def test_translocation():
     pa = Preassembler(hierarchies, stmts=[st1, st2, st3])
     pa.combine_related()
     assert(len(pa.related_stmts) == 2)
+
 
 def test_grounding_aggregation():
     braf1 = Agent('BRAF', db_refs={'TEXT': 'braf', 'HGNC': '1097'})
@@ -408,6 +430,7 @@ def test_grounding_aggregation():
     unique_stmts = pa.combine_duplicates()
     assert(len(unique_stmts) == 3)
 
+
 def test_grounding_aggregation_complex():
     mek = Agent('MEK')
     braf1 = Agent('BRAF', db_refs={'TEXT': 'braf', 'HGNC': '1097'})
@@ -419,6 +442,7 @@ def test_grounding_aggregation_complex():
     pa = Preassembler(hierarchies, stmts=[st1, st2, st3])
     unique_stmts = pa.combine_duplicates()
     assert(len(unique_stmts) == 3)
+
 
 def test_render_stmt_graph():
     braf = Agent('BRAF', db_refs={'HGNC': '1097'})
@@ -448,6 +472,7 @@ def test_render_stmt_graph():
     # 6 + 5 + 1 + 1 + 2 = 15 edges
     assert len(graph.edges()) == 15
 
+
 def test_flatten_evidence_hierarchy():
     braf = Agent('BRAF')
     mek = Agent('MAP2K1')
@@ -468,6 +493,7 @@ def test_flatten_evidence_hierarchy():
     assert len(supporting_stmt.evidence) == 1
     assert supporting_stmt.evidence[0].text == 'foo'
 
+
 def test_flatten_stmts():
     st1 = Phosphorylation(Agent('MAP3K5'), Agent('RAF1'), 'S', '338')
     st2 = Phosphorylation(None, Agent('RAF1'), 'S', '338')
@@ -481,6 +507,7 @@ def test_flatten_stmts():
     assert(len(flatten_stmts(pa.unique_stmts)) == 4)
     assert(len(flatten_stmts(pa.related_stmts)) == 4)
 
+
 def test_complex_refinement_order():
     st1 = Complex([Agent('MED23'), Agent('ELK1')])
     st2 = Complex([Agent('ELK1', mods=[ModCondition('phosphorylation')]),
@@ -489,6 +516,7 @@ def test_complex_refinement_order():
     pa.combine_duplicates()
     pa.combine_related()
     assert(len(pa.related_stmts) == 1)
+
 
 def test_activation_refinement():
     subj = Agent('alcohol', db_refs={'CHEBI': 'CHEBI:16236',
@@ -504,6 +532,7 @@ def test_activation_refinement():
     pa.combine_related()
     assert(len(pa.related_stmts) == 2)
 
+
 def test_homodimer_refinement():
     egfr = Agent('EGFR')
     erbb = Agent('ERBB2')
@@ -514,6 +543,7 @@ def test_homodimer_refinement():
     assert(len(pa.unique_stmts) == 2)
     pa.combine_related()
     assert(len(pa.related_stmts) == 2)
+
 
 def test_return_toplevel():
     src = Agent('SRC', db_refs = {'HGNC': '11283'})
@@ -532,6 +562,7 @@ def test_return_toplevel():
     assert(len(stmts[1-ix].supported_by[0].supports) == 1)
     assert(len(stmts[ix].supports) == 1)
     assert(len(stmts[ix].supports[0].supported_by) == 1)
+
 
 def test_multiprocessing():
     braf = Agent('BRAF', db_refs={'HGNC': '1097'})
@@ -553,6 +584,7 @@ def test_multiprocessing():
     toplevel = pa.combine_related(return_toplevel=True, poolsize=1,
                                   size_cutoff=2)
     assert len(toplevel) == 3, 'Got %d toplevel statements.' % len(toplevel)
+
 
 def test_conversion_refinement():
     ras = Agent('RAS', db_refs={'FPLX': 'RAS'})
@@ -661,3 +693,61 @@ def test_preassemble_related_complex():
     top = pa.combine_related()
     assert len(top) == 1
 
+
+def test_agent_text_storage():
+    A1 = Agent('A', db_refs={'TEXT': 'A'})
+    A2 = Agent('A', db_refs={'TEXT': 'alpha'})
+    B1 = Agent('B', db_refs={'TEXT': 'bag'})
+    B2 = Agent('B', db_refs={'TEXT': 'bug'})
+    C = Agent('C')
+    D = Agent('D')
+    inp = [
+        Complex([A1, B1], evidence=Evidence(text='A complex bag.')),
+        Complex([B2, A2], evidence=Evidence(text='bug complex alpha once.')),
+        Complex([B2, A2], evidence=Evidence(text='bug complex alpha again.')),
+        Complex([A1, C, B2], evidence=Evidence(text='A complex C bug.')),
+        Phosphorylation(A1, B1, evidence=Evidence(text='A phospo bags.')),
+        Phosphorylation(A2, B2, evidence=Evidence(text='alpha phospho bugs.')),
+        Conversion(D, [A1, B1], [C, D],
+                   evidence=Evidence(text='D: A bag -> C D')),
+        Conversion(D, [B1, A2], [C, D],
+                   evidence=Evidence(text='D: bag a -> C D')),
+        Conversion(D, [B2, A2], [D, C],
+                   evidence=Evidence(text='D: bug a -> D C')),
+        Conversion(D, [B1, A1], [C, D],
+                   evidence=Evidence(text='D: bag A -> C D')),
+        Conversion(D, [A1], [A1, C],
+                   evidence=Evidence(text='D: A -> A C'))
+        ]
+    pa = Preassembler(hierarchies, inp)
+    unq1 = pa.combine_duplicates()
+    assert len(unq1) == 5, len(unq1)
+    assert all([len(ev.annotations['prior_uuids']) == 1
+                for s in unq1 for ev in s.evidence]),\
+        'There can only be one prior evidence per uuid at this stage.'
+    ev_uuid_dict = {ev.annotations['prior_uuids'][0]: ev.annotations['agents']
+                    for s in unq1 for ev in s.evidence}
+    for s in inp:
+        raw_text = [ag.db_refs.get('TEXT')
+                    for ag in s.agent_list(deep_sorted=True)]
+        assert raw_text == ev_uuid_dict[s.uuid]['raw_text'],\
+            str(raw_text) + '!=' + str(ev_uuid_dict[s.uuid]['raw_text'])
+
+    # Now run pa on the above corpus plus another statement.
+    inp2 = unq1 + [
+        Complex([A1, C, B1], evidence=Evidence(text='A complex C bag.'))
+        ]
+    pa2 = Preassembler(hierarchies, inp2)
+    unq2 = pa2.combine_duplicates()
+    assert len(unq2) == 5, len(unq2)
+    old_ev_list = []
+    new_ev = None
+    for s in unq2:
+        for ev in s.evidence:
+            if ev.text == inp2[-1].evidence[0].text:
+                new_ev = ev
+            else:
+                old_ev_list.append(ev)
+    assert all([len(ev.annotations['prior_uuids']) == 2 for ev in old_ev_list])
+    assert new_ev
+    assert len(new_ev.annotations['prior_uuids']) == 1

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -79,15 +79,16 @@ def test_combine_duplicates():
     pa = Preassembler(hierarchies, stmts=stmts)
     pa.combine_duplicates()
     # The statements come out sorted by their matches_key
-    assert(len(pa.unique_stmts) == 4)
-    assert(pa.unique_stmts[0].matches(p6)) # MEK dephos ERK
-    assert(len(pa.unique_stmts[0].evidence) == 3)
-    assert(pa.unique_stmts[1].matches(p9)) # SRC dephos KRAS
-    assert(len(pa.unique_stmts[1].evidence) == 1)
-    assert(pa.unique_stmts[2].matches(p5)) # MEK phos ERK
-    assert(len(pa.unique_stmts[2].evidence) == 1)
-    assert(pa.unique_stmts[3].matches(p1)) # RAF phos MEK
-    assert(len(pa.unique_stmts[3].evidence) == 4)
+    assert len(pa.unique_stmts) == 4, len(pa.unique_stmts)
+    num_evs =[len(s.evidence) for s in pa.unique_stmts]
+    assert pa.unique_stmts[0].matches(p6) # MEK dephos ERK
+    assert num_evs[0] == 3, num_evs[0]
+    assert pa.unique_stmts[1].matches(p9) # SRC dephos KRAS
+    assert num_evs[1] == 1, num_evs[1]
+    assert pa.unique_stmts[2].matches(p5) # MEK phos ERK
+    assert num_evs[2] == 1, num_evs[2]
+    assert pa.unique_stmts[3].matches(p1) # RAF phos MEK
+    assert num_evs[3] == 4, num_evs[3]
 
 def test_combine_evidence_exact_duplicates():
     raf = Agent('RAF1')


### PR DESCRIPTION
The PR allows the raw text rextractions for agents to be preserved in the evidence during preassembly, or on-load from the database. The uuid of the past statements is also preserved as another means of tracing a statements history.

This required refactoring the agent_list functionality to enforce a canonical order for all types of statement, however there should be no change in the outward functionality of the method.

This PR addresses #617