### PR TITLE
Trips shared objects

### DIFF
--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -6,6 +6,7 @@ import logging
 import operator
 import itertools
 import collections
+from copy import deepcopy
 import xml.etree.ElementTree as ET
 from indra.util import read_unicode_csv
 from indra.statements import *
@@ -169,9 +170,13 @@ class TripsProcessor(object):
             for a1, a2 in _agent_list_product((activator_agent,
                                                affected_agent)):
                 if is_activation:
-                    st = Activation(a1, a2, evidence=[ev])
+                    st = Activation(deepcopy(a1),
+                                    deepcopy(a2),
+                                    evidence=[deepcopy(ev)])
                 else:
-                    st = Inhibition(a1, a2, evidence=[ev])
+                    st = Inhibition(deepcopy(a1),
+                                    deepcopy(a2),
+                                    evidence=[deepcopy(ev)])
                 _stmt_location_to_agents(st, location)
                 self.statements.append(st)
 
@@ -230,9 +235,13 @@ class TripsProcessor(object):
                 for a1, a2 in _agent_list_product((factor_agent,
                                                    outcome_agent)):
                     if is_activation:
-                        st = Activation(a1, a2, evidence=[ev])
+                        st = Activation(deepcopy(a1),
+                                        deepcopy(a2),
+                                        evidence=[deepcopy(ev)])
                     else:
-                        st = Inhibition(a1, a2, evidence=[ev])
+                        st = Inhibition(deepcopy(a1),
+                                        deepcopy(a2),
+                                        evidence=[deepcopy(ev)])
                     _stmt_location_to_agents(st, location)
                     self.statements.append(st)
 
@@ -287,7 +296,9 @@ class TripsProcessor(object):
                     continue
                 for a1, a2 in _agent_list_product((controller_agent,
                                                    affected_agent)):
-                    st = Activation(a1, a2, evidence=[ev])
+                    st = Activation(deepcopy(a1),
+                                    deepcopy(a2),
+                                    evidence=[deepcopy(ev)])
                     _stmt_location_to_agents(st, location)
                     self.statements.append(st)
             elif affected_event_type.text == 'ONT::ACTIVITY':
@@ -300,7 +311,9 @@ class TripsProcessor(object):
                     continue
                 for a1, a2 in _agent_list_product((controller_agent,
                                                    affected_agent)):
-                    st = Activation(a1, a2, evidence=[ev])
+                    st = Activation(deepcopy(a1),
+                                    deepcopy(a2),
+                                    evidence=[deepcopy(ev)])
                     _stmt_location_to_agents(st, location)
                     self.statements.append(st)
 
@@ -351,7 +364,9 @@ class TripsProcessor(object):
             location = self._get_event_location(event)
             for subj, obj in \
                     _agent_list_product((agent_agent, affected_agent)):
-                st = DecreaseAmount(subj, obj, evidence=ev)
+                st = DecreaseAmount(deepcopy(subj),
+                                    deepcopy(obj),
+                                    evidence=deepcopy(ev))
                 _stmt_location_to_agents(st, location)
                 self.statements.append(st)
             self._add_extracted(_get_type(event), event.attrib['id'])
@@ -411,7 +426,9 @@ class TripsProcessor(object):
             location = self._get_event_location(event)
             for subj, obj in \
                     _agent_list_product((agent_agent, affected_agent)):
-                st = IncreaseAmount(subj, obj, evidence=ev)
+                st = IncreaseAmount(deepcopy(subj),
+                                    deepcopy(obj),
+                                    evidence=deepcopy(ev))
                 _stmt_location_to_agents(st, location)
                 self.statements.append(st)
             self._add_extracted(_get_type(event), event.attrib['id'])
@@ -486,7 +503,9 @@ class TripsProcessor(object):
                         _agent_list_product((agent_agent, affected_agent)):
                     if obj is None:
                         continue
-                    st = cls(subj, obj, evidence=ev)
+                    st = cls(deepcopy(subj),
+                             deepcopy(obj),
+                             evidence=deepcopy(ev))
                     _stmt_location_to_agents(st, location)
                     self.statements.append(st)
                 self._add_extracted(_get_type(event), event.attrib['id'])
@@ -551,7 +570,9 @@ class TripsProcessor(object):
                         _agent_list_product((agent_agent, affected_agent)):
                     if obj is None:
                         continue
