### PR TITLE
Add function to get protein description from UniProt

### DIFF
--- a/indra/databases/uniprot_client.py
+++ b/indra/databases/uniprot_client.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import os
-import logging
 import rdflib
+import logging
 import requests
+from xml.etree import ElementTree
 try:
     # Python 3
     from functools import lru_cache
@@ -611,6 +612,29 @@ def get_rat_id(human_protein_id):
         The UniProt ID of a rat protein orthologous to the given human protein
     """
     return um.uniprot_human_rat.get(human_protein_id)
+
+
+def get_function(protein_id):
+    """Return the function description of a given protein.
+
+    Parameters
+    ----------
+    protein_id : str
+        The UniProt ID of the protein.
+
+    Returns
+    -------
+    str
+        The function description of the protein.
+    """
+    url = uniprot_url + protein_id + '.xml'
+    ret = requests.get(url)
+    et = ElementTree.fromstring(ret.content)
+    function = et.find('up:entry/up:comment[@type="function"]/up:text',
+                       namespaces={'up': 'http://uniprot.org/uniprot'})
+    if function is None:
+        return None
+    return function.text
 
 
 class UniprotMapper(object):

--- a/indra/tests/test_uniprot_client.py
+++ b/indra/tests/test_uniprot_client.py
@@ -181,3 +181,9 @@ def test_mouse_from_human():
 
 def test_rat_from_human():
     assert(uniprot_client.get_rat_id('P04049') == 'P11345')
+
+
+@attr('webservice')
+def test_get_function():
+    fun = uniprot_client.get_function('P15056')
+    assert fun.startswith('Protein kinase involved in the transduction')


### PR DESCRIPTION
Interestingly, the RDF endpoint doesn't provide the description and so this function uses the XML endpoint of the UniProt web service. In the longer term we might want to consolidate on a single web service end point.