### PR TITLE
Adding synonyms for cellular locations

### DIFF
--- a/indra/resources/cellular_components_patch.tsv
+++ b/indra/resources/cellular_components_patch.tsv
@@ -1,0 +1,88 @@
+GO:0000407	pre-autophagosomal structure
+GO:0000418	DNA-directed RNA polymerase IV complex
+GO:0000419	DNA-directed RNA polymerase V complex
+GO:0000439	core TFIIH complex
+GO:0000935	barrier septum
+GO:0001405	presequence translocase-associated import motor
+GO:0005578	proteinaceous extracellular matrix
+GO:0005605	basal lamina
+GO:0005633	ascus lipid particle
+GO:0005665	DNA-directed RNA polymerase II, core complex
+GO:0005666	DNA-directed RNA polymerase III complex
+GO:0005675	holo TFIIH complex
+GO:0005736	DNA-directed RNA polymerase I complex
+GO:0005744	mitochondrial inner membrane presequence translocase complex
+GO:0005811	lipid particle
+GO:0005889	hydrogen:potassium-exchanging ATPase complex
+GO:0008002	lamina lucida
+GO:0008003	lamina densa
+GO:0008004	lamina reticularis
+GO:0008282	ATP-sensitive potassium channel complex
+GO:0009359	Type II site-specific deoxyribonuclease complex
+GO:0016533	cyclin-dependent protein kinase 5 holoenzyme complex
+GO:0016586	RSC complex
+GO:0016591	DNA-directed RNA polymerase II, holoenzyme
+GO:0019812	Type I site-specific deoxyribonuclease complex
+GO:0019813	Type III site-specific deoxyribonuclease complex
+GO:0030134	ER to Golgi transport vesicle
+GO:0030142	Golgi to ER transport vesicle
+GO:0030143	inter-Golgi transport vesicle
+GO:0030529	intracellular ribonucleoprotein complex
+GO:0032068	Type IV site-specific deoxyribonuclease complex
+GO:0032838	cell projection cytoplasm
+GO:0032991	macromolecular complex
+GO:0033107	CVT vesicle
+GO:0034045	pre-autophagosomal structure membrane
+GO:0034270	CVT complex
+GO:0034993	LINC complex
+GO:0036396	MIS complex
+GO:0038037	G-protein coupled receptor dimeric complex
+GO:0038038	G-protein coupled receptor homodimeric complex
+GO:0038039	G-protein coupled receptor heterodimeric complex
+GO:0042721	mitochondrial inner membrane protein insertion complex
+GO:0043234	protein complex
+GO:0043677	germination pore
+GO:0044186	host cell lipid particle
+GO:0044233	ER-mitochondrion membrane contact site
+GO:0061618	sublamina densa
+GO:0070018	transforming growth factor beta type I receptor homodimeric complex
+GO:0070019	transforming growth factor beta type II receptor homodimeric complex
+GO:0070020	transforming growth factor beta1-type II receptor complex
+GO:0070021	transforming growth factor beta1-type II receptor-type I receptor complex
+GO:0070022	transforming growth factor beta receptor complex
+GO:0070160	occluding junction
+GO:0070258	inner membrane complex
+GO:0070604	PBAF complex
+GO:0070688	MLL5-L complex
+GO:0070985	TFIIK complex
+GO:0071142	SMAD2 protein complex
+GO:0071143	SMAD3 protein complex
+GO:0071144	SMAD2-SMAD3 protein complex
+GO:0071145	SMAD2-SMAD4 protein complex
+GO:0071146	SMAD3-SMAD4 protein complex
+GO:0071686	horsetail nucleus
+GO:0071687	horsetail nucleus leading edge
+GO:0090544	BAF-type complex
+GO:0097015	bacterial-type flagellar cytoplasm
+GO:0097311	biofilm matrix
+GO:0097312	biofilm matrix component
+GO:0097313	biofilm matrix surface
+GO:0097441	basilar dendrite
+GO:0097482	muscle cell postsynaptic density
+GO:0097632	extrinsic component of pre-autophagosomal structure membrane
+GO:0097633	intrinsic component of pre-autophagosomal structure membrane
+GO:0097634	integral component of pre-autophagosomal structure membrane
+GO:0097648	G-protein coupled receptor complex
+GO:0098666	G-protein coupled serotonin receptor complex
+GO:0098853	ER-vacuole membrane contact site
+GO:0099535	synapse associated extracellular matrix
+GO:1902712	G-protein coupled GABA receptor complex
+GO:1990251	Mmi1 nuclear focus complex
+GO:1990296	scaffoldin complex
+GO:1990316	ATG1/ULK1 kinase complex
+GO:1990328	RNA polymerase II, RPB4-RPB7 subcomplex
+GO:1990531	Lem3p-Dnf1p complex
+GO:1990746	HCN4 channel complex
+GO:1990759	HCN2 channel complex
+GO:1990811	Msd1-Wdr8-Pkl1 complex
+GO:1990903	extracellular ribonucleoprotein complex

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1898,3 +1898,13 @@ def test_context_bool():
     assert not WorldContext()
     assert WorldContext(time=TimeContext())
     assert WorldContext(geo_location=RefContext(name='x'))
+
+
+def test_deprecated_cellular_location():
+    stmt = Translocation(Agent('x'), 'HCN4 channel complex',
+                         'pre-autophagosomal structure')
+    assert stmt.from_location == 'HCN4 channel complex'
+    assert stmt.to_location == 'pre-autophagosomal structure'
+    stmt = Statement._from_json(stmt.to_json())
+    assert stmt.from_location == 'HCN4 channel complex'
+    assert stmt.to_location == 'pre-autophagosomal structure'


### PR DESCRIPTION
Having considered some solution possibilities, the best fix seems to be to keep track of old "synonyms" of cellular locations in a patch file under resources, which is loaded in statements.py. If and when reader output is re-processed into Statements, the `get_valid_location` function ensures that the new name will be instantiated in the new Statement. This fixes #691 