### PR TITLE
Eidos processor extensions

### DIFF
--- a/indra/sources/eidos/api.py
+++ b/indra/sources/eidos/api.py
@@ -101,9 +101,6 @@ def process_json_str(json_str):
         A EidosProcessor containing the extracted INDRA Statements
         in ep.statements.
     """
-    logger.warning('This method is deprecated and will be removed in the next'
-                   ' version, please use the equivalent process_json_str'
-                   ' instead.')
     json_dict = json.loads(json_str)
     return process_json(json_dict)
 
@@ -129,16 +126,15 @@ def process_json(json_dict):
 
 def initialize_reader():
     """Instantiate an Eidos reader for fast subsequent reading."""
-    eidos_reader.process_text('', 'json_ld')
+    eidos_reader.process_text('')
 
 
 def process_json_ld_file(file_name):
     """DEPRECATED: see process_json_file"""
     logger.warning('This method is deprecated and will be removed in the next'
-                   ' version, please use the equivalent process_json_ld_file'
+                   ' version, please use the equivalent process_json_file'
                    ' instead.')
     return process_json_file(file_name)
-
 
 
 def process_json_ld_str(json_str):

--- a/indra/sources/eidos/api.py
+++ b/indra/sources/eidos/api.py
@@ -123,7 +123,7 @@ def process_json(json_dict):
         in ep.statements.
     """
     ep = EidosProcessor(json_dict)
-    ep.get_events()
+    ep.get_causal_relations()
     return ep
 
 

--- a/indra/sources/eidos/api.py
+++ b/indra/sources/eidos/api.py
@@ -121,6 +121,7 @@ def process_json(json_dict):
     """
     ep = EidosProcessor(json_dict)
     ep.get_causal_relations()
+    ep.get_correlations()
     return ep
 
 

--- a/indra/sources/eidos/api.py
+++ b/indra/sources/eidos/api.py
@@ -4,7 +4,7 @@ from past.builtins import basestring
 import json
 import logging
 import requests
-from .processor import EidosJsonProcessor, EidosJsonLdProcessor
+from .processor import EidosProcessor
 
 logger = logging.getLogger('eidos')
 
@@ -31,9 +31,9 @@ def process_text(text, out_format='json_ld', save_json='eidos_output.json',
     ----------
     text : str
         The text to be processed.
-    out_format : str
-        The type of Eidos output to read into and process. Can be one of
-        "json" or "json_ld". Default: "json_ld"
+    out_format : Optional[str]
+        The type of Eidos output to read into and process. Currently only
+        'json-ld' is supported which is also the default value used.
     save_json : Optional[str]
         The name of a file in which to dump the JSON output of Eidos.
     webservice : Optional[str]
@@ -41,9 +41,9 @@ def process_text(text, out_format='json_ld', save_json='eidos_output.json',
 
     Returns
     -------
-    ep : EidosJsonProcessor or EidosJsonLdProcessor depending on out_format
-        A EidosJsonProcessor or EidosJsonLdProcessor containing the extracted
-        INDRA Statements in ep.statements.
+    ep : EidosProcessor
+        An EidosProcessor containing the extracted INDRA Statements in its
+        statements attribute.
     """
     if not webservice:
         if eidos_reader is None:
@@ -57,30 +57,24 @@ def process_text(text, out_format='json_ld', save_json='eidos_output.json',
     if save_json:
         with open(save_json, 'wt') as fh:
             json.dump(json_dict, fh, indent=2)
-    if out_format == 'json':
-        return process_json(json_dict)
-    elif out_format == 'json_ld':
-        return process_json_ld(json_dict)
-    else:
-        logger.error('Output format %s is invalid.' % output_format)
-        return None
+    return process_json(json_dict)
 
 
 def process_json_file(file_name):
-    """Return an EidosProcessor by processing the given Eidos json file.
+    """Return an EidosProcessor by processing the given Eidos JSON-LD file.
 
-    The output from the Eidos reader is in json format. This function is
+    The output from the Eidos reader is in JSON-LD format. This function is
     useful if the output is saved as a file and needs to be processed.
 
     Parameters
     ----------
     file_name : str
-        The name of the json file to be processed.
+        The name of the JSON-LD file to be processed.
 
     Returns
     -------
-    ep : EidosJsonProcessor
-        A EidosJsonProcessor containing the extracted INDRA Statements
+    ep : EidosProcessor
+        A EidosProcessor containing the extracted INDRA Statements
         in ep.statements.
     """
     try:
@@ -91,61 +85,8 @@ def process_json_file(file_name):
         logger.exception('Could not read file %s.' % file_name)
 
 
-def process_json_ld_file(file_name):
-    """Return an EidosProcessor by processing the given Eidos JSON-LD file.
-
-    The output from the Eidos reader is in json-LD format. This function is
-    useful if the output is saved as a file and needs to be processed.
-
-    Parameters
-    ----------
-    file_name : str
-        The name of the JSON-LD file to be processed.
-
-    Returns
-    -------
-    ep : EidosJsonLdProcessor
-        A EidosJsonLdProcessor containing the extracted INDRA Statements
-        in ep.statements.
-    """
-    try:
-        with open(file_name, 'rb') as fh:
-            json_str = fh.read().decode('utf-8')
-            return process_json_ld_str(json_str)
-    except IOError:
-        logger.exception('Could not read file %s.' % file_name)
-
-
 def process_json_str(json_str):
-    """Return an EidosProcessor by processing the given Eidos json string.
-
-    The output from the Eidos parser is in json format.
-
-    Parameters
-    ----------
-    json_str : str
-        The json string to be processed.
-
-    Returns
-    -------
-    ep : EidosJsonProcessor
-        A EidosProcessor containing the extracted INDRA Statements
-        in ep.statements.
-    """
-    if not isinstance(json_str, basestring):
-        raise TypeError('{} is {} instead of {}'.format(json_str,
-                                                        json_str.__class__,
-                                                        basestring))
-    try:
-        json_dict = json.loads(json_str)
-    except ValueError:
-        logger.error('Could not decode JSON string.')
-        return None
-    return process_json(json_dict)
-
-
-def process_json_ld_str(json_str):
-    """Return an EidosJsonLdProcessor by processing the Eidos JSON-LD string.
+    """Return an EidosProcessor by processing the Eidos JSON-LD string.
 
     The output from the Eidos parser is in JSON-LD format.
 
@@ -156,44 +97,19 @@ def process_json_ld_str(json_str):
 
     Returns
     -------
-    ep : EidosJsonLdProcessor
-        A EidosJsonLdProcessor containing the extracted INDRA Statements
+    ep : EidosProcessor
+        A EidosProcessor containing the extracted INDRA Statements
         in ep.statements.
     """
-    if not isinstance(json_str, basestring):
-        raise TypeError('{} is {} instead of {}'.format(json_str,
-                                                        json_str.__class__,
-                                                        basestring))
-    try:
-        json_dict = json.loads(json_str)
-    except ValueError:
-        logger.error('Could not decode JSON-LD string.')
-        return None
-    return process_json_ld(json_dict)
+    logger.warning('This method is deprecated and will be removed in the next'
+                   ' version, please use the equivalent process_json_str'
+                   ' instead.')
+    json_dict = json.loads(json_str)
+    return process_json(json_dict)
 
 
 def process_json(json_dict):
-    """Return an EidosJsonProcessor by processing the given Eidos JSON dict.
-
-    Parameters
-    ----------
-    json_dict : dict
-        The JSON dict to be processed.
-
-    Returns
-    -------
-    ep : EidosJsonProcessor
-        A EidosJsonProcessor containing the extracted INDRA Statements
-        in ep.statements.
-    """
-
-    ep = EidosJsonProcessor(json_dict)
-    ep.get_events()
-    return ep
-
-
-def process_json_ld(json_dict):
-    """Return an EidosJsonLdProcessor by processing a Eidos JSON-LD dict.
+    """Return an EidosProcessor by processing a Eidos JSON-LD dict.
 
     Parameters
     ----------
@@ -202,12 +118,11 @@ def process_json_ld(json_dict):
 
     Returns
     -------
-    ep : EidosJsonLdProcessor
-        A EidosJsonLdProcessor containing the extracted INDRA Statements
+    ep : EidosProcessor
+        A EidosProcessor containing the extracted INDRA Statements
         in ep.statements.
     """
-
-    ep = EidosJsonLdProcessor(json_dict)
+    ep = EidosProcessor(json_dict)
     ep.get_events()
     return ep
 
@@ -215,3 +130,27 @@ def process_json_ld(json_dict):
 def initialize_reader():
     """Instantiate an Eidos reader for fast subsequent reading."""
     eidos_reader.process_text('', 'json_ld')
+
+
+def process_json_ld_file(file_name):
+    """DEPRECATED: see process_json_file"""
+    logger.warning('This method is deprecated and will be removed in the next'
+                   ' version, please use the equivalent process_json_ld_file'
+                   ' instead.')
+    return process_json_file(file_name)
+
+
+
+def process_json_ld_str(json_str):
+    """DEPRECATED: see process_json_str"""
+    logger.warning('This method is deprecated and will be removed in the next'
+                   ' version, please use the equivalent process_json_str'
+                   ' instead.')
+    return process_json_str(json_str)
+
+
+def process_json_ld(json_dict):
+    """DEPRECATED: see process_json"""
+    logger.warning('This method is deprecated and will be removed in the next'
+                   ' version, please use the equivalent process_json instead.')
+    return process_json(json_dict)

--- a/indra/sources/eidos/api.py
+++ b/indra/sources/eidos/api.py
@@ -63,8 +63,8 @@ def process_text(text, out_format='json_ld', save_json='eidos_output.json',
 def process_json_file(file_name):
     """Return an EidosProcessor by processing the given Eidos JSON-LD file.
 
-    The output from the Eidos reader is in JSON-LD format. This function is
-    useful if the output is saved as a file and needs to be processed.
+    This function is useful if the output from Eidos is saved as a file and
+    needs to be processed.
 
     Parameters
     ----------
@@ -75,7 +75,7 @@ def process_json_file(file_name):
     -------
     ep : EidosProcessor
         A EidosProcessor containing the extracted INDRA Statements
-        in ep.statements.
+        in its statements attribute.
     """
     try:
         with open(file_name, 'rb') as fh:
@@ -88,18 +88,16 @@ def process_json_file(file_name):
 def process_json_str(json_str):
     """Return an EidosProcessor by processing the Eidos JSON-LD string.
 
-    The output from the Eidos parser is in JSON-LD format.
-
     Parameters
     ----------
     json_str : str
-        The json-LD string to be processed.
+        The JSON-LD string to be processed.
 
     Returns
     -------
     ep : EidosProcessor
         A EidosProcessor containing the extracted INDRA Statements
-        in ep.statements.
+        in its statements attribute.
     """
     json_dict = json.loads(json_str)
     return process_json(json_dict)
@@ -117,7 +115,7 @@ def process_json(json_dict):
     -------
     ep : EidosProcessor
         A EidosProcessor containing the extracted INDRA Statements
-        in ep.statements.
+        in its statements attribute.
     """
     ep = EidosProcessor(json_dict)
     ep.get_causal_relations()

--- a/indra/sources/eidos/cli.py
+++ b/indra/sources/eidos/cli.py
@@ -9,7 +9,7 @@ import glob
 import logging
 import subprocess
 from indra import get_config
-from .api import process_json_ld_file
+from .api import process_json_file
 
 
 eip = get_config('EIDOSPATH')
@@ -85,7 +85,7 @@ def extract_and_process(path_in, path_out):
                 (len(jsons), path_out))
     stmts = []
     for json in jsons:
