### PR TITLE
Hume mapping override, polarities fix, canonical GeoNames

### DIFF
--- a/indra/sources/hume/processor.py
+++ b/indra/sources/hume/processor.py
@@ -121,7 +121,8 @@ class HumeJsonLdProcessor(object):
                 entity_id = argument["value"]["@id"]
                 loc_entity = self.concept_dict[entity_id]
                 place = loc_entity["canonicalName"]
-                loc_context = RefContext(name=place)
+                geo_id = loc_entity.get('geoname_id')
+                loc_context = RefContext(name=place, db_refs={"GEO_ID": geo_id})
             if argument["type"] == "time":
                 entity_id = argument["value"]["@id"]
                 temporal_entity = self.concept_dict[entity_id]

--- a/indra/sources/hume/processor.py
+++ b/indra/sources/hume/processor.py
@@ -122,7 +122,7 @@ class HumeJsonLdProcessor(object):
                 loc_entity = self.concept_dict[entity_id]
                 place = loc_entity["canonicalName"]
                 geo_id = loc_entity.get('geoname_id')
-                loc_context = RefContext(name=place, db_refs={"GEO_ID": geo_id})
+                loc_context = RefContext(name=place, db_refs={"GEOID": geo_id})
             if argument["type"] == "time":
                 entity_id = argument["value"]["@id"]
                 temporal_entity = self.concept_dict[entity_id]

--- a/indra/sources/hume/processor.py
+++ b/indra/sources/hume/processor.py
@@ -56,7 +56,6 @@ class HumeJsonLdProcessor(object):
 
         # Get relations from extractions
         relations = []
-        concepts = []
         for e in extractions:
             label_set = set(e.get('labels', []))
             if 'DirectedRelation' in label_set:
@@ -92,10 +91,10 @@ class HumeJsonLdProcessor(object):
             # Apply the naive polarity from the type of statement. For the
             # purpose of the multiplication here, if obj_delta['polarity'] is
             # None to begin with, we assume it is positive
-            obj_delta['polarity'] = \
-                polarities[relation_type] * \
-                (obj_delta['polarity'] if obj_delta['polarity'] is not None
-                 else 1)
+            obj_pol = obj_delta['polarity']
+            obj_pol = obj_pol if obj_pol is not None else 1
+            rel_pol = polarities[relation_type]
+            obj_delta['polarity'] = rel_pol * obj_pol if rel_pol else None
 
             if not subj_concept or not obj_concept:
                 continue

--- a/indra/tests/wm_m12.ben_sentence.json-ld
+++ b/indra/tests/wm_m12.ben_sentence.json-ld
@@ -34,6 +34,7 @@
             "@id": "Entity-ENG_NW_20180101-0-1", 
             "@type": "Extraction", 
             "canonicalName": "South Sudan", 
+            "geoname_id": "7909807", 
             "grounding": [
                 {
                     "@type": "Grounding", 


### PR DESCRIPTION
This PR adds a custom mapping override from the Hume to the UN ontology which is now taken into account in the OntologyMapper. It also fixes an issue in the processor with neutral polarities. Finally, grounded GeoName IDs are extracted along with the geo location names.