### PR TITLE
Grounding map docs

### DIFF
--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -97,9 +97,18 @@ class GroundingMapper(object):
         return
 
     def map_agents_for_stmt(self, stmt, do_rename=True):
+        """Map the agents within a statement, returning a new statement
+
+        Parameters
+        ----------
+        stmt: indra.statements.Statement
+        statement whose agents need mapping
+
+        do_rename: bool
+        Whether to rename the agent text
+        """
         mapped_stmt = deepcopy(stmt)
         # Iterate over the agents
-        mapped_agent_list = mapped_stmt.agent_list()
 
         # Update agents directly participating in the statement
         agent_list = mapped_stmt.agent_list()

--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -274,12 +274,12 @@ class GroundingMapper(object):
 
         Parameters
         ----------
-        stmts : list of `:py:class:indra.statements.Statement`
+        stmts : list of :py:class:`indra.statements.Statement`
             List of statements whose Agents need their names updated.
 
         Returns
         -------
-        mapped_stmts : list of `:py:class:`indra.statements.Statement`
+        mapped_stmts : list of :py:class:`indra.statements.Statement`
             A new list of Statements with updated Agent names
         """
         # Make a copy of the stmts

--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -32,37 +32,37 @@ class GroundingMapper(object):
         self.agent_map = agent_map if agent_map is not None else {}
 
     def update_agent_db_refs(self, agent, agent_text, do_rename=True):
-        """Update db_refs of agent by mapping agent_text in the grounding map
-
-        Parameters
-        ----------
-        agent: indra.statements.Agent
-        The agent whose db_refs will be updated
+        """Update db_refs of agent using the grounding map
 
         If the grounding map is missing one of the HGNC symbol or Uniprot ID,
         attempts to reconstruct one from the other.
 
-        agent_text: str
-        The agent_text to find a grounding for in the grounding map dictionary.
-        Typically this will be agent.db_refs['TEXT'] but there may be
-        situations where a different value should be used.
+        Parameters
+        ----------
+        agent : :py:class:`indra.statements.Agent`
+            The agent whose db_refs will be updated
+
+        agent_text : str
+            The agent_text to find a grounding for in the grounding map
+            dictionary. Typically this will be agent.db_refs['TEXT'] but
+            there may be situations where a different value should be used.
 
         do_rename: bool
-        Whether to rename the agent text. If do_rename is True the priority
-        for setting the name is
-        1. FamPlex ID
-        2. HGNC symbol from the grounding map_agent
-        3. Gene name associated with Uniprot ID in Uniprot
+            Whether to rename the agent text. If do_rename is True the priority
+            for setting the name is FamPlex ID, HGNC symbol, then the gene name
+            from Uniprot.
 
         Raises
         ------
-        ValueError: If the the grounding map contains and HGNC symbol for
-        agent_text but no HGNC ID can be found for it.
+        ValueError
+            If the the grounding map contains and HGNC symbol for
+            agent_text but no HGNC ID can be found for it.
 
-        ValueError: If the grounding map contains both an HGNC symbol and a
-        Uniprot ID, but the HGNC symbol and the gene name associated with the
-        gene in Uniprot do not match or if there is no associated gene name in
-        Uniprot.
+        ValueError
+            If the grounding map contains both an HGNC symbol and a
+            Uniprot ID, but the HGNC symbol and the gene name associated with
+            the gene in Uniprot do not match or if there is no associated gene
+            name in Uniprot.
         """
         gene_name = None
         map_db_refs = deepcopy(self.gm.get(agent_text))
@@ -133,7 +133,7 @@ class GroundingMapper(object):
 
         Parameters
         ----------
-        stmt : indra.statements.Statement
+        stmt : :py:class:`indra.statements.Statement`
             The Statement whose agents need mapping.
 
         do_rename : Optional[bool]
@@ -142,7 +142,7 @@ class GroundingMapper(object):
 
         Returns
         -------
-        mapped_stmt : indra.statements.Statement
+        mapped_stmt : :py:class:`indra.statements.Statement`
             The mapped Statement.
         """
         mapped_stmt = deepcopy(stmt)
@@ -192,7 +192,7 @@ class GroundingMapper(object):
 
         Parameters
         ----------
-        agent : indra.statements.Agent
+        agent : :py:class:`indra.statements.Agent`
             The Agent to map.
         do_rename : bool
             If True, the agent names will be changed to the new standard name
@@ -201,7 +201,7 @@ class GroundingMapper(object):
 
         Returns
         -------
-        grounded_agent : indra.statements.Agent
+        grounded_agent : :py:class:`indra.statements.Agent`
             The grounded Agent.
         maps_to_none : bool
             True if the Agent is in the grounding map and maps to None.
@@ -233,23 +233,22 @@ class GroundingMapper(object):
         return agent, False
 
     def map_agents(self, stmts, do_rename=True):
-        """Ground the agents in each statement in a list of statements.
-
-        Produces a new list of statements without modifying the original list
+        """Return a new list of statements whose agents have been mapped
 
         Parameters
         ----------
-        stmts: list[indra.statements.Statement]
-        The statements whose agents need mapping
+            stmts : list of :py:class:`indra.statements.Statement`
+                The statements whose agents need mapping
 
-        do_rename: bool
-        Whether to rename the agent texts
+            do_rename : bool
+                If True, the agent names will be changed to the new standard
+                name implied by grounding. Default: True
 
         Returns
         -------
-        mapped_stmts: list[indra.statements.Statement]
-        A list of statements given by mapping the agents from each statement
-        in the input list
+        mapped_stmts : list of :py:class`indra.statements.Statement`
+            A list of statements given by mapping the agents from each
+            statement in the input list
         """
         # Make a copy of the stmts
         mapped_stmts = []

--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -32,6 +32,8 @@ class GroundingMapper(object):
         self.agent_map = agent_map if agent_map is not None else {}
 
     def update_agent_db_refs(self, agent, agent_text, do_rename=True):
+        """
+        """
         gene_name = None
         map_db_refs = deepcopy(self.gm.get(agent_text))
         up_id = map_db_refs.get('UP')
@@ -223,6 +225,27 @@ class GroundingMapper(object):
         return mapped_stmts
 
     def rename_agents(self, stmts):
+        """Update the names of the agents in a statement
+
+        Creates a new list of statements without modifying the original list.
+
+        The agents in a statement should be renamed if the grounding map has
+        updated their db_refs. If an agent contains a FamPlex grounding, the
+        FamPlex ID is used as a name. Otherwise if it contains a Uniprot ID,
+        an attempt is made to find the associated HGNC gene name. If one can
+        be found it is used as the agent name and the associated HGNC ID is
+        added as an entry to the db_refs. If neither a FamPlex ID or HGNC name
+        can be found, falls back to the original name.
+
+        Parameters
+        __________
+        stmts: list[indra.statements.Statement]
+        list of statements whose agents need their names updated
+        Returns
+        _______
+        mapped_stmts: list[indra.statements.Statement]
+        a new list of statements with updated agent names
+        """
         # Make a copy of the stmts
         mapped_stmts = deepcopy(stmts)
         # Iterate over the statements

--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -554,8 +554,15 @@ def get_agents_with_name(name, stmts):
 
 
 def save_base_map(filename, grouped_by_text):
-    """Dump a list of agents along with groundings and their counts as output
-    by agent_texts_with_grounding into a csv file.
+    """Dump a list of agents along with groundings and counts into a csv file
+
+    Parameters
+    ----------
+    filename : str
+        filepath for output file
+
+    grouped_by_text : list of tuple
+        list of tuples of the form output by agent_texts_with_grounding
     """
     rows = []
     for group in grouped_by_text:
@@ -573,12 +580,25 @@ def save_base_map(filename, grouped_by_text):
 
 
 def protein_map_from_twg(twg):
-    """Build map of entity texts to validate protein grounding.
+    """Build  map of entity texts to validate protein grounding.
 
     Looks at the grounding of the entity texts extracted from the statements
     and finds proteins where there is grounding to a human protein that maps to
     an HGNC name that is an exact match to the entity text. Returns a dict that
     can be used to update/expand the grounding map.
+
+    Parameters
+    ----------
+    twg : list of tuple
+        list of tuples of the form output by agent_texts_with_grounding
+
+    Returns
+    -------
+    protein_map : dict
+        dict keyed on agent text with associated values
+        {'TEXT': agent_text, 'UP': uniprot_id}. Entries are for agent texts
+        where the grounding map was able to find human protein grounded to
+        this agent_text in Uniprot.
     """
 
     protein_map = {}

--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -41,12 +41,10 @@ class GroundingMapper(object):
         ----------
         agent : :py:class:`indra.statements.Agent`
             The agent whose db_refs will be updated
-
         agent_text : str
             The agent_text to find a grounding for in the grounding map
             dictionary. Typically this will be agent.db_refs['TEXT'] but
             there may be situations where a different value should be used.
-
         do_rename: bool
             Whether to rename the agent text. If do_rename is True the priority
             for setting the name is FamPlex ID, HGNC symbol, then the gene name
@@ -57,7 +55,6 @@ class GroundingMapper(object):
         ValueError
             If the the grounding map contains and HGNC symbol for
             agent_text but no HGNC ID can be found for it.
-
         ValueError
             If the grounding map contains both an HGNC symbol and a
             Uniprot ID, but the HGNC symbol and the gene name associated with
@@ -135,7 +132,6 @@ class GroundingMapper(object):
         ----------
         stmt : :py:class:`indra.statements.Statement`
             The Statement whose agents need mapping.
-
         do_rename : Optional[bool]
             If True, the agent names will be changed to the new standard name
             implied by grounding. Default: True
@@ -239,7 +235,6 @@ class GroundingMapper(object):
         ----------
         stmts : list of :py:class:`indra.statements.Statement`
             The statements whose agents need mapping
-
         do_rename : bool
             If True, the agent names will be changed to the new standard
             name implied by grounding. Default: True
@@ -323,15 +318,16 @@ class GroundingMapper(object):
 # key (e.g., ROS, ER)
 def load_grounding_map(grounding_map_path, ignore_path=None,
                        lineterminator='\r\n'):
-    """Returns a grounding map dictionary loaded from a csv file.
+    """Return a grounding map dictionary loaded from a csv file.
 
-    Where the number of name_space ID pairs varies per row and commas are
+    In the file pointed to by grounding_map_path, the number of name_space ID
+    pairs can vary per row and commas are
     used to pad out entries containing fewer than the maximum amount of
     name spaces appearing in the file. Lines should be terminated with \r\n
-    both a carriage return and a new line.
+    both a carriage return and a new line by default.
 
-    Optionally, specify another csv file containing agent texts that are
-    degenerate and should be ignored.
+    Optionally, one can specify another csv file (pointed to by ignore_path)
+    containing agent texts that are degenerate and should be filtered out.
 
     Parameters
     ----------
@@ -339,17 +335,14 @@ def load_grounding_map(grounding_map_path, ignore_path=None,
         Path to csv file containing grounding map information. Rows of the file
         should be of the form <agent_text>,<name_space_1>,<ID_1>,...
         <name_space_n>,<ID_n>
-
     ignore_path : Optional[str]
         Path to csv file containing terms that should be filtered out during
         the grounding mapping process. The file Should be of the form
         <agent_text>,,..., where the number of commas that
         appear is the same as in the csv file at grounding_map_path.
         Default: None
-
     lineterminator : Optional[str]
-        Line terminator used in input csv file.
-        Default: '\r\n'
+        Line terminator used in input csv file. Default: \r\n
 
     Returns
     -------

--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -246,7 +246,7 @@ class GroundingMapper(object):
 
         Returns
         -------
-        mapped_stmts : list of :py:class`indra.statements.Statement`
+        mapped_stmts : list of :py:class:`indra.statements.Statement`
             A list of statements given by mapping the agents from each
             statement in the input list
         """
@@ -279,12 +279,12 @@ class GroundingMapper(object):
 
         Parameters
         ----------
-        stmts : list[indra.statements.Statement]
+        stmts : list of `:py:class:indra.statements.Statement`
             List of statements whose Agents need their names updated.
 
         Returns
         -------
-        mapped_stmts : list[indra.statements.Statement]
+        mapped_stmts : list of `:py:class:`indra.statements.Statement`
             A new list of Statements with updated Agent names
         """
         # Make a copy of the stmts
@@ -323,7 +323,7 @@ class GroundingMapper(object):
 # key (e.g., ROS, ER)
 def load_grounding_map(grounding_map_path, ignore_path=None,
                        lineterminator='\r\n'):
-    """Load the grounding map dictionary from a csv file.
+    """Returns a grounding map dictionary loaded from a csv file.
 
     Where the number of name_space ID pairs varies per row and commas are
     used to pad out entries containing fewer than the maximum amount of
@@ -331,7 +331,7 @@ def load_grounding_map(grounding_map_path, ignore_path=None,
     both a carriage return and a new line.
 
     Optionally, specify another csv file containing agent texts that are
-    degenerate and should be ignored. 
+    degenerate and should be ignored.
 
     Parameters
     ----------
@@ -346,6 +346,10 @@ def load_grounding_map(grounding_map_path, ignore_path=None,
         <agent_text>,,..., where the number of commas that
         appear is the same as in the csv file at grounding_map_path.
         Default: None
+
+    lineterminator : Optional[str]
+        Line terminator used in input csv file.
+        Default: '\r\n'
 
     Returns
     -------
@@ -386,7 +390,17 @@ def load_grounding_map(grounding_map_path, ignore_path=None,
 # Some useful functions for analyzing the grounding of sets of statements
 # Put together all agent texts along with their grounding
 def all_agents(stmts):
-    """ Returns a list of all of the agents from a list of statements"""
+    """ Returns a list of all of the agents from a list of statements
+
+    Parameters
+    ----------
+    stmts : list of :py:class:`indra.statements.Statement`
+
+    Returns
+    -------
+    agents : list of :py:class:`indra.statements.Agent`
+        list of agents that appear in the input list of indra statements
+    """
     agents = []
     for stmt in stmts:
         for agent in stmt.agent_list():
@@ -400,16 +414,39 @@ def all_agents(stmts):
 def agent_texts(agents):
     """Return a list of all agent texts from a list of agents.
 