-        ep = process_json_ld_file(json)
+        ep = process_json_file(json)
         if ep:
             stmts += ep.statements
     return stmts

--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -184,8 +184,10 @@ class EidosJsonLdProcessor(object):
                 if timexes:
                     time_text = timexes[0].get('text')
                     constraint = timexes[0]['intervals'][0]
-                    start = constraint['start']
-                    end = constraint['end']
+                    start = None if constraint['start'] == 'Undef' else \
+                        constraint['start']
+                    end = None if constraint['end'] == 'Undef' else \
+                        constraint['end']
                     duration = constraint['duration']
                     time_annot = {'text': time_text, 'start': start,
                                   'end': end, 'duration': duration}

--- a/indra/sources/eidos/reader.py
+++ b/indra/sources/eidos/reader.py
@@ -69,10 +69,19 @@ class EidosReader(object):
             eidos = autoclass(eidos_package + '.EidosSystem')
             self.eidos_reader = eidos(autoclass('java.lang.Object')())
 
-        annot_doc = self.eidos_reader.extractFromText(text, False, False, None)
+        default_arg = autoclass('scala.Some')(None)
+
+        annot_doc = \
+            self.eidos_reader.extractFromText(text,
+                                              True, # keep text
+                                              False, # CAG-relevant only
+                                              default_arg, # doc creation time
+                                              default_arg # file name
+                                              )
         if format == 'json':
             mentions = annot_doc.odinMentions()
-            ser = autoclass(eidos_package + '.serialization.json.WMJSONSerializer')
+            ser = autoclass(eidos_package +
+                            '.serialization.json.WMJSONSerializer')
             mentions_json = ser.toJsonStr(mentions)
         elif format == 'json_ld':
             # We need to get a Scala Seq of annot docs here

--- a/indra/sources/eidos/reader.py
+++ b/indra/sources/eidos/reader.py
@@ -1,5 +1,6 @@
 import os
 import json
+import datetime
 from indra import get_config
 
 # Before the import, we have to deal with the CLASSPATH to avoid clashes
@@ -69,15 +70,17 @@ class EidosReader(object):
             eidos = autoclass(eidos_package + '.EidosSystem')
             self.eidos_reader = eidos(autoclass('java.lang.Object')())
 
-        default_arg = autoclass('scala.Some')(None)
+        default_arg = lambda x: autoclass('scala.Some')(x)
+        today = datetime.date.today().strftime("%Y-%m-%d")
+        fname = 'default_file_name'
 
-        annot_doc = \
-            self.eidos_reader.extractFromText(text,
-                                              True, # keep text
-                                              False, # CAG-relevant only
-                                              default_arg, # doc creation time
-                                              default_arg # file name
-                                              )
+        annot_doc = self.eidos_reader.extractFromText(
+            text,
+            True, # keep text
+            False, # CAG-relevant only
+            default_arg(today), # doc creation time
+            default_arg(fname) # file name
+            )
         if format == 'json':
             mentions = annot_doc.odinMentions()
             ser = autoclass(eidos_package +

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -171,6 +171,7 @@ __all__ = [
     'Activation', 'GtpActivation', 'ActiveForm', 'HasActivity', 'Gef', 'Gap',
     'Complex', 'Translocation', 'RegulateAmount', 'DecreaseAmount',
     'IncreaseAmount', 'Influence', 'Conversion', 'Unresolved',
+    'Association',
 
     # Error classes
     'InputError', 'UnresolvedUuidError', 'InvalidLocationError',
@@ -2459,7 +2460,8 @@ class Complex(Statement):
         self.members = agent_list
 
     def __str__(self):
-        s = "Complex(%s)" % (', '.join([('%s' % m) for m in self.members]))
+        s = '%s(%s)' % (type(self).__name__,
+                        (', '.join([('%s' % m) for m in self.members])))
         return s
 
     def refinement_of(self, other, hierarchies):
@@ -2893,7 +2895,6 @@ class Influence(IncreaseAmount):
         stmt = cls(subj, obj, subj_delta, obj_delta)
         return stmt
 
-
     def __repr__(self):
         if sys.version_info[0] >= 3:
             return self.__str__()
@@ -2920,6 +2921,10 @@ class Influence(IncreaseAmount):
                              _influence_concept_str(self.obj,
                                                     self.obj_delta)))
         return s
