### PR TITLE
Hide Statement JSON in CX networks

### DIFF
--- a/indra/assemblers/cx/assembler.py
+++ b/indra/assemblers/cx/assembler.py
@@ -1,14 +1,14 @@
 from __future__ import absolute_import, print_function, unicode_literals
+from builtins import dict, str
 
-import itertools
+import re
 import json
 import logging
-import re
-from builtins import str
+import itertools
 from collections import OrderedDict
 
-from indra.databases import context_client, ndex_client, get_identifiers_url
 from indra.statements import *
+from indra.databases import context_client, ndex_client, get_identifiers_url
 
 # Python 2
 try:

--- a/indra/assemblers/cx/assembler.py
+++ b/indra/assemblers/cx/assembler.py
@@ -1,12 +1,10 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
-
 import re
 import json
 import logging
 import itertools
 from collections import OrderedDict
-
 from indra.statements import *
 from indra.databases import context_client, ndex_client, get_identifiers_url
 
@@ -169,7 +167,7 @@ class CxAssembler(object):
             cx_str = self.print_cx()
             fh.write(cx_str)
 
-    def upload_model(self, ndex_cred, private=True, style='default'):
+    def upload_model(self, ndex_cred=None, private=True, style='default'):
         """Creates a new NDEx network of the assembled CX model.
 
         To upload the assembled CX model to NDEx, you need to have

--- a/indra/assemblers/cx/assembler.py
+++ b/indra/assemblers/cx/assembler.py
@@ -424,10 +424,9 @@ class CxAssembler(object):
             self.cx['edgeCitations'].append(edge_citation)
 
         # Add the textual supports for the edge
-        texts = [e.text for e in stmt.evidence if e.text]
+        texts = [_fix_evidence_text(e.text) for e in stmt.evidence if e.text]
         edge_supports = []
         for text in texts:
-            text = text.replace('XREF_BIBR', '')
             support_id = self._get_new_id()
             support = {'@id': support_id,
                        'text': text}
@@ -440,7 +439,7 @@ class CxAssembler(object):
 
         belief_str = '%.2f' % stmt.belief
         edge_attribute = {'po': edge_id,
-                          'n': 'Belief score',
+                          'n': 'belief',
                           'v': belief_str}
         self.cx['edgeAttributes'].append(edge_attribute)
 
@@ -450,7 +449,7 @@ class CxAssembler(object):
         if texts:
             text = texts[0]
             edge_attribute = {'po': edge_id,
-                              'n': 'Text',
+                              'n': 'text',
                               'v': text}
             self.cx['edgeAttributes'].append(edge_attribute)
 
@@ -518,6 +517,7 @@ def _get_stmt_type(stmt):
         edge_polarity = 'none'
     return edge_type, edge_polarity
 
+
 def _get_agent_type(agent):
     hgnc_id = agent.db_refs.get('HGNC')
     uniprot_id = agent.db_refs.get('UP')
@@ -541,3 +541,17 @@ def _get_agent_type(agent):
     else:
         agent_type = 'other'
     return agent_type
+
+
+def _fix_evidence_text(txt):
+    """Eliminate some symbols to have cleaner supporting text."""
+    txt = re.sub('[ ]?\( xref \)', '', txt)
+    # This is to make [ xref ] become [] to match the two readers
+    txt = re.sub('\[ xref \]', '[]', txt)
+    txt = re.sub('[\(]?XREF_BIBR[\)]?[,]?', '', txt)
+    txt = re.sub('[\(]?XREF_FIG[\)]?[,]?', '', txt)
+    txt = re.sub('[\(]?XREF_SUPPLEMENT[\)]?[,]?', '', txt)
+    txt = txt.strip()
+    return txt
+
+

--- a/indra/assemblers/cx/assembler.py
+++ b/indra/assemblers/cx/assembler.py
@@ -168,7 +168,7 @@ class CxAssembler(object):
             cx_str = self.print_cx()
             fh.write(cx_str)
 
-    def upload_model(self, ndex_cred=None, private=True):
+    def upload_model(self, ndex_cred, private=True, style='default'):
         """Creates a new NDEx network of the assembled CX model.
 
         To upload the assembled CX model to NDEx, you need to have
