### PR TITLE
Handle timex references and propagate entity context from Eidos

### DIFF
--- a/indra/resources/statements_schema.json
+++ b/indra/resources/statements_schema.json
@@ -131,6 +131,72 @@
             },
             "required": ["name", "db_refs"]
         },
+        "Context": {
+            "type": "object",
+            "description": "The context in which a given Statement was reported.",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "pattern": "^((bio)|(world))$",
+                    "description": "Either 'world' or 'bio', depending on the type of context being repersented."
+                }
+            }
+        },
+        "WorldContext": {
+            "type": "object",
+            "description": "The temporal and spatial context of a Statement.",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "pattern": "^(world)$",
+                    "description": "The type of context, in this case 'world'."
+                },
+                "time": {
+                    "$ref": "#/definitions/TimeContext",
+                    "description": "The temporal context of a Statement."
+                },
+                "geo_location": {
+                    "$ref": "#/definitions/RefContext",
+                    "description": "The geographical context of a Statement."
+                }
+            }
+        },
+        "TimeContext": {
+            "type": "object",
+            "description": "Represents a temporal context.",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The text associated with the temporal context."
+                },
+                "start": {
+                    "type": "string",
+                    "description": "The start time of the temporal context."
+                },
+                "end": {
+                    "type": "string",
+                    "description": "The end time of the temporal context."
+                },
+                "duration": {
+                    "type": "string",
+                    "description": "The duration of the temporal context."
+                }
+            }
+        },
+        "RefContext": {
+            "type": "object",
+            "description": "Represents a context identified by name and grounding references.",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name associated with the context."
+                },
+                "db_refs": {
+                    "type": "object",
+                    "description": "Dictionary of database identifiers associated with this context."
+                }
+            }
+        },
         "Evidence": {
             "type": "object",
             "description": "Container for evidence supporting a given statement.",

--- a/indra/resources/statements_schema.json
+++ b/indra/resources/statements_schema.json
@@ -142,13 +142,48 @@
                 }
             }
         },
+        "BioContext": {
+            "type": "object",
+            "description": "The biological context of a Statement.",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "pattern": "^bio$",
+                    "description": "The type of context, in this case 'bio'."
+                },
+                "location": {
+                    "$ref": "#/definitions/RefContext",
+                    "description": "Cellular location, typically a sub-cellular compartment."
+                },
+                "cell_line": {
+                    "$ref": "#/definitions/RefContext",
+                    "description": "Cell line context, e.g., a specific cell line, like BT20."
+                },
+                "cell_type": {
+                    "$ref": "#/definitions/RefContext",
+                    "description": "Cell type context, broader than a cell line, like macrophage."
+                },
+                "organ": {
+                    "$ref": "#/definitions/RefContext",
+                    "description": "Organ context."
+                },
+                "disease": {
+                    "$ref": "#/definitions/RefContext",
+                    "description": "Disease context."
+                },
+                "species": {
+                    "$ref": "#/definitions/RefContext",
+                    "description": "Species context."
+                }
+            }
+        },
         "WorldContext": {
             "type": "object",
             "description": "The temporal and spatial context of a Statement.",
             "properties": {
                 "type": {
                     "type": "string",
-                    "pattern": "^(world)$",
+                    "pattern": "^world$",
                     "description": "The type of context, in this case 'world'."
                 },
                 "time": {

--- a/indra/resources/statements_schema.json
+++ b/indra/resources/statements_schema.json
@@ -449,7 +449,7 @@
                     "properties": {
                         "type": {
                             "type": "string",
-                            "pattern": "^Complex$",
+                            "pattern": "^((Complex)|(Association))$",
                             "description": "The type of the statement"
                         },
                         "members": {
@@ -460,6 +460,14 @@
                         }
                     },
                     "required": ["type"]
+                }
+            ]
+        },
+        "Association": {
+            "description": "A set of unordered concepts that are associated with each other.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Complex"
                 }
             ]
         },
@@ -602,6 +610,7 @@
             {"$ref": "#/definitions/Gef"},
             {"$ref": "#/definitions/Gap"},
             {"$ref": "#/definitions/Complex"},
+            {"$ref": "#/definitions/Association"},
             {"$ref": "#/definitions/Translocation"},
             {"$ref": "#/definitions/RegulateAmount"},
             {"$ref": "#/definitions/Influence"},

--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -89,10 +89,8 @@ class EidosProcessor(object):
             subj = self.entity_dict[subj_id]
             obj = self.entity_dict[obj_id]
 
-            subj_delta = {'adjectives': self.get_adjectives(subj),
-                          'polarity': self.get_polarity(subj)}
-            obj_delta = {'adjectives': self.get_adjectives(obj),
-                         'polarity': self.get_polarity(obj)}
+            subj_delta = self.extract_entity_states(subj.get('states', []))
+            obj_delta = self.extract_entity_states(obj.get('states', []))
 
             evidence = self.get_evidence(event)
 
