### PR TITLE
PysbAssembler statement-level policies and parameterization

### DIFF
--- a/doc/modules/assemblers/pysb_assembler.rst
+++ b/doc/modules/assemblers/pysb_assembler.rst
@@ -1,6 +1,20 @@
 Executable PySB models (:py:mod:`indra.assemblers.pysb.assembler`)
 ==================================================================
 
+PySB Assembler (:py:mod:`indra.assemblers.pysb.assembler`)
+----------------------------------------------------------
+
 .. automodule:: indra.assemblers.pysb.assembler
     :members:
 
+PySB PreAssembler (:py:mod:`indra.assemblers.pysb.preassembler`)
+----------------------------------------------------------------
+
+.. automodule:: indra.assemblers.pysb.preassembler
+    :members:
+
+Base Agents (:py:mod:`indra.assemblers.pysb.base_agents`)
+---------------------------------------------------------
+
+.. automodule:: indra.assemblers.pysb.base_agents
+    :members:

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -856,8 +856,9 @@ class Policy(object):
         return str(self)
 
     def __str__(self):
-        param_str = json.dumps(self.parameters) if self.parameters else ''
-        sites_str = json.dumps(self.sites) if self.sites else ''
+        param_dict = {k: str(v) for k, v in self.parameters.items()}
+        param_str = (', ' + json.dumps(param_dict)) if param_dict else ''
+        sites_str = (', ' + json.dumps(self.sites)) if self.sites else ''
         s = 'Policy(%s%s%s)' % (self.name, param_str, sites_str)
         return s
 
@@ -881,6 +882,9 @@ class Param(object):
         self.name = name
         self.value = value
         self.unique = unique
+
+    def __repr__(self):
+        return 'Param(%s,%f)' % (self.name, self.value)
 
 
 

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -1287,7 +1287,7 @@ def phosphorylation_monomers_atp_dependent(stmt, agent_set):
     enz.create_site('ATP')
 
 
-def phosphorylation_assemble_atp_dependent(stmt, model, parameters, agent_set):
+def phosphorylation_assemble_atp_dependent(stmt, model, agent_set, parameters):
     if stmt.enz is None:
         return
     # ATP