@@ -182,9 +182,14 @@ class CxAssembler(object):
             A dictionary with the following entries:
             'user': NDEx user name
             'password': NDEx password
-
         private : Optional[bool]
             Whether or not the created network will be private on NDEX.
+        style : Optional[str]
+            This optional parameter can either be (1)
+            The UUID of an existing NDEx network whose style should be applied
+            to the new network. (2) Unspecified or 'default' to use
+            the default INDRA-assembled network style. (3) None to
+            not set a network style.
 
         Returns
         -------
@@ -198,6 +203,9 @@ class CxAssembler(object):
             ndex_cred = {'user': username,
                          'password': password}
         network_id = ndex_client.create_network(cx_str, ndex_cred, private)
+        if network_id and style:
+            template_id = None if style == 'default' else style
+            ndex_client.set_style(network_id, ndex_cred, style)
         return network_id
 
     def set_context(self, cell_type):

--- a/indra/assemblers/cx/assembler.py
+++ b/indra/assemblers/cx/assembler.py
@@ -388,7 +388,7 @@ class CxAssembler(object):
         if self.add_indra_json:
             indra_stmt_json = json.dumps(stmt.to_json())
             edge_attribute = {'po': edge_id,
-                              'n': 'INDRA json',
+                              'n': '__INDRA json',
                               'v': indra_stmt_json}
             self.cx['edgeAttributes'].append(edge_attribute)
 

--- a/indra/assemblers/cx/assembler.py
+++ b/indra/assemblers/cx/assembler.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str
-import io
-import re
+
+import itertools
 import json
 import logging
-import itertools
+import re
+from builtins import str
 from collections import OrderedDict
-from indra.statements import *
+
 from indra.databases import context_client, ndex_client, get_identifiers_url
+from indra.statements import *
 
 # Python 2
 try:
@@ -193,7 +194,7 @@ class CxAssembler(object):
 
         Returns
         -------
-        network_id :  str
+        network_id : str
             The UUID of the NDEx network that was created by uploading
             the assembled CX model.
         """
@@ -480,6 +481,7 @@ def _get_support_type(stmt):
         return 'database and literature'
     elif not has_db and has_reading:
         return 'literature'
+
 
 def _get_stmt_type(stmt):
     if isinstance(stmt, AddModification):

--- a/indra/databases/ndex_client.py
+++ b/indra/databases/ndex_client.py
@@ -193,9 +193,21 @@ def update_network(cx_str, network_id, ndex_cred=None):
     set_style(network_id, ndex_cred)
 
 
-def set_style(network_id, ndex_cred=None):
-    # Update network style
-    template_uuid = "ea4ea3b7-6903-11e7-961c-0ac135e8bacf"
+def set_style(network_id, ndex_cred=None, template_id=None):
+    """Set the style of the network to a given template network's style
+
+    Parameters
+    ----------
+    network_id : str
+        The UUID of the NDEx network whose style is to be changed.
+    ndex_cred : dict
+        A dictionary of NDEx credentials.
+    template_id : Optional[str]
+        The UUID of the NDEx network whose style is used on the
+        network specified in the first argument.
+    """
+    if not template_id:
+        template_id = "ea4ea3b7-6903-11e7-961c-0ac135e8bacf"
 
     server = 'http://public.ndexbio.org'
     username, password = get_default_ndex_cred(ndex_cred)
@@ -205,7 +217,7 @@ def set_style(network_id, ndex_cred=None):
                                                       uuid=network_id,
                                                       server=server)
 
-    source_network.apply_template(server, template_uuid)
+    source_network.apply_template(server, template_id)
 
     source_network.update_to(network_id, server=server, username=username,
                              password=password)


### PR DESCRIPTION
This PR changes the attribute in which the INDRA Statement JSON is added to CX networks to hide it from the interface while still leaving it part of the network. It also integrates styling as an option directly in the network upload function.