### PR TITLE
Hume mapping override, polarities fix, canonical GeoNames

### DIFF
--- a/indra/preassembler/ontology_mapper.py
+++ b/indra/preassembler/ontology_mapper.py
@@ -159,6 +159,27 @@ def _load_wm_map():
     ontomap = []
     for s, ts in mappings.items():
         ontomap.append(((s[0], s[1]), ts[0], ts[1]))
+
+    # Now apply the Hume -> Eidos override
+    override_file = os.path.join(path_here, '../resources/wm_ontomap.bbn.tsv')
+    override_mappings = []
+    with open(override_file, 'r') as fh:
+        for row in fh.readlines():
+            # Order is target first, source second
+            _, te, _, se = row.strip().split('\t')
+            # Map the entries to our internal naming standards
+            s = 'HUME'
+            t = 'UN'
+            se = se.replace(' ', '_')
+            te = te.replace(' ', '_')
+            if se.startswith('/'):
+                se = se[1:]
+            override_mappings.append((s, se, t, te))
+    for s, se, t, te in override_mappings:
+        for idx, ((so, seo), (eo, teo), score) in enumerate(ontomap):
+            if s == so and se == seo:
+                # Override when a match is found
+                ontomap[idx] = ((s, se), (t, te), 1.0)
     return ontomap
 
 

