### PR TITLE
Hub layout for CX networks

### DIFF
--- a/indra/assemblers/cx/assembler.py
+++ b/indra/assemblers/cx/assembler.py
@@ -182,7 +182,7 @@ class CxAssembler(object):
             A dictionary with the following entries:
             'user': NDEx user name
             'password': NDEx password
-        
+
         private : Optional[bool]
             Whether or not the created network will be private on NDEX.
 
@@ -512,6 +512,7 @@ def _get_agent_type(agent):
     pubchem_id = agent.db_refs.get('PUBCHEM')
     be_id = agent.db_refs.get('FPLX')
     go_id = agent.db_refs.get('GO')
+    mir_id = agnt.db_refs.get('MIRBASEM') or agent.db_refs.get('MIRBASE')
     if hgnc_id or uniprot_id:
         agent_type = 'protein'
     elif pfam_id or fa_id or be_id:
@@ -520,6 +521,8 @@ def _get_agent_type(agent):
         agent_type = 'chemical'
     elif go_id:
         agent_type = 'bioprocess'
+    elif mir_id:
+        agent_type = 'microrna'
     else:
         agent_type = 'other'
     return agent_type

--- a/indra/assemblers/cx/assembler.py
+++ b/indra/assemblers/cx/assembler.py
@@ -140,7 +140,7 @@ class CxAssembler(object):
         full_cx['numberVerification'] = [{'longNumber': 281474976710655}]
         aspects = ['nodes', 'edges', 'supports', 'citations', 'edgeAttributes',
                    'edgeCitations', 'edgeSupports', 'networkAttributes',
-                   'nodeAttributes']
+                   'nodeAttributes', 'cartesianLayout']
         full_cx['metaData'] = []
         for aspect in aspects:
             metadata = _get_aspect_metadata(aspect)
@@ -512,7 +512,7 @@ def _get_agent_type(agent):
     pubchem_id = agent.db_refs.get('PUBCHEM')
     be_id = agent.db_refs.get('FPLX')
     go_id = agent.db_refs.get('GO')
-    mir_id = agnt.db_refs.get('MIRBASEM') or agent.db_refs.get('MIRBASE')
+    mir_id = agent.db_refs.get('MIRBASEM') or agent.db_refs.get('MIRBASE')
     if hgnc_id or uniprot_id:
         agent_type = 'protein'
     elif pfam_id or fa_id or be_id:

--- a/indra/assemblers/cx/hub_layout.py
+++ b/indra/assemblers/cx/hub_layout.py
@@ -1,14 +1,17 @@
+"""This module allows adding a semantic hub layout to NDEx CX networkx. This
+is useful when a network is centered around a single hub node. The
+layout generated here allocates different classes of nodes into segments
+around the hub and then gives them random coordinates within that segment."""
+
 import json
 import math
 import random
 import networkx
 from collections import defaultdict
 
-def find_hub(graph):
-    pass
-
 
 def get_aspect(cx, aspect_name):
+    """Return an aspect given the name of the aspect"""
     if isinstance(cx, dict):
         return cx.get(aspect_name)
     for entry in cx:
@@ -17,6 +20,7 @@ def get_aspect(cx, aspect_name):
 
 
 def edge_type_to_class(edge_type):
+    """Return the edge class for layout purposes based on the edge type"""
     if 'Amount' in edge_type:
         return 'amount'
     if edge_type in ('Activation', 'Inhibition'):
@@ -28,6 +32,7 @@ def edge_type_to_class(edge_type):
 
 
 def classify_nodes(graph, hub):
+    """Classify each node based on its type and relationship to the hub."""
     node_stats = defaultdict(lambda: defaultdict(list))
     for u, v, data in graph.edges(data=True):
         # This means the node is downstream of the hub
@@ -59,6 +64,7 @@ def classify_nodes(graph, hub):
 
 
 def get_attributes(aspect, id):
+    """Return the attributes pointing to a given ID in a given aspect."""
     attributes = {}
     for entry in aspect:
         if entry['po'] == id:
@@ -67,6 +73,7 @@ def get_attributes(aspect, id):
 
 
 def cx_to_networkx(cx):