-                    st = stmt_type(subj, obj, evidence=ev)
+                    st = stmt_type(deepcopy(subj),
+                                   deepcopy(obj),
+                                   evidence=deepcopy(ev))
                     _stmt_location_to_agents(st, location)
                     self.statements.append(st)
 
@@ -690,7 +711,8 @@ class TripsProcessor(object):
             location = self._get_event_location(event)
 
             for a1, a2 in _agent_list_product((agent1, agent2)):
-                st = Complex([a1, a2], evidence=ev)
+                st = Complex([deepcopy(a1), deepcopy(a2)],
+                             evidence=deepcopy(ev))
                 _stmt_location_to_agents(st, location)
                 self.statements.append(st)
             self._add_extracted(_get_type(event), event.attrib['id'])
@@ -885,8 +907,9 @@ class TripsProcessor(object):
                 enzyme_agent.bound_conditions = \
                     [BoundCondition(agent_bound, True)]
                 for m in mods:
-                    st = Transphosphorylation(enzyme_agent, m.residue,
-                                              m.position, evidence=[ev])
+                    st = Transphosphorylation(deepcopy(enzyme_agent),
+                                              m.residue, m.position,
+                                              evidence=[deepcopy(ev)])
                     _stmt_location_to_agents(st, location)
                     stmts.append(st)
                 return stmts
@@ -895,15 +918,15 @@ class TripsProcessor(object):
                 for m in mods:
                     if isinstance(enzyme_agent, list):
                         for ea in enzyme_agent:
-                            st = Autophosphorylation(ea,
-                                                 m.residue, m.position,
-                                                 evidence=[ev])
+                            st = Autophosphorylation(deepcopy(ea),
+                                                     m.residue, m.position,
+                                                     evidence=[deepcopy(ev)])
                             _stmt_location_to_agents(st, location)
                             stmts.append(st)
                     else:
-                        st = Autophosphorylation(enzyme_agent,
+                        st = Autophosphorylation(deepcopy(enzyme_agent),
                                                  m.residue, m.position,
-                                                 evidence=[ev])
+                                                 evidence=[deepcopy(ev)])
                         _stmt_location_to_agents(st, location)
                         stmts.append(st)
                 return stmts
@@ -912,15 +935,15 @@ class TripsProcessor(object):
                 for m in mods:
                     if isinstance(affected_agent, list):
                         for aa in affected_agent:
-                            st = Autophosphorylation(aa,
+                            st = Autophosphorylation(deepcopy(aa),
                                                      m.residue, m.position,
-                                                     evidence=[ev])
+                                                     evidence=[deepcopy(ev)])
                             _stmt_location_to_agents(st, location)
                             stmts.append(st)
                     else:
-                        st = Autophosphorylation(affected_agent,
+                        st = Autophosphorylation(deepcopy(affected_agent),
                                                  m.residue, m.position,
-                                                 evidence=[ev])
+                                                 evidence=[deepcopy(ev)])
                         _stmt_location_to_agents(st, location)
                         stmts.append(st)
                 return stmts
@@ -933,7 +956,10 @@ class TripsProcessor(object):
             if aa is None:
                 continue
             for m in mods:
-                st = mod_stmt(ea, aa, m.residue, m.position, evidence=ev)
+                st = mod_stmt(deepcopy(ea),
+                              deepcopy(aa),
+                              m.residue, m.position,
+                              evidence=deepcopy(ev))
                 _stmt_location_to_agents(st, location)
                 stmts.append(st)
         self._add_extracted(event_type, event.attrib['id'])
@@ -974,12 +1000,15 @@ class TripsProcessor(object):
             ev = self._get_evidence(event)
             if isinstance(agent, list):
                 for aa in agent:
-                    st = Translocation(aa, from_location,
-                                       to_location, evidence=ev)
+                    st = Translocation(aa,
+                                       from_location, to_location,
+                                       evidence=deepcopy(ev))
                     self.statements.append(st)
             else:
-                st = Translocation(agent, from_location,
-                                   to_location, evidence=ev)
+                st = Translocation(agent,
+                                   from_location,
+                                   to_location,
+                                   evidence=deepcopy(ev))
                 self.statements.append(st)
             self._add_extracted('ONT::TRANSLOCATE', event.attrib['id'])
 
@@ -1044,7 +1073,8 @@ class TripsProcessor(object):
                 subj = subj_t[0]
                 # Get evidence
                 ev = self._get_evidence(event)
