### PR TITLE
Refactor the db rest client

### DIFF
--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -310,6 +310,9 @@ def get_statements_by_hash(hash_list, ev_limit=100, best_first=True, tries=2):
         help gracefully handle an unreliable connection, if you're willing to
         wait. Default is 2.
     """
+    if not isinstance(hash_list, list):
+        raise ValueError("The `hash_list` input is a list, not %s."
+                         % type(hash_list))
     resp = _submit_request('post', 'statements/from_hashes',
                            data={'hashes': hash_list}, ev_limit=ev_limit,
                            best_first=best_first, tries=tries, div='')

--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -313,6 +313,11 @@ def get_statements_by_hash(hash_list, ev_limit=100, best_first=True, tries=2):
     if not isinstance(hash_list, list):
         raise ValueError("The `hash_list` input is a list, not %s."
                          % type(hash_list))
+    if isinstance(hash_list[0], str):
+        hash_list = [int(h) for h in hash_list]
+    if not all([isinstance(h, int) for h in hash_list]):
+        raise ValueError("Hashes must be ints or strings that can be converted "
+                         "into ints.")
     resp = _submit_request('post', 'statements/from_hashes',
                            data={'hashes': hash_list}, ev_limit=ev_limit,
                            best_first=best_first, tries=tries, div='')


### PR DESCRIPTION
The `get_statements` method now uses a timeout, which applies to the entire function, rather than making an initial query (and waiting for that to complete, however long), and then optionally continuing. This is of particular value to applications such as the indrabot, and bob, where _any_ response is best given promptly.  This mostly affects corner cases and extremely large queries. It does slightly change the arguments of `get_statements`, specifically removing the `block` option in place of `timeout`. The default behavior related to this argument has not changed, so few if any external applications would be affected. However it would enable refactoring in the indrabot and bioagents to take place.