### PR TITLE
Mesh Client

### DIFF
--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -1,0 +1,31 @@
+import requests
+import functools
+
+mesh_url = 'http://id.nlm.nih.gov/mesh/'
+
+
+def get_mesh_name(mesh_id):
+    """Get the MESH label for the given MESH ID.
+
+    Parameters
+    ----------
+    mesh_id : str
+        MESH Identifier, e.g. 'D003094'.
+
+    Returns
+    -------
+    str
+        Label for the MESH ID, or None if the query failed or no label was
+        found.
+    """
+    url = mesh_url + mesh_id + '.json'
+    resp = requests.get(url)
+    if resp.status_code != 200:
+        return None
+    mesh_json = resp.json()
+    try:
+        label = mesh_json['@graph'][0]['label']['@value']
+    except (KeyError, IndexError) as e:
+        return None
+    return label
+

--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -1,8 +1,17 @@
+import csv
 import requests
-import functools
 
 mesh_url = 'http://id.nlm.nih.gov/mesh/'
 
+# Python3
+try:
+    from functools import lru_cache
+# Python2
+except ImportError:
+    from functools32 import lru_cache
+
+
+def 
 
 def get_mesh_name(mesh_id):
     """Get the MESH label for the given MESH ID.
@@ -28,4 +37,19 @@ def get_mesh_name(mesh_id):
     except (KeyError, IndexError) as e:
         return None
     return label
+
+
+if __name__ == '__main__':
+    with open('mesh_ids.txt', 'rt') as f:
+        mesh_ids = [line.strip() for line in f.readlines()]
+    mesh_mappings = []
+    for mid in mesh_ids:
+        if mid.startswith('MESH:'):
+            mid = mid[5:]
+        mesh_label = get_mesh_name(mid)
+        mesh_mappings.append((mid, mesh_label))
+        print(f"{mid} -> {mesh_label}")
+    with open('mesh_id_label_mappings.tsv', 'wt') as f:
+        csvwriter = csv.writer(f, delimiter='\t')
+        csvwriter.writerows(mesh_mappings)
 

--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -19,8 +19,9 @@ for mesh_id, mesh_label in read_unicode_csv(mesh_file, delimiter='\t'):
     mesh_mappings[mesh_id] = mesh_label
 
 
+@lru_cache(maxsize=1000)
 def get_mesh_name_from_web(mesh_id):
-    """Get the MESH label for the given MESH ID.
+    """Get the MESH label for the given MESH ID using the NLM REST API.
 
     Parameters
     ----------
@@ -47,6 +48,9 @@ def get_mesh_name_from_web(mesh_id):
 
 def get_mesh_name(mesh_id, offline=False):
     """Get the MESH label for the given MESH ID.
+
+    Uses the mappings table in `indra/resources`; if the MESH ID is not listed
+    there, falls back on the NLM REST API.
 
     Parameters
     ----------