@@ -195,7 +193,24 @@ class EidosProcessor(object):
         hedging_texts = [hedging['text'] for hedging in hedgings]
         return hedging_texts
 
+    def extract_entity_states(self, states):
+        polarity = None
+        adjectives = []
+        time_context = None
+        for state in states:
+            if polarity is None:
+                if state['type'] == 'DEC':
+                    polarity = -1
+                    adjectives = state.get('modifiers', [])
+                elif state['type'] == 'INC':
+                    polarity = 1
+                    adjectives = state.get('modifiers', [])
+            if state['type'] == 'TIMEX':
+                time_context = self.time_context_from_timex(state)
+        return {'polarity': polarity, 'adjectives': adjectives,
+                'time_context': time_context}
 
+    '''
     @staticmethod
     def get_polarity(entity):
         """Return the polarity of an entity."""
@@ -220,6 +235,7 @@ class EidosProcessor(object):
                 return []
         else:
             return []
+    '''
 
     @staticmethod
     def get_groundings(entity):

--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -34,6 +34,7 @@ class EidosProcessor(object):
         self.entity_dict = {}
         self.coreferences = {}
         self.timexes = {}
+        self.dct = None
         self._preprocess_extractions()
 
     def _preprocess_extractions(self):
@@ -56,7 +57,8 @@ class EidosProcessor(object):
             dct = document.get('dct')
             # We stash the DCT here as a TimeContext object
             if dct is not None:
-                self.timexes[dct['@id']] = self.time_context_from_dct(dct)
+                self.dct = self.time_context_from_dct(dct)
+                self.timexes[dct['@id']] = self.dct
             sentences = document.get('sentences', [])
             for sent in sentences:
                 self.sentence_dict[sent['@id']] = sent
@@ -160,6 +162,8 @@ class EidosProcessor(object):
 
         annotations = {'found_by': event.get('rule'),
                        'provenance': provenance}
+        if self.dct is not None:
+            annotations['document_creation_time'] = self.dct.to_json()
 
         epistemics = {}
         negations = self.get_negation(event)

--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -228,33 +228,6 @@ class EidosProcessor(object):
         return {'polarity': polarity, 'adjectives': adjectives,
                 'time_context': time_context}
 
-    '''
-    @staticmethod
-    def get_polarity(entity):
-        """Return the polarity of an entity."""
-        # The first state corresponds to increase/decrease
-        if 'states' not in entity:
-            return None
-        if entity['states'][0]['type'] == 'DEC':
-            return -1
-        elif entity['states'][0]['type'] == 'INC':
-            return 1
-        else:
-            return None
-
-    @staticmethod
-    def get_adjectives(entity):
-        """Return the adjectives of an entity."""
-        if 'states' in entity:
-            if 'modifiers' in entity['states'][0]:
-                return [mod['text'] for mod in
-                        entity['states'][0]['modifiers']]
-            else:
-                return []
-        else:
-            return []
-    '''
-
     @staticmethod
     def get_groundings(entity):
         """Return groundings as db_refs for an entity."""
@@ -311,6 +284,7 @@ class EidosProcessor(object):
 
     @staticmethod
     def time_context_from_dct(dct):
+        """Return a time context object given a DCT entry."""
         time_text = dct.get('text')
         start = _get_time_stamp(dct.get('start'))
         end = _get_time_stamp(dct.get('end'))
@@ -320,6 +294,7 @@ class EidosProcessor(object):
         return tc
 
     def time_context_from_ref(self, timex):
+        """Return a time context object given a timex reference entry."""
         # If the timex has a value set, it means that it refers to a DCT or
         # a TimeExpression e.g. "value": {"@id": "_:DCT_1"} and the parameters
         # need to be taken from there
@@ -328,11 +303,7 @@ class EidosProcessor(object):
             # Here we get the TimeContext directly from the stashed DCT
             # dictionary
             tc = self.timexes.get(value['@id'])
-            if tc is None:
-                import ipdb; ipdb.set_trace()
             return tc
-        else:
-            import ipdb; ipdb.set_trace()
         return None
 
     @staticmethod

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -3329,8 +3329,9 @@ class TimeContext(object):
                 return date.strftime('%Y-%m-%dT%H:%M')
         jd = {'text': self.text,
               'start': date_to_str(self.start),
-              'end': date_to_str(self.end),
-              'duration': self.duration}
+              'end': date_to_str(self.end)}
+        if self.duration is not None:
+            jd['duration'] = self.duration
         return jd
 
     @classmethod


### PR DESCRIPTION
This PR adapts the processor to the latest format produced by Eidos in the following ways:
- tracks down references to TimeExpressions and the DCT (document creation time) if they are referred to from entities
- adds subj_context and obj_context to evidence annotations which represents any time context that is available for the two arguments of Influences
- add document_creation_time as a new annotation entry if available

The PR also updates the JSON schema of INDRA Statements to contain the specification of Context classes.