### PR TITLE
Change logger names

### DIFF
--- a/indra/__init__.py
+++ b/indra/__init__.py
@@ -7,7 +7,8 @@ __version__ = '1.10.0'
 __all__ = ['assemblers', 'belief', 'databases', 'explanation', 'literature',
            'mechlinker', 'preassembler', 'sources', 'tools', 'util']
 
-logging.basicConfig(format='%(levelname)s: [%(asctime)s] indra/%(name)s - %(message)s',
+logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'
+                            ' - %(message)s'),
                     level=logging.INFO, datefmt='%Y-%m-%d %H:%M:%S')
 
 # Suppress INFO-level logging from some dependencies

--- a/indra/assemblers/cag/assembler.py
+++ b/indra/assemblers/cag/assembler.py
@@ -14,7 +14,7 @@ try:
 except:
     basestring = str
 
-logger = logging.getLogger('cag_assembler')
+logger = logging.getLogger(__name__)
 
 
 class CAGAssembler(object):

--- a/indra/assemblers/cx/assembler.py
+++ b/indra/assemblers/cx/assembler.py
@@ -16,7 +16,7 @@ try:
 except:
     basestring = str
 
-logger = logging.getLogger('cx_assembler')
+logger = logging.getLogger(__name__)
 
 
 class CxAssembler(object):

--- a/indra/assemblers/cyjs/assembler.py
+++ b/indra/assemblers/cyjs/assembler.py
@@ -21,7 +21,7 @@ try:
 except:
     basestring = str
 
-logger = logging.getLogger('cyjs_assembler')
+logger = logging.getLogger(__name__)
 
 
 class CyJSAssembler(object):

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -3,7 +3,7 @@ from builtins import dict, str
 import logging
 import indra.statements as ist
 
-logger = logging.getLogger('english_assembler')
+logger = logging.getLogger(__name__)
 
 class EnglishAssembler(object):
     """This assembler generates English sentences from INDRA Statements.

--- a/indra/assemblers/graph/assembler.py
+++ b/indra/assemblers/graph/assembler.py
@@ -4,7 +4,7 @@ import logging
 import itertools
 from indra.statements import *
 
-logger = logging.getLogger('graph_assembler')
+logger = logging.getLogger(__name__)
 try:
     import pygraphviz
 except ImportError:

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -10,7 +10,7 @@ from os.path import abspath, dirname, join
 from jinja2 import Template
 import logging
 
-logger = logging.getLogger('html_assembler')
+logger = logging.getLogger(__name__)
 
 from indra.statements import *
 from indra.assemblers.english import EnglishAssembler

--- a/indra/assemblers/index_card/assembler.py
+++ b/indra/assemblers/index_card/assembler.py
@@ -6,9 +6,10 @@ from indra.statements import *
 from indra.literature import id_lookup
 from indra.databases import hgnc_client, uniprot_client, chebi_client
 
-logger = logging.getLogger('index_card_assembler')
+logger = logging.getLogger(__name__)
 
 global_submitter = 'indra'
+
 
 class IndexCardAssembler(object):
     """Assembler creating index cards from a set of INDRA Statements.

--- a/indra/assemblers/kami/assembler.py
+++ b/indra/assemblers/kami/assembler.py
@@ -17,7 +17,8 @@ try:
 except:
     basestring = str
 
