### PR TITLE
Update the db rest client

### DIFF
--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -419,7 +419,8 @@ def get_statements_for_paper(ids, ev_limit=10, best_first=True, tries=2,
     stmts : list[:py:class:`indra.statements.Statement`]
         A list of INDRA Statement instances.
     """
-    resp = _submit_statement_request('post', 'from_papers', data={'ids': ids},
+    id_l = [{'id': id_val, 'type': id_type} for id_type, id_val in ids]
+    resp = _submit_statement_request('post', 'from_papers', data={'ids': id_l},
                                      ev_limit=ev_limit, best_first=best_first,
                                      tries=tries, max_stmts=max_stmts)
     stmts_json = resp.json()['statements']

--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -388,18 +388,16 @@ def get_statements_by_hash(hash_list, ev_limit=100, best_first=True, tries=2):
 
 
 @clockit
-def get_statements_for_paper(id_val, id_type='pmid', ev_limit=10,
-                             best_first=True, tries=2, max_stmts=None):
+def get_statements_for_paper(ids, ev_limit=10, best_first=True, tries=2,
+                             max_stmts=None):
     """Get the set of raw Statements extracted from a paper given by the id.
 
     Parameters
     ----------
-    id_val : str or int
-        The value of the id of the paper of interest.
-    id_type : str
-        This may be one of 'pmid', 'pmcid', 'doi', 'pii', 'manuscript id', or
-        'trid', which is the primary key id of the text references in the
-        database. The default is 'pmid'.
+    ids : list[(<id type>, <id value>)]
+        A list of tuples with ids and their type. The type can be any one of
+        'pmid', 'pmcid', 'doi', 'pii', 'manuscript id', or 'trid', which is the
+        primary key id of the text references in the database.
     ev_limit : int or None
         Limit the amount of evidence returned per Statement. Default is 10.
     best_first : bool
@@ -421,9 +419,9 @@ def get_statements_for_paper(id_val, id_type='pmid', ev_limit=10,
     stmts : list[:py:class:`indra.statements.Statement`]
         A list of INDRA Statement instances.
     """
-    resp = _submit_query_request('from_papers', id=id_val, type=id_type,
-                                 ev_limit=ev_limit, best_first=best_first,
-                                 tries=tries, max_stmts=max_stmts)
+    resp = _submit_statement_request('post', 'from_papers', data={'ids': ids},
+                                     ev_limit=ev_limit, best_first=best_first,
+                                     tries=tries, max_stmts=max_stmts)
     stmts_json = resp.json()['statements']
     return stmts_from_json(stmts_json.values())
 

--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -480,7 +480,7 @@ def _make_request(meth, end_point, query_str, data=None, params=None, tries=2):
         json_data = json.dumps(data)
     else:
         json_data = None
-    params['api-key'] = api_key
+    params['api_key'] = api_key
     logger.info('url and query string: %s',
                 url_path.replace(str(api_key), '[api-key]'))
     logger.info('headers: %s', str(headers).replace(str(api_key), '[api-key]'))


### PR DESCRIPTION
This PR makes a few minor changes to match those in the INDRA DB REST API:
- `api-key` is changed to `api_key`
- queries for statements by paper now allow the submission of multiple papers, addressing #602.