### PR TITLE
Don't add act() around bioprocesses when outputting to PyBEL

### DIFF
--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -450,7 +450,10 @@ def _get_agent_node_no_bcs(agent):
 
     if variants:
         node_data = node_data.with_variants(variants)
-
+    
+    if isinstance(node_data, (bioprocess, pathology)):
+        return node_data, None
+    
     # Also get edge data for the agent
     edge_data = _get_agent_activity(agent)
     return node_data, edge_data


### PR DESCRIPTION
Closes #601 

Includes a new unit test that shows the scenario. Before, it would output things like

```
p(HGNC:YGF) -> act(bp(GO:YFBP))
```

and now it will correctly output

```
p(HGNC:YGF) -> bp(GO:YFBP)
```