--- a/indra/resources/mesh_id_label_mappings.tsv
+++ b/indra/resources/mesh_id_label_mappings.tsv
@@ -1,0 +1,105 @@
+D017209	Apoptosis
+D002470	Cell Survival
+C003528	5-androstene-3,17-dione
+C071834	glycidamide
+C025687	4-hydroxymephenytoin
+C087837	7-hydroxywarfarin
+D010300	Parkinson Disease
+C018911	dibenzoanthracene-1,2-dihydrodiol
+C534072	MIRN101 microRNA, human
+C053003	S-phenyl-N-acetylcysteine
+C097911	methiocarb sulfoxide
+D016922	Cellular Senescence
+C036139	norfluoxetine
+C452229	chlorophenyl isocyanate
+C502239	2-amino-1-methyl-6-phenolimidazo(4,5-b)pyridine-DNA adduct
+D016764	Cell Polarity
+C117710	4-hydroxy-4-(3-pyridyl)butanoic acid
+D014158	Transcription, Genetic
+C085470	2-amino-4-hydroxymethyl-3,8-dimethylimidazo(4,5-f)quinoxaline
+C080580	O-demethyltramadol
+D008070	Lipopolysaccharides
+C545376	3-ketocholanoic acid
+D053903	DNA Breaks, Double-Stranded
+D009361	Neoplasm Invasiveness
+D002248	Carbon Monoxide
+D004260	DNA Repair
+D005963	Glucosylceramides
+D002453	Cell Cycle
+D059016	Tumor Microenvironment
+D058750	Epithelial-Mesenchymal Transition
+C496215	radafaxine
+D007249	Inflammation
+C026486	1,2,5,6-dibenzanthracene
+D011471	Prostatic Neoplasms
+D061745	Antioxidant Response Elements
+D016195	G2 Phase
+C018912	dibenzoanthracene-3,4-dihydrodiol
+D000375	Aging
+C028657	3-methoxymorphinan
+D000068878	Trastuzumab
+C440780	mono-N-desethylamiodarone
+D014176	Protein Biosynthesis
+C580748	hydroxybupropion
+C060974	phosphatidylinositol 3,4,5-triphosphate
+D053078	Membrane Potential, Mitochondrial
+D010778	Photochemotherapy
+D016193	G1 Phase
+D049109	Cell Proliferation
+C039685	Ro 03-7410
+D048708	Cell Growth Processes
+C017228	benzo(a)pyrene 7,8-dihydrodiol
+D042822	Genomic Instability
+D014411	Neoplastic Stem Cells
+C081015	4-fluoro-N-methylaniline
+C039289	6-hydroxychlorzoxazone
+D002454	Cell Differentiation
+D016923	Cell Death
+C077584	2-amino-1-methyl-6-(4-hydroxyphenyl)imidazo(4,5-b)pyridine
+D010716	Phosphatidylinositols
+C117711	4-oxo-4-(3-pyridyl)butanoic acid
+D001343	Autophagy
+C023492	alpha-methyldopamine
+C056033	7-ethoxy-4-trifluoromethylcoumarin
+C077580	7-(deoxyadenosin-N(6)-yl)aristolactam I
+D013860	Thiocholine
+D002448	Cell Adhesion
+C051268	2-hydroxychavicol
+D060833	Cellular Microenvironment
+C008091	6-hydroxywarfarin
+C545880	4,5-dihydropyrazole-1,5-dicarboxylic acid 1-((4-chlorophenyl)-amide) 5-(2-oxo-2H-(1,3')bipyridinyl-6'-yl)-amide
+D000249	Adenosine Monophosphate
+D044127	Epigenesis, Genetic
+C068040	quinone methide
+C482281	4-hydroxy-1-(3-pyridyl)-1-butanone
+D002465	Cell Movement
+C084236	7-hydroxy-4-trifluoromethylcoumarin
+D003094	Collagen
+D009362	Neoplasm Metastasis
+D009101	Multiple Myeloma
+D015398	Signal Transduction
+D059767	Recombinational DNA Repair
+D054709	Lecithins
+D020719	Glucuronides
+C012376	1'-hydroxysafrole
+C093872	2-chloro-N-(2,6-diethylphenyl)acetamide
+D009336	Necrosis
+D004705	Endocytosis
+C054116	norlevorphanol
+D011839	Radiation, Ionizing
+D063646	Carcinogenesis
+C011008	15-ketoprostaglandin E
+C558664	dibenzylfluorescein
+D000650	Amnion
+C023505	2',5'-oligoadenylate
+D055153	Stem Cell Niche
+D015104	3,4-Methylenedioxyamphetamine
+C024581	N-desmethylclobazam
+C036990	2-amino-3,8-dimethylimidazo(4,5-f)quinoxaline
+C120605	7-methoxy-4-(aminomethyl)coumarin
+D008715	Methionine
+D008660	Metabolism
+D006019	Glycolysis
+C486136	16-O-demethylaconitine
+D015687	Cell Hypoxia
+D004249	DNA Damage

--- a/indra/tests/test_mesh.py
+++ b/indra/tests/test_mesh.py
@@ -1,0 +1,6 @@
+from indra.databases import mesh_client
+
+def test_mesh_id_lookup():
+    mesh_id = 'D003094'
+    mesh_name = mesh_client.get_mesh_name(mesh_id)
+    assert mesh_name == 'Collagen'

--- a/indra/tests/test_mesh.py
+++ b/indra/tests/test_mesh.py
@@ -1,11 +1,33 @@
 from indra.databases import mesh_client
 
-def test_mesh_id_lookup():
+
+def test_mesh_id_lookup_from_web():
     mesh_id = 'D003094'
-    mesh_name = mesh_client.get_mesh_name(mesh_id)
+    mesh_name = mesh_client.get_mesh_name_from_web(mesh_id)
     assert mesh_name == 'Collagen'
 
+
 def test_invalid_id():
-    mesh_name = mesh_client.get_mesh_name('34jkgfh')
+    mesh_name = mesh_client.get_mesh_name_from_web('34jkgfh')
     assert mesh_name is None
+
+
+def test_mesh_id_lookup_local():
+    mesh_id = 'D005963'
+    mesh_name = mesh_client.get_mesh_name(mesh_id, offline=True)
+    assert mesh_name == 'Glucosylceramides'
+
+
+def test_mesh_id_local_missing():
+    mesh_id = 'D015242'
+    mesh_name = mesh_client.get_mesh_name(mesh_id, offline=True)
+    assert mesh_name is None
+
+
+def test_mesh_id_fallback_to_rest():
+    mesh_id = 'D015242'
+    mesh_name = mesh_client.get_mesh_name(mesh_id, offline=False)
+    assert mesh_name == 'Ofloxacin'
+
+
 

--- a/indra/tests/test_mesh.py
+++ b/indra/tests/test_mesh.py
@@ -4,3 +4,8 @@ def test_mesh_id_lookup():
     mesh_id = 'D003094'
     mesh_name = mesh_client.get_mesh_name(mesh_id)
     assert mesh_name == 'Collagen'
+
+def test_invalid_id():
+    mesh_name = mesh_client.get_mesh_name('34jkgfh')
+    assert mesh_name is None
+


### PR DESCRIPTION
Adds a new client in databases for getting normalized labels for MESH terms. Includes a mappings file in resources, `mesh_id_label_mappings.tsv`, which includes all of the MESH identifiers that we currently have in the INDRA database (there are only 105 of them). The client draws on this mapping file when possible and falls back to the NLM REST API if necessary.

Documentation on the MESH REST API can be found here: https://id.nlm.nih.gov/mesh/. There's certainly more information we could access from this API, but our principal need is just to normalize the names in our Statements and exported networks.