+    """Return a MultiDiGraph representation of a CX network."""
     graph = networkx.MultiDiGraph()
     for node_entry in get_aspect(cx, 'nodes'):
         id = node_entry['@id']
@@ -82,6 +89,7 @@ def cx_to_networkx(cx):
 
 
 def get_quadrant_from_class(node_class):
+    """Return the ID of the segment of the plane corresponding to a class."""
     up, edge_type, _ = node_class
     if up == 0:
         return 0 if random.random() < 0.5 else 7
@@ -94,7 +102,8 @@ def get_quadrant_from_class(node_class):
     return mappings[(up, edge_type)]
 
 
-def get_coordinates(node, node_class):
+def get_coordinates(node_class):
+    """Generate coordinates for a node in a given class."""
     quadrant_size = (2 * math.pi / 8.0)
     quadrant = get_quadrant_from_class(node_class)
     begin_angle = quadrant_size * quadrant
@@ -102,31 +111,33 @@ def get_coordinates(node, node_class):
     alpha = begin_angle + random.random() * quadrant_size
     x = r * math.cos(alpha)
     y = r * math.sin(alpha)
-    return (x, y)
+    return x, y
 
 
-def get_layout_aspect(graph, hub, node_classes):
-    aspect = []
-    aspect.append({'node': hub, 'x': 0.0, 'y': 0.0})
+def get_layout_aspect(hub, node_classes):
+    """Get the full layout aspect with coordinates for each node."""
+    aspect = [{'node': hub, 'x': 0.0, 'y': 0.0}]
     for node, node_class in node_classes.items():
         if node == hub:
             continue
-        x, y = get_coordinates(node, node_class)
+        x, y = get_coordinates(node_class)
         aspect.append({'node': node, 'x': x, 'y': y})
     return aspect
 
 
 def get_node_by_name(graph, name):
+    """Return a node ID given its name."""
     for id, attrs in graph.nodes(data=True):
         if attrs['n'] == name:
             return id
 
 
 def add_semantic_hub_layout(cx, hub):
+    """Attach a layout aspect to a CX network given a hub node."""
     graph = cx_to_networkx(cx)
     hub_node = get_node_by_name(graph, hub)
     node_classes = classify_nodes(graph, hub_node)
-    layout_aspect = get_layout_aspect(graph, hub_node, node_classes)
+    layout_aspect = get_layout_aspect(hub_node, node_classes)
     cx['cartesianLayout'] = layout_aspect
 
 

--- a/indra/assemblers/cx/semantic_hub.py
+++ b/indra/assemblers/cx/semantic_hub.py
@@ -1,0 +1,78 @@
+import networkx
+from collections import defaultdict
+
+def find_hub(graph):
+    pass
+
+
+def get_aspect(cx, aspect_name):
+    for entry in cx:
+        if list(entry.keys())[0] == aspect_name:
+            return entry[aspect_name]
+
+
+def classify_nodes(graph, hub):
+    node_stats = defaultdict(lambda: defaultdict(list))
+    for u, v, data in graph.edges(data=True):
+        if hub == u:
+            h, o = u, v
+            if data['i'] != 'Complex':
+                node_stats[o]['up'].append(1)
+            else:
+                node_stats[o]['up'].append(0)
+        elif hub == v:
+            h, o = v, u
+            if data['i'] != 'Complex':
+                node_stats[o]['up'].append(-1)
+            else:
+                node_stats[o]['up'].append(0)
+        else:
+            continue
+        node_stats[o]['interaction'].append(data['i'])
+
+    node_classes = {}
+    for node_id, stats in node_stats.items():
+        up = max(set(stats['up']), key=stats['up'].count)
+        edge_type = max(set(stats['interaction']),
+                        key=stats['interaction'].count)
+        node_type = graph.nodes[node_id]['type']
+        node_classes[node_id] = (up, edge_type, node_type)
+    return node_classes
+
+
+def get_attributes(aspect, id):
+    attributes = {}
+    for entry in aspect:
+        if entry['po'] == id:
+            attributes[entry['n']] = entry['v']
+    return attributes
+
+
+def cx_to_networkx(cx):
+    graph = networkx.MultiDiGraph()
+    for node_entry in get_aspect(cx, 'nodes'):
+        id = node_entry['@id']
+        attrs = get_attributes(get_aspect(cx, 'nodeAttributes'), id)
+        attrs['n'] = node_entry['n']
+        graph.add_node(id, **attrs)
+    for edge_entry in get_aspect(cx, 'edges'):
+        id = edge_entry['@id']
+        attrs = get_attributes(get_aspect(cx, 'edgeAttributes'), id)
+        attrs['i'] = edge_entry['i']
+        graph.add_edge(edge_entry['s'], edge_entry['t'], key=id, **attrs)
+    return graph
+
+
+def get_node_by_name(graph, name):
+    for id, attrs in graph.nodes(data=True):
+        if attrs['n'] == name:
+            return id
+
+
+if __name__ == '__main__':
+    import json
+    with open('CDK13.cx', 'r') as fh:
+        cx = json.load(fh)
+    graph = cx_to_networkx(cx)
+
+    node_classes = classify_nodes(graph, get_node_by_name(graph, 'CDK13'))