-                st = Conversion(subj, obj_from, obj_to, evidence=ev)
+                st = Conversion(subj, obj_from, obj_to,
+                                evidence=deepcopy(ev))
                 location = self._get_event_location(event)
                 _stmt_location_to_agents(st, location)
                 self._add_extracted(_get_type(event), event.attrib['id'])

--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -971,7 +971,7 @@ class TripsProcessor(object):
                 to_location = self._get_cell_loc_by_id(to_loc_id)
             if from_location is None and to_location is None:
                 continue
-           
+
             if isinstance(agent, list):
                 for aa in agent:
                     # Get evidence
@@ -981,6 +981,7 @@ class TripsProcessor(object):
                                        evidence=ev)
                     self.statements.append(st)
             else:
+                ev = self._get_evidence(event)
                 st = Translocation(agent, from_location,
                                    to_location, evidence=ev)
                 self.statements.append(st)

--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -163,20 +163,14 @@ class TripsProcessor(object):
             elif _is_type(event, 'ONT::DEACTIVATE'):
                 is_activation = False
                 self._add_extracted('ONT::DEACTIVATE', event.attrib['id'])
-
             ev = self._get_evidence(event)
             location = self._get_event_location(event)
-
             for a1, a2 in _agent_list_product((activator_agent,
                                                affected_agent)):
                 if is_activation:
-                    st = Activation(deepcopy(a1),
-                                    deepcopy(a2),
-                                    evidence=[deepcopy(ev)])
+                    st = Activation(a1, a2, evidence=[deepcopy(ev)])
                 else:
-                    st = Inhibition(deepcopy(a1),
-                                    deepcopy(a2),
-                                    evidence=[deepcopy(ev)])
+                    st = Inhibition(a1, a2, evidence=[deepcopy(ev)])
                 _stmt_location_to_agents(st, location)
                 self.statements.append(st)
 
@@ -235,13 +229,9 @@ class TripsProcessor(object):
                 for a1, a2 in _agent_list_product((factor_agent,
                                                    outcome_agent)):
                     if is_activation:
-                        st = Activation(deepcopy(a1),
-                                        deepcopy(a2),
-                                        evidence=[deepcopy(ev)])
+                        st = Activation(a1, a2, evidence=[deepcopy(ev)])
                     else:
-                        st = Inhibition(deepcopy(a1),
-                                        deepcopy(a2),
-                                        evidence=[deepcopy(ev)])
+                        st = Inhibition(a1, a2, evidence=[deepcopy(ev)])
                     _stmt_location_to_agents(st, location)
                     self.statements.append(st)
 
@@ -296,9 +286,7 @@ class TripsProcessor(object):
                     continue
                 for a1, a2 in _agent_list_product((controller_agent,
                                                    affected_agent)):
-                    st = Activation(deepcopy(a1),
-                                    deepcopy(a2),
-                                    evidence=[deepcopy(ev)])
+                    st = Activation(a1, a2, evidence=[deepcopy(ev)])
                     _stmt_location_to_agents(st, location)
                     self.statements.append(st)
             elif affected_event_type.text == 'ONT::ACTIVITY':
@@ -311,9 +299,7 @@ class TripsProcessor(object):
                     continue
                 for a1, a2 in _agent_list_product((controller_agent,
                                                    affected_agent)):
-                    st = Activation(deepcopy(a1),
-                                    deepcopy(a2),
-                                    evidence=[deepcopy(ev)])
+                    st = Activation(a1, a2, evidence=[deepcopy(ev)])
                     _stmt_location_to_agents(st, location)
                     self.statements.append(st)
 
@@ -359,14 +345,11 @@ class TripsProcessor(object):
                 else:
                     agent_agent = self._get_agent_by_id(agent_id,
                                                         event.attrib['id'])
-
             ev = self._get_evidence(event)
             location = self._get_event_location(event)
             for subj, obj in \
                     _agent_list_product((agent_agent, affected_agent)):
-                st = DecreaseAmount(deepcopy(subj),
-                                    deepcopy(obj),
-                                    evidence=deepcopy(ev))
+                st = DecreaseAmount(subj, obj, evidence=deepcopy(ev))
                 _stmt_location_to_agents(st, location)
                 self.statements.append(st)
             self._add_extracted(_get_type(event), event.attrib['id'])
@@ -426,9 +409,7 @@ class TripsProcessor(object):
             location = self._get_event_location(event)
             for subj, obj in \
                     _agent_list_product((agent_agent, affected_agent)):
