### PR TITLE
Patch sparser's GO groundings.

### DIFF
--- a/indra/sources/sparser/processor.py
+++ b/indra/sources/sparser/processor.py
@@ -34,17 +34,17 @@ def _fix_json_agents(ag_obj):
 
 
 class SparserJSONProcessor(object):
-    """The SparserJSONProcessor extracts INDRA Statements from Sparser's output.
+    """Processor extracting INDRA Statements from Sparser's JSON output.
 
     Parameters
     ----------
-    json_dict : dict
-        A JSON dictionary containing the REACH extractions.
+    json_dict : list
+        JSON containing the raw Sparser extractions.
 
     Attributes
     ----------
-    json_stmts : json dictionary
-        A json list of dictionaries containing the raw sparser output.
+    json_stmts : list
+        JSON containing the raw Sparser extractions.
     statements : list[indra.statements.Statement]
         A list of INDRA Statements that were extracted by the processor.
     """
@@ -148,6 +148,8 @@ class SparserJSONProcessor(object):
     def set_statements_pmid(self, pmid):
         """Set the evidence PMID of Statements that have been extracted.
 
+        Parameters
+        ----------
         pmid : str
             The PMID to be used in the Evidence objects of the Statements
             that were extracted by the processor.
@@ -233,12 +235,12 @@ def _fix_agent(agent):
 
 
 class SparserXMLProcessor(object):
-    """The SparserJSONProcessor extracts INDRA Statements from Sparser's output.
+    """Processor extracting INDRA Statements from Sparser's XML output.
 
     Parameters
     ----------
     xml_etree : xml.etree.ElementTree
-        An xml ElementTree containing the xml output of sparser.
+        An ElementTree containing the XML output of Sparser.
 
     Attributes
     ----------

--- a/indra/sources/sparser/processor.py
+++ b/indra/sources/sparser/processor.py
@@ -145,6 +145,12 @@ def _fix_agent(agent):
         elif db_ns == 'XFAM':
             db_refs_tmp.pop('XFAM', None)
             db_refs_tmp['PF'] = db_id.split('.')[0]
+        elif db_ns == 'GO':
+            db_refs_tmp.pop('GO', None)
+            if db_id.startswith('GO:'):
+                db_refs_tmp['GO'] = db_id
+            else:
+                db_refs_tmp['GO'] = 'GO:' + db_id
     agent.db_refs = db_refs_tmp
     # Check if we have a FPLX entry and handle old BE mappings
     if 'BE' in agent.db_refs:

--- a/indra/sources/sparser/processor.py
+++ b/indra/sources/sparser/processor.py
@@ -146,7 +146,6 @@ def _fix_agent(agent):
             db_refs_tmp.pop('XFAM', None)
             db_refs_tmp['PF'] = db_id.split('.')[0]
         elif db_ns == 'GO':
-            db_refs_tmp.pop('GO', None)
             if db_id.startswith('GO:'):
                 db_refs_tmp['GO'] = db_id
             else:

--- a/indra/sources/sparser/processor.py
+++ b/indra/sources/sparser/processor.py
@@ -23,6 +23,7 @@ except:
 def _fix_json_agents(ag_obj):
     """Fix the json representation of an agent."""
     if isinstance(ag_obj, str):
+        logger.info("Fixing string agent: %s." % ag_obj)
         ret = {'name': ag_obj, 'db_refs': {'TEXT': ag_obj}}
     elif isinstance(ag_obj, list):
         # Recursive for complexes and similar.
@@ -57,6 +58,7 @@ class SparserJSONProcessor(object):
             try:
                 # If type isn't there, we have a very serious problem.
                 stmt_type = json_stmt['type']
+
                 # Step 1: fix JSON directly to reduce errors when deserializing
                 # 1.1 - Check for string agents.
                 stmt_class = get_statement_by_name(stmt_type)
@@ -83,7 +85,8 @@ class SparserJSONProcessor(object):
                     obj_activity = json_stmt.get('obj_activity')
                     if isinstance(obj_activity, list):
                         if len(obj_activity) != 1:
-                            print('Invalid object activity: %s' % obj_activity)
+                            logger.error('Invalid object activity: %s'
+                                         % obj_activity)
                         else:
                             json_stmt['obj_activity'] = obj_activity[0]
                     obj = json_stmt.get('obj')

--- a/indra/sources/sparser/processor.py
+++ b/indra/sources/sparser/processor.py
@@ -20,8 +20,21 @@ except:
     basestring = str
 
 