--- a/indra/assemblers/cx/semantic_hub.py
+++ b/indra/assemblers/cx/semantic_hub.py
@@ -9,6 +9,8 @@ def find_hub(graph):
 
 
 def get_aspect(cx, aspect_name):
+    if isinstance(cx, dict):
+        return cx.get(aspect_name)
     for entry in cx:
         if list(entry.keys())[0] == aspect_name:
             return entry[aspect_name]
@@ -82,22 +84,22 @@ def cx_to_networkx(cx):
 def get_quadrant_from_class(node_class):
     up, edge_type, _ = node_class
     if up == 0:
-        return 0
-    mappings = {(1, 'modification'): 1,
-                (1, 'amount'): 2,
-                (1, 'activity'): 3,
-                (-1, 'activity'): 4,
-                (-1, 'amount'): 5,
-                (-1, 'modification'): 6}
+        return 0 if random.random() < 0.5 else 7
+    mappings = {(-1, 'modification'): 1,
+                (-1, 'amount'): 2,
+                (-1, 'activity'): 3,
+                (1, 'activity'): 4,
+                (1, 'amount'): 5,
+                (1, 'modification'): 6}
     return mappings[(up, edge_type)]
 
 
 def get_coordinates(node, node_class):
     quadrant_size = (2 * math.pi / 8.0)
     quadrant = get_quadrant_from_class(node_class)
-    center_angle = (quadrant_size / 2.0) + quadrant_size * quadrant
-    r = 100 + 200*random.random()
-    alpha = center_angle - (quadrant_size / 2.0) * random.random() * quadrant_size
+    begin_angle = quadrant_size * quadrant
+    r = 200 + 800*random.random()
+    alpha = begin_angle + random.random() * quadrant_size
     x = r * math.cos(alpha)
     y = r * math.sin(alpha)
     return (x, y)
@@ -105,12 +107,12 @@ def get_coordinates(node, node_class):
 
 def get_layout_aspect(graph, hub, node_classes):
     aspect = []
-    aspect.append({'@id': hub, 'x': 0.0, 'y': 0.0})
+    aspect.append({'node': hub, 'x': 0.0, 'y': 0.0})
     for node, node_class in node_classes.items():
         if node == hub:
             continue
         x, y = get_coordinates(node, node_class)
-        aspect.append({'@id': node, 'x': x, 'y': y})
+        aspect.append({'node': node, 'x': x, 'y': y})
     return aspect
 
 

--- a/indra/assemblers/cx/semantic_hub.py
+++ b/indra/assemblers/cx/semantic_hub.py
@@ -120,12 +120,15 @@ def get_node_by_name(graph, name):
             return id
 
 
-if __name__ == '__main__':
-    with open('CDK13.cx', 'r') as fh:
-        cx = json.load(fh)
+def add_semantic_hub_layout(cx, hub):
     graph = cx_to_networkx(cx)
-    hub = 'CDK13'
     hub_node = get_node_by_name(graph, hub)
     node_classes = classify_nodes(graph, hub_node)
     layout_aspect = get_layout_aspect(graph, hub_node, node_classes)
+    cx['cartesianLayout'] = layout_aspect
 
+
+if __name__ == '__main__':
+    with open('CDK13.cx', 'r') as fh:
+        cx = json.load(fh)
+    add_semantic_hub_layout(cx, 'CDK13')

