### PR TITLE
NDEx CX processor handle network summary

### DIFF
--- a/indra/sources/ndex_cx/api.py
+++ b/indra/sources/ndex_cx/api.py
@@ -1,8 +1,12 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import json
+import logging
 import ndex2.client
 from .processor import NdexCxProcessor
+
+
+logger = logging.getLogger(__name__)
 
 
 def process_cx_file(file_name, require_grounding=True):
@@ -56,16 +60,22 @@ def process_ndex_network(network_id, username=None, password=None,
         logger.error('Response: %s' % res.text)
         return None
     json_list = res.json()
-    return process_cx(json_list, require_grounding=require_grounding)
+    summary = nd.get_network_summary(network_id)
+    return process_cx(json_list, summary=summary,
+                      require_grounding=require_grounding)
 
 
-def process_cx(cx_json, require_grounding=True):
+def process_cx(cx_json, summary=None, require_grounding=True):
     """Process a CX JSON object into Statements.
 
     Parameters
     ----------
     cx_json : list
         CX JSON object.
+    summary : Optional[dict]
+        The network summary object which can be obtained via
+        get_network_summary through the web service. THis contains metadata
+        such as the owner and the creation time of the network.
     require_grounding: bool
         Whether network nodes lacking grounding information should be included
         among the extracted Statements (default is True).
@@ -75,6 +85,7 @@ def process_cx(cx_json, require_grounding=True):
     NdexCxProcessor
         Processor containing Statements.
     """
-    ncp = NdexCxProcessor(cx_json, require_grounding=require_grounding)
+    ncp = NdexCxProcessor(cx_json, summary=summary,
+                          require_grounding=require_grounding)
     ncp.get_statements()
     return ncp

--- a/indra/sources/ndex_cx/processor.py
+++ b/indra/sources/ndex_cx/processor.py
@@ -49,6 +49,10 @@ class NdexCxProcessor(object):
     ----------
     cx : list of dicts
         JSON content containing the Cytoscape network in CX format.
+    summary : Optional[dict]
+        The network summary object which can be obtained via
+        get_network_summary through the web service. THis contains metadata
+        such as the owner and the creation time of the network.
 
     Attributes
     ----------
@@ -56,7 +60,7 @@ class NdexCxProcessor(object):
         A list of extracted INDRA Statements. Not all edges in the network
         may be converted into Statements.
     """
-    def __init__(self, cx, require_grounding=True):
+    def __init__(self, cx, summary=None, require_grounding=True):
         self.cx = cx
         self.statements = []
         self.require_grounding = require_grounding
@@ -65,9 +69,10 @@ class NdexCxProcessor(object):
         self._node_agents = {}
         self._network_info = {}
         self._edge_attributes = {}
+        summary = summary if summary else {}
         self._initialize_node_attributes()
         self._initialize_node_agents()
-        self._initialize_network_info()
+        self._initialize_network_info(summary)
         self._initialize_edge_attributes()
 
     def _initialize_node_agents(self):
@@ -110,10 +115,9 @@ class NdexCxProcessor(object):
             logger.info('%s invalid gene symbols: %s' %
                         (verb, ', '.join(invalid_genes)))
 
-    def _initialize_network_info(self):
-        ndex_info = _get_dict_from_list('ndexStatus', self.cx)[0]
-        self._network_info['externalId'] = ndex_info.get('externalId')
-        self._network_info['owner'] = ndex_info.get('owner')
+    def _initialize_network_info(self, summary):
+        self._network_info['externalId'] = summary.get('externalId')
+        self._network_info['owner'] = summary.get('owner')
 
     def _initialize_edge_attributes(self):
         edge_attr = _get_dict_from_list('edgeAttributes', self.cx)

--- a/indra/tests/test_ndex_cx_processor.py
+++ b/indra/tests/test_ndex_cx_processor.py
@@ -70,7 +70,7 @@ def test_get_statements():
 @attr('webservice')
 def test_get_cx_from_ndex():
     # Ras Machine network
-    ncp = process_ndex_network('50e3dff7-133e-11e6-a039-06603eb7f303')
+    ncp = process_ndex_network('fc56fe8d-1b60-11e8-b939-0ac135e8bacf')
 
 
 @raises(HTTPError)


### PR DESCRIPTION
This PR adapts the NDEx CX API and processor to deal with a change on the NDEx server in which the ndexStatus is not included in the CX anymore. This requires making an extra call to the server to get the network summary which is then passed in to the processor as a separate argument.

Fixes #751 