--- a/indra/resources/wm_ontomap.bbn.tsv
+++ b/indra/resources/wm_ontomap.bbn.tsv
@@ -1,0 +1,127 @@
+eidos	UN/interventions	BBN	/event/intervention
+eidos	UN/interventions/provision of goods and services	BBN	/event/intervention/assistance
+eidos	UN/interventions/provision of goods and services	BBN	/event/intervention/provide humanitarian resources
+eidos	UN/interventions/provision of goods and services/education	BBN	/event/intervention/education
+eidos	UN/interventions/provision of goods and services/education/provision of child friendly learning spaces	BBN	/event/intervention/child friendly learning spaces
+eidos	UN/interventions/provision of goods and services/education/provision of provision of education kits	BBN	/event/intervention/provide humanitarian resources/provide stationary
+eidos	UN/interventions/provision of goods and services/food security/provision of cash transfer	BBN	/event/intervention/provide humanitarian resources/provide cash
+eidos	UN/interventions/provision of goods and services/food security/provision of free food distribution	BBN	/event/intervention/provide humanitarian resources/provide food
+eidos	UN/interventions/provision of goods and services/food security/provision of provision of fishing nets and boats	BBN	/event/intervention/provide humanitarian resources/provide fishing tool
+eidos	UN/interventions/provision of goods and services/food security/provision of provision of livestock feed	BBN	/event/intervention/provide humanitarian resources/provide livestock feed
+eidos	UN/interventions/provision of goods and services/food security/provision of provision of seeds, fertilizers and tools	BBN	/event/intervention/provide humanitarian resources/provide farming tool
+eidos	UN/interventions/provision of goods and services/food security/provision of provision of seeds, fertilizers and tools	BBN	/event/intervention/provide humanitarian resources/provide seed
+eidos	UN/interventions/provision of goods and services/food security/provision of provision of veterinary services	BBN	/event/intervention/provide humanitarian resources/provide veterinary service
+eidos	UN/interventions/provision of goods and services/health/provision of anti-retroviral treatment	BBN	/event/intervention/anti-retroviral treatment
+eidos	UN/interventions/provision of goods and services/health/provision of clean home delivery kit distribution	BBN	/event/intervention/provide humanitarian resources/provide delivery kit
+eidos	UN/interventions/provision of goods and services/health/provision of clinical management of sexual violence	BBN	/event/intervention/sexual violence management
+eidos	UN/interventions/provision of goods and services/health/provision of communicable disease outbreak control	BBN	/event/intervention/provide humanitarian resources/provide veterinary drugs vaccines
+eidos	UN/interventions/provision of goods and services/health/provision of first aid and and basic medical care	BBN	/event/healthcare/treatment
+eidos	UN/interventions/provision of goods and services/health/provision of vector control	BBN	/event/intervention/vector control
+eidos	UN/interventions/provision of goods and services/nutrition/provision of therapeutic feeding	BBN	/event/intervention/therapeutic feeding or treating
+eidos	UN/interventions/provision of goods and services/water sanitation hygiene/provision of basic minimum household hygiene item package	BBN	/event/intervention/provide humanitarian resources/provide hygiene tool
+eidos	UN/interventions/peacekeeping and security/protection/disarmament, demobilization and reintegration	BBN	/event/intervention/military operation
+eidos	UN/interventions/peacekeeping and security	BBN	/event/intervention/military operation/counter terrorism operation
+eidos	UN/interventions/institutional support/protection/capacity building of national authorities on human rights	BBN	/event/intervention/capacity building human rights
+eidos	UN/events/crisis	BBN	/event/crisis
+eidos	UN/events/crisis	BBN	/event/crisis/fire
+eidos	UN/events/natural_disaster	BBN	/event/crisis/disaster
+eidos	UN/events/natural_disaster	BBN	/event/crisis/disaster/earthquake
+eidos	UN/events/natural_disaster/flooding	BBN	/event/weather/flooding
+eidos	UN/events/natural_disaster/drought	BBN	/event/weather/drought
+eidos	UN/events/natural_disaster/storm	BBN	/event/weather/storm
+eidos	UN/events/weather/climate	BBN	/event/weather
+eidos	UN/events/weather/precipitation	BBN	/event/weather/precipitation
+eidos	UN/events/weather/temperature	BBN	/entity/temperature
+eidos	UN/events/human/agriculture/food_production	BBN	/event/economic activity/production/agriculture production/crop production
+eidos	UN/events/human/agriculture/farming	BBN	/event/economic activity/production/agriculture production
+eidos	UN/events/human/agriculture/farming	BBN	/event/economic activity/production/agriculture production/fertilization
+eidos	UN/events/human/agriculture	BBN	/event/economic activity/production/agriculture production/livestock production
+eidos	UN/events/human/conflict	BBN	/event/conflict
+eidos	UN/events/human/conflict	BBN	/event/conflict/attack
+eidos	UN/events/human/conflict	BBN	/event/conflict/attack/psychological attack
+eidos	UN/events/human/conflict	BBN	/event/conflict/collision
+eidos	UN/events/human/conflict	BBN	/event/conflict/demostrate
+eidos	UN/events/human/conflict	BBN	/event/conflict/hostility
+eidos	UN/events/human/conflict	BBN	/event/conflict/repression
+eidos	UN/events/human/conflict	BBN	/event/conflict/sabotage
+eidos	UN/events/human/conflict	BBN	/event/conflict/strike
+eidos	UN/events/human/conflict	BBN	/event/conflict/terrorism
+eidos	UN/events/human/conflict	BBN	/event/conflict/war
+eidos	UN/events/human/conflict	BBN	/event/offense/crime
+eidos	UN/events/human/human_migration	BBN	/event/movement/human displacement
+eidos	UN/events/human/famine	BBN	/event/healthcare/famine
+eidos	UN/events/human/death	BBN	/event/death
+eidos	UN/entities/food_availability	BBN	/entity/agriculture/food
+eidos	UN/entities/GPE	BBN	/entity/location/geopolitical entities
+eidos	UN/entities/GPE	BBN	/entity/location/geopolitical entities/city
+eidos	UN/entities/GPE	BBN	/entity/location/geopolitical entities/continent
+eidos	UN/entities/GPE	BBN	/entity/location/geopolitical entities/country
+eidos	UN/entities/GPE	BBN	/entity/location/geopolitical entities/nation
+eidos	UN/entities/GPE	BBN	/entity/location/geopolitical entities/town
+eidos	UN/entities/GPE	BBN	/entity/location/geopolitical entities/village
+eidos	UN/entities/natural	BBN	/entity/nature
+eidos	UN/entities/natural/chemical	BBN	/entity/chemical substance
+eidos	UN/entities/natural/chemical	BBN	/entity/chemical substance/drug
+eidos	UN/entities/natural/natural_resources/abiotic_resources/land	BBN	/entity/nature/land
+eidos	UN/entities/natural/natural_resources/abiotic_resources/land	BBN	/entity/nature/mountain
+eidos	UN/entities/natural/natural_resources/abiotic_resources/land	BBN	/entity/location
+eidos	UN/entities/natural/natural_resources/abiotic_resources/water	BBN	/entity/location/water body
+eidos	UN/entities/natural/natural_resources/abiotic_resources/water	BBN	/entity/location/water body/lake
+eidos	UN/entities/natural/natural_resources/abiotic_resources/water	BBN	/entity/location/water body/sea
+eidos	UN/entities/natural/soil	BBN	/entity/nature/soil
+eidos	UN/entities/natural/soil/soil_contents	BBN	/entity/nature/soil/soil contents
+eidos	UN/entities/natural/watershed	BBN	/entity/location/water body/river
+eidos	UN/entities/natural/crop_technology/fertilizer	BBN	/entity/chemical substance/fertilizer
+eidos	UN/entities/natural/crop_technology/irrigation	BBN	/event/economic activity/production/agriculture production/irrigation
+eidos	UN/entities/natural/crop	BBN	/entity/agriculture/food/crop
+eidos	UN/entities/natural/livestock	BBN	/entity/organism/animal
+eidos	UN/entities/natural/pest	BBN	/entity/organism/pest
+eidos	UN/entities/human/health/disease	BBN	/entity/disease/human disease
+eidos	UN/entities/human/health/disease	BBN	/event/healthcare/human disease
+eidos	UN/entities/human/infrastructure/transportation/transportation_methods	BBN	/entity/artificial physical objects/vehicle
+eidos	UN/entities/human/infrastructure/transportation/road	BBN	/entity/artificial physical objects/road
+eidos	UN/entities/human/infrastructure/building	BBN	/entity/artificial physical objects/facility
+eidos	UN/entities/human/livelihood	BBN	/event/employment
+eidos	UN/entities/human/education	BBN	/entity/organization/educational
+eidos	UN/entities/human/financial/economic/export	BBN	/event/economic activity/cross border trade/export
+eidos	UN/entities/human/financial/economic/import	BBN	/event/economic activity/cross border trade/import
+eidos	UN/entities/human/financial/economic/currency	BBN	/entity/currency
+eidos	UN/entities/human/financial/economic/currency	BBN	/entity/money
+eidos	UN/entities/human/financial/economic/market	BBN	/event/economic activity/market
+eidos	UN/entities/human/financial/economic/market	BBN	/entity/economics/financial/price
+eidos	UN/entities/human/financial/economic/market	BBN	/event/economic activity/market/price
+eidos	UN/entities/human/financial/economic/market	BBN	/event/economic activity/market/price/oil price
+eidos	UN/entities/human/financial/economic/market	BBN	/event/economic activity/market/transaction
+eidos	UN/entities/human/financial/economic/market	BBN	/event/economic activity/market/transaction/oil transaction
+eidos	UN/entities/human/financial/economic/economy	BBN	/entity/economics/financial
+eidos	UN/entities/human/financial/economic/economy	BBN	/event/economic activity
+eidos	UN/entities/human/financial/economic/economy	BBN	/event/economic activity/business
+eidos	UN/entities/human/financial/economic/economy	BBN	/event/economic activity/competition
+eidos	UN/entities/human/financial/economic/economy	BBN	/event/economic activity/consumption
+eidos	UN/entities/human/financial/economic/economy	BBN	/event/economic activity/consumption/food consumption
+eidos	UN/entities/human/financial/economic/economy	BBN	/event/economic activity/cross border trade
+eidos	UN/entities/human/financial/economic/economy	BBN	/event/economic activity/demand
+eidos	UN/entities/human/financial/economic/economy	BBN	/event/economic activity/development
+eidos	UN/entities/human/financial/economic/economy	BBN	/event/economic activity/production
+eidos	UN/entities/human/financial/economic/inflation	BBN	/event/economic activity/market/inflation
+eidos	UN/entities/human/financial/economic/depreciation	BBN	/event/economic activity/market/currency devaluation
+eidos	UN/entities/human/financial/economic/fuel	BBN	/event/economic activity/production/oil production
+eidos	UN/entities/human/financial/economic/assets	BBN	/entity/economics/commodity
+eidos	UN/entities/human/financial/economic/poverty	BBN	/event/condition/poverty
+eidos	UN/entities/human/government/government_actions/regulation	BBN	/entity/rule
+eidos	UN/entities/human/government/government_actions/organization	BBN	/entity/organization
+eidos	UN/entities/human/government/government_actions/organization	BBN	/entity/organization/corporation
+eidos	UN/entities/human/government/government_actions/organization	BBN	/entity/organization/educational/university
+eidos	UN/entities/human/government/government_actions/organization	BBN	/entity/organization/military organizations
+eidos	UN/entities/human/population	BBN	/entity/person/group/community
+eidos	UN/entities/human/population	BBN	/entity/person
+eidos	UN/entities/human/population	BBN	/entity/person/group
+eidos	UN/entities/human/population	BBN	/entity/person/group/tribe
+eidos	UN/entities/human/population	BBN	/entity/person/individual
+eidos	UN/entities/human/food/food_price	BBN	/event/economic activity/market/price/food price
+eidos	UN/entities/human/food/food_insecurity	BBN	/event/access/shortage/food shortage
+eidos	UN/temporal	BBN	/entity/temporal
+eidos	UN/temporal/seasons/	BBN	/entity/temporal/seasons/annual
+eidos	UN/temporal/seasons/season	BBN	/entity/temporal/seasons
+eidos	UN/temporal/seasons/crop_season	BBN	/entity/temporal/seasons/crop season
+eidos	UN/temporal/month	BBN	/entity/temporal/months

