### PR TITLE
Fix how custom belief scores are added to SimpleScorer

### DIFF
--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -101,7 +101,8 @@ class SimpleScorer(BeliefScorer):
     def __init__(self, prior_probs=None, subtype_probs=None):
         self.prior_probs = load_default_probs()
         if prior_probs:
-            self.prior_probs.update(prior_probs)
+            for key in ('rand', 'syst'):
+                self.prior_probs[key].update(prior_probs.get(key, {}))
         for err_type, source_dict in self.prior_probs.items():
             logger.debug("Prior probabilities for %s errors: %s"
                          % (err_type, source_dict))

--- a/indra/tests/test_belief_engine.py
+++ b/indra/tests/test_belief_engine.py
@@ -345,6 +345,9 @@ def test_wm_scorer():
     scorer = wm_scorer.get_eidos_scorer()
     stmt = Influence(Concept('a'), Concept('b'),
                      evidence=[Evidence(source_api='eidos')])
+    # Make sure other sources are still in the map
+    assert 'hume' in scorer.prior_probs['rand']
+    assert 'biopax' in scorer.prior_probs['syst']
     engine = BeliefEngine(scorer)
     engine.set_prior_probs([stmt])
 


### PR DESCRIPTION
This PR fixes an important bug in which the custom scores passed to the SimpleScorer overwrite the default scores completely, instead of just updating them.