### PR TITLE
Add the ability to limit the number of statements returned.

### DIFF
--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -245,7 +245,11 @@ def get_statements(subject=None, object=None, agents=None, stmt_type=None,
         sensitive. If the statement class given has sub-classes
         (e.g. RegulateAmount has IncreaseAmount and DecreaseAmount), then both
         the class itself, and its subclasses, will be queried, by default. If
-        you do not want this behavior, set use_exact_type=True.
+        you do not want this behavior, set use_exact_type=True. Note that if
+        max_stmts is set, it is possible only the exact statement type will
+        be returned, as this is the first searched. The processor then cycles
+        through the types, getting a page of results for each type and adding it
+        to the quota, until the max number of statements is reached.
     use_exact_type : bool
         If stmt_type is given, and you only want to search for that specific
         statement type, set this to True. Default is False.

--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -52,7 +52,7 @@ class IndraDBRestResponse(object):
         self.statement_jsons = {}
         self.__done = False
         self.evidence_counts = {}
-        self.started = False
+        self.__started = False
         if statement_jsons is not None:
             if ev_totals is None:
                 raise IndraDBRestError("If statement_jsons is given, ev_totals "
@@ -93,7 +93,7 @@ class IndraDBRestResponse(object):
         """Reset the response before loading more statements."""
         self.__done = False
         self.__page = page
-        self.started = False
+        self.__started = False
         self.__th = None
         return
 
@@ -110,10 +110,10 @@ class IndraDBRestResponse(object):
                 for evj in sj['evidence']:
                     self.statement_jsons[k]['evidence'].append(evj)
 
-        if not self.started:
+        if not self.__started:
             self.statements_sample = stmts_from_json(
                 self.statement_jsons.values())
-            self.started = True
+            self.__started = True
         return
 
     def compile_statements(self):

--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -76,6 +76,12 @@ class IndraDBRestResponse(object):
         """Get the total evidence count for a statement."""
         return self.__evidence_counts.get(str(stmt.get_hash(shallow=True)))
 
+    def get_hash_statements_dict(self):
+        """Return a dict of Statements keyed by hashes."""
+        res = {stmt_hash: stmts_from_json([stmt])[0]
+               for stmt_hash, stmt in self.__statement_jsons.items()}
+        return res
+
     def extend_statements(self, other_response):
         """Extend this object with new statements."""
         if not isinstance(other_response, self.__class__):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -3407,7 +3407,7 @@ def stmts_from_json(json_in, on_missing_support='handle'):
 
     Parameters
     ----------
-    json_in : list[dict]
+    json_in : iterable[dict]
         A json list containing json dict representations of INDRA Statements,
         as produced by the `to_json` methods of subclasses of Statement, or
         equivalently by `stmts_to_json`.

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from nose.plugins.attrib import attr
 from indra.sources import indra_db_rest as dbr
-from indra.sources.indra_db_rest import IndraDBRestError
+from indra.sources.indra_db_rest import IndraDBRestAPIError
 
 
 def __check_request(seconds, *args, **kwargs):

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -87,10 +87,11 @@ def test_too_big_request_persist_no_block():
     assert num_counts == num_stmts, \
         ("Counts dict was improperly handled before completing: %d counts "
          "for %d statements." % (num_counts, num_stmts))
-    assert not resp_all2.done, "Background complete resolved too fast."
+    assert resp_all2.is_working(), "Background complete resolved too fast."
     assert len(resp_all2.statements_sample) == len(resp_some.statements)
     resp_all2.wait_until_done(120)
-    assert resp_all2.done
+    assert not resp_all2.is_working(), \
+        "Response is still working. Took too long."
     assert resp_all2.statements
     num_counts = sum(resp_all2.get_ev_count(s) is not None
                      for s in resp_all2.statements)


### PR DESCRIPTION
A significant re-write of the IndraRestResponse object to allow the limitation of statements, using the new feature on the API. From the outside, the only change is that `offset` is no longer a valid option (it was not really used or useful), and `max_stmts` is now a valid option.

Some subtleties:
- If your statement is broken into sub-types, the original statement is now queried first.
- The quota of statements, if maximum is set, will cycle through all statement types, loading a page of each until the quota is full. Pages are currently batches of 1000 statements.