-                st = IncreaseAmount(deepcopy(subj),
-                                    deepcopy(obj),
-                                    evidence=deepcopy(ev))
+                st = IncreaseAmount(subj, obj, evidence=deepcopy(ev))
                 _stmt_location_to_agents(st, location)
                 self.statements.append(st)
             self._add_extracted(_get_type(event), event.attrib['id'])
@@ -503,9 +484,7 @@ class TripsProcessor(object):
                         _agent_list_product((agent_agent, affected_agent)):
                     if obj is None:
                         continue
-                    st = cls(deepcopy(subj),
-                             deepcopy(obj),
-                             evidence=deepcopy(ev))
+                    st = cls(subj, obj, evidence=deepcopy(ev))
                     _stmt_location_to_agents(st, location)
                     self.statements.append(st)
                 self._add_extracted(_get_type(event), event.attrib['id'])
@@ -562,7 +541,6 @@ class TripsProcessor(object):
                     continue
                 affected_agent = self._get_agent_by_id(affected_id,
                                                        event.attrib['id'])
-
                 ev = self._get_evidence(event)
                 location = self._get_event_location(event)
                 self._add_extracted(_get_type(event), event.attrib['id'])
@@ -570,9 +548,7 @@ class TripsProcessor(object):
                         _agent_list_product((agent_agent, affected_agent)):
                     if obj is None:
                         continue
-                    st = stmt_type(deepcopy(subj),
-                                   deepcopy(obj),
-                                   evidence=deepcopy(ev))
+                    st = stmt_type(subj, obj, evidence=deepcopy(ev))
                     _stmt_location_to_agents(st, location)
                     self.statements.append(st)
 
