### PR TITLE
PMC extract text

### DIFF
--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -118,6 +118,9 @@ def extract_text(xml_string):
     tree = etree.fromstring(xml_string.encode('utf-8'))
 
     paragraphs = []
+    # In NLM xml, all plaintext is within <p> tags, and is the only thing
+    # that can be contained in <p> tags. To handle to possibility of namespaces
+    # uses regex to search for tags either of the form 'p' or '{<namespace>}p'
     for element in tree.iter():
         if isinstance(element.tag, str) and \
            re.search('(^|})p$', element.tag) and element.text:

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -72,7 +72,7 @@ def get_ids(search_term, retmax=1000):
 
 
 def get_xml(pmc_id):
-    """Returns xml for article corresponding to a PMC ID"""
+    """Returns XML for the article corresponding to a PMC ID."""
     if pmc_id.upper().startswith('PMC'):
         pmc_id = pmc_id[3:]
     # Request params
@@ -103,17 +103,17 @@ def get_xml(pmc_id):
 
 
 def extract_text(xml_string):
-    """Get text from the body of the given NLM xml
+    """Get text from the body of the given NLM XML string.
 
     Parameters
     ----------
-    xml_string: str
-        Valid NLM xml file
+    xml_string : str
+        String containing valid NLM XML.
 
     Returns
     -------
-    str:
-        Extracted plaintext
+    str
+        Extracted plaintext.
     """
     tree = etree.fromstring(xml_string.encode('utf-8'))
 
@@ -136,14 +136,14 @@ def filter_pmids(pmid_list, source_type):
 
     Parameters
     ----------
-    pmid_list: list of str
+    pmid_list : list of str
         List of PMIDs to filter.
-    source_type: string
+    source_type : string
         One of 'fulltext', 'oa_xml', 'oa_txt', or 'auth_xml'.
 
     Returns
     -------
-    list of str:
+    list of str
         PMIDs available in the specified source/format type.
     """
     global pmids_fulltext_dict

--- a/indra/tests/test_pmc_client.py
+++ b/indra/tests/test_pmc_client.py
@@ -106,5 +106,5 @@ def test_extract_text():
     pmc_id = '4322985'
     xml_str = pmc_client.get_xml(pmc_id)
     text = pmc_client.extract_text(xml_str)
-    assert text
+    assert text is not None
     assert unicode_strs(text)

--- a/indra/tests/test_pmc_client.py
+++ b/indra/tests/test_pmc_client.py
@@ -100,3 +100,14 @@ def test_get_xml_invalid():
     xml_str = pmc_client.get_xml(pmc_id)
     assert xml_str is None
 
+
+@attr('webservice')
+def test_extract_text():
+    pmc_id = '4322985'
+    xml_str = pmc_client.get_xml(pmc_id)
+    raw_text = pmc_client.extract_text(xml_str)
+    assert raw_text
+
+    raw_text_nr = pmc_client.extract_text(xml_str, strip_references=True)
+    assert raw_text_nr
+    assert len(raw_text_nr) < len(raw_text)

--- a/indra/tests/test_pmc_client.py
+++ b/indra/tests/test_pmc_client.py
@@ -105,9 +105,6 @@ def test_get_xml_invalid():
 def test_extract_text():
     pmc_id = '4322985'
     xml_str = pmc_client.get_xml(pmc_id)
-    raw_text = pmc_client.extract_text(xml_str)
-    assert raw_text
-
-    raw_text_nr = pmc_client.extract_text(xml_str, strip_references=True)
-    assert raw_text_nr
-    assert len(raw_text_nr) < len(raw_text)
+    text = pmc_client.extract_text(xml_str)
+    assert text
+    assert unicode_strs(text)


### PR DESCRIPTION
This PR adds a function to the PMC client that can extract plaintext from NLM XML. NLM XML is simple to parse, with plaintext always being contained in <p> tags and <p> tags only containing plaintext. Newer NLM XML makes use of namespaces, while older instances do not. Care had to be taken to handle both cases. Despite this morning's discussion, this function was made Python2 compatible. All of the work to make it compatible was done yesterday. 

I've also pep8ified some non-compliant things and fleshed out some Docstrings. 