### PR TITLE
Some more minor changes.

### DIFF
--- a/doc/modules/sources/index.rst
+++ b/doc/modules/sources/index.rst
@@ -1,23 +1,48 @@
 Processors for knowledge input (:py:mod:`indra.sources`)
 ========================================================
+
+INDRA can draw content from many sources, some specifically for biological
+content, and some for more generic causal knowledge; some are from machine
+readers and some are from human-curated or data driven databases.
+
+Biological Reading Systems
+--------------------------
 .. toctree::
    :maxdepth: 3
 
    reach/index
    trips/index
    sparser/index
-   isi/index
    medscan/index
-   geneways/index
    tees/index
+
+General Purpose Reading Systems
+-------------------------------
+.. toctree::
+   :maxdepth: 3
+
+   isi/index
+   geneways/index
    eidos/index
    cwms/index
    sofia/index
    hume/index
+
+Standard Molecular Pathway Databases
+------------------------------------
+.. toctree::
+   :maxdepth: 3
+
    bel/index
    biopax/index
    signor/index
    biogrid/index
+
+Custom Knowledge Bases
+----------------------
+.. toctree::
+   :maxdepth: 3
+
    tas/index
    lincs_drug/index
    ndex_cx/index

--- a/doc/modules/sources/index.rst
+++ b/doc/modules/sources/index.rst
@@ -15,14 +15,14 @@ Biological Reading Systems
    sparser/index
    medscan/index
    tees/index
+   isi/index
+   geneways/index
 
 General Purpose Reading Systems
 -------------------------------
 .. toctree::
    :maxdepth: 3
 
-   isi/index
-   geneways/index
    eidos/index
    cwms/index
    sofia/index

--- a/doc/modules/sources/index.rst
+++ b/doc/modules/sources/index.rst
@@ -1,12 +1,13 @@
 Processors for knowledge input (:py:mod:`indra.sources`)
 ========================================================
 
-INDRA can draw content from many sources, some specifically for biological
-content, and some for more generic causal knowledge; some are from machine
-readers and some are from human-curated or data driven databases.
+INDRA interfaces with and draws knowledge from many sources including
+reading systems (some that extract biological mechanisms, and some that extract
+general causal interactions from text) and also from structured databases,
+which are typically human-curated or derived from experimental data.
 
-Biological Reading Systems
---------------------------
+Biology-oriented Reading Systems
+--------------------------------
 .. toctree::
    :maxdepth: 3
 

--- a/doc/modules/sources/ndex_cx/index.rst
+++ b/doc/modules/sources/ndex_cx/index.rst
@@ -1,4 +1,4 @@
-NDEx CX API (:py:mod:`indra.sources.api`)
+NDEx CX API (:py:mod:`indra.sources.ndex_cx.api`)
 =================================================
 
 .. automodule:: indra.sources.ndex_cx.api

--- a/indra/sources/biogrid.py
+++ b/indra/sources/biogrid.py
@@ -140,7 +140,7 @@ class BiogridProcessor(object):
             object.
         """
         db_refs = {}
-        if text_id != '-':
+        if text_id != '-' and text_id is not None:
             db_refs['TEXT'] = text_id
 
         hgnc_id = hgnc_client.get_hgnc_from_entrez(entrez_id)

--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -456,9 +456,8 @@ def _submit_query_request(end_point, *args, **kwargs):
 
 @clockit
 def _submit_statement_request(meth, end_point, query_str='', data=None,
-                              ev_limit=50, best_first=True, tries=2):
+                              tries=2, **params):
     """Even lower level function to make the request."""
-    params = {'ev_limit': ev_limit, 'best_first': best_first}
     full_end_point = 'statements/' + end_point.lstrip('/')
     return _make_request(meth, full_end_point, query_str, data, params, tries)
 


### PR DESCRIPTION
- Simplify parameters in the db client api to avoid a potential bug.
- Add a level of depth to the documentation for Sources a la #651.
- Prevents biogrid from creating statements with 'TEXT' db_refs set to None.