--- a/indra/sources/hume/processor.py
+++ b/indra/sources/hume/processor.py
@@ -121,7 +121,8 @@ class HumeJsonLdProcessor(object):
                 entity_id = argument["value"]["@id"]
                 loc_entity = self.concept_dict[entity_id]
                 place = loc_entity["canonicalName"]
-                loc_context = RefContext(name=place)
+                geo_id = loc_entity.get('geoname_id')
+                loc_context = RefContext(name=place, db_refs={"GEO_ID": geo_id})
             if argument["type"] == "time":
                 entity_id = argument["value"]["@id"]
                 temporal_entity = self.concept_dict[entity_id]

--- a/indra/sources/hume/processor.py
+++ b/indra/sources/hume/processor.py
@@ -122,7 +122,7 @@ class HumeJsonLdProcessor(object):
                 loc_entity = self.concept_dict[entity_id]
                 place = loc_entity["canonicalName"]
                 geo_id = loc_entity.get('geoname_id')
-                loc_context = RefContext(name=place, db_refs={"GEO_ID": geo_id})
+                loc_context = RefContext(name=place, db_refs={"GEOID": geo_id})
             if argument["type"] == "time":
                 entity_id = argument["value"]["@id"]
                 temporal_entity = self.concept_dict[entity_id]

