### PR TITLE
Track evidence

### DIFF
--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1036,6 +1036,9 @@ class Evidence(object):
     epistemics : dict
         A dictionary describing various forms of epistemic
         certainty associated with the statement.
+    text_references : dict
+        Include a dictionary of various reference ids to the source text, e.g.
+        doi, pmid, url, etc.
     """
     def __init__(self, source_api=None, source_id=None, pmid=None, text=None,
                  annotations=None, epistemics=None, context=None,

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1044,8 +1044,8 @@ class Evidence(object):
         A dictionary describing various forms of epistemic
         certainty associated with the statement.
     text_refs : dict
-        Include a dictionary of various reference ids to the source text, e.g.
-        doi, pmid, url, etc.
+        A dictionary of various reference ids to the source text, e.g.
+        DOI, PMID, URL, etc.
     """
     def __init__(self, source_api=None, source_id=None, pmid=None, text=None,
                  annotations=None, epistemics=None, context=None,
@@ -1055,7 +1055,7 @@ class Evidence(object):
         self.pmid = pmid
         self.text_refs = {}
         if pmid is not None:
-            self.text_refs['pmid'] = pmid
+            self.text_refs['PMID'] = pmid
         if text_refs is not None:
             self.text_refs.update(text_refs)
         self.text = text
@@ -1074,6 +1074,8 @@ class Evidence(object):
     def __setstate__(self, state):
         if 'context' not in state:
             state['context'] = None
+        if 'text_refs' not in state:
+            state['text_refs'] = {}
         self.__dict__ = state
 
     def get_source_hash(self, refresh=False):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1043,7 +1043,7 @@ class Evidence(object):
     epistemics : dict
         A dictionary describing various forms of epistemic
         certainty associated with the statement.
-    text_references : dict
+    text_refs : dict
         Include a dictionary of various reference ids to the source text, e.g.
         doi, pmid, url, etc.
     """

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1038,10 +1038,16 @@ class Evidence(object):
         certainty associated with the statement.
     """
     def __init__(self, source_api=None, source_id=None, pmid=None, text=None,
-                 annotations=None, epistemics=None, context=None):
+                 annotations=None, epistemics=None, context=None,
+                 text_references=None):
         self.source_api = source_api
         self.source_id = source_id
         self.pmid = pmid
+        self.text_references = {}
+        if pmid is not None:
+            self.text_references['pmid'] = pmid
+        if other_refs is not None:
+            self.text_references.update(other_refs)
         self.text = text
         if annotations:
             self.annotations = annotations
@@ -1094,6 +1100,8 @@ class Evidence(object):
             json_dict['epistemics'] = self.epistemics
         if self.context:
             json_dict['context'] = self.context.to_json()
+        if self.text_references:
+            json_dict['text_references'] = self.text_references
         return json_dict
 
     @classmethod
@@ -1105,13 +1113,15 @@ class Evidence(object):
         annotations = json_dict.get('annotations', {}).copy()
         epistemics = json_dict.get('epistemics', {}).copy()
         context_entry = json_dict.get('context')
+        text_refs = json_dict.get('text_references', {}).copy()
         if context_entry:
             context = Context.from_json(context_entry)
         else:
             context = None
         ev = Evidence(source_api=source_api, source_id=source_id,
                       pmid=pmid, text=text, annotations=annotations,
-                      epistemics=epistemics, context=context)
+                      epistemics=epistemics, context=context,
+                      text_references=text_refs)
         return ev
 
     def __str__(self):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1046,8 +1046,8 @@ class Evidence(object):
         self.text_references = {}
         if pmid is not None:
             self.text_references['pmid'] = pmid
-        if other_refs is not None:
-            self.text_references.update(other_refs)
+        if text_references is not None:
+            self.text_references.update(text_references)
         self.text = text
         if annotations:
             self.annotations = annotations

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1082,8 +1082,8 @@ class Evidence(object):
         The resulting value is stored in the source_hash attribute of the class
         and is preserved in the json dictionary.
         """
-        if hasattr('source_hash') and self.source_hash is not None and not \
-                refresh:
+        if hasattr(self, 'source_hash') and self.source_hash is not None \
+                and not refresh:
             return self.source_hash
         s = str(self.text) + str(self.source_api) + str(self.source_id)
         self.source_hash = _make_hash(s, 16)

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1049,15 +1049,15 @@ class Evidence(object):
     """
     def __init__(self, source_api=None, source_id=None, pmid=None, text=None,
                  annotations=None, epistemics=None, context=None,
-                 text_references=None):
+                 text_refs=None):
         self.source_api = source_api
         self.source_id = source_id
         self.pmid = pmid
-        self.text_references = {}
+        self.text_refs = {}
         if pmid is not None:
-            self.text_references['pmid'] = pmid
-        if text_references is not None:
-            self.text_references.update(text_references)
+            self.text_refs['pmid'] = pmid
+        if text_refs is not None:
+            self.text_refs.update(text_refs)
         self.text = text
         if annotations:
             self.annotations = annotations
@@ -1125,8 +1125,8 @@ class Evidence(object):
             json_dict['epistemics'] = self.epistemics
         if self.context:
             json_dict['context'] = self.context.to_json()
-        if self.text_references:
-            json_dict['text_references'] = self.text_references
+        if self.text_refs:
+            json_dict['text_refs'] = self.text_refs
         json_dict['source_hash'] = self.get_source_hash()
         return json_dict
 
@@ -1139,7 +1139,7 @@ class Evidence(object):
         annotations = json_dict.get('annotations', {}).copy()
         epistemics = json_dict.get('epistemics', {}).copy()
         context_entry = json_dict.get('context')
-        text_refs = json_dict.get('text_references', {}).copy()
+        text_refs = json_dict.get('text_refs', {}).copy()
         if context_entry:
             context = Context.from_json(context_entry)
         else:
@@ -1150,7 +1150,7 @@ class Evidence(object):
         ev = Evidence(source_api=source_api, source_id=source_id,
                       pmid=pmid, text=text, annotations=annotations,
                       epistemics=epistemics, context=context,
-                      text_references=text_refs)
+                      text_refs=text_refs)
         return ev
 
     def __str__(self):

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -1085,7 +1085,11 @@ class Evidence(object):
         if hasattr(self, 'source_hash') and self.source_hash is not None \
                 and not refresh:
             return self.source_hash
-        s = str(self.text) + str(self.source_api) + str(self.source_id)
+        s = str(self.source_api) + str(self.source_id)
+        if self.text and isinstance(self.text, str):
+            s += self.text
+        elif self.pmid and isinstance(self.pmid, str):
+            s += self.pmid
         self.source_hash = _make_hash(s, 16)
         return self.source_hash
 

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1337,6 +1337,7 @@ def test_serialize():
     st2 = stmts_from_json([jstr])[0]
     assert(st.equals(st2))
     assert unicode_strs((ev1, st, st2))
+    assert st.evidence[0].source_hash == st2.evidence[0].source_hash
 
 
 def test_location_refinement():


### PR DESCRIPTION
This PR makes two changes:
- Adds a `text_references` attribute and parameter to `Evidence`, to carry more general text ref info besides pmids.
- Adds a `source_hash` attribute and `get_source_hash` method to store and generate a hash based off of the text and source api. This could have major degeneracies for content we get from pathway databases if/when there isn't a `source_id`, but I don't think we can avoid that.