### PR TITLE
Html assembler Table of Contents

### DIFF
--- a/indra/assemblers/html/template.html
+++ b/indra/assemblers/html/template.html
@@ -34,6 +34,13 @@
 a {
   color: #256DC5;
 }
+nav[data-toggle=toc] .nav>li>a {
+  font-size: 0.72em;
+  padding-right: 10px;
+}
+nav[data-toggle=toc] .nav .nav>li>a {
+  font-size: 0.68em;
+}
 p {
   margin-bottom: 0px;
 }
@@ -68,12 +75,12 @@ nav {
   <body data-spy="scroll" data-target="#toc">
 
     <!-- Needed for sidebar -->
-    <div class="container">
+    <div class="container" style="max-width: 90%;">
       <div class="row">
-        <div class="col-4"> <!-- sidebar -->
+        <div class="col-2" style="padding-right: 0px;"> <!-- sidebar -->
           <nav id="toc" data-toggle="toc" class="sticky-top"></nav>
         </div> <!-- /sidebar -->
-        <div class="col"> <!-- main content -->
+        <div class="col" style="padding-left: 0px;"> <!-- main content -->
 
     <!-- Page Header -->
     <div class="container">

--- a/indra/assemblers/html/template.html
+++ b/indra/assemblers/html/template.html
@@ -66,10 +66,10 @@ nav {
     <!-- Needed for sidebar -->
     <div class="container">
       <div class="row">
-        <div class="col-sm-3"> <!-- sidebar -->
+        <div class="col-4"> <!-- sidebar -->
           <nav id="toc" data-toggle="toc" class="sticky-top"></nav>
         </div> <!-- /sidebar -->
-        <div class="col-sm-9"> <!-- main content -->
+        <div class="col"> <!-- main content -->
 
     <!-- Page Header -->
     <div class="container">

--- a/indra/assemblers/html/template.html
+++ b/indra/assemblers/html/template.html
@@ -37,6 +37,10 @@ a {
 p {
   margin-bottom: 0px;
 }
+h5 {
+  display: inline-block;
+  margin: 0px;
+}
 nav {
   overflow-y: auto;
   height: 100vh;
@@ -125,10 +129,10 @@ nav {
     {% for stmt_info in statements %}
     <a name='{{ stmt_info['hash'] }}'></a>
     <div class="statement">
-        <h5 class="align-middle">{{ stmt_info['english'] }}
-            <a href="{{ db_rest_url }}/from_hash/{{ stmt_info['hash'] }}?format=html">
-                <span class="badge badge-secondary badge-pill">{{ stmt_info['evidence_count'] }}</span></a>
-        </h5>
+      <h5 class="align-middle">{{ stmt_info['english'] }}</h5>
+      <a href="{{ db_rest_url }}/from_hash/{{ stmt_info['hash'] }}?format=html">
+        <span class="badge badge-secondary badge-pill">{{ stmt_info['evidence_count'] }}</span>
+      </a>
     </div>
     <div class="evidence">
     <table class="table" id="{{ stmt_info['hash'] }}" style="border-collapse: collapse;">

--- a/indra/assemblers/html/template.html
+++ b/indra/assemblers/html/template.html
@@ -16,7 +16,7 @@
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <!-- TOC plugin: https://afeld.github.io/bootstrap-toc/ -->
-    <link rel="stylesheet" href="https://cdn.rawgit.com/afeld/bootstrap-toc/v1.0.0/dist/bootstrap-toc.min.css">
+    <link rel="stylesheet" href="https://cdn.rawgit.com/afeld/bootstrap-toc/v1.0.0/dist/bootstrap-toc.min.css" crossorigin="anonymous">
 
     <!-- Optional theme -->
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
@@ -24,7 +24,7 @@
     <!-- Latest compiled and minified JavaScript -->
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
     <!-- TOC plugin JS: https://afeld.github.io/bootstrap-toc/ -->
-    <script src="https://cdn.rawgit.com/afeld/bootstrap-toc/v1.0.0/dist/bootstrap-toc.min.js"></script>
+    <script src="https://cdn.rawgit.com/afeld/bootstrap-toc/v1.0.0/dist/bootstrap-toc.min.js" crossorigin="anonymous"></script>
 
 
     <!-- Load curationFunctions.js -->
@@ -53,7 +53,15 @@ a {
 
   </head>
 
-  <body>
+  <body data-spy="scroll" data-target="#toc">
+
+    <!-- Needed for sidebar -->
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-3"> <!-- sidebar -->
+          <nav id="toc" data-toggle="toc" class="sticky-top"></nav>
+        </div> <!-- /sidebar -->
+        <div class="col-sm-9"> <!-- main content -->
 
     <!-- Jumbotron -->
     <div class="jumbotron container">
@@ -99,7 +107,6 @@ a {
     </div>
     <p>&nbsp;</p>
     {% endif %}
-
 
     {% for stmt_info in statements %}
     <a name='{{ stmt_info['hash'] }}'></a>
@@ -160,7 +167,9 @@ a {
     </div> <!-- evidence -->
     {% endfor %}
 
-    </div> <!-- /container -->
+        </div> <!-- /main content -->
+      </div> <!-- /row for sidebar -->
+    </div> <!-- /container for sidebar -->
   </body>
 </html>
 

--- a/indra/assemblers/html/template.html
+++ b/indra/assemblers/html/template.html
@@ -15,12 +15,17 @@
 
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <!-- TOC plugin: https://afeld.github.io/bootstrap-toc/ -->
+    <link rel="stylesheet" href="https://cdn.rawgit.com/afeld/bootstrap-toc/v1.0.0/dist/bootstrap-toc.min.css">
 
     <!-- Optional theme -->
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
 
     <!-- Latest compiled and minified JavaScript -->
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+    <!-- TOC plugin JS: https://afeld.github.io/bootstrap-toc/ -->
+    <script src="https://cdn.rawgit.com/afeld/bootstrap-toc/v1.0.0/dist/bootstrap-toc.min.js"></script>
+
 
     <!-- Load curationFunctions.js -->
     <script src="https://www.indra.bio/indra/assemblers/html/curationFunctions.js"></script>

--- a/indra/assemblers/html/template.html
+++ b/indra/assemblers/html/template.html
@@ -108,13 +108,13 @@ nav {
         <hr>
 
     {% if metadata %}
-    <div class="page-header">
-        <h4>Summary Metadata</h4>
-    <ul>
+    <div class="page-header container" style="padding: 0px;">
+      <h4 class="nav-header" data-toggle="collapse" data-target="#meta_list"><a href="#" title="Click to see metadata" style="color: #000000;">Summary Metadata</a></h4>
+      <ul class="collapse" id="meta_list">
         {% for name, value in metadata.items() %}
         <li>{{ name }}: {{ value }}</li>
         {% endfor %}
-    </ul>
+      </ul>
     </div>
     <p>&nbsp;</p>
     {% endif %}

--- a/indra/assemblers/html/template.html
+++ b/indra/assemblers/html/template.html
@@ -34,6 +34,11 @@
 a {
     color: #256DC5;
 }
+nav {
+  overflow-y: auto;
+  height: 100vh;
+  display: block;
+}
 .badge-subject {
   background-color: #4a36aa;
   color: #FFFFFF;

--- a/indra/assemblers/html/template.html
+++ b/indra/assemblers/html/template.html
@@ -32,7 +32,10 @@
 
   <style>
 a {
-    color: #256DC5;
+  color: #256DC5;
+}
+p {
+  margin-bottom: 0px;
 }
 nav {
   overflow-y: auto;
@@ -68,11 +71,14 @@ nav {
         </div> <!-- /sidebar -->
         <div class="col-sm-9"> <!-- main content -->
 
-    <!-- Jumbotron -->
-    <div class="jumbotron container">
-          <h3 class="display-4">{{ title }}</h3>
-          <hr class="my-4">
-          <p>This page allows you to curate the loaded statements.<br>For more information please see the <a href="https://indra.readthedocs.io/en/latest/tutorials/html_curation.html">manual</a>.</p>
+    <!-- Page Header -->
+    <div class="container">
+      <div class="page-header">
+        <h1>{{ title }}</h1>
+      </div>
+        <p>This page allows you to curate the loaded statements.</p>
+        <p>For more information please see the <a href="https://indra.readthedocs.io/en/latest/tutorials/html_curation.html">manual</a>.</p>
+        <hr>
     </div>
 
     <div class="container theme-showcase" role="main">

--- a/indra/assemblers/html/template.html
+++ b/indra/assemblers/html/template.html
@@ -121,7 +121,6 @@ nav {
       </ul>
     </div>
     <p>&nbsp;</p>
-    <hr>
     {% endif %}
 
     <h4>Statements</h4>

--- a/indra/assemblers/html/template.html
+++ b/indra/assemblers/html/template.html
@@ -117,8 +117,11 @@ nav {
       </ul>
     </div>
     <p>&nbsp;</p>
+    <hr>
     {% endif %}
 
+    <h4>Statements</h4>
+    <p>&nbsp;</p>
     {% for stmt_info in statements %}
     <a name='{{ stmt_info['hash'] }}'></a>
     <div class="statement">


### PR DESCRIPTION
This PR adds a left margin, "sticky", table of contents to the HTML assembler output where each natural language statement has its own item in the table. This will make looking over and scrolling through long results from the HTML assembler easier.

Other changes:

* The jumbotron is replaced with a scaled down large header
* Metadata list about results is now collapsible

This resolves issue #763.