### PR TITLE
Temporary fix for Statement type compatibility

### DIFF
--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -328,7 +328,7 @@ class Preassembler(object):
         # Make a list of Statement types
         stmts_by_type = collections.defaultdict(lambda: [])
         for idx, stmt in enumerate(unique_stmts):
-            stmts_by_type[type(stmt)].append((idx, stmt))
+            stmts_by_type[stmt_type(stmt)].append((idx, stmt))
 
         child_proc_groups = []
         parent_proc_groups = []
@@ -557,7 +557,7 @@ class Preassembler(object):
         # Make a dict of Statement by type
         stmts_by_type = collections.defaultdict(lambda: [])
         for idx, stmt in enumerate(self.stmts):
-            stmts_by_type[type(stmt)].append((idx, stmt))
+            stmts_by_type[stmt_type(stmt)].append((idx, stmt))
 
         # Handle Statements with polarity first
         pos_stmts = AddModification.__subclasses__()

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -15,6 +15,7 @@ except ImportError:
     pass
 from indra.util import fast_deepcopy
 from indra.statements import *
+from indra.statements import stmt_type as indra_stmt_type
 
 logger = logging.getLogger(__name__)
 
@@ -328,7 +329,7 @@ class Preassembler(object):
         # Make a list of Statement types
         stmts_by_type = collections.defaultdict(lambda: [])
         for idx, stmt in enumerate(unique_stmts):
-            stmts_by_type[stmt_type(stmt)].append((idx, stmt))
+            stmts_by_type[indra_stmt_type(stmt)].append((idx, stmt))
 
         child_proc_groups = []
         parent_proc_groups = []
@@ -557,7 +558,7 @@ class Preassembler(object):
         # Make a dict of Statement by type
         stmts_by_type = collections.defaultdict(lambda: [])
         for idx, stmt in enumerate(self.stmts):
-            stmts_by_type[stmt_type(stmt)].append((idx, stmt))
+            stmts_by_type[indra_stmt_type(stmt)].append((idx, stmt))
 
         # Handle Statements with polarity first
         pos_stmts = AddModification.__subclasses__()

--- a/indra/statements/statements.py
+++ b/indra/statements/statements.py
@@ -577,7 +577,7 @@ class Modification(Statement):
             enz_key = None
         else:
             enz_key = self.enz.matches_key()
