### PR TITLE
Site Mapper/Assemble Corpus Fix

### DIFF
--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -38,7 +38,10 @@ class MappedStatement(object):
         elements: ((gene_name, residue, position), mapped_site).  If the
         invalid position was not found in the site map, mapped_site is
         None; otherwise it is a tuple consisting of (residue, position,
-        comment).
+        comment). Note that some entries in the site map are curated *errors*,
+        that is, sites that are known to be frequent misattributions
+        to certain proteins. Such sites are mapped to tuples
+        (None, None, comment).
     mapped_stmt : :py:class:`indra.statements.Statement`
         The statement after mapping. Note that if no information was found
         in the site map, it will be identical to the original statement.

--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -481,8 +481,7 @@ class SiteMapper(object):
                         continue
             # Now check the site map
             mapped_site = self.site_map.get(site_key, None)
-            # No entry in the site map, or no valid mapping; set site info
-            # to None
+            # No entry in the site map; set site info to None
             if mapped_site is None:
                 self._cache[site_key] = None
                 invalid_sites.append((site_key, None))

--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -378,8 +378,7 @@ class SiteMapper(object):
         list
             A list of invalid sites, where each entry in the list has two
             elements: ((gene_name, residue, position), mapped_site).  If the
-            invalid position was not found in the site map, or if it is curated
-            in the site map as a known error with no mapping, mapped_site is
+            invalid position was not found in the site map, mapped_site is
             None; otherwise it is a tuple consisting of (residue, position,
             comment).
         """
@@ -479,14 +478,6 @@ class SiteMapper(object):
                         continue
             # Now check the site map
             mapped_site = self.site_map.get(site_key, None)
-            # If there is an entry in the site map that is intended to flag
-            # a site as incorrect, with no viable mapping (i.e., either of the
-            # the entries in the mapping tuple are None), then set the
-            # mapped_site to None (not a tuple) so that it doesn't get
-            # misinterpreted as an actual mapping
-            if mapped_site is not None and \
-               (mapped_site[0] is None or mapped_site[1] is None):
-                mapped_site = None
             # No entry in the site map, or no valid mapping; set site info
             # to None
             if mapped_site is None:

--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -167,8 +167,6 @@ class SiteMapper(object):
                     invalid_sites += agent_invalid_sites
                     new_agent.bound_conditions[ind].agent = new_b
 
-
-
                 new_agent_list.append(new_agent)
             else:
                 new_agent_list.append(agent)
@@ -380,7 +378,8 @@ class SiteMapper(object):
         list
             A list of invalid sites, where each entry in the list has two
             elements: ((gene_name, residue, position), mapped_site).  If the
-            invalid position was not found in the site map, mapped_site is
+            invalid position was not found in the site map, or if it is curated
+            in the site map as a known error with no mapping, mapped_site is
             None; otherwise it is a tuple consisting of (residue, position,
             comment).
         """
@@ -480,8 +479,17 @@ class SiteMapper(object):
                         continue
             # Now check the site map
             mapped_site = self.site_map.get(site_key, None)
+            # If there is an entry in the site map that is intended to flag
+            # a site as incorrect, with no viable mapping (i.e., either of the
+            # the entries in the mapping tuple are None), then set the
+            # mapped_site to None (not a tuple) so that it doesn't get
+            # misinterpreted as an actual mapping
+            if mapped_site is not None and \
+               (mapped_site[0] is None or mapped_site[1] is None):
+                mapped_site = None
+            # No entry in the site map, or no valid mapping; set site info
+            # to None
             if mapped_site is None:
-                # No entry in the site map--set site info to None
                 self._cache[site_key] = None
                 invalid_sites.append((site_key, None))
             # Manually mapped in the site map

--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -331,7 +331,6 @@ def test_map_sequence_blank_entries():
     mapped = ac.map_sequence([st1, st2])
     assert len(mapped) == 0
 
-    rps6 = Agent('RPS6', db_refs={'UP': 'P62753'})
 
 def test_filter_by_type():
     st_out = ac.filter_by_type([st1, st14], Phosphorylation)

