### PR TITLE
Format evidence repr more nicely

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -265,17 +265,18 @@ the value in the configuration file. In other words, an environment variable,
 when set, takes precedence over the value set in the config file.
 
 Configuration values include:
+
 - REACHPATH: The location of the JAR file containing a local instance of the
-REACH reading system
+  REACH reading system
 
 - EIDOSPATH: The location of the JAR file containing a local instance of the
-Eidos reading system
+  Eidos reading system
 
 - SPARSERPATH: The location of a local instance of the Sparser
-reading system (path to a folder)
+  reading system (path to a folder)
 
 - DRUMPATH: The location of a local installation of the DRUM reading system
-(path to a folder)
+  (path to a folder)
 
 - NDEX_USERNAME, NDEX_PASSWORD: Credentials for accessing the NDEx web service
 

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1205,7 +1205,7 @@ class Evidence(object):
 
         div = ',\n' + ' '*9
         ev_str += div.join(lines)
-        if len(lines) > 1:
+        if len(ev_str.splitlines()) > 1:
             ev_str += '\n' + ' '*9
         ev_str += ')\n\n'
         return ev_str

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1173,9 +1173,7 @@ class Evidence(object):
             txt = _indented_join(textwrap.wrap(self.text, width=65), 15)
             ev_str += '         text=\'%s\',\n' % txt
         if self.annotations:
-            annot = json.dumps(self.annotations, indent=1)
-            annot = _indented_join(annot.splitlines(), 22)
-            ev_str += '         annotations=%s' % annot
+            ev_str += _format_dict(self.annotations, 'annotations')
         ev_str += ')\n\n'
         return ev_str
 
@@ -1188,6 +1186,12 @@ class Evidence(object):
 
 def _indented_join(s_list, depth):
     return '\n'.join(' '*depth + s for s in s_list).lstrip(' ')
+
+
+def _format_dict(d, name, indent=9):
+    s = json.dumps(d, indent=1)
+    s = _indented_join(s.splitlines(), indent+len(name)+1)
+    return ' '*9 + name + s
 
 
 class Statement(object):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1048,6 +1048,17 @@ class Evidence(object):
     text_refs : dict
         A dictionary of various reference ids to the source text, e.g.
         DOI, PMID, URL, etc.