+
+
+class Association(Complex):
+    pass
 
 
 class Conversion(Statement):

--- a/indra/tests/eidos_coref.json
+++ b/indra/tests/eidos_coref.json
@@ -1,0 +1,1326 @@
+{
+  "@context": {
+    "Argument": "https://github.com/clulab/eidos/wiki/JSON-LD#Argument",
+    "Corpus": "https://github.com/clulab/eidos/wiki/JSON-LD#Corpus",
+    "Dependency": "https://github.com/clulab/eidos/wiki/JSON-LD#Dependency",
+    "Document": "https://github.com/clulab/eidos/wiki/JSON-LD#Document",
+    "Extraction": "https://github.com/clulab/eidos/wiki/JSON-LD#Extraction",
+    "Grounding": "https://github.com/clulab/eidos/wiki/JSON-LD#Grounding",
+    "Groundings": "https://github.com/clulab/eidos/wiki/JSON-LD#Groundings",
+    "Interval": "https://github.com/clulab/eidos/wiki/JSON-LD#Interval",
+    "Provenance": "https://github.com/clulab/eidos/wiki/JSON-LD#Provenance",
+    "Sentence": "https://github.com/clulab/eidos/wiki/JSON-LD#Sentence",
+    "Trigger": "https://github.com/clulab/eidos/wiki/JSON-LD#Trigger",
+    "Word": "https://github.com/clulab/eidos/wiki/JSON-LD#Word"
+  },
+  "@type": "Corpus",
+  "documents": [
+    {
+      "@type": "Document",
+      "@id": "_:Document_1",
+      "title": "default_file_name",
+      "text": "Rainfall causes floods. That causes displacement.",
+      "sentences": [
+        {
+          "@type": "Sentence",
+          "@id": "_:Sentence_1",
+          "text": "Rainfall causes floods .",
+          "words": [
+            {
+              "@type": "Word",
+              "@id": "_:Word_1",
+              "text": "Rainfall",
+              "tag": "NN",
+              "entity": "O",
+              "startOffset": 0,
+              "endOffset": 8,
+              "lemma": "rainfall",
+              "chunk": "B-NP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_2",
+              "text": "causes",
+              "tag": "VBZ",
+              "entity": "O",
+              "startOffset": 9,
+              "endOffset": 15,
+              "lemma": "cause",
+              "chunk": "B-VP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_3",
+              "text": "floods",
+              "tag": "NNS",
+              "entity": "O",
+              "startOffset": 16,
+              "endOffset": 22,
+              "lemma": "flood",
+              "chunk": "B-NP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_4",
+              "text": ".",
+              "tag": ".",
+              "entity": "O",
+              "startOffset": 22,
+              "endOffset": 23,
+              "lemma": ".",
+              "chunk": "O",
+              "norm": "O"
+            }
+          ],
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_2"
+              },
+              "destination": {
+                "@id": "_:Word_1"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_2"
+              },
+              "destination": {
+                "@id": "_:Word_3"
+              },
+              "relation": "dobj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_2"
+              },
+              "destination": {
+                "@id": "_:Word_4"
+              },
+              "relation": "punct"
+            }
+          ]
+        },
+        {
+          "@type": "Sentence",
+          "@id": "_:Sentence_2",
+          "text": "That causes displacement .",
+          "words": [
+            {
+              "@type": "Word",
+              "@id": "_:Word_5",
+              "text": "That",
+              "tag": "DT",
+              "entity": "O",
+              "startOffset": 24,
+              "endOffset": 28,
+              "lemma": "that",
+              "chunk": "B-NP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_6",
+              "text": "causes",
+              "tag": "VBZ",
+              "entity": "O",
+              "startOffset": 29,
+              "endOffset": 35,
+              "lemma": "cause",
+              "chunk": "B-VP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_7",
+              "text": "displacement",
+              "tag": "NN",
+              "entity": "O",
+              "startOffset": 36,
+              "endOffset": 48,
+              "lemma": "displacement",
+              "chunk": "B-NP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_8",
+              "text": ".",
+              "tag": ".",
+              "entity": "O",
+              "startOffset": 48,
+              "endOffset": 49,
+              "lemma": ".",
+              "chunk": "O",
+              "norm": "O"
+            }
+          ],
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_6"
+              },
+              "destination": {
+                "@id": "_:Word_7"
+              },
+              "relation": "dobj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_6"
+              },
+              "destination": {
+                "@id": "_:Word_8"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_6"
+              },
+              "destination": {
+                "@id": "_:Word_5"
+              },
+              "relation": "nsubj"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "extractions": [
+    {
+      "@type": "Extraction",
+      "@id": "_:Extraction_4",
+      "type": "concept",
+      "subtype": "entity",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "text": "floods",
+      "rule": "simple-np",
+      "canonicalName": "flood",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/natural_disaster/flooding",
+              "value": 0.9353290274886591
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/natural_disaster/storm",
+              "value": 0.6189894339124961
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/natural_disaster/drought",
+              "value": 0.5289940920564022
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/peacekeeping and security/water sanitation hygiene/creation of temporary water points",
+              "value": 0.5053679501454721
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/irrigation",
+              "value": 0.4809641828969437
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/weather/precipitation",
+              "value": 0.473470676221186
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/natural_resources/abiotic_resources/water",
+              "value": 0.4679383993282176
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/water sanitation hygiene/provision of water treatment of piped water supply",
+              "value": 0.4534984084117691
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/infrastructure/water_management",
+              "value": 0.4477323114993594
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/food security/provision of food security or famine early warning system",
+              "value": 0.42911973146258015
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "wdi",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Droughts,_floods,_extreme_temperatures_(%_of_population,_average_1990-2009)",
+              "value": 0.5718668060545544
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Agricultural_irrigated_land_(%_of_total_agricultural_land)",
+              "value": 0.500026796782901
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Surface_area_(sq._km)",
+              "value": 0.4718357568605044
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Renewable_internal_freshwater_resources,_total_(billion_cubic_meters)",
+              "value": 0.44444700441727664
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/People_using_safely_managed_drinking_water_services_(%_of_population)",
+              "value": 0.43058831598440517
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/People_using_safely_managed_drinking_water_services,_rural_(%_of_rural_population)",
+              "value": 0.43058831598440517
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/People_using_safely_managed_drinking_water_services,_urban_(%_of_urban_population)",
+              "value": 0.43058831598440517
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Renewable_internal_freshwater_resources_per_capita_(cubic_meters)",
+              "value": 0.42065920089750114
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/People_using_at_least_basic_sanitation_services_(%_of_population)",
+              "value": 0.4198439490711321
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/People_using_at_least_basic_sanitation_services,_urban_(%_of_urban_population)",
+              "value": 0.4198439490711321
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "fao",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Share in Forest area/Planted forest",
+              "value": 0.40045577935246784
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Share in Forest area/Primary forest",
+              "value": 0.40045577935246784
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Value/Prevalence of severe food insecurity in the total population",
+              "value": 0.38994353912848706
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Share in Forest area/Other naturally regenerated forest",
+              "value": 0.38107122068417076
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Share in Agricultural area/Total area equipped for irrigation",
+              "value": 0.37878457603449306
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Area/Arable land and Permanent crops",
+              "value": 0.37690497218300145
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Area/Total area equipped for irrigation",
+              "value": 0.3721119108704715
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Burned Area/Closed shrubland",
+              "value": 0.36908992407750263
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Burned Area/Open shrubland",
+              "value": 0.36908992407750263
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Gross Production Value (constant 2004-2006 1000 I$)/Fruit, tropical fresh nes",
+              "value": 0.3579761216824978
+            }
+          ]
+        }
+      ],
+      "provenance": [
+        {
+          "@type": "Provenance",
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "documentCharInterval": [
+            {
+              "@type": "Interval",
+              "start": 17,
+              "end": 22
+            }
+          ],
+          "sentence": {
+            "@id": "_:Sentence_1"
+          },
+          "positions": [
+            {
+              "@type": "Interval",
+              "start": 3,
+              "end": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "Extraction",
+      "@id": "_:Extraction_5",
+      "type": "concept",
+      "subtype": "entity",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "text": "displacement",
+      "rule": "simple-np",
+      "canonicalName": "displacement",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/human_migration",
+              "value": 0.6546270763202365
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/physical_insecurity",
+              "value": 0.5671727886043954
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/famine",
+              "value": 0.5569336505634456
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/financial/economic/poverty",
+              "value": 0.4764737470607766
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_insecurity",
+              "value": 0.4283068640558835
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/natural_disaster/drought",
+              "value": 0.41650638042599636
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/nature_impact/pollution/climate_change",
+              "value": 0.40917020219348643
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/conflict",
+              "value": 0.38051240824949834
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/protection/provision of legal aid for displaced persons",
+              "value": 0.37166802229289825
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/intervention/intervention",
+              "value": 0.367468114798105
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "wdi",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Internally_displaced_persons,_total_displaced_by_conflict_and_violence_(number_of_people)",
+              "value": 0.5188317090209378
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Internally_displaced_persons,_new_displacement_associated_with_disasters_(number_of_cases)",
+              "value": 0.5022043752824866
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Internally_displaced_persons,_new_displacement_associated_with_conflict_and_violence_(number_of_cases)",
+              "value": 0.5022043752824866
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Droughts,_floods,_extreme_temperatures_(%_of_population,_average_1990-2009)",
+              "value": 0.46678378443611845
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Rural_poverty_gap_at_national_poverty_lines_(%)",
+              "value": 0.43441694024698546
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Urban_poverty_gap_at_national_poverty_lines_(%)",
+              "value": 0.43126518636252725
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Intentional_homicides_(per_100,000_people)",
+              "value": 0.41879478458419633
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Battle-related_deaths_(number_of_people)",
+              "value": 0.40916073966520444
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Rural_poverty_headcount_ratio_at_national_poverty_lines_(%_of_rural_population)",
+              "value": 0.40098559359431146
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Urban_poverty_headcount_ratio_at_national_poverty_lines_(%_of_urban_population)",
+              "value": 0.39733830102505346
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "fao",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Value/Prevalence of severe food insecurity in the total population",
+              "value": 0.5134661984857619
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Rural population/Population - Est. & Proj.",
+              "value": 0.4080055031379335
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Urban population/Population - Est. & Proj.",
+              "value": 0.4080055031379335
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Gross Production Value (constant 2004-2006 1000 I$)/Meat indigenous, total",
+              "value": 0.348034511855539
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Net Production Value (constant 2004-2006 1000 I$)/Meat indigenous, total",
+              "value": 0.348034511855539
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Value/Per capita food production variability (I$ per person constant 2004-06)",
+              "value": 0.3305800488856844
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Value/Political stability and absence of violence\\/terrorism (index)",
+              "value": 0.3286796004901052
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Value/Number of people undernourished (millions) (3-year average)",
+              "value": 0.3193548825158809
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Value/Prevalence of undernourishment (%) (3-year average)",
+              "value": 0.3134795705369154
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Production/Meat indigenous, total",
+              "value": 0.29557280987826856
+            }
+          ]
+        }
+      ],
+      "provenance": [
+        {
+          "@type": "Provenance",
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "documentCharInterval": [
+            {
+              "@type": "Interval",
+              "start": 37,
+              "end": 48
+            }
+          ],
+          "sentence": {
+            "@id": "_:Sentence_2"
+          },
+          "positions": [
+            {
+              "@type": "Interval",
+              "start": 3,
+              "end": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "Extraction",
+      "@id": "_:Extraction_6",
+      "type": "concept",
+      "subtype": "entity",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "text": "That",
+      "rule": "simple-np",
+      "canonicalName": "That",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/health/provision of first aid and and basic medical care",
+              "value": 0.46430080490350506
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/food security/provision of food for work",
+              "value": 0.45173303320459995
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/early recovery/provision of provision of credit and training for income generation",
+              "value": 0.44767158882602637
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/food security/provision of cash for work",
+              "value": 0.445423450049089
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/food security/provision of provision of seeds, fertilizers and tools",
+              "value": 0.4264678064477528
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/nutrition/provision of infant and young child feeding",
+              "value": 0.42138512710525294
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/food security/provision of food security or famine early warning system",
+              "value": 0.4188199306449723
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/emergency shelter and nfi/provision of support to hosting families or communities",
+              "value": 0.40408600007304485
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/protection/provision of public information campaigns on explosive hazards",
+              "value": 0.40255090237958485
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/health/provision of assessment and triage of health facilities",
+              "value": 0.4006319302422844
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "wdi",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Literacy_rate,_adult_total_(%_of_people_ages_15_and_above)",
+              "value": 0.46426056144640576
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Literacy_rate,_adult_female_(%_of_females_ages_15_and_above)",
+              "value": 0.46426056144640576
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Literacy_rate,_youth_total_(%_of_people_ages_15-24)",
+              "value": 0.46426056144640576
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Literacy_rate,_youth_female_(%_of_females_ages_15-24)",
+              "value": 0.46426056144640576
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Literacy_rate,_youth_male_(%_of_males_ages_15-24)",
+              "value": 0.46426056144640576
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Literacy_rate,_adult_male_(%_of_males_ages_15_and_above)",
+              "value": 0.46426056144640576
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Inflation,_GDP_deflator:_linked_series_(annual_%)",
+              "value": 0.44771666159158924
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Residual,_debt_stock-flow_reconciliation_(current_US$)",
+              "value": 0.4377757123402855
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Informal_payments_to_public_officials_(%_of_firms)",
+              "value": 0.4361068820966492
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Nonpregnant_and_nonnursing_women_can_do_the_same_jobs_as_men_(1=yes;_0=no)",
+              "value": 0.43099767942130907
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "fao",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Emissions intensity/Milk, whole fresh cow",
+              "value": 0.3585802199426559
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Production/Cabbages and other brassicas",
+              "value": 0.351815677489778
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Production/Melons, other (inc.cantaloupes)",
+              "value": 0.3439785830836689
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Yield/Melons, other (inc.cantaloupes)",
+              "value": 0.3439785830836689
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Production/Plantains and others",
+              "value": 0.34155525318939634
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Value/Percentage of children under 5 years of age affected by wasting (%)",
+              "value": 0.3355177716376748
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Value/Percentage of children under 5 years of age who are stunted (%)",
+              "value": 0.33335092431748026
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Value/Percentage of children under 5 years of age who are overweight",
+              "value": 0.33322288348683554
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Emissions (CO2eq)/Milk, whole fresh cow",
+              "value": 0.3279954488216938
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Milk Animals/Milk, whole fresh cow",
+              "value": 0.3279954488216938
+            }
+          ]
+        }
+      ],
+      "provenance": [
+        {
+          "@type": "Provenance",
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "documentCharInterval": [
+            {
+              "@type": "Interval",
+              "start": 25,
+              "end": 28
+            }
+          ],
+          "sentence": {
+            "@id": "_:Sentence_2"
+          },
+          "positions": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "Extraction",
+      "@id": "_:Extraction_7",
+      "type": "concept",
+      "subtype": "entity",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "text": "Rainfall",
+      "rule": "simple-np",
+      "canonicalName": "rainfall",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/weather/precipitation",
+              "value": 0.8835828506228278
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/natural_disaster/storm",
+              "value": 0.6318839623705592
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/natural_disaster/drought",
+              "value": 0.5856365341308741
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/natural_disaster/flooding",
+              "value": 0.5203313035622629
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/natural_resources/abiotic_resources/water",
+              "value": 0.4489542471740163
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/agriculture/farming",
+              "value": 0.43529457032420366
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/irrigation",
+              "value": 0.43501602393092303
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/nature_impact/pollution/climate_change",
+              "value": 0.4322568304741899
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/temporal/seasons/season",
+              "value": 0.4279267678803291
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/nature_impact/pollution/land_pollution",
+              "value": 0.4126711799296319
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "wdi",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Droughts,_floods,_extreme_temperatures_(%_of_population,_average_1990-2009)",
+              "value": 0.6012187996587823
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Average_precipitation_in_depth_(mm_per_year)",
+              "value": 0.5206149126386592
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Adjusted_savings:_particulate_emission_damage_(%_of_GNI)",
+              "value": 0.4701822078576575
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Adjusted_savings:_particulate_emission_damage_(current_US$)",
+              "value": 0.4701822078576575
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Renewable_internal_freshwater_resources,_total_(billion_cubic_meters)",
+              "value": 0.4665010640719087
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/PM2.5_air_pollution,_mean_annual_exposure_(micrograms_per_cubic_meter)",
+              "value": 0.45454589722273697
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Agricultural_irrigated_land_(%_of_total_agricultural_land)",
+              "value": 0.4454120235983008
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Renewable_internal_freshwater_resources_per_capita_(cubic_meters)",
+              "value": 0.4356758804045064
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Annual_freshwater_withdrawals,_agriculture_(%_of_total_freshwater_withdrawal)",
+              "value": 0.41969824611912776
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/PM2.5_pollution,_population_exposed_to_levels_exceeding_WHO_Interim_Target-2_value_(%_of_total)",
+              "value": 0.41887922562083435
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "fao",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Area harvested/Fruit, tropical fresh nes",
+              "value": 0.49830057444752196
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Gross Production Value (constant 2004-2006 1000 I$)/Fruit, tropical fresh nes",
+              "value": 0.46862428543298285
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Net Production Value (constant 2004-2006 1000 I$)/Fruit, tropical fresh nes",
+              "value": 0.46862428543298285
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Production/Fruit, tropical fresh nes",
+              "value": 0.4668152548354123
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Yield/Fruit, tropical fresh nes",
+              "value": 0.4668152548354123
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Implied emission factor for CH4 (Burning - savanna)/Open shrubland",
+              "value": 0.45916093813118886
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Implied emission factor for CH4 (Burning - savanna)/Closed shrubland",
+              "value": 0.45916093813118886
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Implied emission factor for N2O (Burning - savanna)/Open shrubland",
+              "value": 0.45916093813118886
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Implied emission factor for N2O (Burning - savanna)/Closed shrubland",
+              "value": 0.45916093813118886
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Emissions (CO2eq) (Crop residues)/Beans, dry",
+              "value": 0.43770723984560744
+            }
+          ]
+        }
+      ],
+      "provenance": [
+        {
+          "@type": "Provenance",
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "documentCharInterval": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 8
+            }
+          ],
+          "sentence": {
+            "@id": "_:Sentence_1"
+          },
+          "positions": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "Extraction",
+      "@id": "_:Extraction_1",
+      "type": "relation",
+      "subtype": "causation",
+      "labels": [
+        "Causal",
+        "DirectedRelation",
+        "EntityLinker",
+        "Event"
+      ],
+      "text": "That causes displacement",
+      "rule": "ported_syntax_1_verb-Causal",
+      "canonicalName": "That cause displacement",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "un"
+        },
+        {
+          "@type": "Groundings",
+          "name": "wdi"
+        },
+        {
+          "@type": "Groundings",
+          "name": "fao"
+        }
+      ],
+      "provenance": [
+        {
+          "@type": "Provenance",
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "documentCharInterval": [
+            {
+              "@type": "Interval",
+              "start": 25,
+              "end": 48
+            }
+          ],
+          "sentence": {
+            "@id": "_:Sentence_2"
+          },
+          "positions": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 3
+            }
+          ]
+        }
+      ],
+      "trigger": {
+        "@type": "Trigger",
+        "text": "causes",
+        "provenance": [
+          {
+            "@type": "Provenance",
+            "document": {
+              "@id": "_:Document_1"
+            },
+            "documentCharInterval": [
+              {
+                "@type": "Interval",
+                "start": 30,
+                "end": 35
+              }
+            ],
+            "sentence": {
+              "@id": "_:Sentence_2"
+            },
+            "positions": [
+              {
+                "@type": "Interval",
+                "start": 2,
+                "end": 2
+              }
+            ]
+          }
+        ]
+      },
+      "arguments": [
+        {
+          "@type": "Argument",
+          "type": "source",
+          "value": {
+            "@id": "_:Extraction_6"
+          }
+        },
+        {
+          "@type": "Argument",
+          "type": "destination",
+          "value": {
+            "@id": "_:Extraction_5"
+          }
+        }
+      ]
+    },
+    {
+      "@type": "Extraction",
+      "@id": "_:Extraction_2",
+      "type": "relation",
+      "subtype": "causation",
+      "labels": [
+        "Causal",
+        "DirectedRelation",
+        "EntityLinker",
+        "Event"
+      ],
+      "text": "Rainfall causes floods",
+      "rule": "ported_syntax_1_verb-Causal",
+      "canonicalName": "rainfall cause flood",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "un"
+        },
+        {
+          "@type": "Groundings",
+          "name": "wdi"
+        },
+        {
+          "@type": "Groundings",
+          "name": "fao"
+        }
+      ],
+      "provenance": [
+        {
+          "@type": "Provenance",
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "documentCharInterval": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 22
+            }
+          ],
+          "sentence": {
+            "@id": "_:Sentence_1"
+          },
+          "positions": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 3
+            }
+          ]
+        }
+      ],
+      "trigger": {
+        "@type": "Trigger",
+        "text": "causes",
+        "provenance": [
+          {
+            "@type": "Provenance",
+            "document": {
+              "@id": "_:Document_1"
+            },
+            "documentCharInterval": [
+              {
+                "@type": "Interval",
+                "start": 10,
+                "end": 15
+              }
+            ],
+            "sentence": {
+              "@id": "_:Sentence_1"
+            },
+            "positions": [
+              {
+                "@type": "Interval",
+                "start": 2,
+                "end": 2
+              }
+            ]
+          }
+        ]
+      },
+      "arguments": [
+        {
+          "@type": "Argument",
+          "type": "source",
+          "value": {
+            "@id": "_:Extraction_7"
+          }
+        },
+        {
+          "@type": "Argument",
+          "type": "destination",
+          "value": {
+            "@id": "_:Extraction_4"
+          }
+        }
+      ]
+    },
+    {
+      "@type": "Extraction",
+      "@id": "_:Extraction_3",
+      "type": "relation",
+      "subtype": "coreference",
+      "labels": [
+        "Coreference",
+        "DirectedRelation",
+        "EntityLinker",
+        "Event"
+      ],
+      "text": "floods . . . That",
+      "rule": "BasicCorefAction_ant:ported_syntax_1_verb-Causal_ana:ported_syntax_1_verb-Causal",
+      "canonicalName": "flood That",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "un"
+        },
+        {
+          "@type": "Groundings",
+          "name": "wdi"
+        },
+        {
+          "@type": "Groundings",
+          "name": "fao"
+        }
+      ],
+      "provenance": [
+        {
+          "@type": "Provenance",
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "documentCharInterval": [
+            {
+              "@type": "Interval",
+              "start": 17,
+              "end": 22
+            }
+          ],
+          "sentence": {
+            "@id": "_:Sentence_1"
+          },
+          "positions": [
+            {
+              "@type": "Interval",
+              "start": 3,
+              "end": 3
+            }
+          ]
+        },
+        {
+          "@type": "Provenance",
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "documentCharInterval": [
+            {
+              "@type": "Interval",
+              "start": 25,
+              "end": 28
+            }
+          ],
+          "sentence": {
+            "@id": "_:Sentence_2"
+          },
+          "positions": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 1
+            }
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "@type": "Argument",
+          "type": "anchor",
+          "value": {
+            "@id": "_:Extraction_4"
+          }
+        },
+        {
+          "@type": "Argument",
+          "type": "reference",
+          "value": {
+            "@id": "_:Extraction_6"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/indra/tests/eidos_correlation.json
+++ b/indra/tests/eidos_correlation.json
@@ -1,0 +1,932 @@
+{
+  "@context": {
+    "Argument": "https://github.com/clulab/eidos/wiki/JSON-LD#Argument",
+    "Corpus": "https://github.com/clulab/eidos/wiki/JSON-LD#Corpus",
+    "Dependency": "https://github.com/clulab/eidos/wiki/JSON-LD#Dependency",
+    "Document": "https://github.com/clulab/eidos/wiki/JSON-LD#Document",
+    "Extraction": "https://github.com/clulab/eidos/wiki/JSON-LD#Extraction",
+    "Grounding": "https://github.com/clulab/eidos/wiki/JSON-LD#Grounding",
+    "Groundings": "https://github.com/clulab/eidos/wiki/JSON-LD#Groundings",
+    "Interval": "https://github.com/clulab/eidos/wiki/JSON-LD#Interval",
+    "Provenance": "https://github.com/clulab/eidos/wiki/JSON-LD#Provenance",
+    "Sentence": "https://github.com/clulab/eidos/wiki/JSON-LD#Sentence",
+    "State": "https://github.com/clulab/eidos/wiki/JSON-LD#State",
+    "Trigger": "https://github.com/clulab/eidos/wiki/JSON-LD#Trigger",
+    "Word": "https://github.com/clulab/eidos/wiki/JSON-LD#Word"
+  },
+  "@type": "Corpus",
+  "documents": [
+    {
+      "@type": "Document",
+      "@id": "_:Document_1",
+      "title": "default_file_name",
+      "text": "Requirements are higher than usual given below-average harvests.",
+      "sentences": [
+        {
+          "@type": "Sentence",
+          "@id": "_:Sentence_1",
+          "text": "Requirements are higher than usual given below-average harvests .",
+          "words": [
+            {
+              "@type": "Word",
+              "@id": "_:Word_1",
+              "text": "Requirements",
+              "tag": "NNS",
+              "entity": "O",
+              "startOffset": 0,
+              "endOffset": 12,
+              "lemma": "requirement",
+              "chunk": "B-NP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_2",
+              "text": "are",
+              "tag": "VBP",
+              "entity": "O",
+              "startOffset": 13,
+              "endOffset": 16,
+              "lemma": "be",
+              "chunk": "B-VP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_3",
+              "text": "higher",
+              "tag": "JJR",
+              "entity": "O",
+              "startOffset": 17,
+              "endOffset": 23,
+              "lemma": "higher",
+              "chunk": "B-ADJP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_4",
+              "text": "than",
+              "tag": "IN",
+              "entity": "O",
+              "startOffset": 24,
+              "endOffset": 28,
+              "lemma": "than",
+              "chunk": "B-PP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_5",
+              "text": "usual",
+              "tag": "JJ",
+              "entity": "B-Quantifier",
+              "startOffset": 29,
+              "endOffset": 34,
+              "lemma": "usual",
+              "chunk": "B-ADJP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_6",
+              "text": "given",
+              "tag": "VBN",
+              "entity": "O",
+              "startOffset": 35,
+              "endOffset": 40,
+              "lemma": "give",
+              "chunk": "B-PP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_7",
+              "text": "below-average",
+              "tag": "JJ",
+              "entity": "B-Quantifier",
+              "startOffset": 41,
+              "endOffset": 54,
+              "lemma": "below-average",
+              "chunk": "B-NP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_8",
+              "text": "harvests",
+              "tag": "NNS",
+              "entity": "O",
+              "startOffset": 55,
+              "endOffset": 63,
+              "lemma": "harvest",
+              "chunk": "I-NP",
+              "norm": "O"
+            },
+            {
+              "@type": "Word",
+              "@id": "_:Word_9",
+              "text": ".",
+              "tag": ".",
+              "entity": "O",
+              "startOffset": 63,
+              "endOffset": 64,
+              "lemma": ".",
+              "chunk": "O",
+              "norm": "O"
+            }
+          ],
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_3"
+              },
+              "destination": {
+                "@id": "_:Word_1"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_3"
+              },
+              "destination": {
+                "@id": "_:Word_2"
+              },
+              "relation": "cop"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_3"
+              },
+              "destination": {
+                "@id": "_:Word_5"
+              },
+              "relation": "advcl_than"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_3"
+              },
+              "destination": {
+                "@id": "_:Word_8"
+              },
+              "relation": "nmod_given"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_3"
+              },
+              "destination": {
+                "@id": "_:Word_9"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_5"
+              },
+              "destination": {
+                "@id": "_:Word_4"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_6"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_7"
+              },
+              "relation": "amod"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "extractions": [
+    {
+      "@type": "Extraction",
+      "@id": "_:Extraction_2",
+      "type": "concept",
+      "subtype": "entity",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "text": "below-average harvests",
+      "rule": "gradable-lexiconner++simple-np++quantification2++Decrease_adjective_rule_1",
+      "canonicalName": "harvest",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/agriculture/food_production",
+              "value": 0.7760037688059039
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop",
+              "value": 0.7209174764718157
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/agriculture/farming",
+              "value": 0.7019236796500076
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/temporal/seasons/crop_season",
+              "value": 0.6996931682436409
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/agriculture/planting",
+              "value": 0.5773615983316912
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/natural_disaster/drought",
+              "value": 0.5443016477539813
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/temporal/seasons/season",
+              "value": 0.5274858049999827
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/biology/flora",
+              "value": 0.5023854261927698
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/food_availability",
+              "value": 0.49724580218692427
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/pest",
+              "value": 0.4835281601145614
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "wdi",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Cereal_yield_(kg_per_hectare)",
+              "value": 0.7919416597640769
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Land_under_cereal_production_(hectares)",
+              "value": 0.7610487860514028
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Cereal_production_(metric_tons)",
+              "value": 0.7367477968567713
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Permanent_cropland_(%_of_land_area)",
+              "value": 0.6557552251733537
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Aquaculture_production_(metric_tons)",
+              "value": 0.5801542428678659
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Agricultural_land_(%_of_land_area)",
+              "value": 0.5783654762851472
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Agricultural_land_(sq._km)",
+              "value": 0.5783654762851472
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Food_imports_(%_of_merchandise_imports)",
+              "value": 0.5463343289589009
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Food_exports_(%_of_merchandise_exports)",
+              "value": 0.5463343289589009
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Food_production_index_(2004-2006_=_100)",
+              "value": 0.5335518281903183
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "fao",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Area harvested/Seed cotton",
+              "value": 0.7792690155133223
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Area harvested/Cereals,Total",
+              "value": 0.7592553461847585
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Area harvested/Maize",
+              "value": 0.7592553461847585
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Area harvested/Okra",
+              "value": 0.7592553461847585
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Area harvested/Watermelons",
+              "value": 0.7592553461847585
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Area harvested/Yams",
+              "value": 0.7592553461847585
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Area harvested/Melonseed",
+              "value": 0.7592553461847585
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Area harvested/Tomatoes",
+              "value": 0.7592553461847585
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Area harvested/Wheat",
+              "value": 0.7592553461847585
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Area harvested/Pulses,Total",
+              "value": 0.7592553461847585
+            }
+          ]
+        }
+      ],
+      "provenance": [
+        {
+          "@type": "Provenance",
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "documentCharInterval": [
+            {
+              "@type": "Interval",
+              "start": 42,
+              "end": 63
+            }
+          ],
+          "sentence": {
+            "@id": "_:Sentence_1"
+          },
+          "positions": [
+            {
+              "@type": "Interval",
+              "start": 7,
+              "end": 8
+            }
+          ]
+        }
+      ],
+      "states": [
+        {
+          "@type": "State",
+          "type": "DEC",
+          "text": "below-average",
+          "provenance": {
+            "@type": "Provenance",
+            "document": {
+              "@id": "_:Document_1"
+            },
+            "documentCharInterval": [
+              {
+                "@type": "Interval",
+                "start": 42,
+                "end": 54
+              }
+            ],
+            "sentence": {
+              "@id": "_:Sentence_1"
+            },
+            "positions": [
+              {
+                "@type": "Interval",
+                "start": 7,
+                "end": 7
+              }
+            ]
+          }
+        },
+        {
+          "@type": "State",
+          "type": "QUANT",
+          "text": "below-average",
+          "provenance": {
+            "@type": "Provenance",
+            "document": {
+              "@id": "_:Document_1"
+            },
+            "documentCharInterval": [
+              {
+                "@type": "Interval",
+                "start": 42,
+                "end": 54
+              }
+            ],
+            "sentence": {
+              "@id": "_:Sentence_1"
+            },
+            "positions": [
+              {
+                "@type": "Interval",
+                "start": 7,
+                "end": 7
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "@type": "Extraction",
+      "@id": "_:Extraction_3",
+      "type": "concept",
+      "subtype": "entity",
+      "labels": [
+        "Quantifier"
+      ],
+      "text": "below-average",
+      "rule": "gradable-lexiconner",
+      "canonicalName": "below-average",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "un"
+        },
+        {
+          "@type": "Groundings",
+          "name": "wdi"
+        },
+        {
+          "@type": "Groundings",
+          "name": "fao"
+        }
+      ],
+      "provenance": [
+        {
+          "@type": "Provenance",
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "documentCharInterval": [
+            {
+              "@type": "Interval",
+              "start": 42,
+              "end": 54
+            }
+          ],
+          "sentence": {
+            "@id": "_:Sentence_1"
+          },
+          "positions": [
+            {
+              "@type": "Interval",
+              "start": 7,
+              "end": 7
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "Extraction",
+      "@id": "_:Extraction_4",
+      "type": "concept",
+      "subtype": "entity",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "text": "Requirements",
+      "rule": "simple-np++Increase_ported_syntax_2_verb",
+      "canonicalName": "requirement",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/water sanitation hygiene/provision of basic minimum household hygiene item package",
+              "value": 0.5723718720746214
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/government/government_actions/regulation",
+              "value": 0.5634914984757506
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/education/provision of provision of education kits",
+              "value": 0.5619662090225567
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/education/provision of provision of non-formal education",
+              "value": 0.5572186369656663
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/protection/provision of temporary policing services",
+              "value": 0.5516303038939027
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/nutrition/provision of micro-nutrient supplementation",
+              "value": 0.5375653531358078
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/food security/provision of provision of veterinary services",
+              "value": 0.5282326162692477
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/health/provision of epidemiological surveillance system",
+              "value": 0.5185140557458452
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/nutrition/provision of malnutrition screening",
+              "value": 0.5159445262549787
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/provision of goods and services/health/provision of anti-retroviral treatment",
+              "value": 0.5126603493974067
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "wdi",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Nondiscrimination_clause_mentions_gender_in_the_constitution_(1=yes;_0=no)",
+              "value": 0.6018845797722782
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Time_spent_dealing_with_the_requirements_of_government_regulations_(%_of_senior_management_time)",
+              "value": 0.5798472330192773
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Grants,_excluding_technical_cooperation_(BoP,_current_US$)",
+              "value": 0.5763203850608531
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Strength_of_legal_rights_index_(0=weak_to_12=strong)",
+              "value": 0.5672185432748084
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Procedures_to_register_property_(number)",
+              "value": 0.5667104756525616
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Time_required_to_get_electricity_(days)",
+              "value": 0.5652600216467506
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Law_mandates_nondiscrimination_based_on_gender_in_hiring_(1=yes;_0=no)",
+              "value": 0.5596763764514606
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Time_required_to_enforce_a_contract_(days)",
+              "value": 0.5580706830720562
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Time_to_export,_documentary_compliance_(hours)",
+              "value": 0.5309199153751211
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WDI/Cost_to_export,_documentary_compliance_(US$)",
+              "value": 0.5309199153751211
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "fao",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Implied emission factor for N2O (Manure applied)/Sheep",
+              "value": 0.466289684046509
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Implied emission factor for N2O (Manure applied)/Asses",
+              "value": 0.466289684046509
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Implied emission factor for N2O (Manure applied)/Goats",
+              "value": 0.466289684046509
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Value/Cereal import dependency ratio (%) (3-year average)",
+              "value": 0.454268744008495
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Ratio/Gross Fixed Capital Formation to GDP ratio",
+              "value": 0.452241562960068
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Manure (N content) (Manure applied)/Sheep",
+              "value": 0.38970316497188046
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Manure (N content) (Manure applied)/Sheep and Goats",
+              "value": 0.38970316497188046
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Manure (N content) (Manure applied)/Poultry Birds",
+              "value": 0.38970316497188046
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Manure (N content) (Manure applied)/Chickens",
+              "value": 0.38970316497188046
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "FAO/events/Manure (N content) (Manure applied)/All Animals",
+              "value": 0.38970316497188046
+            }
+          ]
+        }
+      ],
+      "provenance": [
+        {
+          "@type": "Provenance",
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "documentCharInterval": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 12
+            }
+          ],
+          "sentence": {
+            "@id": "_:Sentence_1"
+          },
+          "positions": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 1
+            }
+          ]
+        }
+      ],
+      "states": [
+        {
+          "@type": "State",
+          "type": "INC",
+          "text": "higher",
+          "provenance": {
+            "@type": "Provenance",
+            "document": {
+              "@id": "_:Document_1"
+            },
+            "documentCharInterval": [
+              {
+                "@type": "Interval",
+                "start": 18,
+                "end": 23
+              }
+            ],
+            "sentence": {
+              "@id": "_:Sentence_1"
+            },
+            "positions": [
+              {
+                "@type": "Interval",
+                "start": 3,
+                "end": 3
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "@type": "Extraction",
+      "@id": "_:Extraction_5",
+      "type": "concept",
+      "subtype": "entity",
+      "labels": [
+        "Quantifier"
+      ],
+      "text": "usual",
+      "rule": "gradable-lexiconner",
+      "canonicalName": "usual",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "un"
+        },
+        {
+          "@type": "Groundings",
+          "name": "wdi"
+        },
+        {
+          "@type": "Groundings",
+          "name": "fao"
+        }
+      ],
+      "provenance": [
+        {
+          "@type": "Provenance",
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "documentCharInterval": [
+            {
+              "@type": "Interval",
+              "start": 30,
+              "end": 34
+            }
+          ],
+          "sentence": {
+            "@id": "_:Sentence_1"
+          },
+          "positions": [
+            {
+              "@type": "Interval",
+              "start": 5,
+              "end": 5
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "Extraction",
+      "@id": "_:Extraction_1",
+      "type": "relation",
+      "subtype": "correlation",
+      "labels": [
+        "Correlation",
+        "UndirectedRelation",
+        "EntityLinker",
+        "Event"
+      ],
+      "text": "Requirements are higher than usual given below-average harvests",
+      "rule": "syntax_explicit_Correlation_given",
+      "canonicalName": "requirement give harvest",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "un"
+        },
+        {
+          "@type": "Groundings",
+          "name": "wdi"
+        },
+        {
+          "@type": "Groundings",
+          "name": "fao"
+        }
+      ],
+      "provenance": [
+        {
+          "@type": "Provenance",
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "documentCharInterval": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 63
+            }
+          ],
+          "sentence": {
+            "@id": "_:Sentence_1"
+          },
+          "positions": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 8
+            }
+          ]
+        }
+      ],
+      "trigger": {
+        "@type": "Trigger",
+        "text": "given",
+        "provenance": [
+          {
+            "@type": "Provenance",
+            "document": {
+              "@id": "_:Document_1"
+            },
+            "documentCharInterval": [
+              {
+                "@type": "Interval",
+                "start": 36,
+                "end": 40
+              }
+            ],
+            "sentence": {
+              "@id": "_:Sentence_1"
+            },
+            "positions": [
+              {
+                "@type": "Interval",
+                "start": 6,
+                "end": 6
+              }
+            ]
+          }
+        ]
+      },
+      "arguments": [
+        {
+          "@type": "Argument",
+          "type": "argument",
+          "value": {
+            "@id": "_:Extraction_2"
+          }
+        },
+        {
+          "@type": "Argument",
+          "type": "argument",
+          "value": {
+            "@id": "_:Extraction_4"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/indra/tests/test_eidos.py
+++ b/indra/tests/test_eidos.py
@@ -1,8 +1,8 @@
 import os
+import json
+import requests
 from indra.sources import eidos
 from indra.statements import Influence
-import requests
-import json
 from indra.assemblers.cag import CAGAssembler
 from indra.assemblers.cx import CxAssembler
 from indra.assemblers.pysb import PysbAssembler
@@ -22,15 +22,14 @@ def __get_remote_jsonld():
 
 def __get_stmts_from_remote_jsonld():
     ex_json = __get_remote_jsonld()
-    ep = eidos.process_json_ld(ex_json)
+    ep = eidos.process_json(ex_json)
     assert ep is not None, 'Failed to handle json with eidos processor.'
     assert len(ep.statements), 'Did not get statements from json.'
     return ep.statements
 
 
 def test_process_text():
-    ep = eidos.process_text('The cost of fuel decreases water trucking.',
-                            out_format='json_ld')
+    ep = eidos.process_text('The cost of fuel decreases water trucking.')
     assert ep is not None
     assert len(ep.statements) == 1
     stmt = ep.statements[0]
@@ -43,8 +42,7 @@ def test_process_text():
 
 
 def test_process_text_json_ld():
-    ep = eidos.process_text('The cost of fuel decreases water trucking.',
-                            out_format='json_ld')
+    ep = eidos.process_text('The cost of fuel decreases water trucking.')
     assert ep is not None
     assert len(ep.statements) == 1
     stmt = ep.statements[0]
@@ -68,10 +66,11 @@ def test_process_text_json_ld():
 
 
 def test_process_json_ld_file():
-    ep = eidos.process_json_ld_file(test_jsonld)
+    ep = eidos.process_json_file(test_jsonld)
     assert len(ep.statements) == 1
     assert 'UN' in ep.statements[0].subj.db_refs
     assert 'UN' in ep.statements[0].obj.db_refs
+
 
 def test_eidos_to_cag():
     stmts = __get_stmts_from_remote_jsonld()

--- a/indra/tests/test_eidos.py
+++ b/indra/tests/test_eidos.py
@@ -60,8 +60,11 @@ def test_process_text_json_ld():
     # this should work
     # assert len(stmt.subj.db_refs['UN']) > 5
     # assert len(stmt.obj.db_refs['UN']) > 5
+
+
+def test_sanitize():
     # Make sure sanitization works
-    sanitized = ep._sanitize('-LRB-something-RRB-')
+    sanitized = eidos.processor._sanitize('-LRB-something-RRB-')
     assert sanitized == '(something)'
 
 

--- a/indra/tests/test_eidos.py
+++ b/indra/tests/test_eidos.py
@@ -72,6 +72,18 @@ def test_process_json_ld_file():
     assert 'UN' in ep.statements[0].obj.db_refs
 
 
+def test_process_corefs():
+    coref_jsonld = os.path.join(path_this, 'eidos_coref.json')
+    ep = eidos.process_json_file(coref_jsonld)
+    assert ep.coreferences.get('_:Extraction_6') == '_:Extraction_4'
+    assert len(ep.statements) == 2
+    # Get summaru of subj/objs from statements
+    concepts = [(s.subj.name, s.obj.name) for s in ep.statements]
+    assert ('rainfall', 'flood') in concepts, concepts
+    # This ensures that the coreference was successfully resolved
+    assert ('flood', 'displacement') in concepts, concepts
+
+
 def test_eidos_to_cag():
     stmts = __get_stmts_from_remote_jsonld()
     ca = CAGAssembler()

--- a/indra/tests/test_eidos.py
+++ b/indra/tests/test_eidos.py
@@ -2,7 +2,7 @@ import os
 import json
 import requests
 from indra.sources import eidos
-from indra.statements import Influence
+from indra.statements import Influence, Association
 from indra.assemblers.cag import CAGAssembler
 from indra.assemblers.cx import CxAssembler
 from indra.assemblers.pysb import PysbAssembler
@@ -82,6 +82,16 @@ def test_process_corefs():
     assert ('rainfall', 'flood') in concepts, concepts
     # This ensures that the coreference was successfully resolved
     assert ('flood', 'displacement') in concepts, concepts
+
+
+def test_process_correlations():
+    correl_jsonld = os.path.join(path_this, 'eidos_correlation.json')
+    ep = eidos.process_json_file(correl_jsonld)
+    assert len(ep.statements) == 1
+    st = ep.statements[0]
+    assert isinstance(st, Association)
+    names = {c.name for c in st.members}
+    assert names == {'harvest', 'requirement'}, names
 
 
 def test_eidos_to_cag():


### PR DESCRIPTION
This PR makes the following changes to `indra.sources.eidos`:
- Update the EidosReader to handle the latest method signature for EidosSystem's extractFromText
- Track down coreferences and map entities through these coreferences to their "targets"
- Extract Correlations as `Association` Statements
- Remove the deprecated mentionsJSON-related API functions and Processor and simplify the naming of the API and the remaining JSON-LD Processor (now called EidosProcessor)
- Clean up and refactor the EidosProcessor