### PR TITLE
Install pyjnius from PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
   - pip install git+https://github.com/pysb/pysb.git
   # Biopax/Paxtools dependencies
-  - pip install git+https://github.com/kivy/pyjnius.git@1cbfef
+  - pip install pyjnius==1.1.4
   # Download a number of useful resource files for testing purposes
   - pip install .[all]
   - cd indra/benchmarks/assembly_eval/batch4

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,9 @@ install:
   - tar xzf bionetgen.tar.gz
   - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
   - pip install git+https://github.com/pysb/pysb.git
-  # Biopax/Paxtools dependencies
-  - pip install pyjnius==1.1.4
-  # Download a number of useful resource files for testing purposes
   - pip install .[all]
   - cd indra/benchmarks/assembly_eval/batch4
+  # Download a number of useful resource files for testing purposes
   - wget http://sorger.med.harvard.edu/data/bachman/trips_reach_batch4.gz -nv
   - tar -xf trips_reach_batch4.gz
   - cd $TRAVIS_BUILD_DIR

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -153,7 +153,7 @@ and add `JNI` to `JVMCapabilities` as
 .. code-block:: bash
 
     pip install cython
-    pip install git+https://github.com/kivy/pyjnius.git@1cbfef
+    pip install pjnius==1.1.4
 
 Graphviz
 ````````

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ def main():
 
     extras_require = {
                       # Inputs and outputs
-                      'biopax': ['cython', 'pyjnius'],
+                      'biopax': ['cython', 'pyjnius==1.1.4'],
                       'trips_offline': ['pykqml'],
-                      'reach_offline': ['cython', 'pyjnius'],
-                      'eidos_offline': ['pyyaml', 'cython', 'pyjnius'],
+                      'reach_offline': ['cython', 'pyjnius==1.1.4'],
+                      'eidos_offline': ['pyyaml', 'cython', 'pyjnius==1.1.4'],
                       'geneways': ['stemming', 'nltk'],
                       'sofia': ['openpyxl'],
                       'bel': ['pybel'],


### PR DESCRIPTION
This PR changes the guidelines for installing `pyjnius`, whose INDRA-compatible version has finally been released on PyPI. It can now simply be pip installed (though I pinned the version to 1.1.4 just in case it breaks later).