### PR TITLE
Py2 bel timeout

### DIFF
--- a/indra/tests/test_bel.py
+++ b/indra/tests/test_bel.py
@@ -6,6 +6,8 @@ from indra.sources import bel
 from indra.sources.bel.rdf_processor import BelRdfProcessor
 from indra.statements import RegulateAmount, BioContext, RefContext
 from nose.plugins.attrib import attr
+from nose.plugins.skip import SkipTest
+from indra.tests.util import skip_if, IS_PY3
 
 concept_prefix = 'http://www.openbel.org/bel/namespace//'
 entity_prefix = 'http://www.openbel.org/bel/'
@@ -19,10 +21,11 @@ def assert_pmids(stmts):
     for stmt in stmts:
         for ev in stmt.evidence:
             if ev.pmid is not None:
-                assert ev.pmid.isdigit(), ev.pmid 
+                assert ev.pmid.isdigit(), ev.pmid
 
 
 @attr('webservice', 'slow')
+@skip_if(not IS_PY3, 'Python 2 detected. Runtime may be excessive')
 def test_bel_ndex_query():
     bp = bel.process_ndex_neighborhood(['NFKB1'])
     assert_pmids(bp.statements)

--- a/indra/tests/test_bel.py
+++ b/indra/tests/test_bel.py
@@ -6,7 +6,6 @@ from indra.sources import bel
 from indra.sources.bel.rdf_processor import BelRdfProcessor
 from indra.statements import RegulateAmount, BioContext, RefContext
 from nose.plugins.attrib import attr
-from nose.plugins.skip import SkipTest
 from indra.tests.util import skip_if, IS_PY3
 
 concept_prefix = 'http://www.openbel.org/bel/namespace//'

--- a/indra/tests/util.py
+++ b/indra/tests/util.py
@@ -14,3 +14,18 @@ def needs_py3(func):
             raise SkipTest("This tests features only supported in Python 3.x")
         return func(*args, **kwargs)
     return test_with_py3_func
+
+
+def skip_if(condition, reason=None):
+    """Skip test if condition is true"""
+    def decorate(func):
+        wraps(func)
+        func_name = func.__name__
+
+        def f(*args, **kwargs):
+            if not condition:
+                raise SkipTest("'%s' skipped: %s" % (func_name, reason))
+            else:
+                return func(*args, **kwargs)
+        return f
+    return decorate


### PR DESCRIPTION
This PR updates test_bel.py to skip the test_bel_ndex_query if python2 is detected. The test seems to take longer than 10 minutes to complete on Travis when using python2.  For whatever reason the test runs slightly faster when using python3. A skip_if decorator has been added to indra.tests.util, allowing tests to be skipped if a condition holds

Fixes #687