-        key = (stmt_type(self), enz_key, self.sub.matches_key(),
+        key = (stmt_type(self, True), enz_key, self.sub.matches_key(),
                str(self.residue), str(self.position))
         return mk_str(key)
 
@@ -741,7 +741,7 @@ class SelfModification(Statement):
         return s
 
     def matches_key(self):
-        key = (stmt_type(self), self.enz.matches_key(),
+        key = (stmt_type(self, True), self.enz.matches_key(),
                str(self.residue), str(self.position))
         return mk_str(key)
 
@@ -996,7 +996,7 @@ class RegulateActivity(Statement):
         self.__dict__.update(state)
 
     def matches_key(self):
-        key = (stmt_type(self), self.subj.matches_key(),
+        key = (stmt_type(self, True), self.subj.matches_key(),
                self.obj.matches_key(), str(self.obj_activity),
                str(self.is_activation))
         return mk_str(key)
@@ -1220,7 +1220,7 @@ class ActiveForm(Statement):
         self.is_active = is_active
 
     def matches_key(self):
-        key = (stmt_type(self), self.agent.matches_key(),
+        key = (stmt_type(self, True), self.agent.matches_key(),
                str(self.activity), str(self.is_active))
         return mk_str(key)
 
@@ -1354,7 +1354,7 @@ class HasActivity(Statement):
         self.has_activity = has_activity
 
     def matches_key(self):
-        key = (stmt_type(self), self.agent.matches_key(),
+        key = (stmt_type(self, True), self.agent.matches_key(),
                str(self.activity), str(self.has_activity))
         return mk_str(key)
 
@@ -1422,7 +1422,7 @@ class Gef(Statement):
         self.ras = ras
 
     def matches_key(self):
-        key = (stmt_type(self), self.gef.matches_key(),
+        key = (stmt_type(self, True), self.gef.matches_key(),
                self.ras.matches_key())
         return mk_str(key)
 
@@ -1509,7 +1509,7 @@ class Gap(Statement):
         self.ras = ras
 
     def matches_key(self):
-        key = (stmt_type(self), self.gap.matches_key(),
+        key = (stmt_type(self, True), self.gap.matches_key(),
                self.ras.matches_key())
         return mk_str(key)
 
@@ -1591,7 +1591,7 @@ class Complex(Statement):
 
     def matches_key(self):
         members = sorted(self.members, key=lambda x: x.matches_key())
-        key = (stmt_type(self), tuple(m.matches_key() for m in members))
+        key = (stmt_type(self, True), tuple(m.matches_key() for m in members))
         return mk_str(key)
 
     def entities_match_key(self):
@@ -1712,7 +1712,7 @@ class Translocation(Statement):
         return matches
 
     def matches_key(self):
-        key = (stmt_type(self), self.agent.matches_key(),
+        key = (stmt_type(self, True), self.agent.matches_key(),
                str(self.from_location), str(self.to_location))
         return mk_str(key)
 
@@ -1759,7 +1759,7 @@ class RegulateAmount(Statement):
             subj_key = None
         else:
             subj_key = self.subj.matches_key()
-        key = (stmt_type(self), subj_key, self.obj.matches_key())
+        key = (stmt_type(self, True), subj_key, self.obj.matches_key())
         return mk_str(key)
 
     def set_agent_list(self, agent_list):
@@ -1955,7 +1955,7 @@ class Influence(IncreaseAmount):
         return matches
 
     def matches_key(self):
-        key = (stmt_type(self), self.subj.matches_key(),
+        key = (stmt_type(self, True), self.subj.matches_key(),
                self.obj.matches_key(),
                self.subj_delta['polarity'],
                sorted(list(set(self.subj_delta['adjectives']))),
@@ -2079,7 +2079,7 @@ class Conversion(Statement):
             self.obj_to = [obj_to]
 
     def matches_key(self):
-        keys = [stmt_type(self)]
+        keys = [stmt_type(self, True)]
         keys += [self.subj.matches_key() if self.subj else None]
         keys += [agent.matches_key() for agent in sorted_agents(self.obj_to)]
         keys += [agent.matches_key() for agent in sorted_agents(self.obj_from)]
@@ -2347,18 +2347,17 @@ def get_unresolved_support_uuids(stmts):
             if isinstance(s, Unresolved)}
 
 
-def stmt_type(obj):
+def stmt_type(obj, mk=True):
     """Return standardized, backwards compatible object type String.
 
     This is a temporary solution to make sure type comparisons and
     matches keys of Statements and related classes are backwards
     compatible.
     """
-    if isinstance(obj, Statement):
+    if isinstance(obj, Statement) and mk:
         return type(obj)
     else:
-        type_str = type(obj).__name__
-    return type_str
+        return type(obj).__name__
 
 
 def mk_str(mk):

--- a/indra/statements/statements.py
+++ b/indra/statements/statements.py
@@ -579,7 +579,7 @@ class Modification(Statement):
             enz_key = self.enz.matches_key()
         key = (stmt_type(self), enz_key, self.sub.matches_key(),
                str(self.residue), str(self.position))
-        return str(key)
+        return mk_str(key)
 
     def set_agent_list(self, agent_list):
         if len(agent_list) != 2:
@@ -743,7 +743,7 @@ class SelfModification(Statement):
     def matches_key(self):
         key = (stmt_type(self), self.enz.matches_key(),
                str(self.residue), str(self.position))
-        return str(key)
+        return mk_str(key)
 
     def set_agent_list(self, agent_list):
         if len(agent_list) != 1:
@@ -999,7 +999,7 @@ class RegulateActivity(Statement):
         key = (stmt_type(self), self.subj.matches_key(),
                self.obj.matches_key(), str(self.obj_activity),
                str(self.is_activation))
-        return str(key)
+        return mk_str(key)
 
     def set_agent_list(self, agent_list):
         if len(agent_list) != 2:
@@ -1222,7 +1222,7 @@ class ActiveForm(Statement):
     def matches_key(self):
         key = (stmt_type(self), self.agent.matches_key(),
                str(self.activity), str(self.is_active))
-        return str(key)
+        return mk_str(key)
 
     def set_agent_list(self, agent_list):
         if len(agent_list) != 1:
@@ -1356,7 +1356,7 @@ class HasActivity(Statement):
     def matches_key(self):
         key = (stmt_type(self), self.agent.matches_key(),
                str(self.activity), str(self.has_activity))
-        return str(key)
+        return mk_str(key)
 
     def set_agent_list(self, agent_list):
         if len(agent_list) != 1:
@@ -1424,7 +1424,7 @@ class Gef(Statement):
     def matches_key(self):
         key = (stmt_type(self), self.gef.matches_key(),
                self.ras.matches_key())
-        return str(key)
+        return mk_str(key)
 
     def set_agent_list(self, agent_list):
         if len(agent_list) != 2:
@@ -1511,7 +1511,7 @@ class Gap(Statement):
     def matches_key(self):
         key = (stmt_type(self), self.gap.matches_key(),
                self.ras.matches_key())
-        return str(key)
+        return mk_str(key)
 
     def set_agent_list(self, agent_list):
         if len(agent_list) != 2:
@@ -1592,7 +1592,7 @@ class Complex(Statement):
     def matches_key(self):
         members = sorted(self.members, key=lambda x: x.matches_key())
         key = (stmt_type(self), tuple(m.matches_key() for m in members))
-        return str(key)
+        return mk_str(key)
 
     def entities_match_key(self):
         key = tuple(a.entity_matches_key() if a is not None
@@ -1714,7 +1714,7 @@ class Translocation(Statement):
     def matches_key(self):
         key = (stmt_type(self), self.agent.matches_key(),
                str(self.from_location), str(self.to_location))
-        return str(key)
+        return mk_str(key)
 
     def to_json(self, use_sbo=False):
         generic = super(Translocation, self).to_json(use_sbo)
@@ -1760,7 +1760,7 @@ class RegulateAmount(Statement):
         else:
             subj_key = self.subj.matches_key()
         key = (stmt_type(self), subj_key, self.obj.matches_key())
-        return str(key)
+        return mk_str(key)
 
     def set_agent_list(self, agent_list):
         if len(agent_list) != 2:
@@ -1961,7 +1961,7 @@ class Influence(IncreaseAmount):
                sorted(list(set(self.subj_delta['adjectives']))),
                self.obj_delta['polarity'],
                sorted(list(set(self.obj_delta['adjectives']))))
-        return str(key)
+        return mk_str(key)
 
     def contradicts(self, other, hierarchies):
         # First case is if they are "consistent" and related
@@ -2083,7 +2083,7 @@ class Conversion(Statement):
         keys += [self.subj.matches_key() if self.subj else None]
         keys += [agent.matches_key() for agent in sorted_agents(self.obj_to)]
         keys += [agent.matches_key() for agent in sorted_agents(self.obj_from)]
-        return str(keys)
+        return mk_str(keys)
 
     def set_agent_list(self, agent_list):
         num_obj_from = len(self.obj_from)
@@ -2355,8 +2355,12 @@ def stmt_type(obj):
     compatible.
     """
     if isinstance(obj, Statement):
-        class_name = type(obj).__name__
-        type_str = "<class 'indra.statements.%s'>" % class_name
+        return type(obj)
     else:
         type_str = type(obj).__name__
     return type_str
+
+
+def mk_str(mk):
+    """Replace class path for backwards compatibility of matches keys."""
+    return str(mk).replace('indra.statements.statements', 'indra.statements')

--- a/indra/statements/statements.py
+++ b/indra/statements/statements.py
@@ -195,7 +195,7 @@ __all__ = [
     'amino_acids', 'amino_acids_reverse', 'activity_types',
     'cellular_components', 'cellular_components_reverse', 'modtype_to_modclass',
     'modclass_to_modtype', 'modtype_conditions', 'modtype_to_inverse',
-    'modclass_to_inverse', 'get_statement_by_name', 'make_hash'
+    'modclass_to_inverse', 'get_statement_by_name', 'make_hash', 'stmt_type'
     ]
 
 import abc
@@ -2348,4 +2348,9 @@ def get_unresolved_support_uuids(stmts):
 
 
 def stmt_type(obj):
-    return type(obj).__name__
+    if isinstance(obj, Statement):
+        class_name = type(obj).__name__
+        type_str = "<class 'indra.statements.%s'>" % class_name
+    else:
+        type_str = type(obj).__name__
+    return type_str

--- a/indra/statements/statements.py
+++ b/indra/statements/statements.py
@@ -2348,6 +2348,12 @@ def get_unresolved_support_uuids(stmts):
 
 
 def stmt_type(obj):
+    """Return standardized, backwards compatible object type String.
+
+    This is a temporary solution to make sure type comparisons and
+    matches keys of Statements and related classes are backwards
+    compatible.
+    """
     if isinstance(obj, Statement):
         class_name = type(obj).__name__
         type_str = "<class 'indra.statements.%s'>" % class_name

--- a/indra/statements/statements.py
+++ b/indra/statements/statements.py
@@ -383,7 +383,7 @@ class Statement(object):
             return str(self).encode('utf-8')
 
     def equals(self, other):
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
         if len(self.agent_list()) == len(other.agent_list()):
             for s, o in zip(self.agent_list(), other.agent_list()):
@@ -577,7 +577,7 @@ class Modification(Statement):
             enz_key = None
         else:
             enz_key = self.enz.matches_key()
-        key = (type(self), enz_key, self.sub.matches_key(),
+        key = (stmt_type(self), enz_key, self.sub.matches_key(),
                str(self.residue), str(self.position))
         return str(key)
 
@@ -589,7 +589,7 @@ class Modification(Statement):
 
     def refinement_of(self, other, hierarchies):
         # Make sure the statement types match
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
 
         # Check agent arguments
@@ -741,7 +741,7 @@ class SelfModification(Statement):
         return s
 
     def matches_key(self):
-        key = (type(self), self.enz.matches_key(),
+        key = (stmt_type(self), self.enz.matches_key(),
                str(self.residue), str(self.position))
         return str(key)
 
@@ -752,7 +752,7 @@ class SelfModification(Statement):
 
     def refinement_of(self, other, hierarchies):
         # Make sure the statement types match
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
 
         # Check agent arguments
@@ -996,7 +996,7 @@ class RegulateActivity(Statement):
         self.__dict__.update(state)
 
     def matches_key(self):
-        key = (type(self), self.subj.matches_key(),
+        key = (stmt_type(self), self.subj.matches_key(),
                self.obj.matches_key(), str(self.obj_activity),
                str(self.is_activation))
         return str(key)
@@ -1009,7 +1009,7 @@ class RegulateActivity(Statement):
 
     def refinement_of(self, other, hierarchies):
         # Make sure the statement types match
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
         if self.is_activation != other.is_activation:
             return False
@@ -1220,7 +1220,7 @@ class ActiveForm(Statement):
         self.is_active = is_active
 
     def matches_key(self):
-        key = (type(self), self.agent.matches_key(),
+        key = (stmt_type(self), self.agent.matches_key(),
                str(self.activity), str(self.is_active))
         return str(key)
 
@@ -1231,7 +1231,7 @@ class ActiveForm(Statement):
 
     def refinement_of(self, other, hierarchies):
         # Make sure the statement types match
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
 
         # Check agent arguments
@@ -1249,7 +1249,7 @@ class ActiveForm(Statement):
 
     def contradicts(self, other, hierarchies):
         # Make sure the statement types match
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
         # Check that the polarity is constradicting up front
         # TODO: we could also check for cases where the polarities are
@@ -1354,7 +1354,7 @@ class HasActivity(Statement):
         self.has_activity = has_activity
 
     def matches_key(self):
-        key = (type(self), self.agent.matches_key(),
+        key = (stmt_type(self), self.agent.matches_key(),
                str(self.activity), str(self.has_activity))
         return str(key)
 
@@ -1365,7 +1365,7 @@ class HasActivity(Statement):
 
     def refinement_of(self, other, hierarchies):
         # Make sure the statement types match
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
 
         # Check agent arguments
@@ -1422,7 +1422,7 @@ class Gef(Statement):
         self.ras = ras
 
     def matches_key(self):
-        key = (type(self), self.gef.matches_key(),
+        key = (stmt_type(self), self.gef.matches_key(),
                self.ras.matches_key())
         return str(key)
 
@@ -1438,7 +1438,7 @@ class Gef(Statement):
 
     def refinement_of(self, other, hierarchies):
         # Make sure the statement types match
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
         # Check the GEF
         if self.gef.refinement_of(other.gef, hierarchies) and \
@@ -1509,7 +1509,7 @@ class Gap(Statement):
         self.ras = ras
 
     def matches_key(self):
-        key = (type(self), self.gap.matches_key(),
+        key = (stmt_type(self), self.gap.matches_key(),
                self.ras.matches_key())
         return str(key)
 
@@ -1521,7 +1521,7 @@ class Gap(Statement):
 
     def refinement_of(self, other, hierarchies):
         # Make sure the statement types match
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
         # Check the GAP
         if self.gap.refinement_of(other.gap, hierarchies) and \
@@ -1591,7 +1591,7 @@ class Complex(Statement):
 
     def matches_key(self):
         members = sorted(self.members, key=lambda x: x.matches_key())
-        key = (type(self), tuple(m.matches_key() for m in members))
+        key = (stmt_type(self), tuple(m.matches_key() for m in members))
         return str(key)
 
     def entities_match_key(self):
@@ -1610,7 +1610,7 @@ class Complex(Statement):
 
     def refinement_of(self, other, hierarchies):
         # Make sure the statement types match
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
         # Make sure the length of the members list is the same. Note that this
         # treats Complex([A, B, C]) as distinct from Complex([A, B]), rather
@@ -1690,7 +1690,7 @@ class Translocation(Statement):
 
     def refinement_of(self, other, hierarchies=None):
         # Make sure the statement types match
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
         # Check several conditions for refinement
         ch = hierarchies['cellular_component']
@@ -1712,8 +1712,8 @@ class Translocation(Statement):
         return matches
 
     def matches_key(self):
-        key = (type(self), self.agent.matches_key(), str(self.from_location),
-               str(self.to_location))
+        key = (stmt_type(self), self.agent.matches_key(),
+               str(self.from_location), str(self.to_location))
         return str(key)
 
     def to_json(self, use_sbo=False):
@@ -1759,7 +1759,7 @@ class RegulateAmount(Statement):
             subj_key = None
         else:
             subj_key = self.subj.matches_key()
-        key = (type(self), subj_key, self.obj.matches_key())
+        key = (stmt_type(self), subj_key, self.obj.matches_key())
         return str(key)
 
     def set_agent_list(self, agent_list):
@@ -1806,7 +1806,7 @@ class RegulateAmount(Statement):
 
     def refinement_of(self, other, hierarchies):
         # Make sure the statement types match
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
 
         # Check agent arguments
@@ -1931,7 +1931,7 @@ class Influence(IncreaseAmount):
             return pol_refinement and adj_refinement
 
         # Make sure the statement types match
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
 
         # Check agent arguments
@@ -1955,7 +1955,7 @@ class Influence(IncreaseAmount):
         return matches
 
     def matches_key(self):
-        key = (type(self), self.subj.matches_key(),
+        key = (stmt_type(self), self.subj.matches_key(),
                self.obj.matches_key(),
                self.subj_delta['polarity'],
                sorted(list(set(self.subj_delta['adjectives']))),
@@ -2079,7 +2079,7 @@ class Conversion(Statement):
             self.obj_to = [obj_to]
 
     def matches_key(self):
-        keys = [type(self)]
+        keys = [stmt_type(self)]
         keys += [self.subj.matches_key() if self.subj else None]
         keys += [agent.matches_key() for agent in sorted_agents(self.obj_to)]
         keys += [agent.matches_key() for agent in sorted_agents(self.obj_from)]
@@ -2132,7 +2132,7 @@ class Conversion(Statement):
 
     def refinement_of(self, other, hierarchies):
         # Make sure the statement types match
-        if type(self) != type(other):
+        if stmt_type(self) != stmt_type(other):
             return False
 
         if self.subj is None and other.subj is None:
@@ -2345,3 +2345,7 @@ def get_unresolved_support_uuids(stmts):
     """Get uuids unresolved in support from stmts from stmts_from_json."""
     return {s.uuid for stmt in stmts for s in stmt.supports + stmt.supported_by
             if isinstance(s, Unresolved)}
+
+
+def stmt_type(obj):
+    return type(obj).__name__

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1913,7 +1913,13 @@ def test_deprecated_cellular_location():
 def test_stmt_type():
     stmt = Phosphorylation(None, Agent('x'))
     t = stmt_type(stmt)
-    assert t == "<class 'indra.statements.Phosphorylation'>", t
+    assert t == type(stmt), t
     mc = ModCondition('phosphorylation', 'S', '123')
     t = stmt_type(mc)
     assert t == 'ModCondition', t
+
+
+def test_mk_str():
+    stmt = Phosphorylation(None, Agent('x'))
+    mk = stmt.matches_key()
+    assert mk.startswith("(<class \'indra.statements.Phosphorylation\'>")

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1908,3 +1908,12 @@ def test_deprecated_cellular_location():
     stmt = Statement._from_json(stmt.to_json())
     assert stmt.from_location == 'HCN4 channel complex'
     assert stmt.to_location == 'pre-autophagosomal structure'
+
+
+def test_stmt_type():
+    stmt = Phosphorylation(None, Agent('x'))
+    t = stmt_type(stmt)
+    assert t == "<class 'indra.statements.Phosphorylation'>", t
+    mc = ModCondition('phosphorylation', 'S', '123')
+    t = stmt_type(mc)
+    assert t == 'ModCondition', t


### PR DESCRIPTION
This PR replaces `type` in several places with a function that makes it backwards compatible with Statements before the restructuring. This is temporary while outside resources like the DB, and relevant pickle files are updated.