-
 class SparserJSONProcessor(object):
+    """The SparserJSONProcessor extracts INDRA Statements from Sparser's output.
+
+    Parameters
+    ----------
+    json_dict : dict
+        A JSON dictionary containing the REACH extractions.
+
+    Attributes
+    ----------
+    json_stmts : json dictionary
+        A json list of dictionaries containing the raw sparser output.
+    statements : list[indra.statements.Statement]
+        A list of INDRA Statements that were extracted by the processor.
+    """
     def __init__(self, json_dict):
         self.json_stmts = json_dict
         self.statements = []
@@ -197,6 +210,22 @@ def _fix_agent(agent):
 
 
 class SparserXMLProcessor(object):
+    """The SparserJSONProcessor extracts INDRA Statements from Sparser's output.
+
+    Parameters
+    ----------
+    xml_etree : xml.etree.ElementTree
+        An xml ElementTree containing the xml output of sparser.
+
+    Attributes
+    ----------
+    tree : objectpath.Tree
+        The objectpath Tree object representing the extractions.
+    statements : list[indra.statements.Statement]
+        A list of INDRA Statements that were extracted by the processor.
+    pmid : str
+        The pmid of the content the statements were extracted from.
+    """
     def __init__(self, xml_etree):
         self.tree = xml_etree
         self.statements = []
@@ -288,7 +317,8 @@ class SparserXMLProcessor(object):
                 continue
             for event, sentence in events:
                 # Get the subject of the activation
-                subj_ref = event.find("ref/var/[@name='by-means-of-or-agent']/ref")
+                subj_ref = event.find("ref/var/[@name='by-means-of-or-agent']"
+                                      "/ref")
                 if subj_ref is None:
                     subj_ref = event.find("ref/var/[@name='agent']/ref")
                 if subj_ref is None:

--- a/indra/tests/test_sparser.py
+++ b/indra/tests/test_sparser.py
@@ -1,7 +1,7 @@
 import json
 from indra.sources import sparser
 from indra.sources.sparser.processor import _fix_agent
-from indra.statements import Agent, Phosphorylation
+from indra.statements import Agent, Phosphorylation, Complex
 from nose.plugins.attrib import attr
 
 # ############################
@@ -92,6 +92,16 @@ def test_process_json_str():
     assert sp.json_stmts[0]['evidence'][0]['pmid'] == '1234567'
 
 
+def test_process_json_str_with_bad_agents():
+    sp = sparser.process_json_dict(json.loads(json_str2))
+    assert sp is not None
+    assert len(sp.statements) == 2, len(sp.statements)
+    print(sp.statements)
+    types = {type(s) for s in sp.statements}
+    assert types == {Complex, Phosphorylation}, types
+    assert all(len(s.agent_list()) == 2 for s in sp.statements)
+
+
 xml_str1 = '''
 <article pmid="54321">
  <interpretation>
@@ -177,4 +187,36 @@ json_str1 = '''
       "TEXT": "MEK"},
     "TEXT": "MEK"}
  }
+]'''
+
+json_str2 = '''
+[
+  {
+    "type": "Phosphorylation",
+    "evidence": [
+      {
+          "source_api": "sparser",
+          "text": "MEK phosphorylates ERK",
+          "pmid": "PMC_3500"}],
+    "sub": "ERK",
+    "enz": {
+      "name": "MEK",
+      "db_refs": {
+          "FPLX": "MEK",
+          "TEXT": "MEK"},
+      "TEXT": "MEK"}
+  },
+  {
+    "type": "Complex",
+    "members": [
+      "MEK",
+      {
+        "name": "ERK",
+        "db_refs": {"FPLX": "ERK",
+                    "TEXT": "ERK"}
+      }
+    ],
+    "belief": 1,
+    "id": "3eedc7a9-fbbd-4e2e-b227-07d96f4bcff5"
+  }
 ]'''

--- a/indra/tests/test_sparser.py
+++ b/indra/tests/test_sparser.py
@@ -96,7 +96,6 @@ def test_process_json_str_with_bad_agents():
     sp = sparser.process_json_dict(json.loads(json_str2))
     assert sp is not None
     assert len(sp.statements) == 2, len(sp.statements)
-    print(sp.statements)
     types = {type(s) for s in sp.statements}
     assert types == {Complex, Phosphorylation}, types
     assert all(len(s.agent_list()) == 2 for s in sp.statements)


### PR DESCRIPTION
Sparser omits the 'GO:' prefix to GO ids in at least a majority of cases. This PR simply adds it on.