+
+    Additional Attributes
+    ---------------------
+    source_hash : int
+        A hash calculated from the evidence text, source api, and pmid and/or
+        source_id if available. This is generated automatcially when the object
+        is instantiated.
+    stmt_tag : int
+        This is a hash calculated by a Statement to which this evidence refers,
+        and is set by said Statement. It is useful for tracing ownership of
+        an Evidence object.
     """
     def __init__(self, source_api=None, source_id=None, pmid=None, text=None,
                  annotations=None, epistemics=None, context=None,
@@ -1079,6 +1090,10 @@ class Evidence(object):
             state['context'] = None
         if 'text_refs' not in state:
             state['text_refs'] = {}
+        if 'stmt_tag' not in state:
+            state['stmt_tag'] = None
+        if 'source_hash' not in state:
+            state['source_hash'] = None
         self.__dict__ = state
 
     def get_source_hash(self, refresh=False):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1049,8 +1049,9 @@ class Evidence(object):
         A dictionary of various reference ids to the source text, e.g.
         DOI, PMID, URL, etc.
 
-    Additional Attributes
-    ---------------------
+
+    There are some attributes which are not set by the parameters above:
+
     source_hash : int
         A hash calculated from the evidence text, source api, and pmid and/or
         source_id if available. This is generated automatcially when the object
@@ -1134,6 +1135,7 @@ class Evidence(object):
         return matches
 
     def to_json(self):
+        """Convert the evidence object into a JSON dict."""
         json_dict = _o({})
         if self.source_api:
             json_dict['source_api'] = self.source_api
@@ -1230,8 +1232,6 @@ class Evidence(object):
             return str(self)
         else:
             return str(self).encode('utf-8')
-
-
 
 
 class Statement(object):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -200,10 +200,12 @@ __all__ = [
 import os
 import abc
 import sys
+import json
 import uuid
 import rdflib
 import logging
 import networkx
+import textwrap
 import datetime
 import itertools
 from hashlib import md5
@@ -1162,8 +1164,15 @@ class Evidence(object):
     def __str__(self):
         ev_str = 'Evidence(source_api=\'%s\',\n' % self.source_api
         ev_str += '         pmid=\'%s\',\n' % self.pmid
-        ev_str += '         text=\'%s\',\n' % self.text
-        ev_str += '         annotations=%s)' % self.annotations
+        if self.text:
+            txt_lines = textwrap.wrap(self.text, width=65)
+            txt = textwrap.indent('\n'.join(txt_lines), prefix=' '*15).lstrip(' ')
+            ev_str += '         text=\'%s\',\n' % txt
+        if self.annotations:
+            annot = json.dumps(self.annotations, indent=1)
+            annot = textwrap.indent(annot, prefix=' '*22).lstrip(' ')
+            ev_str += '         annotations=%s' % annot
+        ev_str += ')\n\n'
         return ev_str
 
     def __repr__(self):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1165,12 +1165,11 @@ class Evidence(object):
         ev_str = 'Evidence(source_api=\'%s\',\n' % self.source_api
         ev_str += '         pmid=\'%s\',\n' % self.pmid
         if self.text:
-            txt_lines = textwrap.wrap(self.text, width=65)
-            txt = textwrap.indent('\n'.join(txt_lines), prefix=' '*15).lstrip(' ')
+            txt = _indented_join(textwrap.wrap(self.text, width=65), 15)
             ev_str += '         text=\'%s\',\n' % txt
         if self.annotations:
             annot = json.dumps(self.annotations, indent=1)
-            annot = textwrap.indent(annot, prefix=' '*22).lstrip(' ')
+            annot = _indented_join(annot.splitlines(), 22)
             ev_str += '         annotations=%s' % annot
         ev_str += ')\n\n'
         return ev_str
@@ -1180,6 +1179,10 @@ class Evidence(object):
             return str(self)
         else:
             return str(self).encode('utf-8')
+
+
+def _indented_join(s_list, depth):
+    return '\n'.join(' '*depth + s for s in s_list).lstrip(' ')
 
 
 class Statement(object):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1072,6 +1072,7 @@ class Evidence(object):
         self.context = context
         self.source_hash = None
         self.get_source_hash()
+        self.stmt_tag = None
 
     def __setstate__(self, state):
         if 'context' not in state:
@@ -1136,6 +1137,8 @@ class Evidence(object):
         if self.text_refs:
             json_dict['text_refs'] = self.text_refs
         json_dict['source_hash'] = self.get_source_hash()
+        if self.stmt_tag:
+            json_dict['stmt_tag'] = self.stmt_tag
         return json_dict
 
     @classmethod
@@ -1152,6 +1155,7 @@ class Evidence(object):
             context = Context.from_json(context_entry)
         else:
             context = None
+        stmt_tag = json_dict.get('stmt_tag')
         # Note that the source hash will be re-generated upon loading, so if
         # any of the relevant attributes used to create the hash changed, the
         # hash will also have changed.
@@ -1159,6 +1163,7 @@ class Evidence(object):
                       pmid=pmid, text=text, annotations=annotations,
                       epistemics=epistemics, context=context,
                       text_refs=text_refs)
+        ev.stmt_tag = stmt_tag
         return ev
 
     def __str__(self):
@@ -1277,6 +1282,13 @@ class Statement(object):
                     _make_hash(self.matches_key() + str(ev_mk_list), 16)
             ret = self._full_hash
         return ret
+
+    def _tag_evidence(self):
+        """Set all the Evidence stmt_tag to my deep matches-key hash."""
+        h = self.get_hash(shallow=False)
+        for ev in self.evidence:
+            ev.stmt_tag = h
+        return
 
     def agent_list_with_bound_condition_agents(self):
         # Returns the list of agents both directly participating in the

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1167,20 +1167,46 @@ class Evidence(object):
         return ev
 
     def __str__(self):
-        ev_str = 'Evidence(source_api=\'%s\',\n' % self.source_api
-        ev_str += '         pmid=\'%s\',\n' % self.pmid
+        ev_str = 'Evidence('
+        tab_len = len(ev_str)
+
+        def _indented_join(s_list, depth):
+            return '\n'.join(' '*depth + s for s in s_list).lstrip(' ')
+
+        lines = []
+
+        def _add_line(name, s):
+            lines.append('%s=%s' % (name, s))
+
+        def _format_line(name, s):
+            return _add_line(name, "'%s'" % s)
+
+        def _format_dict(d, name, indent=9):
+            s = json.dumps(d, indent=1)
+            s = _indented_join(s.splitlines(), indent+len(name)+1)
+            return _add_line(name, s)
+
+        if self.source_api:
+            _format_line('source_api', self.source_api)
+        if self.pmid:
+            _format_line('pmid', self.pmid)
         if self.source_id:
-            ev_str += ' '*9 + 'source_id=\'%s\',\n' % self.source_id
+            _format_line('source_id', self.source_id)
         if self.text:
-            txt = _indented_join(textwrap.wrap(self.text, width=65), 15)
-            ev_str += '         text=\'%s\'' % txt
+            txt = _indented_join(textwrap.wrap(self.text, width=65),
+                                 tab_len+6)
+            _format_line('text', txt)
         if self.annotations:
-            ev_str += ',\n' + _format_dict(self.annotations, 'annotations')
+            _format_dict(self.annotations, 'annotations')
         if self.context:
-            ev_str += ',\n' + _format_dict(self.context.to_json(), 'context')
+            _format_dict(self.context.to_json(), 'context')
         if self.epistemics:
-            ev_str += ',\n' + _format_dict(self.epistemics, 'epistemics')
-        ev_str += '\n'
+            _format_dict(self.epistemics, 'epistemics')
+
+        div = ',\n' + ' '*9
+        ev_str += div.join(lines)
+        if len(lines) > 1:
+            ev_str += '\n' + ' '*9
         ev_str += ')\n\n'
         return ev_str
 
@@ -1191,14 +1217,6 @@ class Evidence(object):
             return str(self).encode('utf-8')
 
 
-def _indented_join(s_list, depth):
-    return '\n'.join(' '*depth + s for s in s_list).lstrip(' ')
-
-
-def _format_dict(d, name, indent=9):
-    s = json.dumps(d, indent=1)
-    s = _indented_join(s.splitlines(), indent+len(name)+1)
-    return ' '*9 + name + '=' + s
 
 
 class Statement(object):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1169,11 +1169,17 @@ class Evidence(object):
     def __str__(self):
         ev_str = 'Evidence(source_api=\'%s\',\n' % self.source_api
         ev_str += '         pmid=\'%s\',\n' % self.pmid
+        if self.source_id:
+            ev_str += ' '*9 + 'source_id=%s' % self.source_id
         if self.text:
             txt = _indented_join(textwrap.wrap(self.text, width=65), 15)
             ev_str += '         text=\'%s\',\n' % txt
         if self.annotations:
             ev_str += _format_dict(self.annotations, 'annotations')
+        if self.context:
+            ev_str += _format_dict(self.context.to_json(), 'context')
+        if self.epistemics:
+            ev_str += _format_dict(self.epistemics, 'epistemics')
         ev_str += ')\n\n'
         return ev_str
 

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1170,16 +1170,17 @@ class Evidence(object):
         ev_str = 'Evidence(source_api=\'%s\',\n' % self.source_api
         ev_str += '         pmid=\'%s\',\n' % self.pmid
         if self.source_id:
-            ev_str += ' '*9 + 'source_id=%s' % self.source_id
+            ev_str += ' '*9 + 'source_id=%s,\n' % self.source_id
         if self.text:
             txt = _indented_join(textwrap.wrap(self.text, width=65), 15)
-            ev_str += '         text=\'%s\',\n' % txt
+            ev_str += '         text=\'%s\'' % txt
         if self.annotations:
-            ev_str += _format_dict(self.annotations, 'annotations')
+            ev_str += ',\n' + _format_dict(self.annotations, 'annotations')
         if self.context:
-            ev_str += _format_dict(self.context.to_json(), 'context')
+            ev_str += ',\n' + _format_dict(self.context.to_json(), 'context')
         if self.epistemics:
-            ev_str += _format_dict(self.epistemics, 'epistemics')
+            ev_str += ',\n' + _format_dict(self.epistemics, 'epistemics')
+        ev_str += '\n'
         ev_str += ')\n\n'
         return ev_str
 

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1170,7 +1170,7 @@ class Evidence(object):
         ev_str = 'Evidence(source_api=\'%s\',\n' % self.source_api
         ev_str += '         pmid=\'%s\',\n' % self.pmid
         if self.source_id:
-            ev_str += ' '*9 + 'source_id=%s,\n' % self.source_id
+            ev_str += ' '*9 + 'source_id=\'%s\',\n' % self.source_id
         if self.text:
             txt = _indented_join(textwrap.wrap(self.text, width=65), 15)
             ev_str += '         text=\'%s\'' % txt
@@ -1198,7 +1198,7 @@ def _indented_join(s_list, depth):
 def _format_dict(d, name, indent=9):
     s = json.dumps(d, indent=1)
     s = _indented_join(s.splitlines(), indent+len(name)+1)
-    return ' '*9 + name + s
+    return ' '*9 + name + '=' + s
 
 
 class Statement(object):
@@ -3191,6 +3191,7 @@ class Unresolved(Statement):
 
 
 class Context(object):
+    """An abstract class for Contexts."""
     @classmethod
     def from_json(cls, jd):
         context_type = jd.get('type')
@@ -3203,7 +3204,7 @@ class Context(object):
 
 
 class BioContext(Context):
-    """An oject representing the context of a Statement in biology.
+    """An object representing the context of a Statement in biology.
 
     Parameters
     ----------


### PR DESCRIPTION
In #613 I changed the repr for Evidence objects to add some formatting. But the result has been pretty bad for long evidence sentences and annotations that weren't wrapped. This PR attempts to marginally improve the situation by adding some textwrapping and indentation when displaying evidences. One issue is that Statement.evidence is a plain list and so we can't really control if new lines are added between elements, this results in some strange looking formatting when displaying a list vs a single Evidence but still better than it was overall. Here is an example:
```
In [12]: stmts[10].evidence
Out[12]: 
[Evidence(source_api='reach',
          pmid='29085365',
          text='However, SOCS1 suppresses the effect of IFN-gamma on
                keratinocytes by inhibiting the JAK2 and STAT1 pathway.',
          annotations={
                        "found_by": "Negative_activation_syntax_1_verb",
                        "agents": {
                         "raw_text": [
                          "SOCS1",
                          "STAT1"
                         ]
                        },
                        "prior_uuids": [
                         "b8d9f340-50f1-48d3-bcbc-8b00dfea943c"
                        ],
                        "content_source": "pmc_oa"
                       })
 , Evidence(source_api='sparser',
          pmid='29235573',
          text='Western blot analysis of the effects of overexpression of SOCS1
                in DF-1 cells infected with IBDV (Supplementary Figure  xref )
                also demonstrated elevated levels of the IBDV VP2/3 protein but
                reduced levels of phosphorylated STAT1 compared to untransfected
                control cells (total levels of STAT1 were unchanged), indicating
                partial inhibition of virus-induced activation of STAT1 by SOCS1.',
          annotations={
                        "agents": {
                         "raw_text": [
                          "SOCS1",
                          "STAT1"
                         ]
                        },
                        "prior_uuids": [
                         "38017b06-491e-4359-b8de-b0aa516742b2"
                        ],
                        "content_source": "pmc_oa"
                       })

```