### PR TITLE
Fix the version finding regex to handle merges.

### DIFF
--- a/indra/util/get_version.py
+++ b/indra/util/get_version.py
@@ -20,14 +20,16 @@ def get_git_info():
     start_dir = abspath(curdir)
     try:
         chdir(dirname(abspath(__file__)))
-        re_patt_str = (r'commit\s+(?P<commit_hash>\w+)\s+Author:\s+'
+        re_patt_str = (r'commit\s+(?P<commit_hash>\w+).*?Author:\s+'
                        r'(?P<author_name>.*?)\s+<(?P<author_email>.*?)>\s+Date:\s+'
-                       r'(?P<date>.*?)\n\s+(?P<commit_msg>.*?)\s+diff')
+                       r'(?P<date>.*?)\n\s+(?P<commit_msg>.*?)(?:\ndiff.*?)?$')
         show_out = check_output(['git', 'show']).decode('ascii')
         revp_out = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
         revp_out = revp_out.decode('ascii').strip()
-        m = re.match(re_patt_str, show_out)
-        assert m is not None, "Regex failed."
+        m = re.search(re_patt_str, show_out, re.DOTALL)
+        assert m is not None, \
+            "Regex pattern:\n\n\"%s\"\n\n failed to match string:\n\n\"%s\"" \
+            % (re_patt_str, show_out)
         ret_dict = m.groupdict()
         ret_dict['branch_name'] = revp_out
     finally:


### PR DESCRIPTION
Fix a bug in the `get_git_info` function's regex which prevented it from parsing merge commits.