### PR TITLE
Make adding SBO annotations optional

### DIFF
--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1547,7 +1547,7 @@ class Modification(Statement):
         return mc
 
     def to_json(self, use_sbo=True):
-        generic = super(Modification, self).to_json()
+        generic = super(Modification, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.enz is not None:
             json_dict['enz'] = self.enz.to_json()
@@ -1674,7 +1674,7 @@ class SelfModification(Statement):
         return mc
 
     def to_json(self, use_sbo=True):
-        generic = super(SelfModification, self).to_json()
+        generic = super(SelfModification, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.enz is not None:
             json_dict['enz'] = self.enz.to_json()
@@ -1945,7 +1945,7 @@ class RegulateActivity(Statement):
         return True
 
     def to_json(self, use_sbo=True):
-        generic = super(RegulateActivity, self).to_json()
+        generic = super(RegulateActivity, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.subj is not None:
             json_dict['subj'] = self.subj.to_json()
@@ -2168,7 +2168,7 @@ class ActiveForm(Statement):
         return False
 
     def to_json(self, use_sbo=True):
-        generic = super(ActiveForm, self).to_json()
+        generic = super(ActiveForm, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         json_dict.update({'agent': self.agent.to_json(),
                           'activity': self.activity,
@@ -2345,7 +2345,7 @@ class Gef(Statement):
         return matches
 
     def to_json(self, use_sbo=True):
-        generic = super(Gef, self).to_json()
+        generic = super(Gef, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.gef is not None:
             json_dict['gef'] = self.gef.to_json()
@@ -2432,7 +2432,7 @@ class Gap(Statement):
         return matches
 
     def to_json(self, use_sbo=True):
-        generic = super(Gap, self).to_json()
+        generic = super(Gap, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.gap is not None:
             json_dict['gap'] = self.gap.to_json()
@@ -2547,8 +2547,8 @@ class Complex(Statement):
         matches = super(Complex, self).equals(other)
         return matches
 
-    def to_json(self):
-        generic = super(Complex, self).to_json()
+    def to_json(self, use_sbo=True):
+        generic = super(Complex, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         members = [m.to_json() for m in self.members]
         json_dict['members'] = members
@@ -2626,8 +2626,8 @@ class Translocation(Statement):
                str(self.to_location))
         return str(key)
 
-    def to_json(self):
-        generic = super(Translocation, self).to_json()
+    def to_json(self, use_sbo=True):
+        generic = super(Translocation, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         json_dict['agent'] = self.agent.to_json()
         if self.from_location is not None:
@@ -2680,7 +2680,7 @@ class RegulateAmount(Statement):
         self.obj = agent_list[1]
 
     def to_json(self, use_sbo=True):
-        generic = super(RegulateAmount, self).to_json()
+        generic = super(RegulateAmount, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.subj is not None:
             json_dict['subj'] = self.subj.to_json()
@@ -3006,7 +3006,7 @@ class Conversion(Statement):
         self.obj_to = agent_list[num_obj_from+1:]
 
     def to_json(self, use_sbo=True):
-        generic = super(Conversion, self).to_json()
+        generic = super(Conversion, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.subj is not None:
             json_dict['subj'] = self.subj.to_json()

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1310,10 +1310,10 @@ class Statement(object):
         # Placeholder for implementation in subclasses
         return False
 
-    def to_json(self):
+    def to_json(self, use_sbo=True):
         """Return serialized Statement as a json dict."""
         stmt_type = type(self).__name__
-        # Oringal comment: For backwards compatibility, could be removed later
+        # Original comment: For backwards compatibility, could be removed later
         all_stmts = [self] + self.supports + self.supported_by
         for st in all_stmts:
             if not hasattr(st, 'uuid'):
@@ -1339,9 +1339,10 @@ class Statement(object):
                 sbo_term = stmt_sbo_map.get(cls.__name__.lower())
             return sbo_term
 
-        sbo_term = get_sbo_term(self.__class__)
-        json_dict['sbo'] = \
-            'http://identifiers.org/sbo/SBO:%s' % sbo_term
+        if use_sbo:
+            sbo_term = get_sbo_term(self.__class__)
+            json_dict['sbo'] = \
+                'http://identifiers.org/sbo/SBO:%s' % sbo_term
         return json_dict
 
     @classmethod
@@ -1545,17 +1546,21 @@ class Modification(Statement):
         mc = ModCondition(mod_type, self.residue, self.position, True)
         return mc
 
-    def to_json(self):
+    def to_json(self, use_sbo=True):
         generic = super(Modification, self).to_json()
         json_dict = _o({'type': generic['type']})
         if self.enz is not None:
             json_dict['enz'] = self.enz.to_json()
-            json_dict['enz']['sbo'] = \
-                'http://identifiers.org/sbo/SBO:0000460'  # enzymatic catalyst
+            if use_sbo:
+                # enzymatic catalyst
+                json_dict['enz']['sbo'] = \
+                    'http://identifiers.org/sbo/SBO:0000460'
         if self.sub is not None:
             json_dict['sub'] = self.sub.to_json()
-            json_dict['sub']['sbo'] = \
-                'http://identifiers.org/sbo/SBO:0000015'  # substrate
+            if use_sbo:
+                # substrate
+                json_dict['sub']['sbo'] = \
+                    'http://identifiers.org/sbo/SBO:0000015'
         if self.residue is not None:
             json_dict['residue'] = self.residue
         if self.position is not None:
@@ -1668,13 +1673,15 @@ class SelfModification(Statement):
         mc = ModCondition(mod_type, self.residue, self.position, True)
         return mc
 
-    def to_json(self):
+    def to_json(self, use_sbo=True):
         generic = super(SelfModification, self).to_json()
         json_dict = _o({'type': generic['type']})
         if self.enz is not None:
             json_dict['enz'] = self.enz.to_json()
-            json_dict['enz']['sbo'] = \
-                'http://identifiers.org/sbo/SBO:0000460'  # enzymatic catalyst
+            if use_sbo:
+                # enzymatic catalyst
+                json_dict['enz']['sbo'] = \
+                    'http://identifiers.org/sbo/SBO:0000460'
         if self.residue is not None:
             json_dict['residue'] = self.residue
         if self.position is not None:
@@ -1937,25 +1944,27 @@ class RegulateActivity(Statement):
         # Otherwise they are contradicting
         return True
 
-    def to_json(self):
+    def to_json(self, use_sbo=True):
         generic = super(RegulateActivity, self).to_json()
         json_dict = _o({'type': generic['type']})
         if self.subj is not None:
             json_dict['subj'] = self.subj.to_json()
-            if self.is_activation:
-                json_dict['subj']['sbo'] = \
-                    'http://identifiers.org/sbo/SBO:0000459'  # stimulator
-            else:
-                json_dict['subj']['sbo'] = \
-                    'http://identifiers.org/sbo/SBO:0000020'  # inhibitor
+            if use_sbo:
+                if self.is_activation:
+                    json_dict['subj']['sbo'] = \
+                        'http://identifiers.org/sbo/SBO:0000459'  # stimulator
+                else:
+                    json_dict['subj']['sbo'] = \
+                        'http://identifiers.org/sbo/SBO:0000020'  # inhibitor
         if self.obj is not None:
             json_dict['obj'] = self.obj.to_json()
-            if self.is_activation:
-                json_dict['obj']['sbo'] = \
-                    'http://identifiers.org/sbo/SBO:0000643'  # stimulated
-            else:
-                json_dict['obj']['sbo'] = \
-                    'http://identifiers.org/sbo/SBO:0000642'  # inhibited
+            if use_sbo:
+                if self.is_activation:
+                    json_dict['obj']['sbo'] = \
+                        'http://identifiers.org/sbo/SBO:0000643'  # stimulated
+                else:
+                    json_dict['obj']['sbo'] = \
+                        'http://identifiers.org/sbo/SBO:0000642'  # inhibited
         if self.obj_activity is not None:
             json_dict['obj_activity'] = self.obj_activity
         json_dict.update(generic)
@@ -2158,14 +2167,15 @@ class ActiveForm(Statement):
                 return True
         return False
 
-    def to_json(self):
+    def to_json(self, use_sbo=True):
         generic = super(ActiveForm, self).to_json()
         json_dict = _o({'type': generic['type']})
         json_dict.update({'agent': self.agent.to_json(),
                           'activity': self.activity,
                           'is_active': self.is_active})
-        json_dict['agent']['sbo'] = \
-            'http://identifiers.org/sbo/SBO:0000644'  # modified
+        if use_sbo:
+            json_dict['agent']['sbo'] = \
+                'http://identifiers.org/sbo/SBO:0000644'  # modified
         json_dict.update(generic)
         return json_dict
 
@@ -2334,17 +2344,19 @@ class Gef(Statement):
         matches = super(Gef, self).equals(other)
         return matches
 
-    def to_json(self):
+    def to_json(self, use_sbo=True):
         generic = super(Gef, self).to_json()
         json_dict = _o({'type': generic['type']})
         if self.gef is not None:
             json_dict['gef'] = self.gef.to_json()
-            json_dict['gef']['sbo'] = \
-                'http://identifiers.org/sbo/SBO:0000013'  # catalyst
+            if use_sbo:
+                json_dict['gef']['sbo'] = \
+                    'http://identifiers.org/sbo/SBO:0000013'  # catalyst
         if self.ras is not None:
             json_dict['ras'] = self.ras.to_json()
-            json_dict['ras']['sbo'] = \
-                'http://identifiers.org/sbo/SBO:0000015'  # substrate
+            if use_sbo:
+                json_dict['ras']['sbo'] = \
+                    'http://identifiers.org/sbo/SBO:0000015'  # substrate
         json_dict.update(generic)
         return json_dict
 
@@ -2419,17 +2431,19 @@ class Gap(Statement):
         matches = super(Gap, self).equals(other)
         return matches
 
-    def to_json(self):
+    def to_json(self, use_sbo=True):
         generic = super(Gap, self).to_json()
         json_dict = _o({'type': generic['type']})
         if self.gap is not None:
             json_dict['gap'] = self.gap.to_json()
-            json_dict['gap']['sbo'] = \
-                'http://identifiers.org/sbo/SBO:0000013'  # catalyst
+            if use_sbo:
+                json_dict['gap']['sbo'] = \
+                    'http://identifiers.org/sbo/SBO:0000013'  # catalyst
         if self.ras is not None:
             json_dict['ras'] = self.ras.to_json()
-            json_dict['ras']['sbo'] = \
-                'http://identifiers.org/sbo/SBO:0000015'  # substrate
+            if use_sbo:
+                json_dict['ras']['sbo'] = \
+                    'http://identifiers.org/sbo/SBO:0000015'  # substrate
         json_dict.update(generic)
         return json_dict
 
@@ -2665,25 +2679,27 @@ class RegulateAmount(Statement):
         self.subj = agent_list[0]
         self.obj = agent_list[1]
 
-    def to_json(self):
+    def to_json(self, use_sbo=True):
         generic = super(RegulateAmount, self).to_json()
         json_dict = _o({'type': generic['type']})
         if self.subj is not None:
             json_dict['subj'] = self.subj.to_json()
-            if isinstance(self, IncreaseAmount):
-                json_dict['subj']['sbo'] = \
-                    'http://identifiers.org/sbo/SBO:0000459'  # stimulator
-            else:
-                json_dict['subj']['sbo'] = \
-                    'http://identifiers.org/sbo/SBO:0000020'  # inhibitor
+            if use_sbo:
+                if isinstance(self, IncreaseAmount):
+                    json_dict['subj']['sbo'] = \
+                        'http://identifiers.org/sbo/SBO:0000459'  # stimulator
+                else:
+                    json_dict['subj']['sbo'] = \
+                        'http://identifiers.org/sbo/SBO:0000020'  # inhibitor
         if self.obj is not None:
             json_dict['obj'] = self.obj.to_json()
-            if isinstance(self, IncreaseAmount):
-                json_dict['obj']['sbo'] = \
-                    'http://identifiers.org/sbo/SBO:0000011'  # product
-            else:
-                json_dict['obj']['sbo'] = \
-                    'http://identifiers.org/sbo/SBO:0000010'  # reactant
+            if use_sbo:
+                if isinstance(self, IncreaseAmount):
+                    json_dict['obj']['sbo'] = \
+                        'http://identifiers.org/sbo/SBO:0000011'  # product
+                else:
+                    json_dict['obj']['sbo'] = \
+                        'http://identifiers.org/sbo/SBO:0000010'  # reactant
         json_dict.update(generic)
         return json_dict
 
@@ -2891,19 +2907,14 @@ class Influence(IncreaseAmount):
             pol = p1 * p2
         return pol
 
-    def to_json(self):
-        generic = super(Influence, self).to_json()
+    def to_json(self, use_sbo=False):
+        generic = super(Influence, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         json_dict['subj'] = generic['subj']
         json_dict['subj_delta'] = self.subj_delta
         json_dict['obj'] = generic['obj']
         json_dict['obj_delta'] = self.obj_delta
         json_dict.update(generic)
-        del json_dict['sbo']
-        if json_dict['subj'].get('sbo'):
-            json_dict['subj'].pop('sbo')
-        if json_dict['obj'].get('sbo'):
-            json_dict['obj'].pop('sbo')
         return json_dict
 
     @classmethod
@@ -2994,21 +3005,24 @@ class Conversion(Statement):
         self.obj_from = agent_list[1:num_obj_from+1]
         self.obj_to = agent_list[num_obj_from+1:]
 
-    def to_json(self):
+    def to_json(self, use_sbo=True):
         generic = super(Conversion, self).to_json()
         json_dict = _o({'type': generic['type']})
         if self.subj is not None:
             json_dict['subj'] = self.subj.to_json()
-            json_dict['subj']['sbo'] = \
-                'http://identifiers.org/sbo/SBO:0000013'  # catalyst
+            if use_sbo:
+                json_dict['subj']['sbo'] = \
+                    'http://identifiers.org/sbo/SBO:0000013'  # catalyst
         json_dict['obj_from'] = [o.to_json() for o in self.obj_from]
-        for of in json_dict['obj_from']:
-            of['sbo'] = \
-                'http://identifiers.org/sbo/SBO:0000010'  # reactant
+        if use_sbo:
+            for of in json_dict['obj_from']:
+                of['sbo'] = \
+                    'http://identifiers.org/sbo/SBO:0000010'  # reactant
         json_dict['obj_to'] = [o.to_json() for o in self.obj_to]
-        for ot in json_dict['obj_to']:
-            ot['sbo'] = \
-                'http://identifiers.org/sbo/SBO:0000011'  # product
+        if use_sbo:
+            for ot in json_dict['obj_to']:
+                ot['sbo'] = \
+                    'http://identifiers.org/sbo/SBO:0000011'  # product
         json_dict.update(generic)
         return json_dict
 
@@ -3445,12 +3459,12 @@ def get_unresolved_support_uuids(stmts):
             if isinstance(s, Unresolved)}
 
 
-def stmts_to_json(stmts_in):
+def stmts_to_json(stmts_in, use_sbo=True):
     if not isinstance(stmts_in, list):
-        json_dict = stmts_in.to_json()
+        json_dict = stmts_in.to_json(use_sbo)
         return json_dict
     else:
-        json_dict = [st.to_json() for st in stmts_in]
+        json_dict = [st.to_json(use_sbo) for st in stmts_in]
     return json_dict
 
 

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1311,7 +1311,19 @@ class Statement(object):
         return False
 
     def to_json(self, use_sbo=False):
-        """Return serialized Statement as a json dict."""
+        """Return serialized Statement as a JSON dict.
+
+        Parameters
+        ----------
+        use_sbo : Optional[bool]
+            If True, SBO annotations are added to each applicable element of
+            the JSON. Default: False
+
+        Returns
+        -------
+        json_dict : dict
+            The JSON-serialized INDRA Statement.
+        """
         stmt_type = type(self).__name__
         # Original comment: For backwards compatibility, could be removed later
         all_stmts = [self] + self.supports + self.supported_by
@@ -3460,6 +3472,21 @@ def get_unresolved_support_uuids(stmts):
 
 
 def stmts_to_json(stmts_in, use_sbo=False):
+    """Return the JSON-serialized form of one or more INDRA Statements.
+
+    Parameters
+    ----------
+    stmts_in : Statement or list[Statement]
+        A Statement or list of Statement objects to serialize into JSON.
+    use_sbo : Optional[bool]
+        If True, SBO annotations are added to each applicable element of the
+        JSON. Default: False
+
+    Returns
+    -------
+    json_dict : dict
+        JSON-serialized INDRA Statements.
+    """
     if not isinstance(stmts_in, list):
         json_dict = stmts_in.to_json(use_sbo)
         return json_dict

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1310,7 +1310,7 @@ class Statement(object):
         # Placeholder for implementation in subclasses
         return False
 
-    def to_json(self, use_sbo=True):
+    def to_json(self, use_sbo=False):
         """Return serialized Statement as a json dict."""
         stmt_type = type(self).__name__
         # Original comment: For backwards compatibility, could be removed later
@@ -1546,7 +1546,7 @@ class Modification(Statement):
         mc = ModCondition(mod_type, self.residue, self.position, True)
         return mc
 
-    def to_json(self, use_sbo=True):
+    def to_json(self, use_sbo=False):
         generic = super(Modification, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.enz is not None:
@@ -1673,7 +1673,7 @@ class SelfModification(Statement):
         mc = ModCondition(mod_type, self.residue, self.position, True)
         return mc
 
-    def to_json(self, use_sbo=True):
+    def to_json(self, use_sbo=False):
         generic = super(SelfModification, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.enz is not None:
@@ -1944,7 +1944,7 @@ class RegulateActivity(Statement):
         # Otherwise they are contradicting
         return True
 
-    def to_json(self, use_sbo=True):
+    def to_json(self, use_sbo=False):
         generic = super(RegulateActivity, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.subj is not None:
@@ -2167,7 +2167,7 @@ class ActiveForm(Statement):
                 return True
         return False
 
-    def to_json(self, use_sbo=True):
+    def to_json(self, use_sbo=False):
         generic = super(ActiveForm, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         json_dict.update({'agent': self.agent.to_json(),
@@ -2344,7 +2344,7 @@ class Gef(Statement):
         matches = super(Gef, self).equals(other)
         return matches
 
-    def to_json(self, use_sbo=True):
+    def to_json(self, use_sbo=False):
         generic = super(Gef, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.gef is not None:
@@ -2431,7 +2431,7 @@ class Gap(Statement):
         matches = super(Gap, self).equals(other)
         return matches
 
-    def to_json(self, use_sbo=True):
+    def to_json(self, use_sbo=False):
         generic = super(Gap, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.gap is not None:
@@ -2547,7 +2547,7 @@ class Complex(Statement):
         matches = super(Complex, self).equals(other)
         return matches
 
-    def to_json(self, use_sbo=True):
+    def to_json(self, use_sbo=False):
         generic = super(Complex, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         members = [m.to_json() for m in self.members]
@@ -2626,7 +2626,7 @@ class Translocation(Statement):
                str(self.to_location))
         return str(key)
 
-    def to_json(self, use_sbo=True):
+    def to_json(self, use_sbo=False):
         generic = super(Translocation, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         json_dict['agent'] = self.agent.to_json()
@@ -2679,7 +2679,7 @@ class RegulateAmount(Statement):
         self.subj = agent_list[0]
         self.obj = agent_list[1]
 
-    def to_json(self, use_sbo=True):
+    def to_json(self, use_sbo=False):
         generic = super(RegulateAmount, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.subj is not None:
@@ -3005,7 +3005,7 @@ class Conversion(Statement):
         self.obj_from = agent_list[1:num_obj_from+1]
         self.obj_to = agent_list[num_obj_from+1:]
 
-    def to_json(self, use_sbo=True):
+    def to_json(self, use_sbo=False):
         generic = super(Conversion, self).to_json(use_sbo)
         json_dict = _o({'type': generic['type']})
         if self.subj is not None:
@@ -3459,7 +3459,7 @@ def get_unresolved_support_uuids(stmts):
             if isinstance(s, Unresolved)}
 
 
-def stmts_to_json(stmts_in, use_sbo=True):
+def stmts_to_json(stmts_in, use_sbo=False):
     if not isinstance(stmts_in, list):
         json_dict = stmts_in.to_json(use_sbo)
         return json_dict

--- a/indra/tests/test_statements_serialization.py
+++ b/indra/tests/test_statements_serialization.py
@@ -104,6 +104,9 @@ def test_influence():
     jd = stmt.to_json()
     assert 'sbo' not in jd['subj']
     assert 'sbo' not in jd['obj']
+    jd_sbo = stmt.to_json(use_sbo=True)
+    assert 'sbo' in jd_sbo['subj']
+    assert 'sbo' in jd_sbo['obj']
     stmt.to_graph()
     st_deserialize = Statement._from_json(jd)
     assert st_deserialize.subj_delta['polarity'] == 1


### PR DESCRIPTION
This PR adds an extra bool argument to the various to_json functions in `indra.statements` to allow for controlling whether SBO annotations are added to the JSON. I set the default to False since these aren't needed in most applications.