--- a/indra/sources/hume/processor.py
+++ b/indra/sources/hume/processor.py
@@ -56,7 +56,6 @@ class HumeJsonLdProcessor(object):
 
         # Get relations from extractions
         relations = []
-        concepts = []
         for e in extractions:
             label_set = set(e.get('labels', []))
             if 'DirectedRelation' in label_set:
@@ -92,10 +91,10 @@ class HumeJsonLdProcessor(object):
             # Apply the naive polarity from the type of statement. For the
             # purpose of the multiplication here, if obj_delta['polarity'] is
             # None to begin with, we assume it is positive
-            obj_delta['polarity'] = \
-                polarities[relation_type] * \
-                (obj_delta['polarity'] if obj_delta['polarity'] is not None
-                 else 1)
+            obj_pol = obj_delta['polarity']
+            obj_pol = obj_pol if obj_pol is not None else 1
+            rel_pol = polarities[relation_type]
+            obj_delta['polarity'] = rel_pol * obj_pol if rel_pol else None
 
             if not subj_concept or not obj_concept:
                 continue

--- a/indra/tests/wm_m12.ben_sentence.json-ld
+++ b/indra/tests/wm_m12.ben_sentence.json-ld
@@ -34,6 +34,7 @@
             "@id": "Entity-ENG_NW_20180101-0-1", 
             "@type": "Extraction", 
             "canonicalName": "South Sudan", 
+            "geoname_id": "7909807", 
             "grounding": [
                 {
                     "@type": "Grounding", 


### PR DESCRIPTION
This PR adds a custom mapping override from the Hume to the UN ontology which is now taken into account in the OntologyMapper. It also fixes an issue in the processor with neutral polarities. Finally, grounded GeoName IDs are extracted along with the geo location names.