@@ -1590,11 +1590,11 @@ def regulateactivity_assemble_one_step(stmt, model, agent_set, parameters, rate_
         param_name = ('Km_' + stmt.subj.name[0].lower() +
                       stmt.obj.name[0].lower() + '_act')
         Kmp = parameters.get('Km', Param(param_name, 1e8, True))
-        Km = get_create_parameter(model, Kmp.name)
+        Km = get_create_parameter(model, Kmp)
         param_name = ('kc_' + stmt.subj.name[0].lower() +
                       stmt.obj.name[0].lower() + '_act')
         kcp = parameters.get('kc', Param(param_name, 100, True))
-        kcat = get_create_parameter(model, kcp.name)
+        kcat = get_create_parameter(model, kcp)
 
         # We need an observable for the substrate to use in the rate law
         obj_to_observe = obj_active if stmt.is_activation else obj_inactive

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -449,20 +449,25 @@ class UnknownPolicyError(Exception):
 class PysbAssembler(object):
     """Assembler creating a PySB model from a set of INDRA Statements.
 
+    Parameters
+    ----------
+    statements : list[indra.statements.Statement]
+        A list of INDRA Statements to be assembled.
+
     Attributes
     ----------
     policies : dict
         A dictionary of policies that defines assembly policies for Statement
         types. It is assigned in the constructor.
-    statements : list
+    statements : list[indra.statements.Statement]
         A list of INDRA statements to be assembled.
     model : pysb.Model
         A PySB model object that is assembled by this class.
     agent_set : _BaseAgentSet
         A set of BaseAgents used during the assembly process.
     """
-    def __init__(self):
-        self.statements = []
+    def __init__(self, statements=None):
+        self.statements = statements if statements else []
         self.agent_set = None
         self.model = None
         self.default_initial_amount = 10000.0

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -1195,13 +1195,16 @@ def modification_assemble_two_step(stmt, model, agent_set, parameters):
 
     param_name = ('kf_' + stmt.enz.name[0].lower() +
                   stmt.sub.name[0].lower() + '_bind')
-    kf_bind = get_create_parameter(model, param_name, 1e-6)
+    kfp = parameters.get('kf', Param(param_name, 1e-6, True))
+    kf_bind = get_create_parameter(model, kfp.name, kfp.value, kfp.unique)
     param_name = ('kr_' + stmt.enz.name[0].lower() +
                   stmt.sub.name[0].lower() + '_bind')
-    kr_bind = get_create_parameter(model, param_name, 1e-1)
+    krp = parameters.get('kr', Param(param_name, 1e-1, True))
+    kr_bind = get_create_parameter(model, krp.name, krp.value, krp.unique)
     param_name = ('kc_' + stmt.enz.name[0].lower() +
                   stmt.sub.name[0].lower() + '_' + mc.mod_type)
-    kf_mod = get_create_parameter(model, param_name, 100)
+    kcp = parameters.get('kc', Param(param_name, 100, True))
+    kf_mod = get_create_parameter(model, kcp.name, kcp.value, kcp.unique)
 
     mod_site = get_mod_site_name(mc)
 
@@ -1818,6 +1821,7 @@ def decreaseamount_assemble_interactions_only(stmt, model, agent_set, parameters
     obj = model.monomers[obj_base_agent.name]
     rule_subj_str = get_agent_rule_str(stmt.subj)
     rule_obj_str = get_agent_rule_str(stmt.obj)
+    st
     rule_name = '%s_degrades_%s' % (rule_subj_str, rule_obj_str)
 
     subj_site_name = get_binding_site_name(stmt.obj)

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -1394,22 +1394,12 @@ demodification_assemble_default = demodification_assemble_one_step
 # Modification assembly function
 policies = ['interactions_only', 'one_step', 'two_step', 'default']
 
-mod_classes = [cls for cls in ist.AddModification.__subclasses__()]
+mod_classes = [cls for cls in ist.Modification.__subclasses__()]
 for mc, func_type, pol in itertools.product(mod_classes,
                                             ('monomers', 'assemble'),
                                             policies):
     code = '{mc}_{func_type}_{pol} = ' \
             'modification_{func_type}_{pol}'.format(
-                    mc=ist.modclass_to_modtype[mc], func_type=func_type,
-                    pol=pol)
-    exec(code)
-
-demod_classes = [cls for cls in ist.RemoveModification.__subclasses__()]
-for mc, func_type, pol in itertools.product(demod_classes,
-                                            ('monomers', 'assemble'),
-                                            policies):
-    code = '{mc}_{func_type}_{pol} = ' \
-            'demodification_{func_type}_{pol}'.format(
                     mc=ist.modclass_to_modtype[mc], func_type=func_type,
                     pol=pol)
     exec(code)
@@ -1423,16 +1413,6 @@ for mc, rate_law in itertools.product(mod_classes, rate_laws):
             'lambda a, b, c, d: modification_assemble_' \
             'one_step(a, b, c, d, "{rate_law}")'.format(
                 mc=ist.modclass_to_modtype[mc], rate_law=rate_law)
-    exec(code)
-
-for mc, rate_law in itertools.product(demod_classes, rate_laws):
-    code = '{mc}_monomers_{rate_law} = {mc}_monomers_one_step'.format(
-                mc=ist.modclass_to_modtype[mc], rate_law=rate_law)
-    exec(code)
-    code = '{mc}_assemble_{rate_law} = ' \
-            'lambda a, b, c, d: demodification_assemble_' \
-            'one_step(a, b, c, d, "{rate_law}")'.format(
-                    mc=ist.modclass_to_modtype[mc], rate_law=rate_law)
     exec(code)
 
 

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -1527,8 +1527,10 @@ def regulateactivity_monomers_one_step(stmt, agent_set):
     obj.add_activity_type(stmt.obj_activity)
 
 
-def regulateactivity_assemble_interactions_only(stmt, model, agent_set, parameters):
-    kf_bind = get_create_parameter(model, 'kf_bind', 1.0, unique=False)
+def regulateactivity_assemble_interactions_only(stmt, model, agent_set,
+                                                parameters):
+    kfp = parameters.get('kf', Param('kf_bind', 1.0))
+    kf_bind = get_create_parameter(model, kfp.name, kfp.value, kfp.unique)
     subj = model.monomers[stmt.subj.name]
     obj = model.monomers[stmt.obj.name]
 
@@ -1575,15 +1577,19 @@ def regulateactivity_assemble_one_step(stmt, model, agent_set, parameters, rate_
     if not rate_law:
         param_name = 'kf_' + stmt.subj.name[0].lower() + \
             stmt.obj.name[0].lower() + '_act'
-        act_rate = get_create_parameter(model, param_name, 1e-6)
+        kfp = parameters.get('kf', Param(param_name, 1e-6, True))
+        act_rate = get_create_parameter(model, kfp.name, kfp.value,
+                                        kfp.unique)
     elif rate_law == 'michaelis_menten':
         # Parameters
         param_name = ('Km_' + stmt.subj.name[0].lower() +
                       stmt.obj.name[0].lower() + '_act')
-        Km = get_create_parameter(model, param_name, 1e8)
+        Kmp = parameters.get('Km', Param(param_name, 1e8, True))
+        Km = get_create_parameter(model, Kmp.name, Kmp.value, Kmp.unique)
         param_name = ('kc_' + stmt.subj.name[0].lower() +
                       stmt.obj.name[0].lower() + '_act')
-        kcat = get_create_parameter(model, param_name, 100)
+        kcp = parameters.get('kc', Param(param_name, 100, True))
+        kcat = get_create_parameter(model, kcp.name, kcp.value, kcp.unique)
 
         # We need an observable for the substrate to use in the rate law
         obj_to_observe = obj_active if stmt.is_activation else obj_inactive
@@ -2036,8 +2042,9 @@ def conversion_assemble_one_step(stmt, model, agent_set, parameters):
         rule_name = '%s_converted_to_%s' % (rule_obj_from_str, rule_obj_to_str)
         param_name = 'kf_%s%s_convert' % (obj_from.name[0].lower(),
                                           obj_to_monomers[0].name[0].lower())
-        kf_one_step_convert = get_create_parameter(model, param_name, 2,
-                                                   unique=True)
+        kfp = parameters.get('kf', Param(param_name, 2, True))
+        kf_one_step_convert = get_create_parameter(model, kfp.name, kfp.value,
+                                                   kfp.unique)
         r = Rule(rule_name, obj_from_pattern >> obj_to_pattern,
                  kf_one_step_convert)
     else:
@@ -2052,7 +2059,9 @@ def conversion_assemble_one_step(stmt, model, agent_set, parameters):
              obj_to_monomers[0].name[0].lower())
         # Scale the average apparent increaseamount rate by the default
         # protein initial condition
-        kf_one_step_convert = get_create_parameter(model, param_name, 2e-4)
+        kfp = parameters.get('kf', Param(param_name, 2e-4, True))
+        kf_one_step_convert = get_create_parameter(model, kfp.name, kfp.value,
+                                                   kfp.unique)
 
         r = Rule(rule_name, subj_pattern + obj_from_pattern >>
                             result_pattern,

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -18,6 +18,8 @@ from indra.databases import context_client, get_identifiers_url
 from indra.preassembler.hierarchy_manager import hierarchies
 from indra.tools.expand_families import _agent_from_uri
 
+from .base_agents import _BaseAgent, _BaseAgentSet
+
 # Python 2
 try:
     basestring
@@ -52,150 +54,6 @@ def _is_whitelisted(stmt):
         if isinstance(stmt, s):
             return True
     return False
-
-# BaseAgent classes ####################################################
-class _BaseAgentSet(object):
-    """Container for a dict of BaseAgents with their names as keys."""
-    def __init__(self):
-        self.agents = {}
-
-    def get_create_base_agent(self, agent):
-        """Return base agent with given name, creating it if needed."""
-        try:
-            base_agent = self.agents[_n(agent.name)]
-        except KeyError:
-            base_agent = _BaseAgent(_n(agent.name))
-            self.agents[_n(agent.name)] = base_agent
-
-        # If it's a molecular agent
-        if isinstance(agent, ist.Agent):
-            # Handle bound conditions
-            for bc in agent.bound_conditions:
-                bound_base_agent = self.get_create_base_agent(bc.agent)
-                bound_base_agent.create_site(get_binding_site_name(agent))
-                base_agent.create_site(get_binding_site_name(bc.agent))
-
-            # Handle modification conditions
-            for mc in agent.mods:
-                base_agent.create_mod_site(mc)
-
-            # Handle mutation conditions
-            for mc in agent.mutations:
-                res_from = mc.residue_from if mc.residue_from else 'mut'
-                res_to = mc.residue_to if mc.residue_to else 'X'
-                if mc.position is None:
-                    mut_site_name = res_from
-                else:
-                    mut_site_name = res_from + mc.position
-
-                base_agent.create_site(mut_site_name, states=['WT', res_to])
-
-            # Handle location condition
-            if agent.location is not None:
-                base_agent.create_site('loc', [_n(agent.location)])
-
-            # Handle activity
-            if agent.activity is not None:
-                site_name = agent.activity.activity_type
-                base_agent.create_site(site_name, ['inactive', 'active'])
-
-        # There might be overwrites here
-        for db_name, db_ref in agent.db_refs.items():
-            base_agent.db_refs[db_name] = db_ref
-
-        return base_agent
-
-    def items(self):
-        """Return items for the set of BaseAgents that this class wraps.
-        """
-        return self.agents.items()
-
-    def __getitem__(self, name):
-        return self.agents[name]
-
-
-class _BaseAgent(object):
-    """A BaseAgent aggregates the global properties of an Agent.
-
-    The BaseAgent class aggregates the name, sites, site states, active forms,
-    inactive forms and database references of Agents from individual INDRA
-    Statements. This allows the PySB Assembler to correctly assemble the
-    Monomer signatures in the model.
-    """
-
-    def __init__(self, name):
-        self.name = name
-        self.sites = []
-        self.site_states = {}
-        self.site_annotations = []
-        # The list of site/state configurations that lead to this agent
-        # being active (where the agent is currently assumed to have only
-        # one type of activity)
-        self.active_forms = []
-        self.activity_types = []
-        self.inactive_forms = []
-        self.db_refs = {}
-
-    def create_site(self, site, states=None):
-        """Create a new site on an agent if it doesn't already exist."""
-        if site not in self.sites:
-            self.sites.append(site)
-        if states is not None:
-            self.site_states.setdefault(site, [])
-            try:
-                states = list(states)
-            except TypeError:
-                return
-            self.add_site_states(site, states)
-
-    def create_mod_site(self, mc):
-        """Create modification site for the BaseAgent from a ModCondition."""
-        site_name = get_mod_site_name(mc.mod_type,
-                                      mc.residue, mc.position)
-        (unmod_site_state, mod_site_state) = states[mc.mod_type]
-        self.create_site(site_name, (unmod_site_state, mod_site_state))
-        site_anns = [Annotation((site_name, mod_site_state), mc.mod_type,
-                                'is_modification')]
-        if mc.residue:
-            site_anns.append(Annotation(site_name, mc.residue, 'is_residue'))
-        if mc.position:
-            site_anns.append(Annotation(site_name, mc.position, 'is_position'))
-        self.site_annotations += site_anns
-
-    def add_site_states(self, site, states):
-        """Create new states on an agent site if the state doesn't exist."""
-        for state in states:
-            if state not in self.site_states[site]:
-                self.site_states[site].append(state)
-
-    def add_activity_form(self, activity_pattern, is_active):
-        """Adds the pattern as an active or inactive form to an Agent.
-
-        Parameters
-        ----------
-        activity_pattern : dict
-            A dictionary of site names and their states.
-        is_active : bool
-            Is True if the given pattern corresponds to an active state.
-        """
-        if is_active:
-            if activity_pattern not in self.active_forms:
-                self.active_forms.append(activity_pattern)
-        else:
-            if activity_pattern not in self.inactive_forms:
-                self.inactive_forms.append(activity_pattern)
-
-    def add_activity_type(self, activity_type):
-        """Adds an activity type to an Agent.
-
-        Parameters
-        ----------
-        activity_type : str
-            The type of activity to add such as 'activity', 'kinase',
-            'gtpbound'
-        """
-        if activity_type not in self.activity_types:
-            self.activity_types.append(activity_type)
 
 # Site/state information ###############################################
 

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -848,7 +848,7 @@ def complex_monomers_one_step(stmt, agent_set):
 complex_monomers_default = complex_monomers_one_step
 
 
-def complex_assemble_one_step(stmt, model, agent_set):
+def complex_assemble_one_step(stmt, model, agent_set, parameters):
     pairs = itertools.combinations(stmt.members, 2)
     for pair in pairs:
         agent1 = pair[0]
@@ -910,7 +910,7 @@ def complex_assemble_one_step(stmt, model, agent_set):
         add_rule_to_model(model, r, anns)
 
 
-def complex_assemble_multi_way(stmt, model, agent_set):
+def complex_assemble_multi_way(stmt, model, agent_set, parameters):
     # Get the rate parameter
     abbr_name = ''.join([m.name[0].lower() for m in stmt.members])
     kf_bind = get_create_parameter(model, 'kf_' + abbr_name + '_bind', 1e-6)
@@ -1052,7 +1052,7 @@ def modification_monomers_two_step(stmt, agent_set):
     sub.create_site(get_binding_site_name(stmt.enz))
 
 
-def modification_assemble_interactions_only(stmt, model, agent_set):
+def modification_assemble_interactions_only(stmt, model, agent_set, parameters):
     if stmt.enz is None:
         return
     kf_bind = get_create_parameter(model, 'kf_bind', 1.0, unique=False)
@@ -1080,7 +1080,7 @@ def modification_assemble_interactions_only(stmt, model, agent_set):
     add_rule_to_model(model, r_fwd)
 
 
-def modification_assemble_one_step(stmt, model, agent_set, rate_law=None):
+def modification_assemble_one_step(stmt, model, agent_set, parameters, rate_law=None):
     if stmt.enz is None:
         return
     mod_condition_name = stmt.__class__.__name__.lower()
@@ -1137,7 +1137,7 @@ def modification_assemble_one_step(stmt, model, agent_set, rate_law=None):
     add_rule_to_model(model, r, anns)
 
 
-def modification_assemble_two_step(stmt, model, agent_set):
+def modification_assemble_two_step(stmt, model, agent_set, parameters):
     mod_condition_name = stmt.__class__.__name__.lower()
     if stmt.enz is None:
         return
@@ -1231,7 +1231,7 @@ def phosphorylation_monomers_atp_dependent(stmt, agent_set):
     enz.create_site('ATP')
 
 
-def phosphorylation_assemble_atp_dependent(stmt, model, agent_set):
+def phosphorylation_assemble_atp_dependent(stmt, model, parameters, agent_set):
     if stmt.enz is None:
         return
     # ATP
@@ -1376,7 +1376,7 @@ def demodification_monomers_two_step(stmt, agent_set):
     sub.create_site(get_binding_site_name(stmt.enz))
 
 
-def demodification_assemble_interactions_only(stmt, model, agent_set):
+def demodification_assemble_interactions_only(stmt, model, agent_set, parameters):
     if stmt.enz is None:
         return
     kf_bind = get_create_parameter(model, 'kf_bind', 1.0, unique=False)
@@ -1399,7 +1399,7 @@ def demodification_assemble_interactions_only(stmt, model, agent_set):
     add_rule_to_model(model, r)
 
 
-def demodification_assemble_one_step(stmt, model, agent_set, rate_law=None):
+def demodification_assemble_one_step(stmt, model, agent_set, parameters, rate_law=None):
     if stmt.enz is None:
         return
     demod_condition_name = stmt.__class__.__name__.lower()
@@ -1450,7 +1450,7 @@ def demodification_assemble_one_step(stmt, model, agent_set, rate_law=None):
     add_rule_to_model(model, r, anns)
 
 
-def demodification_assemble_two_step(stmt, model, agent_set):
+def demodification_assemble_two_step(stmt, model, parameters, agent_set):
     if stmt.enz is None:
         return
     demod_condition_name = stmt.__class__.__name__.lower()
@@ -1592,11 +1592,11 @@ def autophosphorylation_monomers_one_step(stmt, agent_set):
 autophosphorylation_monomers_default = autophosphorylation_monomers_one_step
 
 
-def autophosphorylation_assemble_interactions_only(stmt, model, agent_set):
-    stmt.assemble_one_step(model, agent_set)
+def autophosphorylation_assemble_interactions_only(stmt, model, agent_set, parameters):
+    return autophosphorylation_assemble_one_step(stmt, model, agent_set, parameters)
 
 
-def autophosphorylation_assemble_one_step(stmt, model, agent_set):
+def autophosphorylation_assemble_one_step(stmt, model, agent_set, parameters):
     param_name = 'kf_' + stmt.enz.name[0].lower() + '_autophos'
     # http://www.jbc.org/content/286/4/2689.full
     kf_autophospho = get_create_parameter(model, param_name, 1e-2)
@@ -1646,11 +1646,11 @@ def transphosphorylation_monomers_one_step(stmt, agent_set):
 transphosphorylation_monomers_default = transphosphorylation_monomers_one_step
 
 
-def transphosphorylation_assemble_interactions_only(stmt, model, agent_set):
-    stmt.assemble_one_step(model, agent_set)
+def transphosphorylation_assemble_interactions_only(stmt, model, agent_set, parameters):
+    return transphosphorylation_assemble_one_step(stmt, model, agent_set, parameters)
 
 
-def transphosphorylation_assemble_one_step(stmt, model, agent_set):
+def transphosphorylation_assemble_one_step(stmt, model, agent_set, parameters):
     param_name = ('kf_' + stmt.enz.name[0].lower() +
                   _n(stmt.enz.bound_conditions[0].agent.name[0]).lower() +
                   '_transphos')
@@ -1704,7 +1704,7 @@ def regulateactivity_monomers_one_step(stmt, agent_set):
     obj.add_activity_type(stmt.obj_activity)
 
 
-def regulateactivity_assemble_interactions_only(stmt, model, agent_set):
+def regulateactivity_assemble_interactions_only(stmt, model, agent_set, parameters):
     kf_bind = get_create_parameter(model, 'kf_bind', 1.0, unique=False)
     subj = model.monomers[stmt.subj.name]
     obj = model.monomers[stmt.obj.name]
@@ -1732,7 +1732,7 @@ def regulateactivity_assemble_interactions_only(stmt, model, agent_set):
     add_rule_to_model(model, r)
 
 
-def regulateactivity_assemble_one_step(stmt, model, agent_set, rate_law=None):
+def regulateactivity_assemble_one_step(stmt, model, agent_set, parameters, rate_law=None):
     # This is the pattern coming directly from the subject Agent state
     # TODO: handle context here in conjunction with active forms
     subj_pattern = get_monomer_pattern(model, stmt.subj)
@@ -1794,8 +1794,8 @@ activation_monomers_default = regulateactivity_monomers_one_step
 activation_assemble_default = regulateactivity_assemble_one_step
 
 activation_monomers_michaelis_menten = regulateactivity_monomers_one_step
-activation_assemble_michaelis_menten = lambda a, b, c: \
-    regulateactivity_assemble_one_step(a, b, c, 'michaelis_menten')
+activation_assemble_michaelis_menten = lambda a, b, c, d: \
+    regulateactivity_assemble_one_step(a, b, c, d, 'michaelis_menten')
 
 inhibition_monomers_interactions_only = \
                     regulateactivity_monomers_interactions_only
@@ -1807,8 +1807,8 @@ inhibition_monomers_default = regulateactivity_monomers_one_step
 inhibition_assemble_default = regulateactivity_assemble_one_step
 
 inhibition_monomers_michaelis_menten = regulateactivity_monomers_one_step
-inhibition_assemble_michaelis_menten = lambda a, b, c: \
-    regulateactivity_assemble_one_step(a, b, c, 'michaelis_menten')
+inhibition_assemble_michaelis_menten = lambda a, b, c, d: \
+    regulateactivity_assemble_one_step(a, b, c, d, 'michaelis_menten')
 
 # GEF #####################################################
 
@@ -1831,7 +1831,7 @@ def gef_monomers_one_step(stmt, agent_set):
 gef_monomers_default = gef_monomers_one_step
 
 
-def gef_assemble_interactions_only(stmt, model, agent_set):
+def gef_assemble_interactions_only(stmt, model, agent_set, parameters):
     kf_bind = get_create_parameter(model, 'kf_bind', 1.0, unique=False)
     gef = model.monomers[stmt.gef.name]
     ras = model.monomers[stmt.ras.name]
@@ -1847,7 +1847,7 @@ def gef_assemble_interactions_only(stmt, model, agent_set):
     add_rule_to_model(model, r)
 
 
-def gef_assemble_one_step(stmt, model, agent_set):
+def gef_assemble_one_step(stmt, model, agent_set, parameters):
     gef_pattern = get_monomer_pattern(model, stmt.gef)
     ras_inactive = get_monomer_pattern(model, stmt.ras,
         extra_fields={'gtpbound': 'inactive'})
@@ -1894,7 +1894,7 @@ def gap_monomers_one_step(stmt, agent_set):
 gap_monomers_default = gap_monomers_one_step
 
 
-def gap_assemble_interactions_only(stmt, model, agent_set):
+def gap_assemble_interactions_only(stmt, model, agent_set, parameters):
     kf_bind = get_create_parameter(model, 'kf_bind', 1.0, unique=False)
     gap = model.monomers[stmt.gap.name]
     ras = model.monomers[stmt.ras.name]
@@ -1910,7 +1910,7 @@ def gap_assemble_interactions_only(stmt, model, agent_set):
     add_rule_to_model(model, r)
 
 
-def gap_assemble_one_step(stmt, model, agent_set):
+def gap_assemble_one_step(stmt, model, agent_set, parameters):
     gap_pattern = get_monomer_pattern(model, stmt.gap)
     ras_inactive = get_monomer_pattern(model, stmt.ras,
         extra_fields={'gtpbound': 'inactive'})
@@ -1952,11 +1952,11 @@ def activeform_monomers_one_step(stmt, agent_set):
 activeform_monomers_default = activeform_monomers_one_step
 
 
-def activeform_assemble_interactions_only(stmt, model, agent_set):
+def activeform_assemble_interactions_only(stmt, model, agent_set, parameters):
     pass
 
 
-def activeform_assemble_one_step(stmt, model, agent_set):
+def activeform_assemble_one_step(stmt, model, agent_set, parameters):
     pass
 
 activeform_assemble_default = activeform_assemble_one_step
@@ -1979,7 +1979,7 @@ def translocation_monomers_default(stmt, agent_set):
 
     agent.create_site('loc', states)
 
-def translocation_assemble_default(stmt, model, agent_set):
+def translocation_assemble_default(stmt, model, agent_set, parameters):
     if stmt.to_location is None:
         return
     from_loc = stmt.from_location if stmt.from_location else 'cytoplasm'
@@ -2015,7 +2015,7 @@ def decreaseamount_monomers_one_step(stmt, agent_set):
     if stmt.subj is not None:
         subj = agent_set.get_create_base_agent(stmt.subj)
 
-def decreaseamount_assemble_interactions_only(stmt, model, agent_set):
+def decreaseamount_assemble_interactions_only(stmt, model, agent_set, parameters):
     # No interaction when subj is None
     if stmt.subj is None:
         return
@@ -2042,7 +2042,7 @@ def decreaseamount_assemble_interactions_only(stmt, model, agent_set):
         anns += [Annotation(rule_name, subj.name, 'rule_has_subject')]
     add_rule_to_model(model, r, anns)
 
-def decreaseamount_assemble_one_step(stmt, model, agent_set):
+def decreaseamount_assemble_one_step(stmt, model, agent_set, parameters):
     obj_pattern = get_monomer_pattern(model, stmt.obj)
     rule_obj_str = get_agent_rule_str(stmt.obj)
 
@@ -2082,7 +2082,7 @@ increaseamount_monomers_interactions_only = \
 
 increaseamount_monomers_one_step = decreaseamount_monomers_one_step
 
-def increaseamount_assemble_interactions_only(stmt, model, agent_set):
+def increaseamount_assemble_interactions_only(stmt, model, agent_set, parameters):
     # No interaction when subj is None
     if stmt.subj is None:
         return
@@ -2108,7 +2108,7 @@ def increaseamount_assemble_interactions_only(stmt, model, agent_set):
         anns += [Annotation(rule_name, subj.name, 'rule_has_subject')]
     add_rule_to_model(model, r, anns)
 
-def increaseamount_assemble_one_step(stmt, model, agent_set, rate_law=None):
+def increaseamount_assemble_one_step(stmt, model, agent_set, parameters, rate_law=None):
     if stmt.subj is not None and (stmt.subj.name == stmt.obj.name):
         if not isinstance(stmt, ist.Influence):
             logger.warning('%s transcribes itself, skipping' % stmt.obj.name)
@@ -2212,7 +2212,7 @@ def conversion_monomers_one_step(stmt, agent_set):
         agent_set.get_create_base_agent(obj)
 
 
-def conversion_assemble_one_step(stmt, model, agent_set):
+def conversion_assemble_one_step(stmt, model, agent_set, parameters):
     # Skip statements with more than one from object due to complications
     # with rate law
     if len(stmt.obj_from) != 1:

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -489,10 +489,18 @@ class PysbAssembler(object):
             for stmt in self.statements:
                 processed_policies[stmt.uuid] = policies
         else:
+            other_policy = policies.get('other', 'default')
+            for stmt in self.statements:
+                processed_policies[stmt.uuid] = other_policy
             for k, v in policies.items():
-                # Assume this is a policy like
-                # {'Phosphorylation': 'two-step'}
-                if isinstance(v, basestring):
+                if k == 'other':
+                    continue
+                # This means it's a UUID
+                if k in processed_policies:
+                    processed_policies[k] = v
+                else:
+                    # Assume this is a policy like
+                    # {'Phosphorylation': 'two-step'}
                     try:
                         stmt_type = ist.get_statement_by_name(k)
                         for stmt in self.statements:
@@ -501,13 +509,6 @@ class PysbAssembler(object):
                     except ist.NotAStatementName:
                         msg = 'Invalid policy entry for key %s' % k
                         raise UnknownPolicyError(msg)
-                    # Here we assume the key is a UUID
-                    else:
-                        if k not in processed_policies:
-                            msg = 'Policy key not a valid Statement UUID'
-                            raise UnknownPolicyError(msg)
-                        else:
-                            processed_policies[k] = v
         return processed_policies
 
     def make_model(self, policies=None, initial_conditions=True,

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import re
 import math
+import json
 import logging
 import itertools
 from indra.util import fast_deepcopy
@@ -1047,6 +1048,22 @@ class PysbAssembler(object):
             if _is_whitelisted(stmt):
                 self._dispatch(stmt, 'assemble', self.model, self.agent_set)
 
+
+class Policy(object):
+    """Represent a policy that can be associated with a speficic Statement."""
+    def __init__(self, name, parameters=None, sites=None):
+        self.name = name
+        self.parameters = parameters if parameters else []
+        self.sites = sites if sites else []
+
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        param_str = json.dumps(self.parameters) if self.parameters else ''
+        sites_str = json.dumps(self.sites) if self.sites else ''
+        s = 'Policy(%s%s%s)' % (self.name, param_str, sites_str)
+        return s
 
 # COMPLEX ############################################################
 

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -1556,8 +1556,8 @@ for mc, rate_law in itertools.product(mod_classes, rate_laws):
                 mc=ist.modclass_to_modtype[mc], rate_law=rate_law)
     exec(code)
     code = '{mc}_assemble_{rate_law} = ' \
-            'lambda a, b, c: modification_assemble_' \
-            'one_step(a, b, c, "{rate_law}")'.format(
+            'lambda a, b, c, d: modification_assemble_' \
+            'one_step(a, b, c, d, "{rate_law}")'.format(
                 mc=ist.modclass_to_modtype[mc], rate_law=rate_law)
     exec(code)
 
@@ -1566,8 +1566,8 @@ for mc, rate_law in itertools.product(demod_classes, rate_laws):
                 mc=ist.modclass_to_modtype[mc], rate_law=rate_law)
     exec(code)
     code = '{mc}_assemble_{rate_law} = ' \
-            'lambda a, b, c: demodification_assemble_' \
-            'one_step(a, b, c, "{rate_law}")'.format(
+            'lambda a, b, c, d: demodification_assemble_' \
+            'one_step(a, b, c, d, "{rate_law}")'.format(
                     mc=ist.modclass_to_modtype[mc], rate_law=rate_law)
     exec(code)
 
@@ -2179,8 +2179,8 @@ def increaseamount_assemble_one_step(stmt, model, agent_set, parameters, rate_la
 increaseamount_monomers_default = increaseamount_monomers_one_step
 increaseamount_assemble_default = increaseamount_assemble_one_step
 increaseamount_monomers_hill = increaseamount_monomers_one_step
-increaseamount_assemble_hill = lambda a, b, c: \
-        increaseamount_assemble_one_step(a, b, c, 'hill')
+increaseamount_assemble_hill = lambda a, b, c, d: \
+        increaseamount_assemble_one_step(a, b, c, d, 'hill')
 
 
 # INFLUENCE ###################################################

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -5,7 +5,6 @@ import math
 import json
 import logging
 import itertools
-from indra.util import fast_deepcopy
 
 from pysb import (Model, Monomer, Parameter, Expression, Observable, Rule,
         Annotation, ComponentDuplicateNameError, ComplexPattern,
@@ -18,6 +17,7 @@ from indra.databases import context_client, get_identifiers_url
 
 from .sites import *
 from .base_agents import _BaseAgentSet
+from .preassembler import PysbPreassembler
 
 # Python 2
 try:
@@ -2278,163 +2278,6 @@ def conversion_assemble_one_step(stmt, model, agent_set):
 conversion_monomers_default = conversion_monomers_one_step
 conversion_assemble_default = conversion_assemble_one_step
 
-class PysbPreassembler(object):
-    def __init__(self, stmts=None):
-        if not stmts:
-            stmts = []
-        self.statements = stmts
-        self.agent_set = _BaseAgentSet()
-
-    def add_statements(self, stmts):
-        self.statements = stmts
-
-    def _gather_active_forms(self):
-        for stmt in self.statements:
-            if isinstance(stmt, ist.ActiveForm):
-                base_agent = self.agent_set.get_create_base_agent(stmt.agent)
-                # Handle the case where an activity flag is set
-                agent_to_add = stmt.agent
-                if stmt.agent.activity:
-                    new_agent = fast_deepcopy(stmt.agent)
-                    new_agent.activity = None
-                    agent_to_add = new_agent
-                base_agent.add_activity_form(agent_to_add, stmt.is_active)
-
-    def replace_activities(self):
-        logger.debug('Running PySB Preassembler replace activities')
-        # TODO: handle activity hierarchies
-        new_stmts = []
-        def has_agent_activity(stmt):
-            """Return True if any agents in the Statement have activity."""
-            for agent in stmt.agent_list():
-                if isinstance(agent, ist.Agent) and agent.activity is not None:
-                    return True
-            return False
-        # First collect all explicit active forms
-        self._gather_active_forms()
-        # Iterate over all statements
-        for j, stmt in enumerate(self.statements):
-            logger.debug('%d/%d %s' % (j + 1, len(self.statements), stmt))
-            # If the Statement doesn't have any activities, we can just
-            # keep it and move on
-            if not has_agent_activity(stmt):
-                new_stmts.append(stmt)
-                continue
-            stmt_agents = stmt.agent_list()
-            num_agents = len(stmt_agents)
-            # Make a list with an empty list for each Agent so that later
-            # we can build combinations of Agent forms
-            agent_forms = [[] for a in stmt_agents]
-            for i, agent in enumerate(stmt_agents):
-                # This is the case where there is an activity flag on an
-                # Agent which we will attempt to replace with an explicit
-                # active form
-                if agent is not None and isinstance(agent, ist.Agent) and \
-                        agent.activity is not None:
-                    base_agent = self.agent_set.get_create_base_agent(agent)
-                    # If it is an "active" state
-                    if agent.activity.is_active:
-                        active_forms = base_agent.active_forms
-                        # If no explicit active forms are known then we use
-                        # the generic one
-                        if not active_forms:
-                            active_forms = [agent]
-                    # If it is an "inactive" state
-                    else:
-                        active_forms = base_agent.inactive_forms
-                        # If no explicit inactive forms are known then we use
-                        # the generic one
-                        if not active_forms:
-                            active_forms = [agent]
-                    # We now iterate over the active agent forms and create
-                    # new agents
-                    for af in active_forms:
-                        new_agent = fast_deepcopy(agent)
-                        self._set_agent_context(af, new_agent)
-                        agent_forms[i].append(new_agent)
-                # Otherwise we just copy over the agent as is
-                else:
-                    agent_forms[i].append(agent)
-            # Now create all possible combinations of the agents and create new
-            # statements as needed
-            agent_combs = itertools.product(*agent_forms)
-            for agent_comb in agent_combs:
-                new_stmt = fast_deepcopy(stmt)
-                new_stmt.set_agent_list(agent_comb)
-                new_stmts.append(new_stmt)
-        self.statements = new_stmts
-
-    def add_reverse_effects(self):
-        # TODO: generalize to other modification sites
-        pos_mod_sites = {}
-        neg_mod_sites = {}
-        syntheses = []
-        degradations = []
-        for stmt in self.statements:
-            if isinstance(stmt, ist.Phosphorylation):
-                agent = stmt.sub.name
-                try:
-                    pos_mod_sites[agent].append((stmt.residue, stmt.position))
-                except KeyError:
-                    pos_mod_sites[agent] = [(stmt.residue, stmt.position)]
-            elif isinstance(stmt, ist.Dephosphorylation):
-                agent = stmt.sub.name
-                try:
-                    neg_mod_sites[agent].append((stmt.residue, stmt.position))
-                except KeyError:
-                    neg_mod_sites[agent] = [(stmt.residue, stmt.position)]
-            elif isinstance(stmt, ist.Influence):
-                if stmt.overall_polarity() == 1:
-                    syntheses.append(stmt.obj.name)
-                elif stmt.overall_polarity() == -1:
-                    degradations.append(stmt.obj.name)
-            elif isinstance(stmt, ist.IncreaseAmount):
-                syntheses.append(stmt.obj.name)
-            elif isinstance(stmt, ist.DecreaseAmount):
-                degradations.append(stmt.obj.name)
-
-        new_stmts = []
-        for agent_name, pos_sites in pos_mod_sites.items():
-            neg_sites = neg_mod_sites.get(agent_name, [])
-            no_neg_site = set(pos_sites).difference(set(neg_sites))
-            for residue, position in no_neg_site:
-                st = ist.Dephosphorylation(ist.Agent('phosphatase'),
-                                           ist.Agent(agent_name),
-                                           residue, position)
-                new_stmts.append(st)
-        for agent_name in syntheses:
-            if agent_name not in degradations:
-                st = ist.DecreaseAmount(None, ist.Agent(agent_name))
-                new_stmts.append(st)
-
-        self.statements += new_stmts
-
-    @staticmethod
-    def _set_agent_context(from_agent, to_agent):
-        if not isinstance(from_agent, ist.Agent) or \
-            not isinstance(to_agent, ist.Agent):
-            return
-        def add_no_duplicate(from_lst, to_lst):
-            for fm in from_lst:
-                found = False
-                for tm in to_lst:
-                    if fm.matches(tm):
-                        found = True
-                        break
-                if not found:
-                    to_lst.append(fm)
-            return to_lst
-        # TODO: what can we do about semantic conflicts here like the same
-        # bound condition with True/False is_bound appearing in the
-        # two contexts?
-        to_agent.bound_conditions = \
-            add_no_duplicate(to_agent.bound_conditions,
-                             from_agent.bound_conditions)
-        to_agent.mods = add_no_duplicate(to_agent.mods, from_agent.mods)
-        to_agent.mutations = add_no_duplicate(to_agent.mutations,
-                                              from_agent.mutations)
-        to_agent.location = from_agent.location
-        to_agent.activity = from_agent.activity
 
 def export_sbgn(model):
     """Return an SBGN model string corresponding to the PySB model.

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -16,6 +16,7 @@ from indra import statements as ist
 from indra.databases import context_client, get_identifiers_url
 
 from .sites import *
+from .common import *
 from .export import export_sbgn
 from .base_agents import _BaseAgentSet
 from .preassembler import PysbPreassembler
@@ -41,12 +42,6 @@ statement_whitelist = [ist.Modification, ist.SelfModification, ist.Complex,
                        ist.IncreaseAmount, ist.DecreaseAmount,
                        ist.Conversion]
 
-def _n(name):
-    """Return valid PySB name."""
-    n = name.encode('ascii', errors='ignore').decode('ascii')
-    n = re.sub('[^A-Za-z0-9_]', '_', n)
-    n = re.sub(r'(^[0-9].*)', r'p\1', n)
-    return n
 
 def _is_whitelisted(stmt):
     """Return True if the statement type is in the whitelist."""

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -789,8 +789,12 @@ class PysbAssembler(object):
         task."""
         policy = self.processed_policies[stmt.uuid]
         class_name = stmt.__class__.__name__.lower()
+        # We map remove modifications to their positive counterparts
         if isinstance(stmt, ist.RemoveModification):
             class_name = ist.modclass_to_modtype[stmt.__class__]
+        # We handle any kind of activity regulation in regulateactivity
+        if isinstance(stmt, ist.RegulateActivity):
+            class_name = 'regulateactivity'
         func_name = '%s_%s_%s' % (class_name, stage, policy.name)
         func = globals().get(func_name)
         if func is None:
@@ -1599,32 +1603,10 @@ def regulateactivity_assemble_one_step(stmt, model, agent_set, parameters, rate_
 
 regulateactivity_monomers_default = regulateactivity_monomers_one_step
 regulateactivity_assemble_default = regulateactivity_assemble_one_step
-
-activation_monomers_interactions_only = \
-                    regulateactivity_monomers_interactions_only
-activation_assemble_interactions_only = \
-                    regulateactivity_assemble_interactions_only
-activation_monomers_one_step = regulateactivity_monomers_one_step
-activation_assemble_one_step = regulateactivity_assemble_one_step
-activation_monomers_default = regulateactivity_monomers_one_step
-activation_assemble_default = regulateactivity_assemble_one_step
-
-activation_monomers_michaelis_menten = regulateactivity_monomers_one_step
-activation_assemble_michaelis_menten = lambda a, b, c, d: \
+regulateactivity_monomers_michaelis_menten = regulateactivity_monomers_one_step
+regulateactivity_assemble_michaelis_menten = lambda a, b, c, d: \
     regulateactivity_assemble_one_step(a, b, c, d, 'michaelis_menten')
 
-inhibition_monomers_interactions_only = \
-                    regulateactivity_monomers_interactions_only
-inhibition_assemble_interactions_only = \
-                    regulateactivity_assemble_interactions_only
-inhibition_monomers_one_step = regulateactivity_monomers_one_step
-inhibition_assemble_one_step = regulateactivity_assemble_one_step
-inhibition_monomers_default = regulateactivity_monomers_one_step
-inhibition_assemble_default = regulateactivity_assemble_one_step
-
-inhibition_monomers_michaelis_menten = regulateactivity_monomers_one_step
-inhibition_assemble_michaelis_menten = lambda a, b, c, d: \
-    regulateactivity_assemble_one_step(a, b, c, d, 'michaelis_menten')
 
 # GEF #####################################################
 
@@ -1776,12 +1758,6 @@ def activeform_assemble_one_step(stmt, model, agent_set, parameters):
     pass
 
 activeform_assemble_default = activeform_assemble_one_step
-
-# GTPACTIVATION ######################################
-
-gtpactivation_monomers_default = activation_monomers_default
-
-gtpactivation_assemble_default = activation_assemble_default
 
 
 # TRANSLOCATION ###############################################

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -16,6 +16,7 @@ from indra import statements as ist
 from indra.databases import context_client, get_identifiers_url
 
 from .sites import *
+from .export import export_sbgn
 from .base_agents import _BaseAgentSet
 from .preassembler import PysbPreassembler
 
@@ -2277,79 +2278,3 @@ def conversion_assemble_one_step(stmt, model, agent_set):
 
 conversion_monomers_default = conversion_monomers_one_step
 conversion_assemble_default = conversion_assemble_one_step
-
-
-def export_sbgn(model):
-    """Return an SBGN model string corresponding to the PySB model.
-
-    This function first calls generate_equations on the PySB model to obtain
-    a reaction network (i.e. individual species, reactions). It then iterates
-    over each reaction and and instantiates its reactants, products, and the
-    process itself as SBGN glyphs and arcs.
-
-    Parameters
-    ----------
-    model : pysb.core.Model
-        A PySB model to be exported into SBGN
-
-    Returns
-    -------
-    sbgn_str : str
-        An SBGN model as string
-    """
-    import lxml.etree
-    import lxml.builder
-    from pysb.bng import generate_equations
-    from indra.assemblers.sbgn import SBGNAssembler
-
-    logger.info('Generating reaction network with BNG for SBGN export. ' +
-                'This could take a long time.')
-    generate_equations(model)
-
-    sa = SBGNAssembler()
-
-    glyphs = {}
-    for idx, species in enumerate(model.species):
-        glyph = sa._glyph_for_complex_pattern(species)
-        if glyph is None:
-            continue
-        sa._map.append(glyph)
-        glyphs[idx] = glyph
-    for reaction in model.reactions:
-        # Get all the reactions / products / controllers of the reaction
-        reactants = set(reaction['reactants']) - set(reaction['products'])
-        products = set(reaction['products']) - set(reaction['reactants'])
-        controllers = set(reaction['reactants']) & set(reaction['products'])
-        # Add glyph for reaction
-        process_glyph = sa._process_glyph('process')
-        # Connect reactants with arcs
-        if not reactants:
-            glyph_id = sa._none_glyph()
-            sa._arc('consumption', glyph_id, process_glyph)
-        else:
-            for r in reactants:
-                glyph = glyphs.get(r)
-                if glyph is None:
-                    glyph_id = sa._none_glyph()
-                else:
-                    glyph_id = glyph.attrib['id']
-                sa._arc('consumption', glyph_id, process_glyph)
-        # Connect products with arcs
-        if not products:
-            glyph_id = sa._none_glyph()
-            sa._arc('production', process_glyph, glyph_id)
-        else:
-            for p in products:
-                glyph = glyphs.get(p)
-                if glyph is None:
-                    glyph_id = sa._none_glyph()
-                else:
-                    glyph_id = glyph.attrib['id']
-                sa._arc('production', process_glyph, glyph_id)
-        # Connect controllers with arcs
-        for c in controllers:
-            glyph = glyphs[c]
-            sa._arc('catalysis', glyph.attrib['id'], process_glyph)
-
-    sbgn_str = sa.print_model().decode('utf-8')
-    return sbgn_str

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -820,7 +820,20 @@ class PysbAssembler(object):
 
 
 class Policy(object):
-    """Represent a policy that can be associated with a speficic Statement."""
+    """Represent a policy that can be associated with a speficic Statement.
+
+    Attributes
+    ----------
+    name : str
+        The name of the policy, e.g. one_step
+    parameters : dict[str, Param]
+        A dict of parameters where each key identifies the role
+        of the parameter with respect to the policy, e.g. 'Km',
+        and the value is a Param object.
+    sites : dict
+        A dict of site names corresponding to the interactions
+        induced by the policy.
+    """
     def __init__(self, name, parameters=None, sites=None):
         self.name = name
         self.parameters = parameters if parameters else {}
@@ -834,6 +847,29 @@ class Policy(object):
         sites_str = json.dumps(self.sites) if self.sites else ''
         s = 'Policy(%s%s%s)' % (self.name, param_str, sites_str)
         return s
+
+
+class Param(object):
+    """Represent a parameter as an input to the assembly process.
+
+    Attributes
+    ----------
+    name : str
+        The name of the parameter
+    value : float
+        The value of the parameter
+    unique : Optional[bool]
+        If True, a suffix is added to the end of the
+        parameter name upon assembly to make sure the parameter
+        is unique in the model. If False, the name attribute
+        is used as is. Default: False
+    """
+    def __init__(self, name, value, unique=False):
+        self.name = name
+        self.value = value
+        self.unique = unique
+
+
 
 # COMPLEX ############################################################
 
@@ -1059,13 +1095,6 @@ def modification_monomers_two_step(stmt, agent_set):
     # Create site for binding the substrate
     enz.create_site(get_binding_site_name(stmt.sub))
     sub.create_site(get_binding_site_name(stmt.enz))
-
-
-class Param(object):
-    def __init__(self, name, value, unique=False):
-        self.name = name
-        self.value = value
-        self.unique = unique
 
 
 def modification_assemble_interactions_only(stmt, model, agent_set, parameters):

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -1073,9 +1073,7 @@ def modification_monomers_one_step(stmt, agent_set):
     # Phosphorylation statements, i.e., phosphorylation is assumed to be
     # distributive. If this is not the case, this assumption will need to
     # be revisited.
-    mod_condition_name = stmt.__class__.__name__.lower()
-    sub.create_mod_site(ist.ModCondition(mod_condition_name,
-                                         stmt.residue, stmt.position))
+    sub.create_mod_site(stmt._get_mod_condition())
 
 
 def modification_monomers_two_step(stmt, agent_set):
@@ -1083,10 +1081,7 @@ def modification_monomers_two_step(stmt, agent_set):
         return
     enz = agent_set.get_create_base_agent(stmt.enz)
     sub = agent_set.get_create_base_agent(stmt.sub)
-    mod_condition_name = stmt.__class__.__name__.lower()
-    sub.create_mod_site(ist.ModCondition(mod_condition_name,
-                                         stmt.residue, stmt.position))
-
+    sub.create_mod_site(stmt._get_mod_condition())
     # Create site for binding the substrate
     enz.create_site(get_binding_site_name(stmt.sub))
     sub.create_site(get_binding_site_name(stmt.enz))
@@ -1390,26 +1385,9 @@ def phosphorylation_assemble_atp_dependent(stmt, model, parameters, agent_set):
 
 
 # DEMODIFICATION #####################################################
-demodification_monomers_interactions_only = modification_monomers_interactions_only()
-
-def demodification_monomers_one_step(stmt, agent_set):
-    if stmt.enz is None:
-        return
-    enz = agent_set.get_create_base_agent(stmt.enz)
-    sub = agent_set.get_create_base_agent(stmt.sub)
-    sub.create_mod_site(stmt._get_mod_condition())
-
-
-def demodification_monomers_two_step(stmt, agent_set):
-    if stmt.enz is None:
-        return
-    enz = agent_set.get_create_base_agent(stmt.enz)
-    sub = agent_set.get_create_base_agent(stmt.sub)
-    sub.create_mod_site(stmt._get_mod_condition())
-    # Create site for binding the substrate
-    enz.create_site(get_binding_site_name(stmt.sub))
-    sub.create_site(get_binding_site_name(stmt.enz))
-
+demodification_monomers_interactions_only = modification_monomers_interactions_only
+demodification_monomers_one_step = modification_monomers_one_step
+demodification_monomers_two_step = modification_monomers_two_step
 
 def demodification_assemble_interactions_only(stmt, model, agent_set, parameters):
     if stmt.enz is None:

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -1052,19 +1052,14 @@ def complex_assemble_multi_way(stmt, model, agent_set, parameters):
 complex_assemble_default = complex_assemble_one_step
 
 # MODIFICATION ###################################################
-
 def modification_monomers_interactions_only(stmt, agent_set):
     if stmt.enz is None:
         return
     enz = agent_set.get_create_base_agent(stmt.enz)
-    act_type = mod_acttype_map[stmt.__class__]
-    active_site = act_type
-    enz.create_site(active_site)
     sub = agent_set.get_create_base_agent(stmt.sub)
-    # See NOTE in monomers_one_step, below
-    mod_condition_name = stmt.__class__.__name__.lower()
-    sub.create_mod_site(ist.ModCondition(mod_condition_name,
-                                         stmt.residue, stmt.position))
+    act_type = mod_acttype_map[stmt.__class__]
+    enz.create_site(act_type)
+    sub.create_mod_site(stmt._get_mod_condition())
 
 
 def modification_monomers_one_step(stmt, agent_set):
@@ -1395,27 +1390,14 @@ def phosphorylation_assemble_atp_dependent(stmt, model, parameters, agent_set):
 
 
 # DEMODIFICATION #####################################################
-
-def demodification_monomers_interactions_only(stmt, agent_set):
-    if stmt.enz is None:
-        return
-    enz = agent_set.get_create_base_agent(stmt.enz)
-    sub = agent_set.get_create_base_agent(stmt.sub)
-    active_site = mod_acttype_map[stmt.__class__]
-    enz.create_site(active_site)
-    mod_condition_name = stmt.__class__.__name__.lower()[2:]
-    sub.create_mod_site(ist.ModCondition(mod_condition_name,
-                                         stmt.residue, stmt.position))
-
+demodification_monomers_interactions_only = modification_monomers_interactions_only()
 
 def demodification_monomers_one_step(stmt, agent_set):
     if stmt.enz is None:
         return
     enz = agent_set.get_create_base_agent(stmt.enz)
     sub = agent_set.get_create_base_agent(stmt.sub)
-    mod_condition_name = stmt.__class__.__name__.lower()[2:]
-    sub.create_mod_site(ist.ModCondition(mod_condition_name,
-                                         stmt.residue, stmt.position))
+    sub.create_mod_site(stmt._get_mod_condition())
 
 
 def demodification_monomers_two_step(stmt, agent_set):
@@ -1423,9 +1405,7 @@ def demodification_monomers_two_step(stmt, agent_set):
         return
     enz = agent_set.get_create_base_agent(stmt.enz)
     sub = agent_set.get_create_base_agent(stmt.sub)
-    mod_condition_name = stmt.__class__.__name__.lower()[2:]
-    sub.create_mod_site(ist.ModCondition(mod_condition_name,
-                                         stmt.residue, stmt.position))
+    sub.create_mod_site(stmt._get_mod_condition())
     # Create site for binding the substrate
     enz.create_site(get_binding_site_name(stmt.sub))
     sub.create_site(get_binding_site_name(stmt.enz))
@@ -1439,10 +1419,8 @@ def demodification_assemble_interactions_only(stmt, model, agent_set, parameters
     sub = model.monomers[stmt.sub.name]
     active_site = mod_acttype_map[stmt.__class__]
     # See NOTE in Phosphorylation.monomers_one_step
-    demod_condition_name = stmt.__class__.__name__.lower()
-    mod_condition_name = demod_condition_name[2:]
-    demod_site = get_mod_site_name(mod_condition_name,
-                                   stmt.residue, stmt.position)
+    mc = stmt._get_mod_condition()
+    demod_site = get_mod_site_name(stmt._get_mod_condition())
 
     rule_enz_str = get_agent_rule_str(stmt.enz)
     rule_sub_str = get_agent_rule_str(stmt.sub)

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -15,10 +15,9 @@ import pysb.export
 
 from indra import statements as ist
 from indra.databases import context_client, get_identifiers_url
-from indra.preassembler.hierarchy_manager import hierarchies
-from indra.tools.expand_families import _agent_from_uri
 
-from .base_agents import _BaseAgent, _BaseAgentSet
+from .sites import *
+from .base_agents import _BaseAgentSet
 
 # Python 2
 try:
@@ -54,99 +53,6 @@ def _is_whitelisted(stmt):
         if isinstance(stmt, s):
             return True
     return False
-
-# Site/state information ###############################################
-
-abbrevs = {
-    'phosphorylation': 'phospho',
-    'ubiquitination': 'ub',
-    'farnesylation': 'farnesyl',
-    'hydroxylation': 'hydroxyl',
-    'acetylation': 'acetyl',
-    'sumoylation': 'sumo',
-    'glycosylation': 'glycosyl',
-    'methylation': 'methyl',
-    'ribosylation': 'ribosyl',
-    'geranylgeranylation': 'geranylgeranyl',
-    'palmitoylation': 'palmitoyl',
-    'myristoylation': 'myristoyl',
-    'modification': 'mod',
-}
-
-states = {
-    'phosphorylation': ['u', 'p'],
-    'ubiquitination': ['n', 'y'],
-    'farnesylation': ['n', 'y'],
-    'hydroxylation': ['n', 'y'],
-    'acetylation': ['n', 'y'],
-    'sumoylation': ['n', 'y'],
-    'glycosylation': ['n', 'y'],
-    'methylation': ['n', 'y'],
-    'geranylgeranylation': ['n', 'y'],
-    'palmitoylation': ['n', 'y'],
-    'myristoylation': ['n', 'y'],
-    'ribosylation': ['n', 'y'],
-    'modification': ['n', 'y'],
-}
-
-mod_acttype_map = {
-    ist.Phosphorylation: 'kinase',
-    ist.Dephosphorylation: 'phosphatase',
-    ist.Hydroxylation: 'catalytic',
-    ist.Dehydroxylation: 'catalytic',
-    ist.Sumoylation: 'catalytic',
-    ist.Desumoylation: 'catalytic',
-    ist.Acetylation: 'catalytic',
-    ist.Deacetylation: 'catalytic',
-    ist.Glycosylation: 'catalytic',
-    ist.Deglycosylation: 'catalytic',
-    ist.Ribosylation: 'catalytic',
-    ist.Deribosylation: 'catalytic',
-    ist.Ubiquitination: 'catalytic',
-    ist.Deubiquitination: 'catalytic',
-    ist.Farnesylation: 'catalytic',
-    ist.Defarnesylation: 'catalytic',
-    ist.Palmitoylation: 'catalytic',
-    ist.Depalmitoylation: 'catalytic',
-    ist.Myristoylation: 'catalytic',
-    ist.Demyristoylation: 'catalytic',
-    ist.Geranylgeranylation: 'catalytic',
-    ist.Degeranylgeranylation: 'catalytic',
-    ist.Methylation: 'catalytic',
-    ist.Demethylation: 'catalytic',
-}
-
-
-def get_binding_site_name(agent):
-    """Return a binding site name from a given agent."""
-    # Try to construct a binding site name based on parent
-    grounding = agent.get_grounding()
-    if grounding != (None, None):
-        uri = hierarchies['entity'].get_uri(grounding[0], grounding[1])
-        # Get highest level parents in hierarchy
-        parents = hierarchies['entity'].get_parents(uri, 'top')
-        if parents:
-            # Choose the first parent if there are more than one
-            parent_uri = sorted(list(parents))[0]
-            parent_agent = _agent_from_uri(parent_uri)
-            binding_site = _n(parent_agent.name).lower()
-            return binding_site
-    # Fall back to Agent's own name if one from parent can't be constructed
-    binding_site = _n(agent.name).lower()
-    return binding_site
-
-
-def get_mod_site_name(mod_type, residue, position):
-    """Return site names for a modification."""
-    names = []
-    if residue is None:
-        mod_str = abbrevs[mod_type]
-    else:
-        mod_str = residue
-    mod_pos = position if position is not None else ''
-    name = ('%s%s' % (mod_str, mod_pos))
-    return name
-
 
 # PySB model elements ##################################################
 

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -18,7 +18,7 @@ from indra.databases import context_client, get_identifiers_url
 from .sites import *
 from .common import *
 from .export import export_sbgn
-from .base_agents import _BaseAgentSet
+from .base_agents import BaseAgentSet
 from .preassembler import PysbPreassembler
 
 # Python 2
@@ -470,7 +470,7 @@ class PysbAssembler(object):
         A list of INDRA statements to be assembled.
     model : pysb.Model
         A PySB model object that is assembled by this class.
-    agent_set : _BaseAgentSet
+    agent_set : BaseAgentSet
         A set of BaseAgents used during the assembly process.
     """
     def __init__(self, statements=None):
@@ -571,7 +571,7 @@ class PysbAssembler(object):
         self.statements = ppa.statements
         self.model = Model()
         self.model.name = model_name
-        self.agent_set = _BaseAgentSet()
+        self.agent_set = BaseAgentSet()
         # Collect information about the monomers/self.agent_set from the
         # statements
         self._monomers()

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -1639,7 +1639,8 @@ gef_monomers_default = gef_monomers_one_step
 
 
 def gef_assemble_interactions_only(stmt, model, agent_set, parameters):
-    kf_bind = get_create_parameter(model, 'kf_bind', 1.0, unique=False)
+    kfp = parameters.get('kf', Param('kf_bind', 1.0))
+    kf_bind = get_create_parameter(model, kfp.name, kfp.value, kfp.unique)
     gef = model.monomers[stmt.gef.name]
     ras = model.monomers[stmt.ras.name]
     rule_gef_str = get_agent_rule_str(stmt.gef)
@@ -1663,7 +1664,8 @@ def gef_assemble_one_step(stmt, model, agent_set, parameters):
 
     param_name = 'kf_' + stmt.gef.name[0].lower() + \
                     stmt.ras.name[0].lower() + '_gef'
-    kf_gef = get_create_parameter(model, param_name, 1e-6)
+    kfp = parameters.get('kf', Param(param_name, 1e-6, True))
+    kf_gef = get_create_parameter(model, kfp.name, kfp.value, kfp.unique)
 
     rule_gef_str = get_agent_rule_str(stmt.gef)
     rule_ras_str = get_agent_rule_str(stmt.ras)
@@ -1702,7 +1704,8 @@ gap_monomers_default = gap_monomers_one_step
 
 
 def gap_assemble_interactions_only(stmt, model, agent_set, parameters):
-    kf_bind = get_create_parameter(model, 'kf_bind', 1.0, unique=False)
+    kfp = parameters.get('kf', Param('kf_bind', 1.0))
+    kf_bind = get_create_parameter(model, kfp.name, kfp.value, kfp.unique)
     gap = model.monomers[stmt.gap.name]
     ras = model.monomers[stmt.ras.name]
     rule_gap_str = get_agent_rule_str(stmt.gap)
@@ -1726,7 +1729,8 @@ def gap_assemble_one_step(stmt, model, agent_set, parameters):
 
     param_name = 'kf_' + stmt.gap.name[0].lower() + \
                     stmt.ras.name[0].lower() + '_gap'
-    kf_gap = get_create_parameter(model, param_name, 1e-6)
+    kfp = parameters.get('kf', Param(param_name, 1e-6, True))
+    kf_gap = get_create_parameter(model, kfp.name, kfp.value, kfp.unique)
 
     rule_gap_str = get_agent_rule_str(stmt.gap)
     rule_ras_str = get_agent_rule_str(stmt.ras)

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -913,8 +913,10 @@ def complex_assemble_one_step(stmt, model, agent_set, parameters):
         agent2 = pair[1]
         param_name = agent1.name[0].lower() + \
                      agent2.name[0].lower() + '_bind'
-        kf_bind = get_create_parameter(model, 'kf_' + param_name, 1e-6)
-        kr_bind = get_create_parameter(model, 'kr_' + param_name, 1e-1)
+        kfp = parameters.get('kf', Param('kf_' + param_name, 1e-6, True))
+        kf_bind = get_create_parameter(model, kfp)
+        krp = parameters.get('kr', Param('kr_' + param_name, 1e-1, True))
+        kr_bind = get_create_parameter(model, krp)
 
         # Make a rule name
         rule_name = '_'.join([get_agent_rule_str(m) for m in pair])
@@ -971,8 +973,10 @@ def complex_assemble_one_step(stmt, model, agent_set, parameters):
 def complex_assemble_multi_way(stmt, model, agent_set, parameters):
     # Get the rate parameter
     abbr_name = ''.join([m.name[0].lower() for m in stmt.members])
-    kf_bind = get_create_parameter(model, 'kf_' + abbr_name + '_bind', 1e-6)
-    kr_bind = get_create_parameter(model, 'kr_' + abbr_name + '_bind', 1e-1)
+    kfp = parameters.get('kf', Param('kf_' + abbr_name + '_bind', 1e-6, True))
+    kf_bind = get_create_parameter(model, kfp)
+    krp = parameters.get('kr', Param('kr' + abbr_name + '_bind', 1e-1, True))
+    kr_bind = get_create_parameter(model, krp)
 
     # Make a rule name
     rule_name = '_'.join([get_agent_rule_str(m) for m in stmt.members])
@@ -1320,9 +1324,11 @@ def phosphorylation_assemble_atp_dependent(stmt, model, parameters, agent_set):
 
     # Enzyme binding ATP
     param_name = ('kf_' + stmt.enz.name[0].lower() + '_atp_bind')
-    kf_bind_atp = get_create_parameter(model, param_name, 1e-6)
+    kfap = parameters.get('kfa', Param(param_name, 1e-6, True))
+    kf_bind_atp = get_create_parameter(model, kfap)
     param_name = ('kr_' + stmt.enz.name[0].lower() + '_atp_bind')
-    kr_bind_atp = get_create_parameter(model, param_name, 1.)
+    krap = parameters.get('kra', Param(param_name, 1.0, True))
+    kr_bind_atp = get_create_parameter(model, krap)
     rule_name = '%s_phospho_bind_atp' % (enz_rule_str)
     r = Rule(rule_name,
         enz_atp_unbound() + atp(b=None) >>
@@ -1341,13 +1347,16 @@ def phosphorylation_assemble_atp_dependent(stmt, model, parameters, agent_set):
     # Enzyme binding substrate
     param_name = ('kf_' + stmt.enz.name[0].lower() +
                   stmt.sub.name[0].lower() + '_bind')
-    kf_bind = get_create_parameter(model, param_name, 1e-6)
+    kfp = parameters.get('kf', Param(param_name, 1e-6, True))
+    kf_bind = get_create_parameter(model, kfp)
     param_name = ('kr_' + stmt.enz.name[0].lower() +
                   stmt.sub.name[0].lower() + '_bind')
-    kr_bind = get_create_parameter(model, param_name, 1e-1)
+    krp = parameters.get('kr', Param(param_name, 1e-1, True))
+    kr_bind = get_create_parameter(model, krp)
     param_name = ('kc_' + stmt.enz.name[0].lower() +
                   stmt.sub.name[0].lower() + '_phos')
-    kf_phospho = get_create_parameter(model, param_name, 100)
+    kcp = parameters.get('kc', Param(param_name, 100, True))
+    kf_phospho = get_create_parameter(model, kcp)
 
     phos_site = get_mod_site_name(stmt._get_mod_condition())
 
@@ -1786,8 +1795,8 @@ def translocation_assemble_default(stmt, model, agent_set, parameters):
     from_loc = stmt.from_location if stmt.from_location else 'cytoplasm'
     param_name = 'kf_%s_%s_%s' % (_n(stmt.agent.name).lower(),
                                   _n(from_loc), _n(stmt.to_location))
-    kf_trans = get_create_parameter(model, param_name, 1.0, unique=True)
-    monomer = model.monomers[_n(stmt.agent.name)]
+    kfp = parameters.get('kf', Param(param_name, 1.0, True))
+    kf_trans = get_create_parameter(model, kfp)
     rule_agent_str = get_agent_rule_str(stmt.agent)
     rule_name = '%s_translocates_%s_to_%s' % (rule_agent_str,
                                               _n(from_loc),

--- a/indra/assemblers/pysb/base_agents.py
+++ b/indra/assemblers/pysb/base_agents.py
@@ -1,0 +1,150 @@
+__all__ = ['_BaseAgentSet', '_BaseAgent']
+from pysb import Annotation
+from indra.statements import *
+from .common import _n
+from .sites import states, get_binding_site_name, get_mod_site_name
+
+
+class _BaseAgentSet(object):
+    """Container for a dict of BaseAgents with their names as keys."""
+    def __init__(self):
+        self.agents = {}
+
+    def get_create_base_agent(self, agent):
+        """Return base agent with given name, creating it if needed."""
+        try:
+            base_agent = self.agents[_n(agent.name)]
+        except KeyError:
+            base_agent = _BaseAgent(_n(agent.name))
+            self.agents[_n(agent.name)] = base_agent
+
+        # If it's a molecular agent
+        if isinstance(agent, Agent):
+            # Handle bound conditions
+            for bc in agent.bound_conditions:
+                bound_base_agent = self.get_create_base_agent(bc.agent)
+                bound_base_agent.create_site(get_binding_site_name(agent))
+                base_agent.create_site(get_binding_site_name(bc.agent))
+
+            # Handle modification conditions
+            for mc in agent.mods:
+                base_agent.create_mod_site(mc)
+
+            # Handle mutation conditions
+            for mc in agent.mutations:
+                res_from = mc.residue_from if mc.residue_from else 'mut'
+                res_to = mc.residue_to if mc.residue_to else 'X'
+                if mc.position is None:
+                    mut_site_name = res_from
+                else:
+                    mut_site_name = res_from + mc.position
+
+                base_agent.create_site(mut_site_name, states=['WT', res_to])
+
+            # Handle location condition
+            if agent.location is not None:
+                base_agent.create_site('loc', [_n(agent.location)])
+
+            # Handle activity
+            if agent.activity is not None:
+                site_name = agent.activity.activity_type
+                base_agent.create_site(site_name, ['inactive', 'active'])
+
+        # There might be overwrites here
+        for db_name, db_ref in agent.db_refs.items():
+            base_agent.db_refs[db_name] = db_ref
+
+        return base_agent
+
+    def items(self):
+        """Return items for the set of BaseAgents that this class wraps.
+        """
+        return self.agents.items()
+
+    def __getitem__(self, name):
+        return self.agents[name]
+
+
+class _BaseAgent(object):
+    """A BaseAgent aggregates the global properties of an Agent.
+
+    The BaseAgent class aggregates the name, sites, site states, active forms,
+    inactive forms and database references of Agents from individual INDRA
+    Statements. This allows the PySB Assembler to correctly assemble the
+    Monomer signatures in the model.
+    """
+
+    def __init__(self, name):
+        self.name = name
+        self.sites = []
+        self.site_states = {}
+        self.site_annotations = []
+        # The list of site/state configurations that lead to this agent
+        # being active (where the agent is currently assumed to have only
+        # one type of activity)
+        self.active_forms = []
+        self.activity_types = []
+        self.inactive_forms = []
+        self.db_refs = {}
+
+    def create_site(self, site, states=None):
+        """Create a new site on an agent if it doesn't already exist."""
+        if site not in self.sites:
+            self.sites.append(site)
+        if states is not None:
+            self.site_states.setdefault(site, [])
+            try:
+                states = list(states)
+            except TypeError:
+                return
+            self.add_site_states(site, states)
+
+    def create_mod_site(self, mc):
+        """Create modification site for the BaseAgent from a ModCondition."""
+        site_name = get_mod_site_name(mc.mod_type,
+                                      mc.residue, mc.position)
+        (unmod_site_state, mod_site_state) = states[mc.mod_type]
+        self.create_site(site_name, (unmod_site_state, mod_site_state))
+        site_anns = [Annotation((site_name, mod_site_state), mc.mod_type,
+                                'is_modification')]
+        if mc.residue:
+            site_anns.append(Annotation(site_name, mc.residue, 'is_residue'))
+        if mc.position:
+            site_anns.append(Annotation(site_name, mc.position, 'is_position'))
+        self.site_annotations += site_anns
+
+    def add_site_states(self, site, states):
+        """Create new states on an agent site if the state doesn't exist."""
+        for state in states:
+            if state not in self.site_states[site]:
+                self.site_states[site].append(state)
+
+    def add_activity_form(self, activity_pattern, is_active):
+        """Adds the pattern as an active or inactive form to an Agent.
+
+        Parameters
+        ----------
+        activity_pattern : dict
+            A dictionary of site names and their states.
+        is_active : bool
+            Is True if the given pattern corresponds to an active state.
+        """
+        if is_active:
+            if activity_pattern not in self.active_forms:
+                self.active_forms.append(activity_pattern)
+        else:
+            if activity_pattern not in self.inactive_forms:
+                self.inactive_forms.append(activity_pattern)
+
+    def add_activity_type(self, activity_type):
+        """Adds an activity type to an Agent.
+
+        Parameters
+        ----------
+        activity_type : str
+            The type of activity to add such as 'activity', 'kinase',
+            'gtpbound'
+        """
+        if activity_type not in self.activity_types:
+            self.activity_types.append(activity_type)
+

--- a/indra/assemblers/pysb/base_agents.py
+++ b/indra/assemblers/pysb/base_agents.py
@@ -1,11 +1,11 @@
-__all__ = ['_BaseAgentSet', '_BaseAgent']
+__all__ = ['BaseAgentSet', 'BaseAgent']
 from pysb import Annotation
 from indra.statements import *
 from .common import _n
 from .sites import states, get_binding_site_name, get_mod_site_name
 
 
-class _BaseAgentSet(object):
+class BaseAgentSet(object):
     """Container for a dict of BaseAgents with their names as keys."""
     def __init__(self):
         self.agents = {}
@@ -15,7 +15,7 @@ class _BaseAgentSet(object):
         try:
             base_agent = self.agents[_n(agent.name)]
         except KeyError:
-            base_agent = _BaseAgent(_n(agent.name))
+            base_agent = BaseAgent(_n(agent.name))
             self.agents[_n(agent.name)] = base_agent
 
         # If it's a molecular agent
@@ -65,7 +65,7 @@ class _BaseAgentSet(object):
         return self.agents[name]
 
 
-class _BaseAgent(object):
+class BaseAgent(object):
     """A BaseAgent aggregates the global properties of an Agent.
 
     The BaseAgent class aggregates the name, sites, site states, active forms,

--- a/indra/assemblers/pysb/base_agents.py
+++ b/indra/assemblers/pysb/base_agents.py
@@ -101,8 +101,7 @@ class _BaseAgent(object):
 
     def create_mod_site(self, mc):
         """Create modification site for the BaseAgent from a ModCondition."""
-        site_name = get_mod_site_name(mc.mod_type,
-                                      mc.residue, mc.position)
+        site_name = get_mod_site_name(mc)
         (unmod_site_state, mod_site_state) = states[mc.mod_type]
         self.create_site(site_name, (unmod_site_state, mod_site_state))
         site_anns = [Annotation((site_name, mod_site_state), mc.mod_type,

--- a/indra/assemblers/pysb/common.py
+++ b/indra/assemblers/pysb/common.py
@@ -1,0 +1,10 @@
+__all__ = ['_n']
+import re
+
+
+def _n(name):
+    """Return valid PySB name."""
+    n = name.encode('ascii', errors='ignore').decode('ascii')
+    n = re.sub('[^A-Za-z0-9_]', '_', n)
+    n = re.sub(r'(^[0-9].*)', r'p\1', n)
+    return n

--- a/indra/assemblers/pysb/export.py
+++ b/indra/assemblers/pysb/export.py
@@ -1,0 +1,79 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def export_sbgn(model):
+    """Return an SBGN model string corresponding to the PySB model.
+
+    This function first calls generate_equations on the PySB model to obtain
+    a reaction network (i.e. individual species, reactions). It then iterates
+    over each reaction and and instantiates its reactants, products, and the
+    process itself as SBGN glyphs and arcs.
+
+    Parameters
+    ----------
+    model : pysb.core.Model
+        A PySB model to be exported into SBGN
+
+    Returns
+    -------
+    sbgn_str : str
+        An SBGN model as string
+    """
+    import lxml.etree
+    import lxml.builder
+    from pysb.bng import generate_equations
+    from indra.assemblers.sbgn import SBGNAssembler
+
+    logger.info('Generating reaction network with BNG for SBGN export. ' +
+                'This could take a long time.')
+    generate_equations(model)
+
+    sa = SBGNAssembler()
+
+    glyphs = {}
+    for idx, species in enumerate(model.species):
+        glyph = sa._glyph_for_complex_pattern(species)
+        if glyph is None:
+            continue
+        sa._map.append(glyph)
+        glyphs[idx] = glyph
+    for reaction in model.reactions:
+        # Get all the reactions / products / controllers of the reaction
+        reactants = set(reaction['reactants']) - set(reaction['products'])
+        products = set(reaction['products']) - set(reaction['reactants'])
+        controllers = set(reaction['reactants']) & set(reaction['products'])
+        # Add glyph for reaction
+        process_glyph = sa._process_glyph('process')
+        # Connect reactants with arcs
+        if not reactants:
+            glyph_id = sa._none_glyph()
+            sa._arc('consumption', glyph_id, process_glyph)
+        else:
+            for r in reactants:
+                glyph = glyphs.get(r)
+                if glyph is None:
+                    glyph_id = sa._none_glyph()
+                else:
+                    glyph_id = glyph.attrib['id']
+                sa._arc('consumption', glyph_id, process_glyph)
+        # Connect products with arcs
+        if not products:
+            glyph_id = sa._none_glyph()
+            sa._arc('production', process_glyph, glyph_id)
+        else:
+            for p in products:
+                glyph = glyphs.get(p)
+                if glyph is None:
+                    glyph_id = sa._none_glyph()
+                else:
+                    glyph_id = glyph.attrib['id']
+                sa._arc('production', process_glyph, glyph_id)
+        # Connect controllers with arcs
+        for c in controllers:
+            glyph = glyphs[c]
+            sa._arc('catalysis', glyph.attrib['id'], process_glyph)
+
+    sbgn_str = sa.print_model().decode('utf-8')
+    return sbgn_str

--- a/indra/assemblers/pysb/preassembler.py
+++ b/indra/assemblers/pysb/preassembler.py
@@ -1,0 +1,168 @@
+import logging
+import itertools
+from indra.statements import *
+from indra.util import fast_deepcopy
+from .base_agents import _BaseAgentSet
+
+logger = logging.getLogger(__name__)
+
+
+class PysbPreassembler(object):
+    def __init__(self, stmts=None):
+        if not stmts:
+            stmts = []
+        self.statements = stmts
+        self.agent_set = _BaseAgentSet()
+
+    def add_statements(self, stmts):
+        self.statements = stmts
+
+    def _gather_active_forms(self):
+        for stmt in self.statements:
+            if isinstance(stmt, ActiveForm):
+                base_agent = self.agent_set.get_create_base_agent(stmt.agent)
+                # Handle the case where an activity flag is set
+                agent_to_add = stmt.agent
+                if stmt.agent.activity:
+                    new_agent = fast_deepcopy(stmt.agent)
+                    new_agent.activity = None
+                    agent_to_add = new_agent
+                base_agent.add_activity_form(agent_to_add, stmt.is_active)
+
+    def replace_activities(self):
+        logger.debug('Running PySB Preassembler replace activities')
+        # TODO: handle activity hierarchies
+        new_stmts = []
+
+        def has_agent_activity(stmt):
+            """Return True if any agents in the Statement have activity."""
+            for agent in stmt.agent_list():
+                if isinstance(agent, Agent) and agent.activity is not None:
+                    return True
+            return False
+        # First collect all explicit active forms
+        self._gather_active_forms()
+        # Iterate over all statements
+        for j, stmt in enumerate(self.statements):
+            logger.debug('%d/%d %s' % (j + 1, len(self.statements), stmt))
+            # If the Statement doesn't have any activities, we can just
+            # keep it and move on
+            if not has_agent_activity(stmt):
+                new_stmts.append(stmt)
+                continue
+            stmt_agents = stmt.agent_list()
+            num_agents = len(stmt_agents)
+            # Make a list with an empty list for each Agent so that later
+            # we can build combinations of Agent forms
+            agent_forms = [[] for a in stmt_agents]
+            for i, agent in enumerate(stmt_agents):
+                # This is the case where there is an activity flag on an
+                # Agent which we will attempt to replace with an explicit
+                # active form
+                if agent is not None and isinstance(agent, Agent) and \
+                        agent.activity is not None:
+                    base_agent = self.agent_set.get_create_base_agent(agent)
+                    # If it is an "active" state
+                    if agent.activity.is_active:
+                        active_forms = base_agent.active_forms
+                        # If no explicit active forms are known then we use
+                        # the generic one
+                        if not active_forms:
+                            active_forms = [agent]
+                    # If it is an "inactive" state
+                    else:
+                        active_forms = base_agent.inactive_forms
+                        # If no explicit inactive forms are known then we use
+                        # the generic one
+                        if not active_forms:
+                            active_forms = [agent]
+                    # We now iterate over the active agent forms and create
+                    # new agents
+                    for af in active_forms:
+                        new_agent = fast_deepcopy(agent)
+                        self._set_agent_context(af, new_agent)
+                        agent_forms[i].append(new_agent)
+                # Otherwise we just copy over the agent as is
+                else:
+                    agent_forms[i].append(agent)
+            # Now create all possible combinations of the agents and create new
+            # statements as needed
+            agent_combs = itertools.product(*agent_forms)
+            for agent_comb in agent_combs:
+                new_stmt = fast_deepcopy(stmt)
+                new_stmt.set_agent_list(agent_comb)
+                new_stmts.append(new_stmt)
+        self.statements = new_stmts
+
+    def add_reverse_effects(self):
+        # TODO: generalize to other modification sites
+        pos_mod_sites = {}
+        neg_mod_sites = {}
+        syntheses = []
+        degradations = []
+        for stmt in self.statements:
+            if isinstance(stmt, Phosphorylation):
+                agent = stmt.sub.name
+                try:
+                    pos_mod_sites[agent].append((stmt.residue, stmt.position))
+                except KeyError:
+                    pos_mod_sites[agent] = [(stmt.residue, stmt.position)]
+            elif isinstance(stmt, Dephosphorylation):
+                agent = stmt.sub.name
+                try:
+                    neg_mod_sites[agent].append((stmt.residue, stmt.position))
+                except KeyError:
+                    neg_mod_sites[agent] = [(stmt.residue, stmt.position)]
+            elif isinstance(stmt, Influence):
+                if stmt.overall_polarity() == 1:
+                    syntheses.append(stmt.obj.name)
+                elif stmt.overall_polarity() == -1:
+                    degradations.append(stmt.obj.name)
+            elif isinstance(stmt, IncreaseAmount):
+                syntheses.append(stmt.obj.name)
+            elif isinstance(stmt, DecreaseAmount):
+                degradations.append(stmt.obj.name)
+
+        new_stmts = []
+        for agent_name, pos_sites in pos_mod_sites.items():
+            neg_sites = neg_mod_sites.get(agent_name, [])
+            no_neg_site = set(pos_sites).difference(set(neg_sites))
+            for residue, position in no_neg_site:
+                st = Dephosphorylation(Agent('phosphatase'),
+                                           Agent(agent_name),
+                                           residue, position)
+                new_stmts.append(st)
+        for agent_name in syntheses:
+            if agent_name not in degradations:
+                st = DecreaseAmount(None, Agent(agent_name))
+                new_stmts.append(st)
+
+        self.statements += new_stmts
+
+    @staticmethod
+    def _set_agent_context(from_agent, to_agent):
+        if not isinstance(from_agent, Agent) or \
+                not isinstance(to_agent, Agent):
+            return
+        def add_no_duplicate(from_lst, to_lst):
+            for fm in from_lst:
+                found = False
+                for tm in to_lst:
+                    if fm.matches(tm):
+                        found = True
+                        break
+                if not found:
+                    to_lst.append(fm)
+            return to_lst
+        # TODO: what can we do about semantic conflicts here like the same
+        # bound condition with True/False is_bound appearing in the
+        # two contexts?
+        to_agent.bound_conditions = \
+            add_no_duplicate(to_agent.bound_conditions,
+                             from_agent.bound_conditions)
+        to_agent.mods = add_no_duplicate(to_agent.mods, from_agent.mods)
+        to_agent.mutations = add_no_duplicate(to_agent.mutations,
+                                              from_agent.mutations)
+        to_agent.location = from_agent.location
+        to_agent.activity = from_agent.activity
+

--- a/indra/assemblers/pysb/sites.py
+++ b/indra/assemblers/pysb/sites.py
@@ -1,0 +1,96 @@
+__all__ = ['abbrevs', 'states', 'mod_acttype_map', 'get_binding_site_name',
+           'get_mod_site_name']
+from indra.statements import *
+from indra.tools.expand_families import _agent_from_uri
+from indra.preassembler.hierarchy_manager import hierarchies
+from .common import _n
+
+abbrevs = {
+    'phosphorylation': 'phospho',
+    'ubiquitination': 'ub',
+    'farnesylation': 'farnesyl',
+    'hydroxylation': 'hydroxyl',
+    'acetylation': 'acetyl',
+    'sumoylation': 'sumo',
+    'glycosylation': 'glycosyl',
+    'methylation': 'methyl',
+    'ribosylation': 'ribosyl',
+    'geranylgeranylation': 'geranylgeranyl',
+    'palmitoylation': 'palmitoyl',
+    'myrylation': 'myryl',
+    'modification': 'mod',
+}
+
+states = {
+    'phosphorylation': ['u', 'p'],
+    'ubiquitination': ['n', 'y'],
+    'farnesylation': ['n', 'y'],
+    'hydroxylation': ['n', 'y'],
+    'acetylation': ['n', 'y'],
+    'sumoylation': ['n', 'y'],
+    'glycosylation': ['n', 'y'],
+    'methylation': ['n', 'y'],
+    'geranylgeranylation': ['n', 'y'],
+    'palmitoylation': ['n', 'y'],
+    'myrylation': ['n', 'y'],
+    'ribosylation': ['n', 'y'],
+    'modification': ['n', 'y'],
+}
+
+mod_acttype_map = {
+    Phosphorylation: 'kinase',
+    Dephosphorylation: 'phosphatase',
+    Hydroxylation: 'catalytic',
+    Dehydroxylation: 'catalytic',
+    Sumoylation: 'catalytic',
+    Desumoylation: 'catalytic',
+    Acetylation: 'catalytic',
+    Deacetylation: 'catalytic',
+    Glycosylation: 'catalytic',
+    Deglycosylation: 'catalytic',
+    Ribosylation: 'catalytic',
+    Deribosylation: 'catalytic',
+    Ubiquitination: 'catalytic',
+    Deubiquitination: 'catalytic',
+    Farnesylation: 'catalytic',
+    Defarnesylation: 'catalytic',
+    Palmitoylation: 'catalytic',
+    Depalmitoylation: 'catalytic',
+    Myristoylation: 'catalytic',
+    Demyristoylation: 'catalytic',
+    Geranylgeranylation: 'catalytic',
+    Degeranylgeranylation: 'catalytic',
+    Methylation: 'catalytic',
+    Demethylation: 'catalytic',
+}
+
+
+def get_binding_site_name(agent):
+    """Return a binding site name from a given agent."""
+    # Try to construct a binding site name based on parent
+    grounding = agent.get_grounding()
+    if grounding != (None, None):
+        uri = hierarchies['entity'].get_uri(grounding[0], grounding[1])
+        # Get highest level parents in hierarchy
+        parents = hierarchies['entity'].get_parents(uri, 'top')
+        if parents:
+            # Choose the first parent if there are more than one
+            parent_uri = sorted(parents))[0]
+            parent_agent = _agent_from_uri(parent_uri)
+            binding_site = _n(parent_agent.name).lower()
+            return binding_site
+    # Fall back to Agent's own name if one from parent can't be constructed
+    binding_site = _n(agent.name).lower()
+    return binding_site
+
+
+def get_mod_site_name(mod_type, residue, position):
+    """Return site names for a modification."""
+    names = []
+    if residue is None:
+        mod_str = abbrevs[mod_type]
+    else:
+        mod_str = residue
+    mod_pos = position if position is not None else ''
+    name = ('%s%s' % (mod_str, mod_pos))
+    return name

--- a/indra/assemblers/pysb/sites.py
+++ b/indra/assemblers/pysb/sites.py
@@ -84,13 +84,13 @@ def get_binding_site_name(agent):
     return binding_site
 
 
-def get_mod_site_name(mod_type, residue, position):
+def get_mod_site_name(mod_condition):
     """Return site names for a modification."""
-    names = []
-    if residue is None:
-        mod_str = abbrevs[mod_type]
+    if mod_condition.residue is None:
+        mod_str = abbrevs[mod_condition.mod_type]
     else:
-        mod_str = residue
-    mod_pos = position if position is not None else ''
+        mod_str = mod_condition.residue
+    mod_pos = mod_condition.position if \
+        mod_condition.position is not None else ''
     name = ('%s%s' % (mod_str, mod_pos))
     return name

--- a/indra/assemblers/pysb/sites.py
+++ b/indra/assemblers/pysb/sites.py
@@ -17,7 +17,7 @@ abbrevs = {
     'ribosylation': 'ribosyl',
     'geranylgeranylation': 'geranylgeranyl',
     'palmitoylation': 'palmitoyl',
-    'myrylation': 'myryl',
+    'myristoylation': 'myryl',
     'modification': 'mod',
 }
 
@@ -32,7 +32,7 @@ states = {
     'methylation': ['n', 'y'],
     'geranylgeranylation': ['n', 'y'],
     'palmitoylation': ['n', 'y'],
-    'myrylation': ['n', 'y'],
+    'myristoylation': ['n', 'y'],
     'ribosylation': ['n', 'y'],
     'modification': ['n', 'y'],
 }
@@ -75,7 +75,7 @@ def get_binding_site_name(agent):
         parents = hierarchies['entity'].get_parents(uri, 'top')
         if parents:
             # Choose the first parent if there are more than one
-            parent_uri = sorted(parents))[0]
+            parent_uri = sorted(parents)[0]
             parent_agent = _agent_from_uri(parent_uri)
             binding_site = _n(parent_agent.name).lower()
             return binding_site

--- a/indra/tests/test_kami_assembler.py
+++ b/indra/tests/test_kami_assembler.py
@@ -22,6 +22,7 @@ mek_phos3 = Agent('MAP2K1', mods=[ModCondition('phosphorylation', 'S',
                                                '222', False)],
                  db_refs={'HGNC': '6840'})
 
+
 def test_complex_no_conditions():
     stmt = Complex([mek, erk])
     ka = KamiAssembler()
@@ -35,6 +36,7 @@ def test_complex_no_conditions():
     assert len(graph_list[1]['graph']['edges']) == 4
     assert len(graph_list[1]['graph']['nodes']) == 5
     print(json.dumps(model, indent=1))
+
 
 def test_complex_bound_condition():
     stmt = Complex([mek_braf, erk])
@@ -50,6 +52,7 @@ def test_complex_bound_condition():
     assert len(graph_list[1]['graph']['nodes']) == 7
     print(json.dumps(model, indent=1))
 
+
 def test_complex_not_bound_condition():
     stmt = Complex([mek_no_braf, erk])
     ka = KamiAssembler()
@@ -63,6 +66,7 @@ def test_complex_not_bound_condition():
     assert len(graph_list[1]['graph']['edges']) == 6
     assert len(graph_list[1]['graph']['nodes']) == 7
     print(json.dumps(model, indent=1))
+
 
 def test_complex_mod_condition():
     meks = [mek_phos, mek_phos2, mek_phos3]
@@ -80,6 +84,7 @@ def test_complex_mod_condition():
         assert len(graph_list[1]['graph']['nodes']) == 6
         print(json.dumps(model, indent=1))
 
+
 def test_mod_one_step():
     stmt = Phosphorylation(mek, erk)
     ka = KamiAssembler()
@@ -93,6 +98,7 @@ def test_mod_one_step():
     assert len(graph_list) == 2
     assert len(graph_list[1]['graph']['edges']) == 3
     assert len(graph_list[1]['graph']['nodes']) == 4
+
 
 def test_demod_one_step():
     stmt = Deubiquitination(mek, erk, 'K', '123')
@@ -108,6 +114,7 @@ def test_demod_one_step():
     assert len(graph_list[1]['graph']['edges']) == 3
     assert len(graph_list[1]['graph']['nodes']) == 4
 
+
 def test_unique_id():
     egf = Agent('EGF')
     egfr = Agent('EGFR', bound_conditions=BoundCondition(egf, True))
@@ -116,4 +123,3 @@ def test_unique_id():
     ka.add_statements([stmt])
     model = ka.make_model()
     print(json.dumps(model, indent=1))
-

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -8,6 +8,7 @@ from indra.statements import *
 from pysb import bng, WILD, Monomer, Annotation
 from pysb.testing import with_model
 
+
 def test_pysb_assembler_complex1():
     member1 = Agent('BRAF')
     member2 = Agent('MEK1')
@@ -15,8 +16,9 @@ def test_pysb_assembler_complex1():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==2
-    assert len(model.monomers)==2
+    assert len(model.rules) == 2
+    assert len(model.monomers) == 2
+
 
 def test_pysb_assembler_complex2():
     member1 = Agent('BRAF')
@@ -26,8 +28,9 @@ def test_pysb_assembler_complex2():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==6
-    assert len(model.monomers)==3
+    assert len(model.rules) == 6
+    assert len(model.monomers) == 3
+
 
 def test_pysb_assembler_complex3():
     hras = Agent('HRAS')
@@ -37,8 +40,9 @@ def test_pysb_assembler_complex3():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==2
-    assert len(model.monomers)==3
+    assert len(model.rules) == 2
+    assert len(model.monomers) == 3
+
 
 def test_pysb_assembler_complex_twostep():
     member1 = Agent('BRAF')
@@ -47,8 +51,9 @@ def test_pysb_assembler_complex_twostep():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model(policies='two_step')
-    assert len(model.rules)==2
-    assert len(model.monomers)==2
+    assert len(model.rules) == 2
+    assert len(model.monomers) == 2
+
 
 def test_pysb_assembler_complex_multiway():
     member1 = Agent('BRAF')
@@ -58,8 +63,9 @@ def test_pysb_assembler_complex_multiway():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model(policies='multi_way')
-    assert len(model.rules)==2
-    assert len(model.monomers)==3
+    assert len(model.rules) == 2
+    assert len(model.monomers) == 3
+
 
 def test_pysb_assembler_actsub():
     stmt = ActiveForm(Agent('BRAF', mutations=[MutCondition('600', 'V', 'E')]),
@@ -67,8 +73,9 @@ def test_pysb_assembler_actsub():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model(policies='two_step')
-    assert len(model.rules)==0
-    assert len(model.monomers)==1
+    assert len(model.rules) == 0
+    assert len(model.monomers) == 1
+
 
 def test_pysb_assembler_phos_noenz():
     enz = None
@@ -77,8 +84,9 @@ def test_pysb_assembler_phos_noenz():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==0
-    assert len(model.monomers)==0
+    assert len(model.rules) == 0
+    assert len(model.monomers) == 0
+
 
 def test_pysb_assembler_dephos_noenz():
     enz = None
@@ -87,8 +95,9 @@ def test_pysb_assembler_dephos_noenz():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==0
-    assert len(model.monomers)==0
+    assert len(model.rules) == 0
+    assert len(model.monomers) == 0
+
 
 def test_pysb_assembler_phos1():
     enz = Agent('BRAF')
@@ -97,8 +106,9 @@ def test_pysb_assembler_phos1():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
+
 
 def test_pysb_assembler_phos2():
     hras = Agent('HRAS')
@@ -108,8 +118,9 @@ def test_pysb_assembler_phos2():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==3
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 3
+
 
 def test_pysb_assembler_phos3():
     hras = Agent('HRAS')
@@ -120,8 +131,9 @@ def test_pysb_assembler_phos3():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==4
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 4
+
 
 def test_pysb_assembler_phos4():
     hras = Agent('HRAS')
@@ -132,8 +144,9 @@ def test_pysb_assembler_phos4():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==4
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 4
+
 
 def test_pysb_assembler_autophos1():
     enz = Agent('MEK1')
@@ -141,8 +154,9 @@ def test_pysb_assembler_autophos1():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==1
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 1
+
 
 def test_pysb_assembler_autophos2():
     raf1 = Agent('RAF1')
@@ -151,8 +165,9 @@ def test_pysb_assembler_autophos2():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
+
 
 def test_pysb_assembler_autophos3():
     egfr = Agent('EGFR')
@@ -161,8 +176,9 @@ def test_pysb_assembler_autophos3():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==1
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 1
+
 
 def test_pysb_assembler_transphos1():
     egfr = Agent('EGFR')
@@ -171,8 +187,9 @@ def test_pysb_assembler_transphos1():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==1
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 1
+
 
 def test_pysb_assembler_act1():
     egfr = Agent('EGFR')
@@ -182,8 +199,9 @@ def test_pysb_assembler_act1():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==3
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 3
+
 
 def test_pysb_assembler_dephos1():
     phos = Agent('PP2A')
@@ -192,8 +210,9 @@ def test_pysb_assembler_dephos1():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
+
 
 def test_pysb_assembler_dephos2():
     phos = Agent('PP2A')
@@ -203,8 +222,9 @@ def test_pysb_assembler_dephos2():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==3
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 3
+
 
 def test_pysb_assembler_gef1():
     gef = Agent('SOS1')
@@ -213,8 +233,9 @@ def test_pysb_assembler_gef1():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
+
 
 def test_pysb_assembler_gap1():
     gap = Agent('NF1')
@@ -223,8 +244,9 @@ def test_pysb_assembler_gap1():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
+
 
 def test_pysb_assembler_actmod1():
     mek = Agent('MEK')
@@ -238,10 +260,11 @@ def test_pysb_assembler_actmod1():
     pa = PysbAssembler()
     pa.add_statements(stmts)
     model = pa.make_model()
-    assert len(model.rules)==2
-    assert len(model.monomers)==2
+    assert len(model.rules) == 2
+    assert len(model.monomers) == 2
     model = pa.make_model(policies='two_step')
-    assert len(model.rules)==5
+    assert len(model.rules) == 5
+
 
 def test_pysb_assembler_actmod2():
     mek = Agent('MEK', activity=ActivityCondition('activity', True))
@@ -258,10 +281,11 @@ def test_pysb_assembler_actmod2():
     pa = PysbAssembler()
     pa.add_statements(stmts)
     model = pa.make_model()
-    assert len(model.rules)==4
-    assert len(model.monomers)==2
+    assert len(model.rules) == 4
+    assert len(model.monomers) == 2
     model = pa.make_model(policies='two_step')
-    assert len(model.rules)==9
+    assert len(model.rules) == 9
+
 
 def test_pysb_assembler_phos_twostep1():
     enz = Agent('BRAF')
@@ -270,8 +294,9 @@ def test_pysb_assembler_phos_twostep1():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model(policies='two_step')
-    assert len(model.rules)==3
-    assert len(model.monomers)==2
+    assert len(model.rules) == 3
+    assert len(model.monomers) == 2
+
 
 def test_pysb_assembler_twostep_mixed():
     member1 = Agent('BRAF')
@@ -281,8 +306,9 @@ def test_pysb_assembler_twostep_mixed():
     pa = PysbAssembler()
     pa.add_statements([st1, st2])
     pa.make_model(policies='two_step')
-    assert len(pa.model.rules)==5
-    assert len(pa.model.monomers)==4
+    assert len(pa.model.rules) == 5
+    assert len(pa.model.monomers) == 4
+
 
 def test_pysb_assembler_phos_twostep_local():
     enz = Agent('BRAF')
@@ -291,8 +317,9 @@ def test_pysb_assembler_phos_twostep_local():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model(policies='two_step')
-    assert len(model.rules)==3
-    assert len(model.monomers)==2
+    assert len(model.rules) == 3
+    assert len(model.monomers) == 2
+
 
 def test_pysb_assembler_phos_twostep_local_to_global():
     enz = Agent('BRAF')
@@ -303,8 +330,9 @@ def test_pysb_assembler_phos_twostep_local_to_global():
     model = pa.make_model(policies='two_step')
     # This call should have reverted to default policy
     model = pa.make_model()
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
+
 
 def test_pysb_assembler_dephos_twostep1():
     phos = Agent('PP2A')
@@ -313,8 +341,9 @@ def test_pysb_assembler_dephos_twostep1():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model(policies='two_step')
-    assert len(model.rules)==3
-    assert len(model.monomers)==2
+    assert len(model.rules) == 3
+    assert len(model.monomers) == 2
+
 
 def test_statement_specific_policies():
     enz = Agent('BRAF')
@@ -327,8 +356,9 @@ def test_statement_specific_policies():
     pa = PysbAssembler()
     pa.add_statements([stmt1, stmt2])
     model = pa.make_model(policies=policies)
-    assert len(model.rules)==4
-    assert len(model.monomers)==3
+    assert len(model.rules) == 4
+    assert len(model.monomers) == 3
+
 
 def test_unspecified_statement_policies():
     enz = Agent('BRAF')
@@ -341,8 +371,9 @@ def test_unspecified_statement_policies():
     pa = PysbAssembler()
     pa.add_statements([stmt1, stmt2])
     model = pa.make_model(policies=policies)
-    assert len(model.rules)==4
-    assert len(model.monomers)==3
+    assert len(model.rules) == 4
+    assert len(model.monomers) == 3
+
 
 def test_activity_activity():
     subj = Agent('KRAS')
@@ -351,8 +382,9 @@ def test_activity_activity():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model(policies='interactions_only')
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
+
 
 def test_activity_activity2():
     subj = Agent('KRAS')
@@ -361,8 +393,9 @@ def test_activity_activity2():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model(policies='one_step')
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
+
 
 def test_activity_activity2():
     subj = Agent('Vemurafenib')
@@ -371,8 +404,9 @@ def test_activity_activity2():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model(policies='interactions_only')
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
+
 
 def test_activity_activity3():
     subj = Agent('Vemurafenib')
@@ -381,12 +415,14 @@ def test_activity_activity3():
     pa = PysbAssembler()
     pa.add_statements([stmt])
     model = pa.make_model(policies='one_step')
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
+
 
 def test_rule_name_str_1():
     s = pa.get_agent_rule_str(Agent('BRAF'))
     assert s == 'BRAF'
+
 
 def test_rule_name_str_2():
     a = Agent('GRB2',
@@ -394,21 +430,25 @@ def test_rule_name_str_2():
     s = pa.get_agent_rule_str(a)
     assert s == 'GRB2_EGFR'
 
+
 def test_rule_name_str_3():
     a = Agent('GRB2',
               bound_conditions=[BoundCondition(Agent('EGFR'), False)])
     s = pa.get_agent_rule_str(a)
     assert s == 'GRB2_nEGFR'
 
+
 def test_rule_name_str_4():
     a = Agent('BRAF', mods=[ModCondition('phosphorylation', 'serine')])
     s = pa.get_agent_rule_str(a)
     assert s == 'BRAF_phosphoS'
 
+
 def test_rule_name_str_5():
     a = Agent('BRAF', mods=[ModCondition('phosphorylation', 'serine', '123')])
     s = pa.get_agent_rule_str(a)
     assert s == 'BRAF_phosphoS123'
+
 
 def test_neg_act_mod():
     mc = ModCondition('phosphorylation', 'serine', '123', False)
@@ -424,6 +464,7 @@ def test_neg_act_mod():
     assert braf.monomer.name == 'BRAF'
     assert braf.site_conditions == {'S123': ('u', WILD)}
 
+
 def test_pos_agent_mod():
     mc = ModCondition('phosphorylation', 'serine', '123', True)
     st = Phosphorylation(Agent('BRAF', mods=[mc]), Agent('MAP2K2'))
@@ -435,6 +476,7 @@ def test_pos_agent_mod():
     braf = r.reactant_pattern.complex_patterns[0].monomer_patterns[0]
     assert braf.monomer.name == 'BRAF'
     assert braf.site_conditions == {'S123': ('p', WILD)}
+
 
 def test_neg_agent_mod():
     mc = ModCondition('phosphorylation', 'serine', '123', False)
@@ -448,6 +490,7 @@ def test_neg_agent_mod():
     assert braf.monomer.name == 'BRAF'
     assert braf.site_conditions == {'S123': ('u', WILD)}
 
+
 def test_mut():
     mut = MutCondition('600', 'V', 'E')
     st = Phosphorylation(Agent('BRAF', mutations=[mut]), Agent('MEK'))
@@ -459,6 +502,7 @@ def test_mut():
     braf = r.reactant_pattern.complex_patterns[0].monomer_patterns[0]
     assert braf.monomer.name == 'BRAF'
     assert braf.site_conditions == {'V600': 'E'}
+
 
 def test_mut_missing1():
     mut = MutCondition('600', 'V', None)
@@ -472,6 +516,7 @@ def test_mut_missing1():
     assert braf.monomer.name == 'BRAF'
     assert braf.site_conditions == {'V600': 'X'}
 
+
 def test_mut_missing2():
     mut = MutCondition('600', None, 'E')
     st = Phosphorylation(Agent('BRAF', mutations=[mut]), Agent('MEK'))
@@ -483,6 +528,7 @@ def test_mut_missing2():
     braf = r.reactant_pattern.complex_patterns[0].monomer_patterns[0]
     assert braf.monomer.name == 'BRAF'
     assert braf.site_conditions == {'mut600': 'E'}
+
 
 def test_mut_missing3():
     mut = MutCondition(None, 'V', 'E')
@@ -496,6 +542,7 @@ def test_mut_missing3():
     assert braf.monomer.name == 'BRAF'
     assert braf.site_conditions == {'V': 'E'}
 
+
 def test_mut_missing4():
     mut = MutCondition(None, None, None)
     st = Phosphorylation(Agent('BRAF', mutations=[mut]), Agent('MEK'))
@@ -508,6 +555,7 @@ def test_mut_missing4():
     assert braf.monomer.name == 'BRAF'
     assert braf.site_conditions == {'mut': 'X'}
 
+
 def test_agent_loc():
     st = Phosphorylation(Agent('BRAF', location='cytoplasm'), Agent('MEK'))
     pa = PysbAssembler()
@@ -517,6 +565,7 @@ def test_agent_loc():
     r = pa.model.rules[0]
     braf = r.reactant_pattern.complex_patterns[0].monomer_patterns[0]
     assert braf.site_conditions == {'loc': 'cytoplasm'}
+
 
 def test_translocation():
     st = Translocation(Agent('FOXO3A'), 'nucleus', 'cytoplasm')
@@ -531,6 +580,7 @@ def test_translocation():
     assert f2.site_conditions == {'loc': 'cytoplasm'}
     assert r.rate_forward.name == 'kf_foxo3a_nucleus_cytoplasm_1'
 
+
 def test_translocation_to():
     st = Translocation(Agent('FOXO3A'), None, 'nucleus')
     pa = PysbAssembler()
@@ -544,12 +594,14 @@ def test_translocation_to():
     assert f2.site_conditions == {'loc': 'nucleus'}
     assert r.rate_forward.name == 'kf_foxo3a_cytoplasm_nucleus_1'
 
+
 def test_phos_atpdep():
     st = Phosphorylation(Agent('BRAF'), Agent('MEK'), 'S', '222')
     pa = PysbAssembler()
     pa.add_statements([st])
     pa.make_model(policies='atp_dependent')
     assert len(pa.model.rules) == 5
+
 
 def test_set_context():
     st = Phosphorylation(Agent('MAP2K1'), Agent('MAPK3'))
@@ -561,6 +613,7 @@ def test_set_context():
     pa.set_context('A375_SKIN')
     assert pa.model.parameters['MAP2K1_0'].value > 10000
     assert pa.model.parameters['MAPK3_0'].value > 10000
+
 
 def test_set_context_monomer_notfound():
     st = Phosphorylation(Agent('MAP2K1'), Agent('XYZ'))
@@ -576,12 +629,14 @@ def test_set_context_monomer_notfound():
     assert pa.model.parameters['MAP2K1_0'].value > 10000
     assert pa.model.parameters['XYZ_0'].value == pa.default_initial_amount
 
+
 def test_set_context_celltype_notfound():
     st = Phosphorylation(Agent('MAP2K1'), Agent('MAPK3'))
     pa = PysbAssembler()
     pa.add_statements([st])
     pa.make_model()
     pa.set_context('XYZ')
+
 
 def test_annotation():
     st = Phosphorylation(Agent('BRAF', db_refs = {'UP': 'P15056'}),
@@ -590,6 +645,7 @@ def test_annotation():
     pa.add_statements([st])
     pa.make_model()
     assert len(pa.model.annotations) == 5
+
 
 def test_annotation_regamount():
     st1 = IncreaseAmount(Agent('BRAF', db_refs = {'UP': 'P15056'}),
@@ -601,6 +657,7 @@ def test_annotation_regamount():
     pa.make_model()
     assert len(pa.model.annotations) == 8
 
+
 def test_print_model():
     st = Phosphorylation(Agent('MAP2K1'), Agent('MAPK3'))
     pa = PysbAssembler()
@@ -608,12 +665,14 @@ def test_print_model():
     pa.make_model()
     pa.save_model('/dev/null')
 
+
 def test_save_rst():
     st = Phosphorylation(Agent('MAP2K1'), Agent('MAPK3'))
     pa = PysbAssembler()
     pa.add_statements([st])
     pa.make_model()
     pa.save_rst('/dev/null')
+
 
 def test_export_model():
     st = Phosphorylation(Agent('MAP2K1'), Agent('MAPK3'))
@@ -626,6 +685,7 @@ def test_export_model():
     assert exp_str
     exp_str = pa.export_model('sbml', file_name='/dev/null')
     assert exp_str
+
 
 def test_assemble_export_sbgn():
     # Add various statements to test their assembly
@@ -650,6 +710,7 @@ def test_assemble_export_sbgn():
     assert glyph_classes.count('process') == 10
     return pa
 
+
 def test_name_standardize():
     n = pa._n('.*/- ^&#@$')
     assert isinstance(n, str)
@@ -661,12 +722,14 @@ def test_name_standardize():
     assert isinstance(n, str)
     assert n == 'bar'
 
+
 def test_generate_equations():
     st = Phosphorylation(Agent('MAP2K1'), Agent('MAPK3'))
     pa = PysbAssembler()
     pa.add_statements([st])
     pa.make_model()
     bng.generate_equations(pa.model)
+
 
 def test_non_python_name_phos():
     st = Phosphorylation(Agent('14-3-3'), Agent('BRAF kinase'))
@@ -678,12 +741,14 @@ def test_non_python_name_phos():
     assert 'p14_3_3' in names
     bng.generate_equations(pa.model)
 
+
 def test_non_python_name_bind():
     st = Complex([Agent('14-3-3'), Agent('BRAF kinase')])
     pa = PysbAssembler()
     pa.add_statements([st])
     pa.make_model()
     bng.generate_equations(pa.model)
+
 
 def test_decreaseamount_one_step():
     subj = Agent('KRAS')
@@ -693,8 +758,9 @@ def test_decreaseamount_one_step():
     pa = PysbAssembler()
     pa.add_statements([st1, st2])
     model = pa.make_model(policies='one_step')
-    assert len(model.rules)==2
-    assert len(model.monomers)==2
+    assert len(model.rules) == 2
+    assert len(model.monomers) == 2
+
 
 def test_decreaseamount_interactions_only():
     subj = Agent('KRAS')
@@ -704,8 +770,9 @@ def test_decreaseamount_interactions_only():
     pa = PysbAssembler()
     pa.add_statements([st1, st2])
     model = pa.make_model(policies='interactions_only')
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
+
 
 def test_increaseamount_one_step():
     subj = Agent('KRAS')
@@ -715,8 +782,9 @@ def test_increaseamount_one_step():
     pa = PysbAssembler()
     pa.add_statements([st1, st2])
     model = pa.make_model(policies='one_step')
-    assert len(model.rules)==2
-    assert len(model.monomers)==2
+    assert len(model.rules) == 2
+    assert len(model.monomers) == 2
+
 
 def test_increaseamount_interactions_only():
     subj = Agent('KRAS')
@@ -726,8 +794,9 @@ def test_increaseamount_interactions_only():
     pa = PysbAssembler()
     pa.add_statements([st1, st2])
     model = pa.make_model(policies='interactions_only')
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
+
 
 def test_missing_catalytic_default_site():
     c8 = Agent('CASP8', activity=ActivityCondition('catalytic', True))
@@ -746,6 +815,7 @@ def test_missing_catalytic_default_site():
     pa.add_statements([stmt])
     model = pa.make_model(policies='two_step')
 
+
 def test_missing_transcription_default_site():
     p53 = Agent('TP53', activity=ActivityCondition('transcription', True))
     bax = Agent('BAX')
@@ -763,6 +833,7 @@ def test_missing_transcription_default_site():
     pa.add_statements([stmt])
     model = pa.make_model(policies='two_step')
 
+
 def test_translocation_loc_special_char():
     st = Translocation(Agent('KSR1'), 'cytoplasm', 'cell surface')
     pa = PysbAssembler()
@@ -775,6 +846,7 @@ def test_translocation_loc_special_char():
     f2 = r.product_pattern.complex_patterns[0].monomer_patterns[0]
     assert f2.site_conditions == {'loc': 'cell_surface'}
     assert r.rate_forward.name == 'kf_ksr1_cytoplasm_cell_surface_1'
+
 
 def test_parse_identifiers_url():
     url1 = 'http://identifiers.org/foo/bar'
@@ -799,6 +871,7 @@ def test_parse_identifiers_url():
     (ns, id) = pa.parse_identifiers_url(url7)
     assert ns == 'XFAM' and id == '12345'
 
+
 @with_model
 def test_get_mp_with_grounding():
     foo = Agent('Foo', db_refs={'HGNC': 'foo'})
@@ -816,6 +889,7 @@ def test_get_mp_with_grounding():
     mps = list(pa.grounded_monomer_patterns(model, b))
     assert len(mps) == 1
     assert mps[0].monomer == B_monomer
+
 
 @with_model
 def test_get_mp_with_grounding_2():
@@ -846,6 +920,7 @@ def test_get_mp_with_grounding_2():
     # TODO Add test involving multiple (possibly degenerate) modifications!
     # TODO Add test for generic double phosphorylation
 
+
 def test_phospho_assemble_grounding():
     a = Agent('MEK1', db_refs={'HGNC': '6840'})
     b = Agent('ERK2', db_refs={'HGNC': '6871'})
@@ -864,6 +939,7 @@ def test_phospho_assemble_grounding():
     for policy in ('one_step', 'interactions_only', 'two_step',
                    'atp_dependent'):
         check_policy(policy)
+
 
 def test_phospho_mod_grounding():
     a = Agent('MEK1', mods=[ModCondition('phosphorylation', 'S', '218'),
@@ -937,26 +1013,28 @@ def _check_mod_assembly(mod_class):
     pa = PysbAssembler()
     pa.add_statements([st1])
     model = pa.make_model(policies='interactions_only')
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
 
     pa = PysbAssembler()
     pa.add_statements([st1])
     model = pa.make_model(policies='one_step')
-    assert len(model.rules)==1
-    assert len(model.monomers)==2
+    assert len(model.rules) == 1
+    assert len(model.monomers) == 2
 
     pa = PysbAssembler()
     pa.add_statements([st1])
     model = pa.make_model(policies='two_step')
-    assert len(model.rules)==3
-    assert len(model.monomers)==2
+    assert len(model.rules) == 3
+    assert len(model.monomers) == 2
+
 
 def test_modification_assembly():
     classes = AddModification.__subclasses__() + \
               RemoveModification.__subclasses__()
     for mod_class in classes:
         _check_mod_assembly(mod_class)
+
 
 def test_rule_annotation():
     a = Agent('A', db_refs={'HGNC': '1234'})
@@ -991,6 +1069,7 @@ def test_rule_annotation():
     #Gef
     #Gap
 
+
 def test_activeform_site():
     a = Agent('A', db_refs={'HGNC': '1234'})
     b = Agent('B', db_refs={'HGNC': '5678'})
@@ -1007,6 +1086,7 @@ def test_activeform_site():
 # TODO Bound condition
 # TODO Unphosphorylated/unmodified forms (try ubiquitinated/acetylated lysine)
 
+
 def test_activation_subj1():
     """No subject activity is defined."""
     st = Activation(Agent('a'), Agent('b'))
@@ -1020,6 +1100,7 @@ def test_activation_subj1():
     subj_right = right.complex_patterns[0].monomer_patterns[0]
     assert subj_left.site_conditions == {}
     assert subj_right.site_conditions == {}
+
 
 def test_activation_subj2():
     """Subject activity is defined explicitly."""
@@ -1038,6 +1119,7 @@ def test_activation_subj2():
     assert subj_left.site_conditions == {u'phospho': (u'p', WILD)}
     assert subj_right.site_conditions == {u'phospho': (u'p', WILD)}
 
+
 def test_activation_subj3():
     """Subject activity is defined implicitly by another statement."""
     a_act = Agent('a', activity=ActivityCondition('activity', True))
@@ -1054,6 +1136,7 @@ def test_activation_subj3():
     subj_right = right.complex_patterns[0].monomer_patterns[0]
     assert subj_left.site_conditions == {u'activity': (u'active')}
     assert subj_right.site_conditions == {u'activity': (u'active')}
+
 
 def test_activation_subj4():
     """Subject activity is defined both explicitly and implicitly."""
@@ -1073,6 +1156,7 @@ def test_activation_subj4():
     assert subj_left.site_conditions == {u'phospho': (u'p', WILD)}
     assert subj_right.site_conditions == {u'phospho': (u'p', WILD)}
 
+
 def test_pysb_preassembler_replace_activities1():
     st1 = ActiveForm(Agent('a', location='nucleus'), 'activity', True)
     st2 = Phosphorylation(Agent('a',
@@ -1083,6 +1167,7 @@ def test_pysb_preassembler_replace_activities1():
     assert len(ppa.statements) == 2
     assert ppa.statements[1].enz.location == 'nucleus'
 
+
 def test_pysb_preassembler_replace_activities2():
     a_act = Agent('a', activity=ActivityCondition('activity', True))
     st = Activation(a_act, Agent('b'))
@@ -1090,6 +1175,7 @@ def test_pysb_preassembler_replace_activities2():
     ppa = PysbPreassembler([st, st2])
     ppa.replace_activities()
     assert len(ppa.statements) == 2
+
 
 def test_pysb_preassembler_replace_activities3():
     p = Agent('PPP2CA')
@@ -1107,6 +1193,7 @@ def test_pysb_preassembler_replace_activities3():
     assert ppa.statements[0].enz.mods
     assert ppa.statements[0].enz.bound_conditions
 
+
 def test_phos_michaelis_menten():
     stmt = Phosphorylation(Agent('MEK'), Agent('ERK'))
     pa = PysbAssembler()
@@ -1114,12 +1201,14 @@ def test_phos_michaelis_menten():
     pa.make_model(policies='michaelis_menten')
     assert len(pa.model.parameters) == 4
 
+
 def test_deubiq_michaelis_menten():
     stmt = Deubiquitination(Agent('MEK'), Agent('ERK'))
     pa = PysbAssembler()
     pa.add_statements([stmt])
     pa.make_model(policies='michaelis_menten')
     assert len(pa.model.parameters) == 4
+
 
 def test_act_michaelis_menten():
     stmt = Activation(Agent('MEK'), Agent('ERK'))
@@ -1129,6 +1218,7 @@ def test_act_michaelis_menten():
     pa.make_model(policies='michaelis_menten')
     assert len(pa.model.parameters) == 7
 
+
 def test_increaseamount_hill():
     stmt = IncreaseAmount(Agent('TP53'), Agent('MDM2'))
     pa = PysbAssembler()
@@ -1136,6 +1226,7 @@ def test_increaseamount_hill():
     pa.make_model(policies='hill')
     pa.save_model()
     assert len(pa.model.parameters) == 5
+
 
 def test_convert_nosubj():
     stmt = Conversion(None, [Agent('PIP2')], [Agent('PIP3')])
@@ -1145,6 +1236,7 @@ def test_convert_nosubj():
     assert len(pa.model.parameters) == 3
     assert len(pa.model.rules) == 1
     assert len(pa.model.monomers) == 2
+
 
 def test_convert_subj():
     stmt = Conversion(Agent('PIK3CA'), [Agent('PIP2')], [Agent('PIP3')])

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -3,7 +3,7 @@ from builtins import dict, str
 import xml.etree.ElementTree as ET
 from indra.assemblers.pysb import PysbAssembler
 import indra.assemblers.pysb.assembler as pa
-from indra.assemblers.pysb.assembler import PysbPreassembler
+from indra.assemblers.pysb.preassembler import PysbPreassembler
 from indra.statements import *
 from pysb import bng, WILD, Monomer, Annotation
 from pysb.testing import with_model

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -14,8 +14,7 @@ def test_pysb_assembler_complex1():
     member1 = Agent('BRAF')
     member2 = Agent('MEK1')
     stmt = Complex([member1, member2])
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 2
     assert len(model.monomers) == 2
@@ -26,8 +25,7 @@ def test_pysb_assembler_complex2():
     member2 = Agent('MEK1')
     member3 = Agent('ERK1')
     stmt = Complex([member1, member2, member3])
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 6
     assert len(model.monomers) == 3
@@ -38,8 +36,7 @@ def test_pysb_assembler_complex3():
     member1 = Agent('BRAF', bound_conditions=[BoundCondition(hras, True)])
     member2 = Agent('MEK1')
     stmt = Complex([member1, member2])
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 2
     assert len(model.monomers) == 3
@@ -49,8 +46,7 @@ def test_pysb_assembler_complex_twostep():
     member1 = Agent('BRAF')
     member2 = Agent('MEK1')
     stmt = Complex([member1, member2])
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='two_step')
     assert len(model.rules) == 2
     assert len(model.monomers) == 2
@@ -61,8 +57,7 @@ def test_pysb_assembler_complex_multiway():
     member2 = Agent('MEK1')
     member3 = Agent('ERK1')
     stmt = Complex([member1, member2, member3])
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='multi_way')
     assert len(model.rules) == 2
     assert len(model.monomers) == 3
@@ -71,8 +66,7 @@ def test_pysb_assembler_complex_multiway():
 def test_pysb_assembler_actsub():
     stmt = ActiveForm(Agent('BRAF', mutations=[MutCondition('600', 'V', 'E')]),
                       'activity', True)
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='two_step')
     assert len(model.rules) == 0
     assert len(model.monomers) == 1
@@ -82,8 +76,7 @@ def test_pysb_assembler_phos_noenz():
     enz = None
     sub = Agent('MEK1')
     stmt = Phosphorylation(enz, sub, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 0
     assert len(model.monomers) == 0
@@ -93,8 +86,7 @@ def test_pysb_assembler_dephos_noenz():
     enz = None
     sub = Agent('MEK1')
     stmt = Phosphorylation(enz, sub, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 0
     assert len(model.monomers) == 0
@@ -104,8 +96,7 @@ def test_pysb_assembler_phos1():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
     stmt = Phosphorylation(enz, sub, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 1
     assert len(model.monomers) == 2
@@ -116,8 +107,7 @@ def test_pysb_assembler_phos2():
     enz = Agent('BRAF', bound_conditions=[BoundCondition(hras, True)])
     sub = Agent('MEK1')
     stmt = Phosphorylation(enz, sub, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 1
     assert len(model.monomers) == 3
@@ -129,8 +119,7 @@ def test_pysb_assembler_phos3():
     enz = Agent('BRAF', bound_conditions=[BoundCondition(hras, True)])
     sub = Agent('MEK1', bound_conditions=[BoundCondition(erk1, True)])
     stmt = Phosphorylation(enz, sub, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 1
     assert len(model.monomers) == 4
@@ -142,8 +131,7 @@ def test_pysb_assembler_phos4():
     enz = Agent('BRAF', bound_conditions=[BoundCondition(hras, True)])
     sub = Agent('MEK1', bound_conditions=[BoundCondition(erk1, False)])
     stmt = Phosphorylation(enz, sub, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 1
     assert len(model.monomers) == 4
@@ -152,8 +140,7 @@ def test_pysb_assembler_phos4():
 def test_pysb_assembler_autophos1():
     enz = Agent('MEK1')
     stmt = Autophosphorylation(enz, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 1
     assert len(model.monomers) == 1
@@ -163,8 +150,7 @@ def test_pysb_assembler_autophos2():
     raf1 = Agent('RAF1')
     enz = Agent('MEK1', bound_conditions=[BoundCondition(raf1, True)])
     stmt = Autophosphorylation(enz, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 1
     assert len(model.monomers) == 2
@@ -174,8 +160,7 @@ def test_pysb_assembler_autophos3():
     egfr = Agent('EGFR')
     enz = Agent('EGFR', bound_conditions=[BoundCondition(egfr, True)])
     stmt = Autophosphorylation(enz, 'tyrosine')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 1
     assert len(model.monomers) == 1
@@ -185,8 +170,7 @@ def test_pysb_assembler_transphos1():
     egfr = Agent('EGFR')
     enz = Agent('EGFR', bound_conditions=[BoundCondition(egfr, True)])
     stmt = Transphosphorylation(enz, 'tyrosine')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 1
     assert len(model.monomers) == 1
@@ -197,8 +181,7 @@ def test_pysb_assembler_act1():
     subj = Agent('GRB2', bound_conditions=[BoundCondition(egfr, True)])
     obj = Agent('SOS1')
     stmt = Activation(subj, obj)
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 1
     assert len(model.monomers) == 3
@@ -208,8 +191,7 @@ def test_pysb_assembler_dephos1():
     phos = Agent('PP2A')
     sub = Agent('MEK1')
     stmt = Dephosphorylation(phos, sub, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 1
     assert len(model.monomers) == 2
@@ -220,8 +202,7 @@ def test_pysb_assembler_dephos2():
     raf1 = Agent('RAF1')
     sub = Agent('MEK1', bound_conditions=[BoundCondition(raf1, True)])
     stmt = Dephosphorylation(phos, sub, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 1
     assert len(model.monomers) == 3
@@ -231,8 +212,7 @@ def test_pysb_assembler_gef1():
     gef = Agent('SOS1')
     ras = Agent('HRAS')
     stmt = Gef(gef, ras)
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 1
     assert len(model.monomers) == 2
@@ -242,8 +222,7 @@ def test_pysb_assembler_gap1():
     gap = Agent('NF1')
     ras = Agent('HRAS')
     stmt = Gap(gap, ras)
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model()
     assert len(model.rules) == 1
     assert len(model.monomers) == 2
@@ -258,8 +237,7 @@ def test_pysb_assembler_actmod1():
     stmts.append(ActiveForm(Agent('MEK', mods=[mc1, mc2]), 'activity', True))
     stmts.append(Phosphorylation(mek, erk, 'threonine', '185'))
     stmts.append(Phosphorylation(mek, erk, 'tyrosine', '187'))
-    pa = PysbAssembler()
-    pa.add_statements(stmts)
+    pa = PysbAssembler(stmts)
     model = pa.make_model()
     assert len(model.rules) == 2
     assert len(model.monomers) == 2
@@ -279,8 +257,7 @@ def test_pysb_assembler_actmod2():
                     'activity', True))
     stmts.append(Phosphorylation(mek, erk, 'threonine', '185'))
     stmts.append(Phosphorylation(mek, erk, 'tyrosine', '187'))
-    pa = PysbAssembler()
-    pa.add_statements(stmts)
+    pa = PysbAssembler(stmts)
     model = pa.make_model()
     assert len(model.rules) == 4
     assert len(model.monomers) == 2
@@ -292,8 +269,7 @@ def test_pysb_assembler_phos_twostep1():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
     stmt = Phosphorylation(enz, sub, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='two_step')
     assert len(model.rules) == 3
     assert len(model.monomers) == 2
@@ -304,8 +280,7 @@ def test_pysb_assembler_twostep_mixed():
     member2 = Agent('RAF1')
     st1 = Complex([member1, member2])
     st2 = Phosphorylation(Agent('MAP2K1'), Agent('MAPK3'))
-    pa = PysbAssembler()
-    pa.add_statements([st1, st2])
+    pa = PysbAssembler([st1, st2])
     pa.make_model(policies='two_step')
     assert len(pa.model.rules) == 5
     assert len(pa.model.monomers) == 4
@@ -315,8 +290,7 @@ def test_pysb_assembler_phos_twostep_local():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
     stmt = Phosphorylation(enz, sub, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='two_step')
     assert len(model.rules) == 3
     assert len(model.monomers) == 2
@@ -326,8 +300,7 @@ def test_pysb_assembler_phos_twostep_local_to_global():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
     stmt = Phosphorylation(enz, sub, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='two_step')
     # This call should have reverted to default policy
     model = pa.make_model()
@@ -339,8 +312,7 @@ def test_pysb_assembler_dephos_twostep1():
     phos = Agent('PP2A')
     sub = Agent('MEK1')
     stmt = Dephosphorylation(phos, sub, 'serine', '222')
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='two_step')
     assert len(model.rules) == 3
     assert len(model.monomers) == 2
@@ -354,8 +326,7 @@ def test_statement_specific_policies():
     stmt2 = Dephosphorylation(phos, sub, 'serine', '222')
     policies = {'Phosphorylation': 'two_step',
                 'Dephosphorylation': 'interactions_only'}
-    pa = PysbAssembler()
-    pa.add_statements([stmt1, stmt2])
+    pa = PysbAssembler([stmt1, stmt2])
     model = pa.make_model(policies=policies)
     assert len(model.rules) == 4
     assert len(model.monomers) == 3
@@ -369,8 +340,7 @@ def test_unspecified_statement_policies():
     stmt2 = Dephosphorylation(phos, sub, 'serine', '222')
     policies = {'Phosphorylation': 'two_step',
                 'other': 'interactions_only'}
-    pa = PysbAssembler()
-    pa.add_statements([stmt1, stmt2])
+    pa = PysbAssembler([stmt1, stmt2])
     model = pa.make_model(policies=policies)
     assert len(model.rules) == 4
     assert len(model.monomers) == 3
@@ -380,8 +350,7 @@ def test_activity_activity():
     subj = Agent('KRAS')
     obj = Agent('BRAF')
     stmt = Activation(subj, obj)
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='interactions_only')
     assert len(model.rules) == 1
     assert len(model.monomers) == 2
@@ -391,8 +360,7 @@ def test_activity_activity2():
     subj = Agent('KRAS')
     obj = Agent('BRAF')
     stmt = Activation(subj, obj)
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='one_step')
     assert len(model.rules) == 1
     assert len(model.monomers) == 2
@@ -402,8 +370,7 @@ def test_activity_activity2():
     subj = Agent('Vemurafenib')
     obj = Agent('BRAF')
     stmt = Inhibition(subj, obj)
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='interactions_only')
     assert len(model.rules) == 1
     assert len(model.monomers) == 2
@@ -413,8 +380,7 @@ def test_activity_activity3():
     subj = Agent('Vemurafenib')
     obj = Agent('BRAF')
     stmt = Inhibition(subj, obj)
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='one_step')
     assert len(model.rules) == 1
     assert len(model.monomers) == 2
@@ -456,8 +422,7 @@ def test_neg_act_mod():
     st1 = ActiveForm(Agent('BRAF', mods=[mc]), 'activity', True)
     braf = Agent('BRAF', activity=ActivityCondition('active', True))
     st2 = Phosphorylation(braf, Agent('MAP2K2'))
-    pa = PysbAssembler()
-    pa.add_statements([st1, st2])
+    pa = PysbAssembler([st1, st2])
     pa.make_model(policies='one_step')
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
@@ -469,8 +434,7 @@ def test_neg_act_mod():
 def test_pos_agent_mod():
     mc = ModCondition('phosphorylation', 'serine', '123', True)
     st = Phosphorylation(Agent('BRAF', mods=[mc]), Agent('MAP2K2'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model(policies='one_step')
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
@@ -482,8 +446,7 @@ def test_pos_agent_mod():
 def test_neg_agent_mod():
     mc = ModCondition('phosphorylation', 'serine', '123', False)
     st = Phosphorylation(Agent('BRAF', mods=[mc]), Agent('MAP2K2'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model(policies='one_step')
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
@@ -495,8 +458,7 @@ def test_neg_agent_mod():
 def test_mut():
     mut = MutCondition('600', 'V', 'E')
     st = Phosphorylation(Agent('BRAF', mutations=[mut]), Agent('MEK'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
@@ -508,8 +470,7 @@ def test_mut():
 def test_mut_missing1():
     mut = MutCondition('600', 'V', None)
     st = Phosphorylation(Agent('BRAF', mutations=[mut]), Agent('MEK'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
@@ -521,8 +482,7 @@ def test_mut_missing1():
 def test_mut_missing2():
     mut = MutCondition('600', None, 'E')
     st = Phosphorylation(Agent('BRAF', mutations=[mut]), Agent('MEK'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
@@ -534,8 +494,7 @@ def test_mut_missing2():
 def test_mut_missing3():
     mut = MutCondition(None, 'V', 'E')
     st = Phosphorylation(Agent('BRAF', mutations=[mut]), Agent('MEK'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
@@ -547,8 +506,7 @@ def test_mut_missing3():
 def test_mut_missing4():
     mut = MutCondition(None, None, None)
     st = Phosphorylation(Agent('BRAF', mutations=[mut]), Agent('MEK'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
@@ -559,8 +517,7 @@ def test_mut_missing4():
 
 def test_agent_loc():
     st = Phosphorylation(Agent('BRAF', location='cytoplasm'), Agent('MEK'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
@@ -570,8 +527,7 @@ def test_agent_loc():
 
 def test_translocation():
     st = Translocation(Agent('FOXO3A'), 'nucleus', 'cytoplasm')
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
@@ -584,8 +540,7 @@ def test_translocation():
 
 def test_translocation_to():
     st = Translocation(Agent('FOXO3A'), None, 'nucleus')
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
@@ -598,16 +553,14 @@ def test_translocation_to():
 
 def test_phos_atpdep():
     st = Phosphorylation(Agent('BRAF'), Agent('MEK'), 'S', '222')
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model(policies='atp_dependent')
     assert len(pa.model.rules) == 5
 
 
 def test_set_context():
     st = Phosphorylation(Agent('MAP2K1'), Agent('MAPK3'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     assert pa.model.parameters['MAP2K1_0'].value == pa.default_initial_amount
     assert pa.model.parameters['MAPK3_0'].value == pa.default_initial_amount
@@ -618,8 +571,7 @@ def test_set_context():
 
 def test_set_context_monomer_notfound():
     st = Phosphorylation(Agent('MAP2K1'), Agent('XYZ'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     assert pa.model.parameters['MAP2K1_0'].value == pa.default_initial_amount
     assert pa.model.parameters['XYZ_0'].value == pa.default_initial_amount
@@ -633,8 +585,7 @@ def test_set_context_monomer_notfound():
 
 def test_set_context_celltype_notfound():
     st = Phosphorylation(Agent('MAP2K1'), Agent('MAPK3'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     pa.set_context('XYZ')
 
@@ -642,8 +593,7 @@ def test_set_context_celltype_notfound():
 def test_annotation():
     st = Phosphorylation(Agent('BRAF', db_refs = {'UP': 'P15056'}),
                          Agent('MAP2K2', db_refs = {'HGNC': '6842'}))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     assert len(pa.model.annotations) == 5
 
@@ -653,32 +603,28 @@ def test_annotation_regamount():
                          Agent('MAP2K2', db_refs = {'HGNC': '6842'}))
     st2 = DecreaseAmount(Agent('BRAF', db_refs = {'UP': 'P15056'}),
                          Agent('MAP2K2', db_refs = {'HGNC': '6842'}))
-    pa = PysbAssembler()
-    pa.add_statements([st1, st2])
+    pa = PysbAssembler([st1, st2])
     pa.make_model()
     assert len(pa.model.annotations) == 8
 
 
 def test_print_model():
     st = Phosphorylation(Agent('MAP2K1'), Agent('MAPK3'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     pa.save_model('/dev/null')
 
 
 def test_save_rst():
     st = Phosphorylation(Agent('MAP2K1'), Agent('MAPK3'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     pa.save_rst('/dev/null')
 
 
 def test_export_model():
     st = Phosphorylation(Agent('MAP2K1'), Agent('MAPK3'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     exp_str = pa.export_model('kappa')
     assert exp_str
@@ -695,8 +641,7 @@ def test_assemble_export_sbgn():
     st2 = Activation(Agent('MAP2K1', mods=[mc]), Agent('MAPK1'))
     st3 = Complex([Agent('MAPK1'), Agent('DUSP6')])
     st4 = DecreaseAmount(None, Agent('DUSP6'))
-    pa = PysbAssembler()
-    pa.add_statements([st, st2, st3, st4])
+    pa = PysbAssembler([st, st2, st3, st4])
     pa.make_model()
     # Export to SBGN
     model = pa.export_model('sbgn')
@@ -726,16 +671,14 @@ def test_name_standardize():
 
 def test_generate_equations():
     st = Phosphorylation(Agent('MAP2K1'), Agent('MAPK3'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     bng.generate_equations(pa.model)
 
 
 def test_non_python_name_phos():
     st = Phosphorylation(Agent('14-3-3'), Agent('BRAF kinase'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     names = [m.name for m in pa.model.monomers]
     assert 'BRAF_kinase' in names
@@ -745,8 +688,7 @@ def test_non_python_name_phos():
 
 def test_non_python_name_bind():
     st = Complex([Agent('14-3-3'), Agent('BRAF kinase')])
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     bng.generate_equations(pa.model)
 
@@ -756,8 +698,7 @@ def test_decreaseamount_one_step():
     obj = Agent('BRAF')
     st1 = DecreaseAmount(subj, obj)
     st2 = DecreaseAmount(None, obj)
-    pa = PysbAssembler()
-    pa.add_statements([st1, st2])
+    pa = PysbAssembler([st1, st2])
     model = pa.make_model(policies='one_step')
     assert len(model.rules) == 2
     assert len(model.monomers) == 2
@@ -768,8 +709,7 @@ def test_decreaseamount_interactions_only():
     obj = Agent('BRAF')
     st1 = DecreaseAmount(subj, obj)
     st2 = DecreaseAmount(None, obj)
-    pa = PysbAssembler()
-    pa.add_statements([st1, st2])
+    pa = PysbAssembler([st1, st2])
     model = pa.make_model(policies='interactions_only')
     assert len(model.rules) == 1
     assert len(model.monomers) == 2
@@ -780,8 +720,7 @@ def test_increaseamount_one_step():
     obj = Agent('BRAF')
     st1 = IncreaseAmount(subj, obj)
     st2 = IncreaseAmount(None, obj)
-    pa = PysbAssembler()
-    pa.add_statements([st1, st2])
+    pa = PysbAssembler([st1, st2])
     model = pa.make_model(policies='one_step')
     assert len(model.rules) == 2
     assert len(model.monomers) == 2
@@ -792,8 +731,7 @@ def test_increaseamount_interactions_only():
     obj = Agent('BRAF')
     st1 = IncreaseAmount(subj, obj)
     st2 = IncreaseAmount(None, obj)
-    pa = PysbAssembler()
-    pa.add_statements([st1, st2])
+    pa = PysbAssembler([st1, st2])
     model = pa.make_model(policies='interactions_only')
     assert len(model.rules) == 1
     assert len(model.monomers) == 2
@@ -804,16 +742,13 @@ def test_missing_catalytic_default_site():
     c3 = Agent('CASP3')
     stmt = Activation(c8, c3, 'catalytic')
     # Interactions only
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='interactions_only')
     # One step
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='one_step')
     # Two step
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='two_step')
 
 
@@ -822,23 +757,19 @@ def test_missing_transcription_default_site():
     bax = Agent('BAX')
     stmt = Activation(p53, bax)
     # Interactions only
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='interactions_only')
     # One step
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='one_step')
     # Two step
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     model = pa.make_model(policies='two_step')
 
 
 def test_translocation_loc_special_char():
     st = Translocation(Agent('KSR1'), 'cytoplasm', 'cell surface')
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
@@ -930,8 +861,7 @@ def test_phospho_assemble_grounding():
     st1 = Phosphorylation(a, b, 'T', '185')
     # One step
     def check_policy(policy):
-        pysb_asmb = pa.PysbAssembler()
-        pysb_asmb.add_statements([st1])
+        pysb_asmb = pa.PysbAssembler([st1])
         model = pysb_asmb.make_model(policies=policy)
         mps = list(pa.grounded_monomer_patterns(model, b_phos))
         assert len(mps) == 1
@@ -950,8 +880,7 @@ def test_phospho_mod_grounding():
     a_phos = Agent('Foo', mods=[ModCondition('phosphorylation', None, None)],
                     db_refs={'HGNC': '6840'})
     st1 = Phosphorylation(a, b, 'T', '185')
-    pysb_asmb = pa.PysbAssembler()
-    pysb_asmb.add_statements([st1])
+    pysb_asmb = pa.PysbAssembler([st1])
     model = pysb_asmb.make_model(policies='one_step')
     mps = list(pa.grounded_monomer_patterns(model, a_phos))
     assert len(mps) == 2
@@ -980,8 +909,7 @@ def test_multiple_grounding_mods():
     st2 = Phosphorylation(mek, erk, 'Y', '187')
     st3 = Ubiquitination(cbl, erk, 'K', '40')
     st4 = Ubiquitination(cbl, erk, 'K', '50')
-    pysb_asmb = pa.PysbAssembler()
-    pysb_asmb.add_statements([st1, st2, st3, st4])
+    pysb_asmb = pa.PysbAssembler([st1, st2, st3, st4])
     model = pysb_asmb.make_model(policies='one_step')
     mps = list(pa.grounded_monomer_patterns(model, ub_phos_erk))
     assert len(mps) == 4
@@ -1000,8 +928,7 @@ def test_grounded_active_pattern():
                    db_refs={'HGNC': '5678'})
     st1 = Phosphorylation(a, b, 'S', '100')
     st2 = ActiveForm(b_phos, 'activity', True)
-    pysba = PysbAssembler()
-    pysba.add_statements([st1, st2])
+    pysba = PysbAssembler([st1, st2])
     model = pysba.make_model(policies='one_step')
     mps = list(pa.grounded_monomer_patterns(model, b_act))
 
@@ -1011,20 +938,17 @@ def _check_mod_assembly(mod_class):
     obj = Agent('BRAF')
     st1 = mod_class(subj, obj)
 
-    pa = PysbAssembler()
-    pa.add_statements([st1])
+    pa = PysbAssembler([st1])
     model = pa.make_model(policies='interactions_only')
     assert len(model.rules) == 1
     assert len(model.monomers) == 2
 
-    pa = PysbAssembler()
-    pa.add_statements([st1])
+    pa = PysbAssembler([st1])
     model = pa.make_model(policies='one_step')
     assert len(model.rules) == 1
     assert len(model.monomers) == 2
 
-    pa = PysbAssembler()
-    pa.add_statements([st1])
+    pa = PysbAssembler([st1])
     model = pa.make_model(policies='two_step')
     assert len(model.rules) == 3
     assert len(model.monomers) == 2
@@ -1042,8 +966,7 @@ def test_rule_annotation():
     b = Agent('B', db_refs={'HGNC': '5678'})
 
     def check_rule_annotation(stmt, policy):
-        pa = PysbAssembler()
-        pa.add_statements([stmt])
+        pa = PysbAssembler([stmt])
         model = pa.make_model(policies=policy)
         subj = [ann.object for ann in model.annotations
                 if ann.predicate == 'rule_has_subject']
@@ -1078,8 +1001,7 @@ def test_activeform_site():
                    db_refs={'HGNC': '5678'})
     st1 = Phosphorylation(a, b, 'S', '100')
     st2 = ActiveForm(b_phos, 'kinase', True)
-    pa = PysbAssembler()
-    pa.add_statements([st1, st2])
+    pa = PysbAssembler([st1, st2])
     model = pa.make_model(policies='one_step')
 
 # TODO Do the same for mutation condition
@@ -1091,8 +1013,7 @@ def test_activeform_site():
 def test_activation_subj1():
     """No subject activity is defined."""
     st = Activation(Agent('a'), Agent('b'))
-    pa = PysbAssembler()
-    pa.add_statements([st])
+    pa = PysbAssembler([st])
     pa.make_model()
     assert pa.model.monomers['a'].sites == []
     left = pa.model.rules[0].reactant_pattern
@@ -1109,8 +1030,7 @@ def test_activation_subj2():
     st = Activation(a_act, Agent('b'))
     st2 = ActiveForm(Agent('a', mods=[ModCondition('phosphorylation')]),
                      'activity', True)
-    pa = PysbAssembler()
-    pa.add_statements([st, st2])
+    pa = PysbAssembler([st, st2])
     pa.make_model()
     assert pa.model.monomers['a'].sites == ['phospho']
     left = pa.model.rules[0].reactant_pattern
@@ -1126,8 +1046,7 @@ def test_activation_subj3():
     a_act = Agent('a', activity=ActivityCondition('activity', True))
     st = Activation(a_act, Agent('b'))
     st2 = Activation(Agent('c'), Agent('a'))
-    pa = PysbAssembler()
-    pa.add_statements([st, st2])
+    pa = PysbAssembler([st, st2])
     pa.make_model()
     assert len(pa.model.rules) == 2
     assert pa.model.monomers['a'].sites == ['activity']
@@ -1146,8 +1065,7 @@ def test_activation_subj4():
     st2 = Activation(Agent('c'), Agent('a'))
     st3 = ActiveForm(Agent('a', mods=[ModCondition('phosphorylation')]),
                      'activity', True)
-    pa = PysbAssembler()
-    pa.add_statements([st, st2, st3])
+    pa = PysbAssembler([st, st2, st3])
     pa.make_model()
     assert set(pa.model.monomers['a'].sites) == set(['activity', 'phospho'])
     left = pa.model.rules[0].reactant_pattern
@@ -1250,8 +1168,7 @@ def test_activity_agent_rule_name():
                            Agent('MAP2K1',
                                  activity=ActivityCondition('activity',
                                                             False)))
-    pa = PysbAssembler()
-    pa.add_statements([stmt])
+    pa = PysbAssembler([stmt])
     pa.make_model()
     assert pa.model.rules[0].name == \
         'BRAF_kin_phosphorylation_MAP2K1_act_inact_phospho', \

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -3,7 +3,7 @@ from builtins import dict, str
 import xml.etree.ElementTree as ET
 from indra.assemblers.pysb import PysbAssembler
 import indra.assemblers.pysb.assembler as pa
-from indra.assemblers.pysb.assembler import Policy
+from indra.assemblers.pysb.assembler import Policy, Param
 from indra.assemblers.pysb.preassembler import PysbPreassembler
 from indra.statements import *
 from pysb import bng, WILD, Monomer, Annotation
@@ -1188,3 +1188,11 @@ def test_policy_object_invalid():
     pa = PysbAssembler([stmt])
     model = pa.make_model(policies={'xyz': Policy('two_step')})
     assert len(model.rules) == 3
+
+
+def test_mod_parameter():
+    stmt = Phosphorylation(Agent('a'), Agent('b'))
+    pol = Policy('one_step', parameters={'kf': Param('my_kf_param', 0.99)})
+    pa = PysbAssembler([stmt])
+    model = pa.make_model(policies={stmt.uuid: pol})
+    assert model.parameters['my_kf_param'].value == 0.99

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -267,9 +267,9 @@ def test_pysb_assembler_phos_twostep1():
     enz = Agent('BRAF')
     sub = Agent('MEK1')
     stmt = Phosphorylation(enz, sub, 'serine', '222')
-    pa = PysbAssembler(policies='two_step')
+    pa = PysbAssembler()
     pa.add_statements([stmt])
-    model = pa.make_model()
+    model = pa.make_model(policies='two_step')
     assert len(model.rules)==3
     assert len(model.monomers)==2
 
@@ -310,9 +310,9 @@ def test_pysb_assembler_dephos_twostep1():
     phos = Agent('PP2A')
     sub = Agent('MEK1')
     stmt = Dephosphorylation(phos, sub, 'serine', '222')
-    pa = PysbAssembler(policies='two_step')
+    pa = PysbAssembler()
     pa.add_statements([stmt])
-    model = pa.make_model()
+    model = pa.make_model(policies='two_step')
     assert len(model.rules)==3
     assert len(model.monomers)==2
 
@@ -324,9 +324,9 @@ def test_statement_specific_policies():
     stmt2 = Dephosphorylation(phos, sub, 'serine', '222')
     policies = {'Phosphorylation': 'two_step',
                 'Dephosphorylation': 'interactions_only'}
-    pa = PysbAssembler(policies=policies)
+    pa = PysbAssembler()
     pa.add_statements([stmt1, stmt2])
-    model = pa.make_model()
+    model = pa.make_model(policies=policies)
     assert len(model.rules)==4
     assert len(model.monomers)==3
 
@@ -338,9 +338,9 @@ def test_unspecified_statement_policies():
     stmt2 = Dephosphorylation(phos, sub, 'serine', '222')
     policies = {'Phosphorylation': 'two_step',
                 'other': 'interactions_only'}
-    pa = PysbAssembler(policies=policies)
+    pa = PysbAssembler()
     pa.add_statements([stmt1, stmt2])
-    model = pa.make_model()
+    model = pa.make_model(policies=policies)
     assert len(model.rules)==4
     assert len(model.monomers)==3
 
@@ -348,9 +348,9 @@ def test_activity_activity():
     subj = Agent('KRAS')
     obj = Agent('BRAF')
     stmt = Activation(subj, obj)
-    pa = PysbAssembler(policies='interactions_only')
+    pa = PysbAssembler()
     pa.add_statements([stmt])
-    model = pa.make_model()
+    model = pa.make_model(policies='interactions_only')
     assert len(model.rules)==1
     assert len(model.monomers)==2
 
@@ -358,9 +358,9 @@ def test_activity_activity2():
     subj = Agent('KRAS')
     obj = Agent('BRAF')
     stmt = Activation(subj, obj)
-    pa = PysbAssembler(policies='one_step')
+    pa = PysbAssembler()
     pa.add_statements([stmt])
-    model = pa.make_model()
+    model = pa.make_model(policies='one_step')
     assert len(model.rules)==1
     assert len(model.monomers)==2
 
@@ -368,9 +368,9 @@ def test_activity_activity2():
     subj = Agent('Vemurafenib')
     obj = Agent('BRAF')
     stmt = Inhibition(subj, obj)
-    pa = PysbAssembler(policies='interactions_only')
+    pa = PysbAssembler()
     pa.add_statements([stmt])
-    model = pa.make_model()
+    model = pa.make_model(policies='interactions_only')
     assert len(model.rules)==1
     assert len(model.monomers)==2
 
@@ -378,9 +378,9 @@ def test_activity_activity3():
     subj = Agent('Vemurafenib')
     obj = Agent('BRAF')
     stmt = Inhibition(subj, obj)
-    pa = PysbAssembler(policies='one_step')
+    pa = PysbAssembler()
     pa.add_statements([stmt])
-    model = pa.make_model()
+    model = pa.make_model(policies='one_step')
     assert len(model.rules)==1
     assert len(model.monomers)==2
 
@@ -415,9 +415,9 @@ def test_neg_act_mod():
     st1 = ActiveForm(Agent('BRAF', mods=[mc]), 'activity', True)
     braf = Agent('BRAF', activity=ActivityCondition('active', True))
     st2 = Phosphorylation(braf, Agent('MAP2K2'))
-    pa = PysbAssembler(policies='one_step')
+    pa = PysbAssembler()
     pa.add_statements([st1, st2])
-    pa.make_model()
+    pa.make_model(policies='one_step')
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
     braf = r.reactant_pattern.complex_patterns[0].monomer_patterns[0]
@@ -427,9 +427,9 @@ def test_neg_act_mod():
 def test_pos_agent_mod():
     mc = ModCondition('phosphorylation', 'serine', '123', True)
     st = Phosphorylation(Agent('BRAF', mods=[mc]), Agent('MAP2K2'))
-    pa = PysbAssembler(policies='one_step')
+    pa = PysbAssembler()
     pa.add_statements([st])
-    pa.make_model()
+    pa.make_model(policies='one_step')
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
     braf = r.reactant_pattern.complex_patterns[0].monomer_patterns[0]
@@ -439,9 +439,9 @@ def test_pos_agent_mod():
 def test_neg_agent_mod():
     mc = ModCondition('phosphorylation', 'serine', '123', False)
     st = Phosphorylation(Agent('BRAF', mods=[mc]), Agent('MAP2K2'))
-    pa = PysbAssembler(policies='one_step')
+    pa = PysbAssembler()
     pa.add_statements([st])
-    pa.make_model()
+    pa.make_model(policies='one_step')
     assert len(pa.model.rules) == 1
     r = pa.model.rules[0]
     braf = r.reactant_pattern.complex_patterns[0].monomer_patterns[0]
@@ -690,9 +690,9 @@ def test_decreaseamount_one_step():
     obj = Agent('BRAF')
     st1 = DecreaseAmount(subj, obj)
     st2 = DecreaseAmount(None, obj)
-    pa = PysbAssembler(policies='one_step')
+    pa = PysbAssembler()
     pa.add_statements([st1, st2])
-    model = pa.make_model()
+    model = pa.make_model(policies='one_step')
     assert len(model.rules)==2
     assert len(model.monomers)==2
 
@@ -701,9 +701,9 @@ def test_decreaseamount_interactions_only():
     obj = Agent('BRAF')
     st1 = DecreaseAmount(subj, obj)
     st2 = DecreaseAmount(None, obj)
-    pa = PysbAssembler(policies='interactions_only')
+    pa = PysbAssembler()
     pa.add_statements([st1, st2])
-    model = pa.make_model()
+    model = pa.make_model(policies='interactions_only')
     assert len(model.rules)==1
     assert len(model.monomers)==2
 
@@ -712,9 +712,9 @@ def test_increaseamount_one_step():
     obj = Agent('BRAF')
     st1 = IncreaseAmount(subj, obj)
     st2 = IncreaseAmount(None, obj)
-    pa = PysbAssembler(policies='one_step')
+    pa = PysbAssembler()
     pa.add_statements([st1, st2])
-    model = pa.make_model()
+    model = pa.make_model(policies='one_step')
     assert len(model.rules)==2
     assert len(model.monomers)==2
 
@@ -723,9 +723,9 @@ def test_increaseamount_interactions_only():
     obj = Agent('BRAF')
     st1 = IncreaseAmount(subj, obj)
     st2 = IncreaseAmount(None, obj)
-    pa = PysbAssembler(policies='interactions_only')
+    pa = PysbAssembler()
     pa.add_statements([st1, st2])
-    model = pa.make_model()
+    model = pa.make_model(policies='interactions_only')
     assert len(model.rules)==1
     assert len(model.monomers)==2
 
@@ -734,34 +734,34 @@ def test_missing_catalytic_default_site():
     c3 = Agent('CASP3')
     stmt = Activation(c8, c3, 'catalytic')
     # Interactions only
-    pa = PysbAssembler(policies='interactions_only')
+    pa = PysbAssembler()
     pa.add_statements([stmt])
-    model = pa.make_model()
+    model = pa.make_model(policies='interactions_only')
     # One step
-    pa = PysbAssembler(policies='one_step')
+    pa = PysbAssembler()
     pa.add_statements([stmt])
-    model = pa.make_model()
+    model = pa.make_model(policies='one_step')
     # Two step
-    pa = PysbAssembler(policies='two_step')
+    pa = PysbAssembler()
     pa.add_statements([stmt])
-    model = pa.make_model()
+    model = pa.make_model(policies='two_step')
 
 def test_missing_transcription_default_site():
     p53 = Agent('TP53', activity=ActivityCondition('transcription', True))
     bax = Agent('BAX')
     stmt = Activation(p53, bax)
     # Interactions only
-    pa = PysbAssembler(policies='interactions_only')
+    pa = PysbAssembler()
     pa.add_statements([stmt])
-    model = pa.make_model()
+    model = pa.make_model(policies='interactions_only')
     # One step
-    pa = PysbAssembler(policies='one_step')
+    pa = PysbAssembler()
     pa.add_statements([stmt])
-    model = pa.make_model()
+    model = pa.make_model(policies='one_step')
     # Two step
-    pa = PysbAssembler(policies='two_step')
+    pa = PysbAssembler()
     pa.add_statements([stmt])
-    model = pa.make_model()
+    model = pa.make_model(policies='two_step')
 
 def test_translocation_loc_special_char():
     st = Translocation(Agent('KSR1'), 'cytoplasm', 'cell surface')
@@ -854,9 +854,9 @@ def test_phospho_assemble_grounding():
     st1 = Phosphorylation(a, b, 'T', '185')
     # One step
     def check_policy(policy):
-        pysb_asmb = pa.PysbAssembler(policies=policy)
+        pysb_asmb = pa.PysbAssembler()
         pysb_asmb.add_statements([st1])
-        model = pysb_asmb.make_model()
+        model = pysb_asmb.make_model(policies=policy)
         mps = list(pa.grounded_monomer_patterns(model, b_phos))
         assert len(mps) == 1
         assert mps[0].monomer.name == 'ERK2'
@@ -873,9 +873,9 @@ def test_phospho_mod_grounding():
     a_phos = Agent('Foo', mods=[ModCondition('phosphorylation', None, None)],
                     db_refs={'HGNC': '6840'})
     st1 = Phosphorylation(a, b, 'T', '185')
-    pysb_asmb = pa.PysbAssembler(policies='one_step')
+    pysb_asmb = pa.PysbAssembler()
     pysb_asmb.add_statements([st1])
-    model = pysb_asmb.make_model()
+    model = pysb_asmb.make_model(policies='one_step')
     mps = list(pa.grounded_monomer_patterns(model, a_phos))
     assert len(mps) == 2
     assert mps[0].monomer.name == 'MEK1'
@@ -903,9 +903,9 @@ def test_multiple_grounding_mods():
     st2 = Phosphorylation(mek, erk, 'Y', '187')
     st3 = Ubiquitination(cbl, erk, 'K', '40')
     st4 = Ubiquitination(cbl, erk, 'K', '50')
-    pysb_asmb = pa.PysbAssembler(policies='one_step')
+    pysb_asmb = pa.PysbAssembler()
     pysb_asmb.add_statements([st1, st2, st3, st4])
-    model = pysb_asmb.make_model()
+    model = pysb_asmb.make_model(policies='one_step')
     mps = list(pa.grounded_monomer_patterns(model, ub_phos_erk))
     assert len(mps) == 4
     assert mps[0].monomer.name == 'ERK2'
@@ -923,9 +923,9 @@ def test_grounded_active_pattern():
                    db_refs={'HGNC': '5678'})
     st1 = Phosphorylation(a, b, 'S', '100')
     st2 = ActiveForm(b_phos, 'activity', True)
-    pysba = PysbAssembler(policies='one_step')
+    pysba = PysbAssembler()
     pysba.add_statements([st1, st2])
-    model = pysba.make_model()
+    model = pysba.make_model(policies='one_step')
     mps = list(pa.grounded_monomer_patterns(model, b_act))
 
 
@@ -934,21 +934,21 @@ def _check_mod_assembly(mod_class):
     obj = Agent('BRAF')
     st1 = mod_class(subj, obj)
 
-    pa = PysbAssembler(policies='interactions_only')
+    pa = PysbAssembler()
     pa.add_statements([st1])
-    model = pa.make_model()
+    model = pa.make_model(policies='interactions_only')
     assert len(model.rules)==1
     assert len(model.monomers)==2
 
-    pa = PysbAssembler(policies='one_step')
+    pa = PysbAssembler()
     pa.add_statements([st1])
-    model = pa.make_model()
+    model = pa.make_model(policies='one_step')
     assert len(model.rules)==1
     assert len(model.monomers)==2
 
-    pa = PysbAssembler(policies='two_step')
+    pa = PysbAssembler()
     pa.add_statements([st1])
-    model = pa.make_model()
+    model = pa.make_model(policies='two_step')
     assert len(model.rules)==3
     assert len(model.monomers)==2
 
@@ -963,9 +963,9 @@ def test_rule_annotation():
     b = Agent('B', db_refs={'HGNC': '5678'})
 
     def check_rule_annotation(stmt, policy):
-        pa = PysbAssembler(policies=policy)
+        pa = PysbAssembler()
         pa.add_statements([stmt])
-        model = pa.make_model()
+        model = pa.make_model(policies=policy)
         subj = [ann.object for ann in model.annotations
                 if ann.predicate == 'rule_has_subject']
         obj = [ann.object for ann in model.annotations
@@ -998,9 +998,9 @@ def test_activeform_site():
                    db_refs={'HGNC': '5678'})
     st1 = Phosphorylation(a, b, 'S', '100')
     st2 = ActiveForm(b_phos, 'kinase', True)
-    pa = PysbAssembler(policies='one_step')
+    pa = PysbAssembler()
     pa.add_statements([st1, st2])
-    model = pa.make_model()
+    model = pa.make_model(policies='one_step')
 
 # TODO Do the same for mutation condition
 # TODO Localization condition

--- a/models/hello_indra.py
+++ b/models/hello_indra.py
@@ -33,7 +33,7 @@ def export_hello(model, formats):
         extension = (f if f != 'pysb_flat' else 'py')
         fname = 'hello_indra_model.%s' % extension
         with open(fname, 'wb') as fh:
-            fh.write(model_export)
+            fh.write(model_export.encode('utf-8'))
 
 
 # User defines text


### PR DESCRIPTION
This PR adds two main features to the PysbAssembler:
- Allowing Statement-level policy specifications
- Allowing passing in custom parameter names and values along with policies

The PR also heavily refactors and simplifies (where possible) the assembler, but doesn't fundamentally change the "dispatch" workflow of Statements to policy-dependent assembly functions:
- Several supplemental pieces are spun off into separate files (base agents, site-related functions, preassembler, exporters) - more could be done here
- Modification and de-modification assembly functions are now completely unified
- Activity regulation assembly functions are also unified
- The assembler now takes a list of statements as its first constructor argument, similar to other assemblers
- Policies are only specified in make_model

Usage example:
```python
from indra.assemblers.pysb.assembler import PysbAssembler, Policy, Param
stmt = Phosphorylation(Agent('a'), Agent('b'))
pa = PysbAssembler([stmt])
policies = {stmt.uuid: Policy('two_step', parameters={'kf': Param('my_kf_a_b', 1.0),
                                                      'kr': Param('my_kr_a_b', 1.0)
                                                      'kc': Param('my_kc_a_b', 1.0)})}
model = pa.make_model(policies=policies)
```
Here a two_step policy is used, specific to the given Statement (identified by UUID), and 