### PR TITLE
Handle negative evidence

### DIFF
--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -153,7 +153,6 @@ class SimpleScorer(BeliefScorer):
                         not ev.epistemics.get('negated')]
         neg_evidence = [ev for ev in st.evidence if
                         ev.epistemics.get('negated')]
-        print(pos_evidence, neg_evidence)
         pp = _score(pos_evidence)
         np = _score(neg_evidence)
         # The basic assumption is that the positive and negative evidence

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -98,8 +98,6 @@ class ReachProcessor(object):
 
             # Skip negated events (i.e. something doesn't happen)
             epistemics = self._get_epistemics(r)
-            if epistemics.get('negative'):
-                continue
 
             annotations, context = self._get_annot_context(r)
             frame_id = r['frame_id']
@@ -229,8 +227,6 @@ class ReachProcessor(object):
 
         for r in res:
             epistemics = self._get_epistemics(r)
-            if epistemics.get('negative'):
-                continue
             # Due to an issue with the REACH output serialization
             # (though seemingly not with the raw mentions), sometimes
             # a redundant complex-assembly event is reported which can
@@ -259,8 +255,6 @@ class ReachProcessor(object):
             return
         for r in res:
             epistemics = self._get_epistemics(r)
-            if epistemics.get('negative'):
-                continue
             sentence = r['verbose-text']
             annotations, context = self._get_annot_context(r)
             ev = Evidence(source_api='reach', text=sentence,
@@ -289,8 +283,6 @@ class ReachProcessor(object):
             return
         for r in res:
             epistemics = self._get_epistemics(r)
-            if epistemics.get('negative'):
-                continue
             sentence = r['verbose-text']
             annotations, context = self._get_annot_context(r)
             ev = Evidence(source_api='reach', text=sentence,
@@ -534,7 +526,7 @@ class ReachProcessor(object):
         # Check whether information is negative
         neg = event.get('is_negated')
         if neg is True:
-            epistemics['negative'] = True
+            epistemics['negated'] = True
         # Check if it is a hypothesis
         hyp = event.get('is_hypothesis')
         if hyp is True:

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -98,6 +98,8 @@ class ReachProcessor(object):
 
             # Skip negated events (i.e. something doesn't happen)
             epistemics = self._get_epistemics(r)
+            if epistemics.get('negated'):
+                continue
 
             annotations, context = self._get_annot_context(r)
             frame_id = r['frame_id']
@@ -183,7 +185,7 @@ class ReachProcessor(object):
         for r in all_res:
             subtype = r.get('subtype')
             epistemics = self._get_epistemics(r)
-            if epistemics.get('negative'):
+            if epistemics.get('negated'):
                 continue
             annotations, context = self._get_annot_context(r)
             frame_id = r['frame_id']
@@ -227,6 +229,8 @@ class ReachProcessor(object):
 
         for r in res:
             epistemics = self._get_epistemics(r)
+            if epistemics.get('negated'):
+                continue
             # Due to an issue with the REACH output serialization
             # (though seemingly not with the raw mentions), sometimes
             # a redundant complex-assembly event is reported which can
@@ -255,6 +259,8 @@ class ReachProcessor(object):
             return
         for r in res:
             epistemics = self._get_epistemics(r)
+            if epistemics.get('negated'):
+                continue
             sentence = r['verbose-text']
             annotations, context = self._get_annot_context(r)
             ev = Evidence(source_api='reach', text=sentence,
@@ -283,6 +289,8 @@ class ReachProcessor(object):
             return
         for r in res:
             epistemics = self._get_epistemics(r)
+            if epistemics.get('negated'):
+                continue
             sentence = r['verbose-text']
             annotations, context = self._get_annot_context(r)
             ev = Evidence(source_api='reach', text=sentence,

--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -333,6 +333,18 @@ def test_filter_no_hypothesis():
     st1 = Phosphorylation(None, a, evidence=[ev1, ev2])
     st2 = Phosphorylation(None, a, evidence=[ev1, ev1])
     st_out = ac.filter_no_hypothesis([st1, st2])
+    assert len(st_out) == 1
+
+
+def test_filter_no_negated():
+    a = Agent('MAPK1')
+    ev1 = Evidence(epistemics={'negated': True})
+    ev2 = Evidence(epistemics={'negated': False})
+    st1 = Phosphorylation(None, a, evidence=[ev1, ev2])
+    st2 = Phosphorylation(None, a, evidence=[ev1, ev1])
+    st_out = ac.filter_no_negated([st1, st2])
+    assert len(st_out) == 1
+
 
 def test_belief_cut_plus_filter_top():
     st1 = Phosphorylation(None, Agent('a'))

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -938,6 +938,7 @@ def filter_direct(stmts_in, **kwargs):
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
 
+
 def filter_no_hypothesis(stmts_in, **kwargs):
     """Filter to statements that are not marked as hypothesis in epistemics.
 
@@ -971,6 +972,42 @@ def filter_no_hypothesis(stmts_in, **kwargs):
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
+
+
+def filter_no_negated(stmts_in, **kwargs):
+    """Filter to statements that are not marked as negated in epistemics.
+
+    Parameters
+    ----------
+    stmts_in : list[indra.statements.Statement]
+        A list of statements to filter.
+    save : Optional[str]
+        The name of a pickle file to save the results (stmts_out) into.
+
+    Returns
+    -------
+    stmts_out : list[indra.statements.Statement]
+        A list of filtered statements.
+    """
+    logger.info('Filtering %d statements to not negated...' % len(stmts_in))
+    stmts_out = []
+    for st in stmts_in:
+        all_negated = True
+        ev = None
+        for ev in st.evidence:
+            if not ev.epistemics.get('negated', False):
+                all_negated = False
+                break
+        if ev is None:
+            all_negated = False
+        if not all_negated:
+            stmts_out.append(st)
+    logger.info('%d statements after filter...' % len(stmts_out))
+    dump_pkl = kwargs.get('save')
+    if dump_pkl:
+        dump_statements(stmts_out, dump_pkl)
+    return stmts_out
+
 
 def filter_evidence_source(stmts_in, source_apis, policy='one', **kwargs):
     """Filter to statements that have evidence from a given set of sources.


### PR DESCRIPTION
This PR handles negative evidences for Statements in the BeliefEngine. There could be many possible ways to represent the fact that a Statement is negated, here I chose one where negation is represented at the level of Evidence, not a the level of Statement. This means that pre-assembled Statements will, in general, have a mixture of positive and negative evidence, and it is up to the BeliefEngine to determine how to score the overall belief associated with the Statement given all its evidence. The PR also adds a filter to get rid of Statements that only have negative evidence. Importantly, however, after this PR we will still only get negated Statements from Eidos (#649), they won't yet be extracted from other sources,.