### PR TITLE
Assembly enhancements

### DIFF
--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -141,6 +141,8 @@ class Preassembler(object):
                     new_stmt.uuid = stmt.uuid
                 raw_text = [None if ag is None else ag.db_refs.get('TEXT')
                             for ag in stmt.agent_list(deep_sorted=True)]
+                raw_grounding = [None if ag is None else ag.db_refs
+                                 for ag in stmt.agent_list(deep_sorted=True)]
                 for ev in stmt.evidence:
                     ev_key = ev.matches_key()
                     if ev_key not in ev_keys:
@@ -149,8 +151,12 @@ class Preassembler(object):
                         # a new key
                         if 'agents' in ev.annotations:
                             ev.annotations['agents']['raw_text'] = raw_text
+                            ev.annotations['agents']['raw_grounding'] = \
+                                raw_grounding
                         else:
                             ev.annotations['agents'] = {'raw_text': raw_text}
+                            ev.annotations['agents'] = {'raw_grounding':
+                                                        raw_grounding}
                         if 'prior_uuids' not in ev.annotations.keys():
                             ev.annotations['prior_uuids'] = []
                         ev.annotations['prior_uuids'].append(stmt.uuid)

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -154,9 +154,9 @@ class Preassembler(object):
                             ev.annotations['agents']['raw_grounding'] = \
                                 raw_grounding
                         else:
-                            ev.annotations['agents'] = {'raw_text': raw_text}
-                            ev.annotations['agents']['raw_grounding'] = \
-                                                        raw_grounding
+                            ev.annotations['agents'] = \
+                                {'raw_text': raw_text,
+                                 'raw_grounding': raw_grounding}
                         if 'prior_uuids' not in ev.annotations.keys():
                             ev.annotations['prior_uuids'] = []
                         ev.annotations['prior_uuids'].append(stmt.uuid)

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -155,8 +155,8 @@ class Preassembler(object):
                                 raw_grounding
                         else:
                             ev.annotations['agents'] = {'raw_text': raw_text}
-                            ev.annotations['agents'] = {'raw_grounding':
-                                                        raw_grounding}
+                            ev.annotations['agents']['raw_grounding'] = \
+                                                        raw_grounding
                         if 'prior_uuids' not in ev.annotations.keys():
                             ev.annotations['prior_uuids'] = []
                         ev.annotations['prior_uuids'].append(stmt.uuid)

--- a/indra/preassembler/ontology_mapper.py
+++ b/indra/preassembler/ontology_mapper.py
@@ -92,7 +92,15 @@ def _load_default_mappings():
     return [(('UN', 'entities/x'), ('HUME', 'entities/y'))]
 
 
-def _load_wm_map():
+def _load_wm_map(exclude_auto=None):
+    """Load an ontology map for world models.
+
+    exclude_auto : None or list[tuple]
+        A list of ontology mappings for which automated mappings should be
+        excluded, e.g. [(HUME, UN)] would result in not using mappings
+        from HUME to UN.
+    """
+    exclude_auto = [] if not exclude_auto else exclude_auto
     path_here = os.path.dirname(os.path.abspath(__file__))
     ontomap_file = os.path.join(path_here, '../resources/wm_ontomap.tsv')
     mappings = {}
@@ -152,18 +160,21 @@ def _load_wm_map():
             # Map the entries to our internal naming standards
             s, se = map_entry(s, se)
             t, te = map_entry(t, te)
-            # We first do the forward mapping
-            if (s, se, t) in mappings:
-                if mappings[(s, se, t)][1] < score:
+            # Skip automated mappings when they should be excluded
+            if (s, t) not in exclude_auto:
+                # We first do the forward mapping
+                if (s, se, t) in mappings:
+                    if mappings[(s, se, t)][1] < score:
+                        mappings[(s, se, t)] = ((t, te), score)
+                else:
                     mappings[(s, se, t)] = ((t, te), score)
-            else:
-                mappings[(s, se, t)] = ((t, te), score)
             # Then we add the reverse mapping
-            if (t, te, s) in mappings:
-                if mappings[(t, te, s)][1] < score:
+            if (t, s) not in exclude_auto:
+                if (t, te, s) in mappings:
+                    if mappings[(t, te, s)][1] < score:
+                        mappings[(t, te, s)] = ((s, se), score)
+                else:
                     mappings[(t, te, s)] = ((s, se), score)
-            else:
-                mappings[(t, te, s)] = ((s, se), score)
     ontomap = []
     for s, ts in mappings.items():
         ontomap.append(((s[0], s[1]), ts[0], ts[1]))

--- a/indra/preassembler/ontology_mapper.py
+++ b/indra/preassembler/ontology_mapper.py
@@ -52,7 +52,12 @@ class OntologyMapper(object):
                     if map_db_name in agent.db_refs:
                         continue
                     if self.scored:
-                        agent.db_refs[map_db_name] = [(map_db_id, score)]
+                        try:
+                            orig_score = agent.db_refs[map_db_name][0][1]
+                        except Exception:
+                            orig_score = 1.0
+                        agent.db_refs[map_db_name] = \
+                            [(map_db_id, score * orig_score)]
                     else:
                         if map_db_name in ('UN', 'HUME'):
                             agent.db_refs[map_db_name] = [(map_db_id, 1.0)]

--- a/indra/preassembler/ontology_mapper.py
+++ b/indra/preassembler/ontology_mapper.py
@@ -48,12 +48,15 @@ class OntologyMapper(object):
                         db_id = db_id[0][0]
                     mappings = self._map_id(db_name, db_id)
                     all_mappings += mappings