--- a/indra/assemblers/cx/semantic_hub.py
+++ b/indra/assemblers/cx/semantic_hub.py
@@ -1,3 +1,5 @@
+import math
+import random
 import networkx
 from collections import defaultdict
 
@@ -76,6 +78,37 @@ def cx_to_networkx(cx):
     return graph
 
 
+def get_quadrant_from_class(node_class):
+    up, edge_type, _ = node_class
+    if up == 0:
+        return 0
+    mappings = {(1, 'modification'): 1,
+                (1, 'amount'): 2,
+                (1, 'activity'): 3,
+                (-1, 'activity'): 4,
+                (-1, 'amount'): 5,
+                (-1, 'modification'): 6}
+    return mappings[(up, edge_type)]
+
+
+def get_coordinates(node, node_class):
+    quadrant_size = (2 * math.pi / 8.0)
+    quadrant = get_quadrant_from_class(node_class)
+    center_angle = (quadrant_size / 2.0) + quadrant_size * quadrant
+    r = 100 + 200*random.random()
+    alpha = center_angle - (quadrant_size / 2.0) * random.random() * quadrant_size
+    x = r / math.sqrt(1 + math.tan(alpha)**2)
+    y = math.sqrt(r**2 - x**2)
+    return (x, y)
+
+
+def layout(graph, hub, node_classes):
+    networkx.set_node_attributes(graph, {hub: {'x': 0.0, 'y': 0.0}})
+    for node in graph.nodes():
+        x, y = get_coordinates(node, node_classes[node])
+        networkx.set_node_attributes(graph, {node: {'x': x, 'y': y}})
+
+
 def get_node_by_name(graph, name):
     for id, attrs in graph.nodes(data=True):
         if attrs['n'] == name:
@@ -87,5 +120,6 @@ if __name__ == '__main__':
     with open('CDK13.cx', 'r') as fh:
         cx = json.load(fh)
     graph = cx_to_networkx(cx)
-
-    node_classes = classify_nodes(graph, get_node_by_name(graph, 'CDK13'))
+    hub = 'CDK13'
+    node_classes = classify_nodes(graph, get_node_by_name(graph, hub))
+    layout(graph, hub, node_classes)

--- a/indra/assemblers/cx/semantic_hub.py
+++ b/indra/assemblers/cx/semantic_hub.py
@@ -1,3 +1,4 @@
+import json
 import math
 import random
 import networkx
@@ -97,16 +98,20 @@ def get_coordinates(node, node_class):
     center_angle = (quadrant_size / 2.0) + quadrant_size * quadrant
     r = 100 + 200*random.random()
     alpha = center_angle - (quadrant_size / 2.0) * random.random() * quadrant_size
-    x = r / math.sqrt(1 + math.tan(alpha)**2)
-    y = math.sqrt(r**2 - x**2)
+    x = r * math.cos(alpha)
+    y = r * math.sin(alpha)
     return (x, y)
 
 
-def layout(graph, hub, node_classes):
-    networkx.set_node_attributes(graph, {hub: {'x': 0.0, 'y': 0.0}})
-    for node in graph.nodes():
-        x, y = get_coordinates(node, node_classes[node])
-        networkx.set_node_attributes(graph, {node: {'x': x, 'y': y}})
+def get_layout_aspect(graph, hub, node_classes):
+    aspect = []
+    aspect.append({'@id': hub, 'x': 0.0, 'y': 0.0})
+    for node, node_class in node_classes.items():
+        if node == hub:
+            continue
+        x, y = get_coordinates(node, node_class)
+        aspect.append({'@id': node, 'x': x, 'y': y})
+    return aspect
 
 
 def get_node_by_name(graph, name):
@@ -116,10 +121,11 @@ def get_node_by_name(graph, name):
 
 
 if __name__ == '__main__':
-    import json
     with open('CDK13.cx', 'r') as fh:
         cx = json.load(fh)
     graph = cx_to_networkx(cx)
     hub = 'CDK13'
-    node_classes = classify_nodes(graph, get_node_by_name(graph, hub))
-    layout(graph, hub, node_classes)
+    hub_node = get_node_by_name(graph, hub)
+    node_classes = classify_nodes(graph, hub_node)
+    layout_aspect = get_layout_aspect(graph, hub_node, node_classes)
+

