### PR TITLE
Load the PMID title on mouseover

### DIFF
--- a/indra/assemblers/html/template.html
+++ b/indra/assemblers/html/template.html
@@ -128,10 +128,14 @@ a {
                     <td style="white-space: nowrap">
                        {% if ev['pmid'] %}
                         <a class="pmid_link"
+                title="Hover again to see info"
+                onmouseover="setPMIDlinkTitle(this.textContent, this); this.onmouseover=null;" 
                 href='https://www.ncbi.nlm.nih.gov/pubmed/{{ ev['pmid'] }}'>
                         {{ ev['pmid'] }}</a>
                         {% elif 'pmid' in ev['text_refs'] and ev['text_refs']['pmid'] %}
                         <a class="pmid_link"
+                title="Hover again to see info"
+                onmouseover="setPMIDlinkTitle(this.textContent, this); this.onmouseover=null;" 
                 href='https://www.ncbi.nlm.nih.gov/pubmed/{{ ev['text_refs']['pmid'] }}'>
                         {{ ev['text_refs']['pmid'] }}</a>
                        {% endif %}


### PR DESCRIPTION
This PR attaches `setPMIDlinkTitle()` to a `onmouseover` event that sets the link title of the current PMID link in `template.html`.