-    With None values associated to agents without an agent text (such as those
-    from database statements.)
+    None values are associated to agents without agent texts
+
+    Parameters
+    ----------
+    agents : list of :py:class:`indra.statements.Agent`
+
+    Returns
+    -------
+    list of str/None
+        agent texts from input list of agents
     """
     return [ag.db_refs.get('TEXT') for ag in agents]
 
 
 def get_sentences_for_agent(text, stmts, max_sentences=None):
-    """Given a list of statements and an agent text, return a list of
-    evidence sentences for all stmts containing an agent with that particular
-    text
+    """Returns evidence sentences with a given agent text from a list of statements
+
+    Parameters
+    ----------
+    text : str
+        an agent text
+
+    stmts : list of :py:class:`indra.statements.Statement`
+        indra statements to search in for evidence statements
+
+    max_sentences : Optional[int/None]
+        Cap on the number of evidence sentences to return. Default: None
+
+    Returns
+    -------
+    sentences : list of str
+        Evidence sentences from the list of statements containing
+        the given agent text.
     """
     sentences = []
     for stmt in stmts:
@@ -424,23 +461,23 @@ def get_sentences_for_agent(text, stmts, max_sentences=None):
 
 
 def agent_texts_with_grounding(stmts):
-    """Given a list of statements, return a list of agents in the statements
-    along with their groundings with counts of how many times the agent appears
-    with that grounding.
+    """Return agent text groundings in a list of statements with their counts
 
     Parameters
     ----------
     stmts: list[indra.statements.Statement]
 
