### PR TITLE
Looks for cycles in supports graph explicitly

### DIFF
--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -286,7 +286,15 @@ class BeliefEngine(object):
             stmts = [g.node[n]['stmt'] for n in node_ranks]
             return stmts
 
+        def has_cycle(g):
+            try:
+                networkx.algorithms.cycles.find_cycle(g)
+            except networkx.exception.NetworkXNoCycle:
+                return False
+            return True
+
         g = build_hierarchy_graph(statements)
+        assert not has_cycle(g), 'Hierarchy graph has an unexpected cycle'
         ranked_stmts = get_ranked_stmts(g)
         for st in ranked_stmts:
             bps = _get_belief_package(st)

--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -286,15 +286,17 @@ class BeliefEngine(object):
             stmts = [g.node[n]['stmt'] for n in node_ranks]
             return stmts
 
-        def has_cycle(g):
+        def assert_no_cycle(g):
+            """If the graph has cycles, throws AssertionError."""
             try:
-                networkx.algorithms.cycles.find_cycle(g)
+                cyc = networkx.algorithms.cycles.find_cycle(g)
             except networkx.exception.NetworkXNoCycle:
-                return False
-            return True
+                return
+            msg = 'Cycle found in hierarchy graph: %s' % cyc
+            assert False, msg
 
         g = build_hierarchy_graph(statements)
-        assert not has_cycle(g), 'Hierarchy graph has an unexpected cycle'
+        assert_no_cycle(g)
         ranked_stmts = get_ranked_stmts(g)
         for st in ranked_stmts:
             bps = _get_belief_package(st)

--- a/indra/tests/test_belief_engine.py
+++ b/indra/tests/test_belief_engine.py
@@ -352,5 +352,17 @@ def test_wm_scorer():
     engine.set_prior_probs([stmt])
 
 
+@raises(AssertionError)
+def test_cycle():
+    st1 = Phosphorylation(Agent('B'), Agent('A1'))
+    st2 = Phosphorylation(None, Agent('A1'))
+    st1.supports = [st2]
+    st1.supported_by = [st2]
+    st2.supports = [st1]
+    st2.supported_by = [st1]
+    engine = BeliefEngine()
+    engine.set_hierarchy_probs([st1, st2])
+
+
 def assert_close_enough(b1, b2):
     assert abs(b1 - b2) < 1e-6, 'Got %.6f, Expected: %.6f' % (b1, b2)


### PR DESCRIPTION
Occasionally, due to bugs, cycles can form in the supports graph. This PR adds an explicit check for this which makes finding and debugging any such issues much more straightforward.