### PR TITLE
Changed loop to handle changed json structure

### DIFF
--- a/indra/statements.py
+++ b/indra/statements.py
@@ -3549,9 +3549,9 @@ def stmts_from_json(json_in, on_missing_support='handle'):
 
     stmts = []
     uuid_dict = {}
-    for json_stmt in json_in:
+    for stmt_hash in json_in['statements']:
         try:
-            st = Statement._from_json(json_stmt)
+            st = Statement._from_json(json_in['statements'][stmt_hash])
         except Exception as e:
             logger.warning("Error creating statement: %s" % e)
             continue


### PR DESCRIPTION
This PR resolves a bug where new json stucture broke the handling of json statements in `stmts_from_json()` in `indra/statements`.

Signed-off-by: kkaris <karis.klas@gmail.com>