-logger = logging.getLogger('kami_assembler')
+logger = logging.getLogger(__name__)
+
 
 class KamiAssembler(PysbAssembler):
     def make_model(self, policies=None, initial_conditions=True,

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -11,7 +11,7 @@ from pybel.language import pmod_namespace
 from indra.statements import *
 from indra.databases import hgnc_client
 
-logger = logging.getLogger('pybel_assembler')
+logger = logging.getLogger(__name__)
 
 
 _indra_pybel_act_map = {

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -24,7 +24,7 @@ try:
 except:
     basestring = str
 
-logger = logging.getLogger('pysb_assembler')
+logger = logging.getLogger(__name__)
 
 SelfExporter.do_export = False
 

--- a/indra/assemblers/sbgn/assembler.py
+++ b/indra/assemblers/sbgn/assembler.py
@@ -7,7 +7,7 @@ import lxml.builder
 from indra.statements import *
 from indra.assemblers.pysb.assembler import PysbPreassembler
 
-logger = logging.getLogger('sbgn_assembler')
+logger = logging.getLogger(__name__)
 
 sbgn_ns = 'http://sbgn.org/libsbgn/pd/0.1'
 emaker = lxml.builder.ElementMaker(nsmap={None: sbgn_ns})

--- a/indra/assemblers/sif/assembler.py
+++ b/indra/assemblers/sif/assembler.py
@@ -7,7 +7,8 @@ import itertools
 import networkx as nx
 from indra.statements import *
 
-logger = logging.getLogger('sif_assembler')
+logger = logging.getLogger(__name__)
+
 
 class SifAssembler(object):
     """The SIF assembler assembles INDRA Statements into a networkx graph.

--- a/indra/assemblers/tsv/assembler.py
+++ b/indra/assemblers/tsv/assembler.py
@@ -7,7 +7,7 @@ from indra.statements import *
 from indra.util import write_unicode_csv
 
 
-logger = logging.getLogger('tsv_assembler')
+logger = logging.getLogger(__name__)
 
 
 class TsvAssembler(object):

--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     use_reach_subtypes = False
 
-logger = logging.getLogger("belief")
+logger = logging.getLogger(__name__)
 
 
 THIS_DIR = path.dirname(path.abspath(__file__))

--- a/indra/benchmarks/bioprocesses/__init__.py
+++ b/indra/benchmarks/bioprocesses/__init__.py
@@ -14,7 +14,7 @@ from indra.util import plot_formatting as pf
 from indra.databases import hgnc_client
 
 
-logger = logging.getLogger('bioprocesses')
+logger = logging.getLogger('indra.benchmarks.bioprocesses')
 
 
 def load_file(stmts_file):

--- a/indra/benchmarks/phosphorylations/__init__.py
+++ b/indra/benchmarks/phosphorylations/__init__.py
@@ -15,7 +15,7 @@ from indra.preassembler.sitemapper import SiteMapper, default_site_map
 psite_fname = 'phosphosite_kin_sub_2016.csv'
 stmts_fname = 'model.pkl'
 
-logger = logging.getLogger('phosphorylations')
+logger = logging.getLogger('indra.benchmarks.phosphorylations')
 
 def phosphosite_to_indra():
     df = pandas.DataFrame.from_csv(psite_fname, index_col=None)

--- a/indra/config.py
+++ b/indra/config.py
@@ -7,7 +7,9 @@ if sys.version_info[0] == 3:
 else:
     from ConfigParser import RawConfigParser
 
-logger = logging.getLogger('indra_config')
+
+logger = logging.getLogger(__name__)
+
 
 # If the configuration file does not exist, try to create it from the default
 home_dir = os.path.expanduser('~')

--- a/indra/databases/__init__.py
+++ b/indra/databases/__init__.py
@@ -1,6 +1,7 @@
 import logging
 
-logger = logging.getLogger('databases')
+logger = logging.getLogger(__name__)
+
 
 def get_identifiers_url(db_name, db_id):
     """Return an identifiers.org URL for a given database name and ID.

--- a/indra/databases/biogrid_client.py
+++ b/indra/databases/biogrid_client.py
@@ -12,7 +12,7 @@ from indra import has_config, get_config
 
 biogrid_url = 'http://webservice.thebiogrid.org/interactions/'
 
-logger = logging.getLogger('biogrid')
+logger = logging.getLogger(__name__)
 
 # For more information see http://wiki.thebiogrid.org/doku.php/biogridrest
 # Try to read the API key from a file
@@ -21,6 +21,7 @@ if not has_config('BIOGRID_API_KEY'):
                  'environment variable.')
 else:
     api_key = get_config('BIOGRID_API_KEY')
+
 
 def get_interactors(gene_name):
     res_dict = _send_request([gene_name], include_interactors=True)

--- a/indra/databases/cbio_client.py
+++ b/indra/databases/cbio_client.py
@@ -14,7 +14,8 @@ except ImportError:
     from functools32 import lru_cache
     from StringIO import StringIO
 
-logger = logging.getLogger('cbio')
+
+logger = logging.getLogger(__name__)
 
 cbio_url = 'http://www.cbioportal.org/webservice.do'
 ccle_study = 'cellline_ccle_broad'

--- a/indra/databases/chembl_client.py
+++ b/indra/databases/chembl_client.py
@@ -7,7 +7,7 @@ from indra.databases import chebi_client, uniprot_client
 from indra.statements import Inhibition, Agent, Evidence
 from collections import defaultdict
 
-logger = logging.getLogger('chembl')
+logger = logging.getLogger(__name__)
 
 
 def get_inhibition(drug, target):

--- a/indra/databases/go_client.py
+++ b/indra/databases/go_client.py
@@ -6,7 +6,7 @@ import rdflib
 from indra.util import read_unicode_csv, write_unicode_csv
 
 
-logger = logging.getLogger('go_client')
+logger = logging.getLogger(__name__)
 
 
 go_mappings_file = join(dirname(abspath(__file__)), '..', 'resources',

--- a/indra/databases/lincs_client.py
+++ b/indra/databases/lincs_client.py
@@ -12,7 +12,7 @@ from io import StringIO, BytesIO
 from indra.util import read_unicode_csv_fileobj
 
 
-logger = logging.getLogger('lincs_client')
+logger = logging.getLogger(__name__)
 
 
 LINCS_URL = 'http://lincs.hms.harvard.edu/db'

--- a/indra/databases/ndex_client.py
+++ b/indra/databases/ndex_client.py
@@ -13,7 +13,7 @@ except ImportError:
     from ndex2.niceCXNetwork import NiceCXNetwork
 from indra import get_config
 
-logger = logging.getLogger('ndex_client')
+logger = logging.getLogger(__name__)
 
 ndex_base_url = 'http://52.37.175.128'
 
@@ -31,6 +31,7 @@ def get_default_ndex_cred(ndex_cred):
     password = get_config('NDEX_PASSWORD')
 
     return username, password
+
 
 def send_request(ndex_service_url, params, is_json=True, use_get=False):
     """Send a request to the NDEx server.

--- a/indra/databases/phosphosite_client.py
+++ b/indra/databases/phosphosite_client.py
@@ -5,7 +5,7 @@ from os.path import dirname, abspath, join
 from collections import namedtuple, defaultdict
 from indra.util import read_unicode_csv
 
-logger = logging.getLogger('phosphosite')
+logger = logging.getLogger(__name__)
 
 PhosphoSite = namedtuple('PhosphoSite',
                          ['GENE', 'PROTEIN', 'ACC_ID', 'HU_CHR_LOC', 'MOD_RSD',

--- a/indra/databases/relevance_client.py
+++ b/indra/databases/relevance_client.py
@@ -9,9 +9,10 @@ try:
 except:
     basestring = str
 
-logger = logging.getLogger('relevance')
+logger = logging.getLogger(__name__)
 
 ndex_relevance = 'http://general.bigmech.ndexbio.org:5602'
+
 
 def get_heat_kernel(network_id):
     """Return the identifier of a heat kernel calculated for a given network.
@@ -37,6 +38,7 @@ def get_heat_kernel(network_id):
         logger.error('Could not get heat kernel for network %s.' % network_id)
         return None
     return kernel_id
+
 
 def get_relevant_nodes(network_id, query_nodes):
     """Return a set of network nodes relevant to a given query set.

--- a/indra/databases/uniprot_client.py
+++ b/indra/databases/uniprot_client.py
@@ -15,7 +15,7 @@ except ImportError:
     from urllib2 import HTTPError
 from indra.util import read_unicode_csv
 
-logger = logging.getLogger('uniprot')
+logger = logging.getLogger(__name__)
 
 uniprot_url = 'http://www.uniprot.org/uniprot/'
 

--- a/indra/explanation/model_checker.py
+++ b/indra/explanation/model_checker.py
@@ -27,7 +27,7 @@ except ImportError:
     has_pg = False
 
 
-logger = logging.getLogger('model_checker')
+logger = logging.getLogger(__name__)
 
 
 class PathMetric(object):

--- a/indra/java_vm.py
+++ b/indra/java_vm.py
@@ -8,13 +8,15 @@ import logging
 import jnius_config
 from indra import get_config
 
-logger = logging.getLogger('java_vm')
+logger = logging.getLogger(__name__)
+
 
 def _has_xmx(options):
     for option in options:
         if option.startswith('-Xmx'):
             return True
     return False
+
 
 default_mem_limit = get_config("INDRA_DEFAULT_JAVA_MEM_LIMIT")
 if default_mem_limit is None:

--- a/indra/literature/__init__.py
+++ b/indra/literature/__init__.py
@@ -13,7 +13,7 @@ except ImportError:
     from functools32 import lru_cache
 from indra.util import UnicodeXMLTreeBuilder as UTB
 
-logger = logging.getLogger('literature')
+logger = logging.getLogger(__name__)
 
 
 def id_lookup(paper_id, idtype):

--- a/indra/literature/crossref_client.py
+++ b/indra/literature/crossref_client.py
@@ -14,7 +14,7 @@ except ImportError:
     from functools32 import lru_cache
 
 
-logger = logging.getLogger('crossref')
+logger = logging.getLogger(__name__)
 
 crossref_url = 'http://api.crossref.org/'
 crossref_search_url = 'http://search.crossref.org/dois'

--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -24,7 +24,7 @@ except ImportError:
 from indra.util import read_unicode_csv
 from indra.util import UnicodeXMLTreeBuilder as UTB
 
-logger = logging.getLogger('elsevier')
+logger = logging.getLogger(__name__)
 
 
 # THE ELSEVIER API URL: ***MUST BE HTTPS FOR SECURITY***

--- a/indra/literature/newsapi_client.py
+++ b/indra/literature/newsapi_client.py
@@ -13,7 +13,7 @@ import requests
 from indra import has_config, get_config
 
 
-logger = logging.getLogger('newsapi_client')
+logger = logging.getLogger(__name__)
 
 
 api_key = None

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -7,7 +7,7 @@ import logging
 from indra.literature import pubmed_client
 from indra.util import UnicodeXMLTreeBuilder as UTB
 
-logger = logging.getLogger('pmc')
+logger = logging.getLogger(__name__)
 
 pmc_url = 'https://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi'
 pmid_convert_url = 'https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/'

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -16,7 +16,7 @@ except ImportError:
 from indra.databases import hgnc_client
 from indra.util import UnicodeXMLTreeBuilder as UTB
 
-logger = logging.getLogger('pubmed')
+logger = logging.getLogger(__name__)
 
 pubmed_search = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi'
 pubmed_fetch = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi'

--- a/indra/literature/s3_client.py
+++ b/indra/literature/s3_client.py
@@ -20,7 +20,7 @@ except:
     basestring = str
 
 # Logger
-logger = logging.getLogger('s3_client')
+logger = logging.getLogger(__name__)
 
 bucket_name ='bigmech'
 client = boto3.client('s3')

--- a/indra/mechlinker/__init__.py
+++ b/indra/mechlinker/__init__.py
@@ -9,7 +9,7 @@ from indra.util import fast_deepcopy
 from indra.statements import *
 from indra.preassembler.hierarchy_manager import hierarchies
 
-logger = logging.getLogger('mechlinker')
+logger = logging.getLogger(__name__)
 
 
 class MechLinker(object):

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -16,7 +16,7 @@ except ImportError:
 from indra.util import fast_deepcopy
 from indra.statements import *
 
-logger = logging.getLogger('preassembler')
+logger = logging.getLogger(__name__)
 
 
 class Preassembler(object):

--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -13,7 +13,7 @@ from indra.statements import Agent
 from indra.databases import uniprot_client, hgnc_client
 from indra.util import read_unicode_csv, write_unicode_csv
 
-logger = logging.getLogger('grounding_mapper')
+logger = logging.getLogger(__name__)
 
 
 class GroundingMapper(object):

--- a/indra/preassembler/hierarchy_manager.py
+++ b/indra/preassembler/hierarchy_manager.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from indra.preassembler.make_entity_hierarchy import ns_map
 
-logger = logging.getLogger('hierarchy_manager')
+logger = logging.getLogger(__name__)
 
 
 def isa_objects(node, g, rel):

--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -17,7 +17,7 @@ try:
 except:
     basestring = str
 
-logger = logging.getLogger('sitemapper')
+logger = logging.getLogger(__name__)
 
 
 if has_config('SITEMAPPER_CACHE_PATH'):

--- a/indra/resources/update_resources.py
+++ b/indra/resources/update_resources.py
@@ -30,7 +30,7 @@ from indra.preassembler.hierarchy_manager import get_bio_hierarchies
 path = os.path.dirname(__file__)
 logging.basicConfig(format='%(levelname)s: indra/%(name)s - %(message)s',
                     level=logging.INFO)
-logger = logging.getLogger('update_resources')
+logger = logging.getLogger('indra.resources.update_resources')
 logging.getLogger('urllib3').setLevel(logging.ERROR)
 logging.getLogger('requests').setLevel(logging.ERROR)
 logger.setLevel(logging.INFO)

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -16,7 +16,7 @@ except ImportError:
     from functools32 import lru_cache
 
 
-logger = logging.getLogger('bel')
+logger = logging.getLogger(__name__)
 
 ndex_bel2rdf = 'http://bel2rdf.bigmech.ndexbio.org'
 

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -14,7 +14,7 @@ __all__ = [
     'get_agent',
 ]
 
-logger = logging.getLogger('pybel_processor')
+logger = logging.getLogger(__name__)
 
 
 _pybel_indra_pmod_map = {

--- a/indra/sources/bel/rdf_processor.py
+++ b/indra/sources/bel/rdf_processor.py
@@ -10,7 +10,7 @@ from indra.statements import *
 from indra.databases import hgnc_client
 from indra.util import read_unicode_csv
 
-logger = logging.getLogger('bel')
+logger = logging.getLogger(__name__)
 
 prefixes = """
     PREFIX belvoc: <http://www.openbel.org/vocabulary/>

--- a/indra/sources/biogrid.py
+++ b/indra/sources/biogrid.py
@@ -14,7 +14,7 @@ from indra.statements import *
 import indra.databases.hgnc_client as hgnc_client
 import indra.databases.uniprot_client as up_client
 
-logger = logging.getLogger('biogrid')
+logger = logging.getLogger(__name__)
 
 
 biogrid_file_url = 'https://downloads.thebiogrid.org/Download/BioGRID/' + \

--- a/indra/sources/biopax/pathway_commons_client.py
+++ b/indra/sources/biopax/pathway_commons_client.py
@@ -10,7 +10,7 @@ try:
 except:
     basestring = str
 
-logger = logging.getLogger('biopax')
+logger = logging.getLogger(__name__)
 
 pc2_url = 'http://www.pathwaycommons.org/pc2/'
 

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -16,7 +16,7 @@ from indra.statements import *
 from . import pathway_commons_client as pcc
 from indra.util import decode_obj
 
-logger = logging.getLogger('biopax')
+logger = logging.getLogger(__name__)
 
 # TODO:
 # - Extract cellularLocation from each PhysicalEntity

--- a/indra/sources/cwms/api.py
+++ b/indra/sources/cwms/api.py
@@ -5,7 +5,7 @@ from indra.sources.cwms.processor import CWMSProcessor
 from indra.sources.cwms.rdf_processor import CWMSRDFProcessor
 from indra.sources.trips import client
 
-logger = logging.getLogger('cwms')
+logger = logging.getLogger(__name__)
 
 
 def process_text(text, save_xml='cwms_output.xml'):

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from indra.statements import *
 from indra.util import UnicodeXMLTreeBuilder as UTB
 
-logger = logging.getLogger('cwms')
+logger = logging.getLogger(__name__)
 
 
 class CWMSError(Exception):

--- a/indra/sources/cwms/rdf_processor.py
+++ b/indra/sources/cwms/rdf_processor.py
@@ -4,7 +4,7 @@ import logging
 import rdflib
 from indra.statements import Influence, Agent, Evidence
 
-logger = logging.getLogger('cwms_rdf')
+logger = logging.getLogger(__name__)
 
 prefixes = """
 PREFIX role: <http://www.cs.rochester.edu/research/trips/role#>

--- a/indra/sources/cwms/util.py
+++ b/indra/sources/cwms/util.py
@@ -12,7 +12,7 @@ except ImportError:
           "cag graphs.")
     HAVE_PYDOT = False
 
-logger = logging.getLogger('cwms_util')
+logger = logging.getLogger(__name__)
 
 
 def make_cag_graphs(cag_rdf_dicts, skip_if_no_dot=True):

--- a/indra/sources/eidos/api.py
+++ b/indra/sources/eidos/api.py
@@ -6,7 +6,7 @@ import logging
 import requests
 from .processor import EidosProcessor
 
-logger = logging.getLogger('eidos')
+logger = logging.getLogger(__name__)
 
 
 try:

--- a/indra/sources/eidos/cli.py
+++ b/indra/sources/eidos/cli.py
@@ -14,7 +14,7 @@ from .api import process_json_file
 
 eip = get_config('EIDOSPATH')
 eidos_package = 'org.clulab.wm.eidos'
-logger = logging.getLogger('eidos_cli')
+logger = logging.getLogger(__name__)
 
 
 def run_eidos(endpoint, *args):

--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -8,7 +8,7 @@ from indra.statements import Influence, Association, Concept, Evidence, \
     WorldContext, TimeContext, RefContext
 
 
-logger = logging.getLogger('eidos')
+logger = logging.getLogger(__name__)
 
 
 class EidosProcessor(object):

--- a/indra/sources/eidos/scala_utils.py
+++ b/indra/sources/eidos/scala_utils.py
@@ -1,7 +1,8 @@
 from jnius import autoclass
 import logging
 
-logger = logging.getLogger('eidos')
+logger = logging.getLogger(__name__)
+
 
 def get_python_list(scala_list):
     """Return list from elements of scala.collection.immutable.List"""

--- a/indra/sources/geneways/processor.py
+++ b/indra/sources/geneways/processor.py
@@ -27,7 +27,7 @@ except ImportError:
     get_ft_mention = False
 
 
-logger = logging.getLogger('geneways')
+logger = logging.getLogger(__name__)
 
 
 # This will take in an action and action mention and create a single statement

--- a/indra/sources/hume/api.py
+++ b/indra/sources/hume/api.py
@@ -4,7 +4,7 @@ import json
 import logging
 from indra.sources.hume import processor
 
-logger = logging.getLogger('hume')
+logger = logging.getLogger(__name__)
 
 
 def process_jsonld_file(fname):

--- a/indra/sources/hume/processor.py
+++ b/indra/sources/hume/processor.py
@@ -8,7 +8,7 @@ from indra.statements import Concept, Influence, Evidence, TimeContext, \
     RefContext, WorldContext
 
 
-logger = logging.getLogger('hume')
+logger = logging.getLogger(__name__)
 
 
 class HumeJsonLdProcessor(object):

--- a/indra/sources/indra_db_rest/client_api.py
+++ b/indra/sources/indra_db_rest/client_api.py
@@ -20,7 +20,7 @@ from indra.statements import stmts_from_json, get_statement_by_name, \
     get_all_descendants
 
 
-logger = logging.getLogger('db_rest_client')
+logger = logging.getLogger(__name__)
 
 
 class IndraDBRestClientError(Exception):

--- a/indra/sources/isi/api.py
+++ b/indra/sources/isi/api.py
@@ -11,7 +11,7 @@ import subprocess
 from indra.sources.isi.processor import IsiProcessor
 from indra.sources.isi.preprocessor import IsiPreprocessor
 
-logger = logging.getLogger('isi')
+logger = logging.getLogger(__name__)
 
 
 def process_text(text, pmid=None, cleanup=True, add_grounding=True):

--- a/indra/sources/isi/preprocessor.py
+++ b/indra/sources/isi/preprocessor.py
@@ -11,7 +11,7 @@ import tempfile
 import subprocess
 from indra import get_config
 
-logger = logging.getLogger('isi')
+logger = logging.getLogger(__name__)
 
 nxml2txt_path = get_config('NXML2TXT_PATH')
 python2_path = get_config('PYTHON2_PATH')

--- a/indra/sources/isi/processor.py
+++ b/indra/sources/isi/processor.py
@@ -6,7 +6,7 @@ import indra.statements as ist
 from indra.preassembler.grounding_mapper import load_grounding_map, \
         GroundingMapper
 
-logger = logging.getLogger('isi')
+logger = logging.getLogger(__name__)
 
 
 class IsiProcessor(object):

--- a/indra/sources/medscan/api.py
+++ b/indra/sources/medscan/api.py
@@ -13,7 +13,7 @@ from .processor import *
 from .fix_csxml_character_encoding import fix_character_encoding
 
 
-logger = logging.getLogger('medscan')
+logger = logging.getLogger(__name__)
 
 
 def process_directory_statements_sorted_by_pmid(directory_name):

--- a/indra/sources/medscan/fix_csxml_character_encoding.py
+++ b/indra/sources/medscan/fix_csxml_character_encoding.py
@@ -6,7 +6,7 @@ import logging
 codec_options = ['utf-8', 'latin_1']
 
 
-logger = logging.getLogger('fix_csxml_character_encoding')
+logger = logging.getLogger(__name__)
 
 
 def try_decode(byte_string, codec):

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -11,7 +11,7 @@ from indra.databases.hgnc_client import get_hgnc_from_entrez, get_uniprot_id, \
 from indra.util import read_unicode_csv
 from indra.sources.reach.processor import ReachProcessor, Site
 
-logger = logging.getLogger('medscan')
+logger = logging.getLogger(__name__)
 
 
 MedscanEntity = collections.namedtuple('MedscanEntity', ['name', 'urn', 'type',

--- a/indra/sources/ndex_cx/processor.py
+++ b/indra/sources/ndex_cx/processor.py
@@ -6,7 +6,7 @@ from indra.databases import uniprot_client, hgnc_client
 from indra.statements import *
 
 
-logger = logging.getLogger('ndex_cx_processor')
+logger = logging.getLogger(__name__)
 
 
 _stmt_map = {

--- a/indra/sources/reach/api.py
+++ b/indra/sources/reach/api.py
@@ -20,7 +20,7 @@ try:  # Python 2
 except NameError:  # Python 3
     basestring = str
 
-logger = logging.getLogger('reach')
+logger = logging.getLogger(__name__)
 
 try:
     # For offline reading

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -12,7 +12,7 @@ from indra.databases import hgnc_client
 import indra.databases.uniprot_client as up_client
 from collections import namedtuple
 
-logger = logging.getLogger('reach')
+logger = logging.getLogger(__name__)
 
 Site = namedtuple('Site', ['residue', 'position'])
 

--- a/indra/sources/reach/reader.py
+++ b/indra/sources/reach/reader.py
@@ -31,7 +31,8 @@ _set_classpath()
 
 from indra.java_vm import autoclass, JavaException
 
-logger = logging.getLogger('reach_reader')
+logger = logging.getLogger(__name__)
+
 
 class ReachReader(object):
     """The ReachReader wraps a singleton instance of the REACH reader.

--- a/indra/sources/signor/api.py
+++ b/indra/sources/signor/api.py
@@ -8,7 +8,7 @@ import requests
 from .processor import SignorProcessor
 from indra.util import read_unicode_csv, read_unicode_csv_fileobj
 
-logger = logging.getLogger('signor')
+logger = logging.getLogger(__name__)
 
 _signor_fields = [
     'ENTITYA',

--- a/indra/sources/signor/processor.py
+++ b/indra/sources/signor/processor.py
@@ -23,7 +23,8 @@ from indra.statements import *
 from indra.util import read_unicode_csv, read_unicode_csv_fileobj
 from indra.databases import hgnc_client, uniprot_client
 
-logger = logging.getLogger('signor')
+logger = logging.getLogger(__name__)
+
 
 def _read_famplex_map():
     fname = join(dirname(__file__), '../../resources/famplex_map.tsv')

--- a/indra/sources/sparser/api.py
+++ b/indra/sources/sparser/api.py
@@ -22,7 +22,7 @@ from indra.util import UnicodeXMLTreeBuilder as UTB
 
 from .processor import SparserXMLProcessor, SparserJSONProcessor
 
-logger = logging.getLogger('sparser')
+logger = logging.getLogger(__name__)
 
 sparser_path_var = 'SPARSERPATH'
 sparser_path = get_config(sparser_path_var)

--- a/indra/sources/sparser/processor.py
+++ b/indra/sources/sparser/processor.py
@@ -11,7 +11,7 @@ from indra.literature import id_lookup
 from indra.statements import *
 from indra.databases import uniprot_client, hgnc_client
 
-logger = logging.getLogger('sparser')
+logger = logging.getLogger(__name__)
 
 
 try:

--- a/indra/sources/tees/api.py
+++ b/indra/sources/tees/api.py
@@ -32,7 +32,7 @@ import networkx.algorithms.dag as dag
 
 __all__ = ['run_on_text', 'process_text', 'extract_output']
 
-logger = logging.getLogger('tees')
+logger = logging.getLogger(__name__)
 
 # If TEES isn't specified, we will check to see if any of these directories
 # contain all of the files in tees_installation_files; if so, we'll assume

--- a/indra/sources/tees/parse_tees.py
+++ b/indra/sources/tees/parse_tees.py
@@ -32,7 +32,7 @@ try:  # Python 2
 except NameError:  # Python 3
     basestring = str
 
-logger = logging.getLogger('tees_parser')
+logger = logging.getLogger(__name__)
 
 
 class TEESEntity:

--- a/indra/sources/trips/api.py
+++ b/indra/sources/trips/api.py
@@ -4,7 +4,7 @@ import logging
 from .processor import TripsProcessor
 from indra.sources.trips import client
 
-logger = logging.getLogger('trips')
+logger = logging.getLogger(__name__)
 
 try:
     from .drum_reader import DrumReader

--- a/indra/sources/trips/client.py
+++ b/indra/sources/trips/client.py
@@ -7,7 +7,7 @@ import xml.dom.minidom
 import logging
 import requests
 
-logger = logging.getLogger('trips')
+logger = logging.getLogger(__name__)
 
 base_url = 'http://trips.ihmc.us/parser/cgi/'
 

--- a/indra/sources/trips/drum_reader.py
+++ b/indra/sources/trips/drum_reader.py
@@ -15,7 +15,8 @@ except ImportError:
     KQMLModule = object
     have_kqml = False
 
-logger = logging.getLogger('drum_reader')
+logger = logging.getLogger(__name__)
+
 
 class DrumReader(KQMLModule):
     """Agent which processes text through a local TRIPS/DRUM instance.

--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -13,7 +13,7 @@ import indra.databases.hgnc_client as hgnc_client
 import indra.databases.uniprot_client as up_client
 from indra.util import UnicodeXMLTreeBuilder as UTB
 
-logger = logging.getLogger('trips')
+logger = logging.getLogger(__name__)
 
 ont_to_mod_type = {
     'ONT::PHOSPHORYLATION': 'phosphorylation',

--- a/indra/statements.py
+++ b/indra/statements.py
@@ -217,7 +217,7 @@ from indra.util import unicode_strs
 import indra.databases.hgnc_client as hgc
 import indra.databases.uniprot_client as upc
 
-logger = logging.getLogger('indra_statements')
+logger = logging.getLogger(__name__)
 
 
 try:  # Python 2

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -24,11 +24,12 @@ from indra.preassembler.grounding_mapper import default_agent_map as agent_map
 from indra.preassembler.sitemapper import SiteMapper, default_site_map
 from copy import deepcopy
 
-logger = logging.getLogger('assemble_corpus')
-indra_logger = logging.getLogger('indra').setLevel(logging.DEBUG)
+logger = logging.getLogger(__name__)
+
 
 def _filter(kwargs, arg_list):
     return dict(filter(lambda x: x[0] in arg_list, kwargs.items()))
+
 
 def dump_statements(stmts, fname):
     """Dump a list of statements into a pickle file.
@@ -44,6 +45,7 @@ def dump_statements(stmts, fname):
     logger.info('Dumping %d statements into %s...' % (len(stmts), fname))
     with open(fname, 'wb') as fh:
         pickle.dump(stmts, fh, protocol=2)
+
 
 def load_statements(fname, as_dict=False):
     """Load statements from a pickle file.
@@ -82,6 +84,7 @@ def load_statements(fname, as_dict=False):
     logger.info('Loaded %d statements' % len(stmts))
     return stmts
 
+
 def map_grounding(stmts_in, **kwargs):
     """Map grounding using the GroundingMapper.
 
@@ -114,6 +117,7 @@ def map_grounding(stmts_in, **kwargs):
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
+
 
 def map_sequence(stmts_in, **kwargs):
     """Map sequences using the SiteMapper.
@@ -230,6 +234,7 @@ def run_preassembly(stmts_in, **kwargs):
     stmts_out = run_preassembly_related(pa, be, **options)
     return stmts_out
 
+
 def run_preassembly_duplicate(preassembler, beliefengine, **kwargs):
     """Run deduplication stage of preassembly on a list of statements.
 
@@ -256,6 +261,7 @@ def run_preassembly_duplicate(preassembler, beliefengine, **kwargs):
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
+
 
 def run_preassembly_related(preassembler, beliefengine, **kwargs):
     """Run related stage of preassembly on a list of statements.
@@ -310,6 +316,7 @@ def run_preassembly_related(preassembler, beliefengine, **kwargs):
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
+
 
 def filter_by_type(stmts_in, stmt_type, **kwargs):
     """Filter to a given statement type.
@@ -392,6 +399,7 @@ def _remove_bound_conditions(agent, keep_criterion):
             new_bc.append(agent.bound_conditions[ind])
     agent.bound_conditions = new_bc
 
+
 def _any_bound_condition_fails_criterion(agent, criterion):
     """Returns True if any bound condition fails to meet the specified
     criterion.
@@ -415,6 +423,7 @@ def _any_bound_condition_fails_criterion(agent, criterion):
         if not criterion(b):
             return True
     return False
+
 
 def filter_grounded_only(stmts_in, **kwargs):
     """Filter to statements that have grounded agents.
@@ -467,6 +476,7 @@ def filter_grounded_only(stmts_in, **kwargs):
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
 
+
 def _agent_is_gene(agent, specific_only):
     """Returns whether an agent is for a gene.
 
@@ -493,6 +503,7 @@ def _agent_is_gene(agent, specific_only):
                agent.db_refs.get('UP')):
             return False
     return True
+
 
 def filter_genes_only(stmts_in, **kwargs):
     """Filter to statements containing genes only.
@@ -546,6 +557,7 @@ def filter_genes_only(stmts_in, **kwargs):
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
 
+
 def filter_belief(stmts_in, belief_cutoff, **kwargs):
     """Filter to statements with belief above a given cutoff.
 
@@ -588,6 +600,7 @@ def filter_belief(stmts_in, belief_cutoff, **kwargs):
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
+
 
 def filter_gene_list(stmts_in, gene_list, policy, allow_families=False,
                      **kwargs):
@@ -903,6 +916,7 @@ def filter_human_only(stmts_in, **kwargs):
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
 
+
 def filter_direct(stmts_in, **kwargs):
     """Filter to statements that are direct interactions
 
@@ -1063,6 +1077,7 @@ def filter_evidence_source(stmts_in, source_apis, policy='one', **kwargs):
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
 
+
 def filter_top_level(stmts_in, **kwargs):
     """Filter to statements that are at the top-level of the hierarchy.
 
@@ -1087,6 +1102,7 @@ def filter_top_level(stmts_in, **kwargs):
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
+
 
 def filter_inconsequential_mods(stmts_in, whitelist=None, **kwargs):
     """Filter out Modifications that modify inconsequential sites
@@ -1151,6 +1167,7 @@ def filter_inconsequential_mods(stmts_in, whitelist=None, **kwargs):
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
 
+
 def filter_inconsequential_acts(stmts_in, whitelist=None, **kwargs):
     """Filter out Activations that modify inconsequential activities
 
@@ -1207,6 +1224,7 @@ def filter_inconsequential_acts(stmts_in, whitelist=None, **kwargs):
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
+
 
 def get_unreachable_mods(stmts_in):
     mods_set = {}
@@ -1304,6 +1322,7 @@ def filter_mutation_status(stmts_in, mutations, deletions, **kwargs):
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
 
+
 def filter_enzyme_kinase(stmts_in, **kwargs):
     """Filter Phosphorylations to ones where the enzyme is a known kinase.
 
@@ -1338,6 +1357,7 @@ def filter_enzyme_kinase(stmts_in, **kwargs):
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
+
 
 def filter_mod_nokinase(stmts_in, **kwargs):
     """Filter non-phospho Modifications to ones with a non-kinase enzyme.
@@ -1374,6 +1394,7 @@ def filter_mod_nokinase(stmts_in, **kwargs):
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
+
 
 def filter_transcription_factor(stmts_in, **kwargs):
     """Filter out RegulateAmounts where subject is not a transcription factor.
@@ -1474,6 +1495,7 @@ def expand_families(stmts_in, **kwargs):
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
 
+
 def reduce_activities(stmts_in, **kwargs):
     """Reduce the activity types in a list of statements
 
@@ -1533,6 +1555,7 @@ def strip_agent_context(stmts_in, **kwargs):
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)
     return stmts_out
+
 
 def dump_stmt_strings(stmts, fname):
     """Save printed statements in a file.

--- a/indra/tools/expand_families.py
+++ b/indra/tools/expand_families.py
@@ -9,7 +9,8 @@ from indra.preassembler.hierarchy_manager import HierarchyManager, \
 from indra.databases import hgnc_client
 from indra.statements import Agent, Complex, Evidence
 
-logger = logging.getLogger('expand_families')
+logger = logging.getLogger(__name__)
+
 
 class Expander(object):
     def __init__(self, hierarchies=None):

--- a/indra/tools/extract_grounding_map.py
+++ b/indra/tools/extract_grounding_map.py
@@ -13,7 +13,7 @@ from indra.util import read_unicode_csv, write_unicode_csv
 import indra.tools.assemble_corpus as ac
 
 
-logger = logging.getLogger('extract_grounding_map')
+logger = logging.getLogger('indra.tools.extract_grounding_map')
 
 
 def string_is_integer(s):

--- a/indra/tools/gene_network.py
+++ b/indra/tools/gene_network.py
@@ -9,7 +9,8 @@ from indra.preassembler import Preassembler
 from indra.preassembler.hierarchy_manager import hierarchies
 from indra.preassembler.sitemapper import default_mapper as sm
 
-logger = logging.getLogger('gene_network')
+logger = logging.getLogger(__name__)
+
 
 class GeneNetwork(object):
     """Build a set of INDRA statements for a given gene list from databases.

--- a/indra/tools/incremental_model.py
+++ b/indra/tools/incremental_model.py
@@ -7,7 +7,7 @@ import indra.tools.assemble_corpus as ac
 from indra.databases import hgnc_client
 from indra.preassembler.hierarchy_manager import hierarchies
 
-logger = logging.getLogger('incremental_model')
+logger = logging.getLogger(__name__)
 
 
 class IncrementalModel(object):

--- a/indra/tools/machine/machine.py
+++ b/indra/tools/machine/machine.py
@@ -35,7 +35,7 @@ except Exception:
 
 global_filters = ['grounding', 'prior_one', 'human_only']
 
-logger = logging.getLogger('rasmachine')
+logger = logging.getLogger(__name__)
 
 
 def build_prior(genes, out_file):

--- a/indra/tools/reading/assemble_reading_stmts.py
+++ b/indra/tools/reading/assemble_reading_stmts.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
     import pickle
     import logging
 
-    logger = logging.getLogger('assemble_reach')
+    logger = logging.getLogger('indra.tools.reading.assemble_reach')
 
     client = boto3.client('s3')
     bucket_name = 'bigmech'

--- a/indra/tools/reading/pmid_reading/read_pmids.py
+++ b/indra/tools/reading/pmid_reading/read_pmids.py
@@ -21,7 +21,7 @@ from platform import system
 import logging
 from indra import get_config
 
-logger = logging.getLogger('runreader')
+logger = logging.getLogger('indra.tools.reading.pmid_reading.read_pmids')
 
 
 parser = argparse.ArgumentParser(

--- a/indra/tools/reading/pmid_reading/read_pmids_aws.py
+++ b/indra/tools/reading/pmid_reading/read_pmids_aws.py
@@ -66,7 +66,8 @@ if __name__ == '__main__':
     import logging
     import sys
 
-    logger = logging.getLogger('read_pmids_aws')
+    logger = \
+        logging.getLogger('indra.tools.reading.pmid_reading.read_pmids_aws')
 
     # Setting default force read/fulltext parameters
     force_read = args.force_read

--- a/indra/tools/reading/read_files.py
+++ b/indra/tools/reading/read_files.py
@@ -6,7 +6,7 @@ import logging
 import pickle
 import random
 
-logger = logging.getLogger('file_reader')
+logger = logging.getLogger('indra.tools.reading.read_files')
 
 from indra.tools.reading.util.script_tools import get_parser, make_statements
 

--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -22,7 +22,7 @@ from indra.util import zip_string
 from indra.sources import sparser, reach
 
 
-logger = logging.getLogger('readers')
+logger = logging.getLogger(__name__)
 
 # Set a character limit for reach reading
 CONTENT_CHARACTER_LIMIT = 5e5

--- a/indra/tools/reading/run_drum_reading.py
+++ b/indra/tools/reading/run_drum_reading.py
@@ -7,7 +7,7 @@ from indra.sources.trips import process_xml
 from indra.sources.trips.drum_reader import DrumReader
 
 
-logger = logging.getLogger('run_drum_reading')
+logger = logging.getLogger('indra.tools.reading.run_drum_reading')
 
 
 def read_pmid_sentences(pmid_sentences, **drum_args):

--- a/indra/tools/reading/starcluster_reading/process_reach_from_s3.py
+++ b/indra/tools/reading/starcluster_reading/process_reach_from_s3.py
@@ -13,7 +13,8 @@ if __name__ == '__main__':
         sys.exit()
 
     # Logger
-    logger = logging.getLogger('processreach')
+    logger = logging.getLogger('indra.tools.reading.starcluster_reading.'
+                               'process_reach_from_s3')
 
     pmid_list_file = sys.argv[1]
     start_ix = int(sys.argv[2])

--- a/indra/tools/reading/starcluster_reading/upload_content_to_s3.py
+++ b/indra/tools/reading/starcluster_reading/upload_content_to_s3.py
@@ -20,7 +20,8 @@ if __name__ == '__main__':
     else:
         force_fulltext = False
 
-    logger = logging.getLogger('upload_content')
+    logger = logging.getLogger('indra.tools.reading.starcluster_reading.'
+                               'upload_content')
 
     pmid_list = sys.argv[1]
     start_index = int(sys.argv[2])

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -14,7 +14,7 @@ from indra.util.aws import get_job_log, tag_instance, get_batch_command
 
 bucket_name = 'bigmech'
 
-logger = logging.getLogger('aws_reading')
+logger = logging.getLogger('indra.tools.reading.submit_reading_pipeline')
 
 
 class BatchReadingError(Exception):

--- a/indra/tools/reading/util/reading_results_stats.py
+++ b/indra/tools/reading/util/reading_results_stats.py
@@ -9,7 +9,7 @@ from collections import Counter
 from matplotlib import pyplot as plt
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 
-logger = logging.getLogger('reading_results')
+logger = logging.getLogger('indra.tools.reading.util.reading_result_stats')
 
 
 if __name__ == '__main__':

--- a/indra/tools/reading/util/script_tools.py
+++ b/indra/tools/reading/util/script_tools.py
@@ -8,7 +8,7 @@ from argparse import ArgumentParser
 from indra.util.get_version import get_version as get_indra_version
 from multiprocessing import Pool
 
-logger = logging.getLogger('script_tools')
+logger = logging.getLogger(__name__)
 
 
 def get_parser(description, input_desc):

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -5,7 +5,7 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from indra import get_config, has_config
 from indra.util.nested_dict import NestedDict
 
-logger = logging.getLogger('aws_utils')
+logger = logging.getLogger(__name__)
 
 
 def kill_all(job_queue, reason='None given', states=None):


### PR DESCRIPTION
This PR removes the `indra/` prefix in the root logger, and changes all other places where loggers are made to ether use `getLogger(__name__)`, or the explicit path to the module if the module is likely to be run as `__main__`.

This fixes #723 