-                for map_db_name, map_db_id, score in all_mappings:
+                for map_db_name, map_db_id, score, orig_db_name in all_mappings:
                     if map_db_name in agent.db_refs:
                         continue
                     if self.scored:
+                        # If the original one is a scored grounding,
+                        # we take that score and multiply it with the mapping
+                        # score. Otherwise we assume the original score is 1.
                         try:
-                            orig_score = agent.db_refs[map_db_name][0][1]
+                            orig_score = agent.db_refs[orig_db_name][0][1]
                         except Exception:
                             orig_score = 1.0
                         agent.db_refs[map_db_name] = \
@@ -81,7 +84,7 @@ class OntologyMapper(object):
             if m1 == (db_name, db_id) or \
                 ((not isinstance(m1, list)) and
                  (m1 == (db_name, db_id.lower()))):
-                mappings.append((m2[0], m2[1], score))
+                mappings.append((m2[0], m2[1], score, db_name))
         return mappings
 
 

--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -307,7 +307,11 @@ class EidosProcessor(object):
             # Only add these groundings if there are actual values listed
             if entries:
                 key = g['name'].upper()
-                db_refs[key] = entries
+                if key == 'UN':
+                    db_refs[key] = [(s[0].replace(' ', '_'), s[1])
+                                    for s in entries]
+                else:
+                    db_refs[key] = entries
         return db_refs
 
     @staticmethod

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -3562,6 +3562,37 @@ def stmts_from_json(json_in, on_missing_support='handle'):
     return stmts
 
 
+def stmts_from_json_file(fname):
+    """Return a list of statements loaded from a JSON file.
+
+    Parameters
+    ----------
+    fname : str
+        Path to the JSON file to load statements from.
+
+    Returns
+    -------
+    list[indra.statements.Statement]
+        The list of INDRA Statements loaded from the JSOn file.
+    """
+    with open(fname, 'r') as fh:
+        return stmts_from_json(json.load(fh))
+
+
+def stmts_to_json_file(stmts, fname):
+    """Serialize a list of INDRA Statements into a JSON file.
+
+    Parameters
+    ----------
+    stmts : list[indra.statement.Statements]
+        The list of INDRA Statements to serialize into the JSON file.
+    fname : str
+        Path to the JSON file to serialize Statements into.
+    """
+    with open(fname, 'w') as fh:
+        json.dump(stmts_to_json(stmts), fh, indent=1)
+
+
 def get_unresolved_support_uuids(stmts):
     """Get uuids unresolved in support from stmts from stmts_from_json."""
     return {s.uuid for stmt in stmts for s in stmt.supports + stmt.supported_by

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -189,6 +189,7 @@ __all__ = [
 
     # Functions and values
     'stmts_from_json', 'get_unresolved_support_uuids', 'stmts_to_json',
+    'stmts_from_json_file', 'stmts_to_json_file',
     'get_valid_residue', 'get_valid_location', 'get_valid_location',
     'draw_stmt_graph', 'get_all_descendants','make_statement_camel',
     'amino_acids', 'amino_acids_reverse', 'activity_types',

--- a/indra/tests/test_statements_serialization.py
+++ b/indra/tests/test_statements_serialization.py
@@ -288,3 +288,10 @@ def test_evidence_context():
     assert evj['pmid'] == '1'
     assert evj['annotations'] == {'a': '2'}
     assert ev.to_json() == Evidence._from_json(ev.to_json()).to_json()
+
+
+def test_file_serialization():
+    stmt = IncreaseAmount(Agent('a'), Agent('b'), evidence=[ev])
+    stmts_to_json_file([stmt], 'test_indra_stmts.json')
+    stmts = stmts_from_json_file('test_indra_stmts.json')
+    assert stmts[0].matches(stmt)

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -175,6 +175,7 @@ def map_sequence(stmts_in, **kwargs):
     del sm
     return stmts_out
 
+
 def run_preassembly(stmts_in, **kwargs):
     """Run preassembly on a list of statements.
 
@@ -200,6 +201,8 @@ def run_preassembly(stmts_in, **kwargs):
         Instance of BeliefScorer class to use in calculating Statement
         probabilities. If None is provided (default), then the default
         scorer is used.
+    hierarchies : dict
+        Dict of hierarchy managers to use for preassembly
     save : Optional[str]
         The name of a pickle file to save the results (stmts_out) into.
     save_unique : Optional[str]
@@ -212,6 +215,8 @@ def run_preassembly(stmts_in, **kwargs):
     """
     dump_pkl_unique = kwargs.get('save_unique')
     belief_scorer = kwargs.get('belief_scorer')
+    use_hierarchies = kwargs['hierarchies'] if 'hierarchies' in kwargs else \
+        hierarchies
     be = BeliefEngine(scorer=belief_scorer)
     pa = Preassembler(hierarchies, stmts_in)
     run_preassembly_duplicate(pa, be, save=dump_pkl_unique)


### PR DESCRIPTION
This PR:
- adds original `db_refs` to the `agents` entry in `annotations` when combining duplicates
- combine the scores associated with the original grounding and the mapping when applying ontology mapping
- allows specifying certain mapping directions to be excluded in ontology mapping
- adds file based JSON reading and writing in `indra.statements`
- allows specifying a custom hierarchy for preassembly via `indra.tools.assemble_corpus`