@@ -709,10 +685,8 @@ class TripsProcessor(object):
             '''
             ev = self._get_evidence(event)
             location = self._get_event_location(event)
-
             for a1, a2 in _agent_list_product((agent1, agent2)):
-                st = Complex([deepcopy(a1), deepcopy(a2)],
-                             evidence=deepcopy(ev))
+                st = Complex([a1, a2], evidence=deepcopy(ev))
                 _stmt_location_to_agents(st, location)
                 self.statements.append(st)
             self._add_extracted(_get_type(event), event.attrib['id'])
@@ -908,7 +882,8 @@ class TripsProcessor(object):
                     [BoundCondition(agent_bound, True)]
                 for m in mods:
                     st = Transphosphorylation(deepcopy(enzyme_agent),
-                                              m.residue, m.position,
+                                              m.residue,
+                                              m.position,
                                               evidence=[deepcopy(ev)])
                     _stmt_location_to_agents(st, location)
                     stmts.append(st)
@@ -996,19 +971,18 @@ class TripsProcessor(object):
                 to_location = self._get_cell_loc_by_id(to_loc_id)
             if from_location is None and to_location is None:
                 continue
-            # Get evidence
-            ev = self._get_evidence(event)
+           
             if isinstance(agent, list):
                 for aa in agent:
-                    st = Translocation(aa,
-                                       from_location, to_location,
-                                       evidence=deepcopy(ev))
+                    # Get evidence
+                    ev = self._get_evidence(event)
+                    st = Translocation(aa, from_location,
+                                       to_location,
+                                       evidence=ev)
                     self.statements.append(st)
             else:
-                st = Translocation(agent,
-                                   from_location,
-                                   to_location,
-                                   evidence=deepcopy(ev))
+                st = Translocation(agent, from_location,
+                                   to_location, evidence=ev)
                 self.statements.append(st)
             self._add_extracted('ONT::TRANSLOCATE', event.attrib['id'])
 
@@ -1716,7 +1690,8 @@ def _stmt_location_to_agents(stmt, location):
 
 def _agent_list_product(lists):
     ll = [_listify(l) for l in lists]
-    return itertools.product(*ll)
+    prod = itertools.product(*ll)
+    return [tuple(deepcopy(agent) for agent in t) for t in prod]
 
 
 def _listify(lst):

--- a/indra/tests/test_trips.py
+++ b/indra/tests/test_trips.py
@@ -223,3 +223,17 @@ def test_simple_decrease():
     assert_if_hgnc_then_up(st)
     assert_grounding_value_or_none(st)
     assert st.evidence
+
+
+@attr('webservice', 'slow')
+def test_no_shared_objects():
+    """Make sure shared objects are not being created between statements"""
+    texts = ('MEK binds ERK and RAF',
+             'HEDGEHOG activates GLI1 and BCL2',
+             'RAF phosphorylates MEK and ALG-2')
+    for text in texts:
+        tp = trips.process_text(text)
+        stmts = tp.statements
+        assert len(stmts) == 2
+        stmt1, stmt2 = stmts
+        assert stmt1.evidence[0] is not stmt2.evidence[0]

--- a/indra/tests/test_trips.py
+++ b/indra/tests/test_trips.py
@@ -228,17 +228,16 @@ def test_simple_decrease():
 @attr('webservice', 'slow')
 def test_no_shared_objects():
     """Make sure shared objects are not being created between statements"""
-    verbs = ('phosphorylates', 'binds', 'activates', 'increases',
-             'degrades', 'transcribes', 'ubiquitinates', 'autophosphorylates',
-             'transphosphorylates')
+    verbs = ('phosphorylates', 'binds', 'activates',
+             ' causes activation of ', 'increases', 'degrades', 'synthesizes',
+             'transcribes', 'ubiquitinates')
     for verb in verbs:
         text = 'HEDGEHOG %s SMURF1 and SMURF2' % verb
-        print(text)
         tp = trips.process_text(text)
         stmts = tp.statements
-        print(len(stmts) == 2)
+        assert len(stmts) == 2
         stmt1, stmt2 = stmts
-        print(stmt1.evidence[0] is not stmt2.evidence[0])
+        assert stmt1.evidence[0] is not stmt2.evidence[0]
         hedgehog1 = stmt1.agent_list()[0]
         hedgehog2 = stmt2.agent_list()[0]
-        print(hedgehog1 is not hedgehog2)
+        assert hedgehog1 is not hedgehog2

--- a/indra/tests/test_trips.py
+++ b/indra/tests/test_trips.py
@@ -237,7 +237,17 @@ def test_no_shared_objects():
         stmts = tp.statements
         assert len(stmts) == 2
         stmt1, stmt2 = stmts
-        assert stmt1.evidence[0] is not stmt2.evidence[0]
+        # assert stmt1.evidence[0] is not stmt2.evidence[0]
         hedgehog1 = stmt1.agent_list()[0]
         hedgehog2 = stmt2.agent_list()[0]
         assert hedgehog1 is not hedgehog2
+    # autophosphorylation
+    text = 'HEDGEHOG phosphorylates itself at Ser1337 and Tyr99'
+    tp = trips.process_text(text)
+    stmts = tp.statements
+    assert len(stmts) == 2
+    stmt1, stmt2 = stmts
+    assert stmt1.evidence[0] is not stmt2.evidence[0]
+    hedgehog1 = stmt1.agent_list()[0]
+    hedgehog2 = stmt2.agent_list()[0]
+    assert hedgehog1 is not hedgehog2

--- a/indra/tests/test_trips.py
+++ b/indra/tests/test_trips.py
@@ -228,12 +228,17 @@ def test_simple_decrease():
 @attr('webservice', 'slow')
 def test_no_shared_objects():
     """Make sure shared objects are not being created between statements"""
-    texts = ('MEK binds ERK and RAF',
-             'HEDGEHOG activates GLI1 and BCL2',
-             'RAF phosphorylates MEK and ALG-2')
-    for text in texts:
+    verbs = ('phosphorylates', 'binds', 'activates', 'increases',
+             'degrades', 'transcribes', 'ubiquitinates', 'autophosphorylates',
+             'transphosphorylates')
+    for verb in verbs:
+        text = 'HEDGEHOG %s SMURF1 and SMURF2' % verb
+        print(text)
         tp = trips.process_text(text)
         stmts = tp.statements
-        assert len(stmts) == 2
+        print(len(stmts) == 2)
         stmt1, stmt2 = stmts
-        assert stmt1.evidence[0] is not stmt2.evidence[0]
+        print(stmt1.evidence[0] is not stmt2.evidence[0])
+        hedgehog1 = stmt1.agent_list()[0]
+        hedgehog2 = stmt2.agent_list()[0]
+        print(hedgehog1 is not hedgehog2)


### PR DESCRIPTION
This PR modifies the trips processor so that it no longer creates shared evidence and agent objects between some statements extracted from the same text. Originally, for a sentence such as
"A binds B and C" the extracted statements Complex(A, B), Complex(A, C) would share evidence objects. The agent object for A would also be shared between the statements. The problem has been solved by making deep copies of agent and evidence objects for all statement instantiations that could possibly lead to shared objects. This route was taken instead of instantiating new agent and evidence objects for each statement instantiation because it was easier to implement.