### PR TITLE
Make ndex2 a basic dependency and pin its version

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -238,8 +238,6 @@ of dependencies.
 +-----------------+------------------------------------------------------+
 |bbn              |BBN reader input processing                           |
 +-----------------+------------------------------------------------------+
-|ndex             |NDEx client for network input processing and CX upload|
-+-----------------+------------------------------------------------------+
 |sbml             |SBML model export through the PySB Assembler          |
 +-----------------+------------------------------------------------------+
 |machine          |Running a local instance of a "RAS machine"           |

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def main():
     # for Python 3)
     install_list = ['pysb>=1.3.0', 'objectpath', 'rdflib==4.2.1',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
-                    'networkx>=2', 'pandas']
+                    'networkx>=2', 'pandas', 'ndex2==2.0.0.8']
     if sys.version_info[0] == 2:
         install_list.append('functools32')
 
@@ -21,12 +21,11 @@ def main():
                       'geneways': ['stemming', 'nltk'],
                       'sofia': ['openpyxl'],
                       'hume': ['rdflib-jsonld'],
-                      'ndex': ['ndex2==1.2.0.58'],
                       'bel': ['pybel'],
                       'sbml': ['python-libsbml'],
                       # Tools and analysis
-                      'machine': ['pytz', 'tzlocal', 'tweepy',
-                                  'ndex2==1.2.0.58', 'pyyaml', 'click'],
+                      'machine': ['pytz', 'tzlocal', 'tweepy', 'pyyaml',
+                                  'click'],
                       'explanation': ['kappy==4.0.0rc1', 'paths-graph'],
                       # AWS interface and database
                       'aws': ['boto3', 'reportlab'],


### PR DESCRIPTION
This PR puts ndex2 into INDRA's main install list. It also pins its version to 2.0.0.8 which was just released and is compatible with INDRA.