### PR TITLE
Fix two issues in BioPAX processor

### DIFF
--- a/indra/sources/biopax/api.py
+++ b/indra/sources/biopax/api.py
@@ -182,4 +182,5 @@ def process_model(model):
     bp.get_gap()
     bp.get_conversions()
     # bp.get_complexes()
+    bp.eliminate_exact_duplicates()
     return bp

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -242,7 +242,6 @@ class BiopaxProcessor(object):
                     stmt = act_class(subj, obj, 'activity', evidence=ev)
                     self.statements.append(decode_obj(stmt, encoding='utf-8'))
 
-
     def get_regulate_amounts(self):
         """Extract INDRA RegulateAmount Statements from the BioPAX model.
 
@@ -400,10 +399,16 @@ class BiopaxProcessor(object):
             obj_right = []
             for participant in left:
                 agent = self._get_agents_from_entity(participant)
-                obj_left.append(agent)
+                if isinstance(agent, list):
+                    obj_left += agent
+                else:
+                    obj_left.append(agent)
             for participant in right:
                 agent = self._get_agents_from_entity(participant)
-                obj_right.append(agent)
+                if isinstance(agent, list):
+                    obj_right += agent
+                else:
+                    obj_right.append(agent)
             ev = self._get_evidence(control)
             for subj in _listify(subj_list):
                 st = Conversion(subj, obj_left, obj_right, evidence=ev)

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 # - Implement extracting modifications with Complex enzyme
 # - Implement extracting modifications with Complex substrate
 
+
 class BiopaxProcessor(object):
     """The BiopaxProcessor extracts INDRA Statements from a BioPAX model.
 
@@ -66,6 +67,21 @@ class BiopaxProcessor(object):
             logger.error('Missing file name')
             return
         pcc.model_to_owl(self.model, file_name)
+
+    def eliminate_exact_duplicates(self):
+        """Eliminate Statements that were extracted multiple times.
+
+        Due to the way the patterns are implemented, they can sometimes yield
+        the same Statement information multiple times, in which case,
+        we end up with redundant Statements that aren't from independent
+        underlying entries. To avoid this, here, we filter out such
+        duplicates.
+        """
+        # Here we use the deep hash of each Statement, and by making a dict,
+        # we effectively keep only one Statement with a given deep hash
+        self.statements = list({stmt.get_hash(shallow=False, refresh=True): stmt
+                               for stmt in self.statements}.values())
+
 
     def get_complexes(self):
         """Extract INDRA Complex Statements from the BioPAX model.

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -80,7 +80,7 @@ class BiopaxProcessor(object):
         # Here we use the deep hash of each Statement, and by making a dict,
         # we effectively keep only one Statement with a given deep hash
         self.statements = list({stmt.get_hash(shallow=False, refresh=True): stmt
-                               for stmt in self.statements}.values())
+                                for stmt in self.statements}.values())
 
 
     def get_complexes(self):

--- a/indra/tests/test_biopax.py
+++ b/indra/tests/test_biopax.py
@@ -162,6 +162,8 @@ def test_pathsfromto():
     assert_pmids(bp.statements)
     assert_source_sub_id(bp.statements)
     assert unicode_strs(bp.statements)
+    num_unique = len({s.get_hash(shallow=False) for s in bp.statements})
+    assert len(bp.statements) == num_unique
 
 def test_all_uniprot_ids():
     for obj in bp.model.getObjects().toArray():


### PR DESCRIPTION
This PR fixes #258 by taking a unique set of Statements with respect to their deep hashes, thereby eliminating duplicates that are artifacts of the pattern queries. It also fixes #253 by rolling out objects of Conversions into flat lists.