--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -323,9 +323,15 @@ def test_map_sequence_blank_entries():
     get treated as valid mappings."""
     mapk1 = Agent('MAPK1', db_refs={'UP': 'P28482'})
     rps6 = Agent('RPS6', db_refs={'UP': 'P62753'})
+    phos_rps6 = Agent('RPS6',
+                 mods=[ModCondition('phosphorylation', 'T', '389')],
+                 db_refs={'UP': 'P62753'})
     st1 = Phosphorylation(mapk1, rps6, 'T', '389')
-    mapped = ac.map_sequence([st1])
+    st2 = Phosphorylation(phos_rps6, mapk1, 'T', '185')
+    mapped = ac.map_sequence([st1, st2])
     assert len(mapped) == 0
+
+    rps6 = Agent('RPS6', db_refs={'UP': 'P62753'})
 
 def test_filter_by_type():
     st_out = ac.filter_by_type([st1, st14], Phosphorylation)

--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -318,6 +318,15 @@ def test_map_sequence():
     st_out = ac.map_sequence([st3])
     assert(len(st_out) == 0)
 
+def test_map_sequence_blank_entries():
+    """Make sure sites curated as erroneous with no mappings don't
+    get treated as valid mappings."""
+    mapk1 = Agent('MAPK1', db_refs={'UP': 'P28482'})
+    rps6 = Agent('RPS6', db_refs={'UP': 'P62753'})
+    st1 = Phosphorylation(mapk1, rps6, 'T', '389')
+    mapped = ac.map_sequence([st1])
+    assert len(mapped) == 0
+
 def test_filter_by_type():
     st_out = ac.filter_by_type([st1, st14], Phosphorylation)
     assert(len(st_out) == 1)

--- a/indra/tests/test_sitemapper.py
+++ b/indra/tests/test_sitemapper.py
@@ -262,6 +262,3 @@ def validate_mapk1(agent1):
     assert agent1.mods[0].matches(ModCondition('phosphorylation', 'T', '185'))
     assert agent1.mods[1].matches(ModCondition('phosphorylation', 'Y', '187'))
 
-if __name__ == '__main__':
-    test_ignore_blank_entries()
-

--- a/indra/tests/test_sitemapper.py
+++ b/indra/tests/test_sitemapper.py
@@ -195,18 +195,6 @@ def test_site_map_hgnc():
     assert len(valid) == 0
     assert len(mapped) == 1
 
-def test_ignore_blank_entries():
-    """Make sure sites curated as erroneous with no mappings don't appear
-    to be valid mappings by setting the mapped_mods entry in the
-    MappedStatement to None."""
-    mapk1 = Agent('MAPK1', db_refs={'UP': 'P28482'})
-    rps6 = Agent('RPS6', db_refs={'UP': 'P62753'})
-    st1 = Phosphorylation(mapk1, rps6, 'T', '389')
-    (valid, mapped) = sm.map_sites([st1])
-    assert len(valid) == 0
-    assert len(mapped) == 1
-    ms = mapped[0]
-    assert ms.mapped_mods[0][1] is None
 
 def test_site_map_within_bound_condition():
     # Here, we test to make sure that agents within a bound condition are

--- a/indra/tests/test_sitemapper.py
+++ b/indra/tests/test_sitemapper.py
@@ -195,6 +195,18 @@ def test_site_map_hgnc():
     assert len(valid) == 0
     assert len(mapped) == 1
 
+def test_ignore_blank_entries():
+    """Make sure sites curated as erroneous with no mappings don't appear
+    to be valid mappings by setting the mapped_mods entry in the
+    MappedStatement to None."""
+    mapk1 = Agent('MAPK1', db_refs={'UP': 'P28482'})
+    rps6 = Agent('RPS6', db_refs={'UP': 'P62753'})
+    st1 = Phosphorylation(mapk1, rps6, 'T', '389')
+    (valid, mapped) = sm.map_sites([st1])
+    assert len(valid) == 0
+    assert len(mapped) == 1
+    ms = mapped[0]
+    assert ms.mapped_mods[0][1] is None
 
 def test_site_map_within_bound_condition():
     # Here, we test to make sure that agents within a bound condition are
@@ -261,3 +273,7 @@ def validate_mapk1(agent1):
     assert len(agent1.mods) == 2
     assert agent1.mods[0].matches(ModCondition('phosphorylation', 'T', '185'))
     assert agent1.mods[1].matches(ModCondition('phosphorylation', 'Y', '187'))
+
+if __name__ == '__main__':
+    test_ignore_blank_entries()
+

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -141,8 +141,8 @@ def map_sequence(stmts_in, **kwargs):
         reference sequence, a mapping is created. Default is True.
     use_cache : boolean
         If True, a cache will be created/used from the laction specified by
-        SITEMAPPER_CACHE_PATH, defined in your Indra config or the environment.
-        If false, no cache is used. For more details on the cache, see the
+        SITEMAPPER_CACHE_PATH, defined in your INDRA config or the environment.
+        If False, no cache is used. For more details on the cache, see the
         SiteMapper class definition.
     save : Optional[str]
         The name of a pickle file to save the results (stmts_out) into.
@@ -159,7 +159,13 @@ def map_sequence(stmts_in, **kwargs):
     valid, mapped = sm.map_sites(stmts_in, **_filter(kwargs, kwarg_list))
     correctly_mapped_stmts = []
     for ms in mapped:
-        if all([mm[1] is not None for mm in ms.mapped_mods]):
+        correctly_mapped = True
+        for mm in ms.mapped_mods:
+            # Handle both the cases where there is no mapping found, and
+            # the one where there is a known error
+            if mm[1] is None or mm[1][0] is None or mm[1][1] is None:
+                correctly_mapped = False
+        if correctly_mapped:
             correctly_mapped_stmts.append(ms.mapped_stmt)
     stmts_out = valid + correctly_mapped_stmts
     logger.info('%d statements with valid sites' % len(stmts_out))


### PR DESCRIPTION
There was a mismatch in the output of the SiteMapper and its handling in assemble_corpus that was causing sites that actually had curations in the site map as *errors* to be passed through as valid sites. This is because the SiteMapper returned a mapping of `None` for sites with no known mapping and a tuple `(None, None, comment)` for sites curated as known errors; by checking for a not-None value, the tuples containing Nones were getting passed through.

The PR keeps this distinction in the SiteMapper but adds necessary documentation to the `MappedStatement` class regarding this behavior. The policy of filtering out both sites with no known mapping and known errors is implemented (and tested) in assemble_corpus.