-    Returns:
-    list(tuple) list of tuples of the form
-    (agent_text: str, ((name_space: str, ID: str, count: int)...),
-    total_count: int)
+    Returns
+    _______
+    list of tuple
+        List of tuples of the form
+        (text: str, ((name_space: str, ID: str, count: int)...),
+        total_count: int)
 
-    Where the counts within the tuple of groundings give the number of times
-    an agent with the given agent_text appears grounded with the particular
-    name space and ID. The total_count gives the total number of times an agent
-    with the given agent text appears in the list of statements.
+        Where the counts within the tuple of groundings give the number of
+        times an agent with the given agent_text appears grounded with the
+        particular name space and ID. The total_count gives the total number
+        of times an agent with text appears in the list of statements.
     """
     allag = all_agents(stmts)
     # Convert PFAM-DEF lists into tuples so that they are hashable and can
@@ -488,8 +525,17 @@ def agent_texts_with_grounding(stmts):
 
 # List of all ungrounded entities by number of mentions
 def ungrounded_texts(stmts):
-    """Given a list of statements, return a list of all ungrounded entities
-    sorted in descending order by the number of mentions.
+    """Return a list of all ungrounded entities ordered by number of mentions
+
+    Parameters
+    ----------
+    stmts : list of :py:class:`indra.statements.Statement`
+
+    Returns
+    -------
+    ungroundc : list of tuple
+       list of tuples of the form (text: str, count: int) sorted in descending
+       order by count.
     """
     ungrounded = [ag.db_refs['TEXT']
                   for s in stmts

--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -45,10 +45,11 @@ class GroundingMapper(object):
             The agent_text to find a grounding for in the grounding map
             dictionary. Typically this will be agent.db_refs['TEXT'] but
             there may be situations where a different value should be used.
-        do_rename: bool
-            Whether to rename the agent text. If do_rename is True the priority
-            for setting the name is FamPlex ID, HGNC symbol, then the gene name
-            from Uniprot.
+        do_rename: Optional[bool]
+            If True, the Agent name is updated based on the mapped grounding.
+            If do_rename is True the priority for setting the name is
+            FamPlex ID, HGNC symbol, then the gene name
+            from Uniprot. Default: True
 
         Raises
         ------
@@ -132,9 +133,11 @@ class GroundingMapper(object):
         ----------
         stmt : :py:class:`indra.statements.Statement`
             The Statement whose agents need mapping.
-        do_rename : Optional[bool]
-            If True, the agent names will be changed to the new standard name
-            implied by grounding. Default: True
+        do_rename: Optional[bool]
+            If True, the Agent name is updated based on the mapped grounding.
+            If do_rename is True the priority for setting the name is
+            FamPlex ID, HGNC symbol, then the gene name
+            from Uniprot. Default: True
 
         Returns
         -------
@@ -190,10 +193,11 @@ class GroundingMapper(object):
         ----------
         agent : :py:class:`indra.statements.Agent`
             The Agent to map.
-        do_rename : bool
-            If True, the agent names will be changed to the new standard name
-            implied by grounding. Otherwise the name is not updated even though
-            the grounding may have changed.
+        do_rename: bool
+            If True, the Agent name is updated based on the mapped grounding.
+            If do_rename is True the priority for setting the name is
+            FamPlex ID, HGNC symbol, then the gene name
+            from Uniprot.
 
         Returns
         -------
@@ -235,9 +239,11 @@ class GroundingMapper(object):
         ----------
         stmts : list of :py:class:`indra.statements.Statement`
             The statements whose agents need mapping
-        do_rename : bool
-            If True, the agent names will be changed to the new standard
-            name implied by grounding. Default: True
+        do_rename: Optional[bool]
+            If True, the Agent name is updated based on the mapped grounding.
+            If do_rename is True the priority for setting the name is
+            FamPlex ID, HGNC symbol, then the gene name
+            from Uniprot. Default: True
 
         Returns
         -------
@@ -260,7 +266,7 @@ class GroundingMapper(object):
         return mapped_stmts
 
     def rename_agents(self, stmts):
-        """Update the names of the agents in a statement
+        """Return a list of mapped statements with updated agent names.
 
         Creates a new list of statements without modifying the original list.
 
@@ -383,7 +389,9 @@ def load_grounding_map(grounding_map_path, ignore_path=None,
 # Some useful functions for analyzing the grounding of sets of statements
 # Put together all agent texts along with their grounding
 def all_agents(stmts):
-    """ Returns a list of all of the agents from a list of statements
+    """Return a list of all of the agents from a list of statements.
+
+    Only agents that are not None and have a TEXT entry are returned.
 
     Parameters
     ----------
@@ -392,7 +400,7 @@ def all_agents(stmts):
     Returns
     -------
     agents : list of :py:class:`indra.statements.Agent`
-        list of agents that appear in the input list of indra statements
+        List of agents that appear in the input list of indra statements.
     """
     agents = []
     for stmt in stmts:
@@ -427,10 +435,10 @@ def get_sentences_for_agent(text, stmts, max_sentences=None):
     Parameters
     ----------
     text : str
-        an agent text
+        An agent text
 
     stmts : list of :py:class:`indra.statements.Statement`
-        indra statements to search in for evidence statements
+        INDRA Statements to search in for evidence statements.
 
     max_sentences : Optional[int/None]
         Cap on the number of evidence sentences to return. Default: None
@@ -458,10 +466,10 @@ def agent_texts_with_grounding(stmts):
 
     Parameters
     ----------
-    stmts: list[indra.statements.Statement]
+    stmts: list of :py:class:`indra.statements.Statement`
 
     Returns
-    _______
+    -------
     list of tuple
         List of tuples of the form
         (text: str, ((name_space: str, ID: str, count: int)...),
@@ -552,10 +560,9 @@ def save_base_map(filename, grouped_by_text):
     Parameters
     ----------
     filename : str
-        filepath for output file
-
+        Filepath for output file
     grouped_by_text : list of tuple
-        list of tuples of the form output by agent_texts_with_grounding
+        List of tuples of the form output by agent_texts_with_grounding
     """
     rows = []
     for group in grouped_by_text:
@@ -630,24 +637,24 @@ def protein_map_from_twg(twg):
 
 
 def save_sentences(twg, stmts, filename, agent_limit=300):
-    """Write evidence sentences for stmts with ungrounded agents to csv file
+    """Write evidence sentences for stmts with ungrounded agents to csv file.
 
     Parameters
     ----------
-        twg: list of tuple
-            list of tuples of ungrounded agent_texts with counts of the
-            number of times they are mentioned in the list of statements.
-            Should be sorted in descending order by the counts.
-            This is of the form output by the function ungrounded texts.
+    twg: list of tuple
+        list of tuples of ungrounded agent_texts with counts of the
+        number of times they are mentioned in the list of statements.
+        Should be sorted in descending order by the counts.
+        This is of the form output by the function ungrounded texts.
 
-        stmts: list of :py:class:`indra.statements.Statement`
+    stmts: list of :py:class:`indra.statements.Statement`
 
-        filename : str
-            Path to output file
+    filename : str
+        Path to output file
 
-        agent_limit : Optional[int]
-            Number of agents to include in output file. Takes the top agents
-            by count.
+    agent_limit : Optional[int]
+        Number of agents to include in output file. Takes the top agents
+        by count.
     """
     sentences = []
     unmapped_texts = [t[0] for t in twg]

--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -181,6 +181,24 @@ class GroundingMapper(object):
         return agent, False
 
     def map_agents(self, stmts, do_rename=True):
+        """Ground the agents in each statement in a list of statements.
+
+        Produces a new list of statements without modifying the original list
+
+        Parameters
+        ----------
+        stmts: list[indra.statements.Statement]
+        The statements whose agents need mapping
+
+        do_rename: bool
+        Whether to rename the agent text
+
+        Returns
+        -------
+        mapped_stmts: list[indra.statements.Statement]
+        A list of statements given by mapping the agents from each statement
+        in the input list
+        """
         # Make a copy of the stmts
         mapped_stmts = []
         num_skipped = 0

--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -637,22 +637,24 @@ def protein_map_from_twg(twg):
 
 
 def save_sentences(twg, stmts, filename, agent_limit=300):
-    """Get all sentences for the top agents that whose texts could not be
-    mapped. Outputs results into csv file.
+    """Write evidence sentences for stmts with ungrounded agents to csv file
 
-    twg: iterable
-    contains agent texts which could not be mapped sorted by the number
-    of mentions. It can be generated from a list of statements with the
-    function ungrounded_texts.
+    Parameters
+    ----------
+        twg: list of tuple
+            list of tuples of ungrounded agent_texts with counts of the
+            number of times they are mentioned in the list of statements.
+            Should be sorted in descending order by the counts.
+            This is of the form output by the function ungrounded texts.
 
-    stmts: list[indra.statements.Statement]
+        stmts: list of :py:class:`indra.statements.Statement`
 
-    filename: str
-    path to output file
+        filename : str
+            Path to output file
 
-    agent_limit: int
-    cutoff when selecting only the most frequently mentioned ungrounded
-    agent texts
+        agent_limit : Optional[int]
+            Number of agents to include in output file. Takes the top agents
+            by count.
     """
     sentences = []
     unmapped_texts = [t[0] for t in twg]

--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -237,12 +237,12 @@ class GroundingMapper(object):
 
         Parameters
         ----------
-            stmts : list of :py:class:`indra.statements.Statement`
-                The statements whose agents need mapping
+        stmts : list of :py:class:`indra.statements.Statement`
+            The statements whose agents need mapping
 
-            do_rename : bool
-                If True, the agent names will be changed to the new standard
-                name implied by grounding. Default: True
+        do_rename : bool
+            If True, the agent names will be changed to the new standard
+            name implied by grounding. Default: True
 
         Returns
         -------
@@ -278,13 +278,14 @@ class GroundingMapper(object):
         can be found, falls back to the original name.
 
         Parameters
-        __________
-        stmts: list[indra.statements.Statement]
-        list of statements whose agents need their names updated
+        ----------
+        stmts : list[indra.statements.Statement]
+            List of statements whose Agents need their names updated.
+
         Returns
-        _______
-        mapped_stmts: list[indra.statements.Statement]
-        a new list of statements with updated agent names
+        -------
+        mapped_stmts : list[indra.statements.Statement]
+            A new list of Statements with updated Agent names
         """
         # Make a copy of the stmts
         mapped_stmts = deepcopy(stmts)
@@ -322,28 +323,34 @@ class GroundingMapper(object):
 # key (e.g., ROS, ER)
 def load_grounding_map(grounding_map_path, ignore_path=None,
                        lineterminator='\r\n'):
-    """ Load the grounding map dictionary from a csv file. Optionally, specify
-    another csv file containing agent texts that are degenerate and should be
-    ignored
-
-    Parameters
-    ----------
-    grounding_map_path: str
-    Path to csv file containing grounding map information. Rows of the file
-    should be of the form
-    <agent_text>,<name_space_1>,<ID_1>,...<name_space_n>,<ID_n>
+    """Load the grounding map dictionary from a csv file.
 
     Where the number of name_space ID pairs varies per row and commas are
     used to pad out entries containing fewer than the maximum amount of
     name spaces appearing in the file. Lines should be terminated with \r\n
     both a carriage return and a new line.
 
-    ignore_path: str or None
-    Path to csv file containing terms that should not be included in the
-    grounding map dict, though they occur in the grounding_map csv file.
+    Optionally, specify another csv file containing agent texts that are
+    degenerate and should be ignored. 
 
-    Should be of the form <agent_text>,,..., where the number of commas that
-    appear is the same as in the csv file at grounding_map_path
+    Parameters
+    ----------
+    grounding_map_path : str
+        Path to csv file containing grounding map information. Rows of the file
+        should be of the form <agent_text>,<name_space_1>,<ID_1>,...
+        <name_space_n>,<ID_n>
+
+    ignore_path : Optional[str]
+        Path to csv file containing terms that should be filtered out during
+        the grounding mapping process. The file Should be of the form
+        <agent_text>,,..., where the number of commas that
+        appear is the same as in the csv file at grounding_map_path.
+        Default: None
+
+    Returns
+    -------
+    g_map : dict
+        The grounding map constructed from the given files.
     """
     g_map = {}
     map_rows = read_unicode_csv(grounding_map_path, delimiter=',',
@@ -391,9 +398,10 @@ def all_agents(stmts):
 
 
 def agent_texts(agents):
-    """Returns a list of all agent texts from a list of agents. With None
-    values associated to agents without an agent text (such as those from
-    database statements.)
+    """Return a list of all agent texts from a list of agents.
+
+    With None values associated to agents without an agent text (such as those
+    from database statements.)
     """
     return [ag.db_refs.get('TEXT') for ag in agents]
 

--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -129,15 +129,21 @@ class GroundingMapper(object):
         return
 
     def map_agents_for_stmt(self, stmt, do_rename=True):
-        """Map the agents within a statement, returning a new statement
+        """Return a new Statement whose agents have been grounding mapped.
 
         Parameters
         ----------
-        stmt: indra.statements.Statement
-        statement whose agents need mapping
+        stmt : indra.statements.Statement
+            The Statement whose agents need mapping.
 
-        do_rename: bool
-        Whether to rename the agent texts
+        do_rename : Optional[bool]
+            If True, the agent names will be changed to the new standard name
+            implied by grounding. Default: True
+
+        Returns
+        -------
+        mapped_stmt : indra.statements.Statement
+            The mapped Statement.
         """
         mapped_stmt = deepcopy(stmt)
         # Iterate over the agents
@@ -178,22 +184,27 @@ class GroundingMapper(object):
         return mapped_stmt
 
     def map_agent(self, agent, do_rename):
-        """Grounds an agent; returns the new agent object (which might be
-        a different object if we load a new agent state from javascript).
+        """Return the given Agent with its grounding mapped.
+
+        This function grounds a single agent. It returns the new Agent object
+        (which might be a different object if we load a new agent state
+        from json) or the same object otherwise.
 
         Parameters
         ----------
-        agent: indra.statements.Agent
-            The agent to map
-        do_rename: bool
-            Whether to rename the agent text
+        agent : indra.statements.Agent
+            The Agent to map.
+        do_rename : bool
+            If True, the agent names will be changed to the new standard name
+            implied by grounding. Otherwise the name is not updated even though
+            the grounding may have changed.
 
         Returns
         -------
-        grounded_agent: indra.statements.Agent
-            The grounded agent
-        maps_to_none: bool
-            Whether the agent is in the grounding map and maps to None
+        grounded_agent : indra.statements.Agent
+            The grounded Agent.
+        maps_to_none : bool
+            True if the Agent is in the grounding map and maps to None.
         """
 
         agent_text = agent.db_refs.get('TEXT')


### PR DESCRIPTION
This PR adds Docstrings to functions in grounding_mapper.py that were previously missing. The function load_grounding_map has also been given an optional argument allowing users to specify the line separator for csv files containing grounding map info.