--- a/indra/assemblers/cx/semantic_hub.py
+++ b/indra/assemblers/cx/semantic_hub.py
@@ -11,24 +11,37 @@ def get_aspect(cx, aspect_name):
             return entry[aspect_name]
 
 
+def edge_type_to_class(edge_type):
+    if 'Amount' in edge_type:
+        return 'amount'
+    if edge_type in ('Activation', 'Inhibition'):
+        return 'activity'
+    if edge_type == 'Complex':
+        return 'complex'
+    else:
+        return 'modification'
+
+
 def classify_nodes(graph, hub):
     node_stats = defaultdict(lambda: defaultdict(list))
     for u, v, data in graph.edges(data=True):
+        # This means the node is downstream of the hub
         if hub == u:
             h, o = u, v
-            if data['i'] != 'Complex':
-                node_stats[o]['up'].append(1)
-            else:
-                node_stats[o]['up'].append(0)
-        elif hub == v:
-            h, o = v, u
             if data['i'] != 'Complex':
                 node_stats[o]['up'].append(-1)
             else:
                 node_stats[o]['up'].append(0)
+        # This means the node is upstream of the hub
+        elif hub == v:
+            h, o = v, u
+            if data['i'] != 'Complex':
+                node_stats[o]['up'].append(1)
+            else:
+                node_stats[o]['up'].append(0)
         else:
             continue
-        node_stats[o]['interaction'].append(data['i'])
+        node_stats[o]['interaction'].append(edge_type_to_class(data['i']))
 
     node_classes = {}
     for node_id, stats in node_stats.items():

--- a/indra/databases/ndex_client.py
+++ b/indra/databases/ndex_client.py
@@ -17,11 +17,12 @@ ndex_base_url = 'http://52.37.175.128'
 
 def get_default_ndex_cred(ndex_cred):
     """Gets the NDEx credentials from the dict, or tries the environment if None"""
-    username = ndex_cred.get('user')
-    password = ndex_cred.get('password')
+    if ndex_cred:
+        username = ndex_cred.get('user')
+        password = ndex_cred.get('password')
 
-    if username is not None and password is not None:
-        return username, password
+        if username is not None and password is not None:
+            return username, password
 
     username = get_config('NDEX_USERNAME')
     password = get_config('NDEX_PASSWORD')
@@ -88,7 +89,7 @@ def send_request(ndex_service_url, params, is_json=True, use_get=False):
         return res.text
 
 
-def create_network(cx_str, ndex_cred, private=True):
+def create_network(cx_str, ndex_cred=None, private=True):
     """Creates a new NDEx network of the assembled CX model.
 
     To upload the assembled CX model to NDEx, you need to have
@@ -130,7 +131,7 @@ def create_network(cx_str, ndex_cred, private=True):
     return network_id
 
 
-def update_network(cx_str, network_id, ndex_cred):
+def update_network(cx_str, network_id, ndex_cred=None):
     """Update an existing CX network on NDEx with new CX content.
 
     Parameters
@@ -188,7 +189,7 @@ def update_network(cx_str, network_id, ndex_cred):
     set_style(network_id, ndex_cred)
 
 
-def set_style(network_id, ndex_cred):
+def set_style(network_id, ndex_cred=None):
     # Update network style
     template_uuid = "ea4ea3b7-6903-11e7-961c-0ac135e8bacf"
 
@@ -206,7 +207,7 @@ def set_style(network_id, ndex_cred):
                              password=password)
 
 
-def set_provenance(provenance, network_id, ndex_cred):
+def set_provenance(provenance, network_id, ndex_cred=None):
     server = 'http://public.ndexbio.org'
     username, password = get_default_ndex_cred(ndex_cred)
     nd = ndex2.client.Ndex2(server, username, password)


### PR DESCRIPTION
This PR adds a separate script to `indra.assemblers.cx` which allows generating a `cartesianLayout` aspect for a given CX network with a single hub node. Currently, the implementation is tailored for CX graphs but with some additional work, it could be generalized to work with other graph-like assemblers (graph, cyjs, cag, etc.).