### PR TITLE
Remove unused import of NiceCXNetwork

### DIFF
--- a/indra/databases/ndex_client.py
+++ b/indra/databases/ndex_client.py
@@ -7,10 +7,6 @@ import time
 import requests
 import logging
 import ndex2.client
-try:
-    from ndex2.nice_cx_network import NiceCXNetwork
-except ImportError:
-    from ndex2.niceCXNetwork import NiceCXNetwork
 from indra import get_config
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Apologies if I've missed something, but it's not obvious why this is being imported. If indra is installed without ndex2, there are several modules that can't be imported without it crashing.