### PR TITLE
Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "2.7"
   - "3.5"
 script:
+  # Credit: https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
   - echo "$TRAVIS_EVENT_TYPE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ install:
   - pip install pybel
   - pip install awscli
   - mkdir -p $HOME/.pybel/data
-  - aws s3 cp s3://bigmech/travis/pybel_cache.db $HOME/.pybel/data/
-  - aws s3 cp s3://bigmech/travis/Phosphorylation_site_dataset.tsv indra/resources/
+  - aws s3 cp s3://bigmech/travis/pybel_cache.db $HOME/.pybel/data/ --no-sign-request
+  - aws s3 cp s3://bigmech/travis/Phosphorylation_site_dataset.tsv indra/resources/ --no-sign-request
   # PySB and dependencies
   - wget "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable_Linux.tar.gz" -O bionetgen.tar.gz -nv
   - tar xzf bionetgen.tar.gz
@@ -48,14 +48,14 @@ install:
   - aws s3 cp s3://bigmech/travis/trips_reach_batch4.gz .
   - tar -xf trips_reach_batch4.gz
   - cd $TRAVIS_BUILD_DIR
-  - aws s3 cp s3://bigmech/travis/reach-82631d-biores-e9ee36.jar .
+  - aws s3 cp s3://bigmech/travis/reach-82631d-biores-e9ee36.jar . --no-sign-request
   - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
   # Get nose notify.
   - mkdir $HOME/.nose_notify
   - git clone https://github.com/pagreene/nose-notify.git $HOME/.nose_notify
   - export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify
   # Get a daily updated Eidos jar for testing
-  - aws s3 cp s3://bigmech/travis/eidos.jar .
+  - aws s3 cp s3://bigmech/travis/eidos.jar . --no-sign-request
   - export EIDOSPATH=$TRAVIS_BUILD_DIR/eidos.jar
   - pip install pycodestyle
   # TEES
@@ -66,7 +66,7 @@ install:
   - |
     if [[ $RUN_SLOW == "true" ]]; then
         sudo apt-get --yes install ruby;
-        aws s3 cp s3://bigmech/travis/TEES.tar.bz2 .;
+        aws s3 cp s3://bigmech/travis/TEES.tar.bz2 . --no-sign-request;
         tar xjf TEES.tar.bz2;
         mv TEES ~/TEES;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,9 @@ script:
      fi
   # Run assembly benchmarks
   - cd $TRAVIS_BUILD_DIR/indra/benchmarks/assembly_eval/batch4
-  - python run_combined.py
+  - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+        python run_combined.py
+    fi
   - cd $TRAVIS_BUILD_DIR
   # Run code style report on diff
   - git remote set-branches --add origin master

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   - cd $TRAVIS_BUILD_DIR
   - wget http://sorger.med.harvard.edu/data/bachman/reach-82631d-biores-e9ee36.jar -nv
   - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
-  - git clone https://github.com/pagreene/nose-notify.git $HOME/.nose_notify
+  - [ "$(ls -A $HOME/.nose_notify)" ] && git clone https://github.come/pagreene/nose-notify.git $HOME/.nose_notify || echo "nose-notify already installed."
   - export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify
   # Get a daily updated Eidos jar for testing
   - wget http://sorger.med.harvard.edu/data/bgyori/eidos.jar -nv

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,15 +103,16 @@ script:
     fi
   # First run TEES and Eidos tests separately for technical reasons
   - python -m nose_notify -v -a $NOSEATTR --process-restartworker indra/tests/test_tees.py
-        --slack_hook $SLACK_NOTIFY_HOOK
+        --slack_hook $SLACK_NOTIFY_HOOK --label "INDRA TEES $TRAVIS_BRANCH"
   - python -m nose_notify -v -a $NOSEATTR indra/tests/test_eidos.py
-        --slack_hook $SLACK_NOTIFY_HOOK
+        --slack_hook $SLACK_NOTIFY_HOOK --label "INDRA EIDOS $TRAVIS_BRANCH"
   # Now run all INDRA tests
   - python -m nose_notify indra -v -a $NOSEATTR
         --exclude='.*tees.*' --exclude='.*eidos.*' --exclude='.*isi.*'
         --with-coverage --cover-inclusive --cover-package=indra
         --with-doctest --with-doctest-ignore-unicode
         --with-timer --timer-top-n 10 --slack_hook $SLACK_NOTIFY_HOOK
+        --label "INDRA $TRAVIS_BRANCH"
   # Run NL model examples only when the environmental variable
   # RUN_NL_MODELS is set to true in the Travis build
   # NOTE: if blocks in Travis DO NOT FAIL even if there is

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,16 +50,10 @@ install:
   - cd $TRAVIS_BUILD_DIR
   - aws s3 cp s3://bigmech/travis/reach-82631d-biores-e9ee36.jar . --no-sign-request  --source-region us-east-1
   - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
-  # Get nose notify, if needed.
-  - |
-    if [[ -z "${SLACK_NOTIFY_HOOK}" ]]; then
-      echo "NOT installing nose-notify.";
-    else
-      echo "Installing nose-notify.";
-      mkdir $HOME/.nose_notify;
-      git clone https://github.com/pagreene/nose-notify.git $HOME/.nose_notify;
-      export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify;
-    fi
+  # Get nose notify.
+  - mkdir $HOME/.nose_notify;
+  - git clone https://github.com/pagreene/nose-notify.git $HOME/.nose_notify;
+  - export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify;
   # Get a daily updated Eidos jar for testing
   - aws s3 cp s3://bigmech/travis/eidos.jar . --no-sign-request --source-region us-east-1
   - export EIDOSPATH=$TRAVIS_BUILD_DIR/eidos.jar
@@ -84,15 +78,6 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3
 script:
-  # Choose which test code to use.
-  - |
-    if [[ -z "${SLACK_NOTIFY_HOOK}" ]]; then
-      echo "run_tests is nosetests.";
-      alias run_tests='nosetests';
-    else
-      echo "run_tests is nose_notify.";
-      alias run_tests='python -m nose_notify --slack_hook $SLACK_NOTIFY_HOOK --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH"';
-    fi
   # Credit: https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
@@ -117,14 +102,15 @@ script:
       export NOSEATTR="!slow,$NOSEATTR";
     fi
   # First run TEES and Eidos tests separately for technical reasons
-  - run_tests indra/tests/test_tees.py -v -a $NOSEATTR --process-restartworker
-  - run_tests indra/tests/test_eidos.py -v -a $NOSEATTR
+  - python -m nose_notify indra/tests/test_tees.py --slack_hook $SLACK_NOTIFY_HOOK
+    --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR --process-restartworker;
+  - python -m nose_notify indra/tests/test_eidos.py --slack_hook $SLACK_NOTIFY_HOOK
+    --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR;
   # Now run all INDRA tests
-  - run_tests indra -v -a $NOSEATTR
-        --exclude='.*tees.*' --exclude='.*eidos.*' --exclude='.*isi.*'
+  - python -m nose_notify --slack_hook $SLACK_NOTIFY_HOOK --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH"
+    indra -v -a $NOSEATTR --exclude='.*tees.*' --exclude='.*eidos.*' --exclude='.*isi.*'
         --with-coverage --cover-inclusive --cover-package=indra
-        --with-doctest --with-doctest-ignore-unicode
-        --with-timer --timer-top-n 10
+        --with-doctest --with-doctest-ignore-unicode --with-timer --timer-top-n 10
   # Run NL model examples only when the environmental variable
   # RUN_NL_MODELS is set to true in the Travis build
   # NOTE: if blocks in Travis DO NOT FAIL even if there is

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ install:
   - pip install pybel
   - pip install awscli
   - mkdir -p $HOME/.pybel/data
-  - aws s3 cp s3://bigmech/travis/pybel_cache.db $HOME/.pybel/data/ --no-sign-request
-  - aws s3 cp s3://bigmech/travis/Phosphorylation_site_dataset.tsv indra/resources/ --no-sign-request
+  - aws s3 cp s3://bigmech/travis/pybel_cache.db $HOME/.pybel/data/ --no-sign-request  --source-region us-east-1
+  - aws s3 cp s3://bigmech/travis/Phosphorylation_site_dataset.tsv indra/resources/ --no-sign-request  --source-region us-east-1
   # PySB and dependencies
   - wget "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable_Linux.tar.gz" -O bionetgen.tar.gz -nv
   - tar xzf bionetgen.tar.gz
@@ -45,10 +45,10 @@ install:
   - pip install .[all]
   - cd indra/benchmarks/assembly_eval/batch4
   # Download a number of useful resource files for testing purposes
-  - aws s3 cp s3://bigmech/travis/trips_reach_batch4.gz .
+  - aws s3 cp s3://bigmech/travis/trips_reach_batch4.gz .  --source-region us-east-1
   - tar -xf trips_reach_batch4.gz
   - cd $TRAVIS_BUILD_DIR
-  - aws s3 cp s3://bigmech/travis/reach-82631d-biores-e9ee36.jar . --no-sign-request
+  - aws s3 cp s3://bigmech/travis/reach-82631d-biores-e9ee36.jar . --no-sign-request  --source-region us-east-1
   - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
   # Get nose notify.
   - |
@@ -61,7 +61,7 @@ install:
       alias test='python -m nose_notify --slack_hook $SLACK_NOTIFY_HOOK --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH"';
     fi
   # Get a daily updated Eidos jar for testing
-  - aws s3 cp s3://bigmech/travis/eidos.jar . --no-sign-request
+  - aws s3 cp s3://bigmech/travis/eidos.jar . --no-sign-request --source-region us-east-1
   - export EIDOSPATH=$TRAVIS_BUILD_DIR/eidos.jar
   - pip install pycodestyle
   # TEES

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
   - |
     if [[ $RUN_SLOW == "true" ]]; then
         sudo apt-get --yes install ruby;
-        aws s3 cp s3://bigmech/travis/TEES.tar.bz2 . --no-sign-request;
+        aws s3 cp s3://bigmech/travis/TEES.tar.bz2 . --no-sign-request --no-sign-request;
         tar xjf TEES.tar.bz2;
         mv TEES ~/TEES;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   - cd $TRAVIS_BUILD_DIR
   - wget http://sorger.med.harvard.edu/data/bachman/reach-82631d-biores-e9ee36.jar -nv
   - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
-  - git clone git@github.com:pagreene/nose-notify.git $HOME/.nose_notify
+  - git clone https://github.com/pagreene/nose-notify.git $HOME/.nose_notify
   - export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify
   # Get a daily updated Eidos jar for testing
   - wget http://sorger.med.harvard.edu/data/bgyori/eidos.jar -nv

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
   - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
   # Get nose notify.
   - mkdir $HOME/.nose_notify
-  - git clone https://github.come/pagreene/nose-notify.git $HOME/.nose_notify
+  - git clone https://github.com/pagreene/nose-notify.git $HOME/.nose_notify
   - export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify
   # Get a daily updated Eidos jar for testing
   - wget http://sorger.med.harvard.edu/data/bgyori/eidos.jar -nv

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,16 +103,16 @@ script:
     fi
   # First run TEES and Eidos tests separately for technical reasons
   - python -m nose_notify -v -a $NOSEATTR --process-restartworker indra/tests/test_tees.py
-        --slack_hook $SLACK_NOTIFY_HOOK --label "INDRA TEES $TRAVIS_BRANCH"
+        --slack_hook $SLACK_NOTIFY_HOOK --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH ~ TEES"
   - python -m nose_notify -v -a $NOSEATTR indra/tests/test_eidos.py
-        --slack_hook $SLACK_NOTIFY_HOOK --label "INDRA EIDOS $TRAVIS_BRANCH"
+        --slack_hook $SLACK_NOTIFY_HOOK --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH ~ EIDOS"
   # Now run all INDRA tests
   - python -m nose_notify indra -v -a $NOSEATTR
         --exclude='.*tees.*' --exclude='.*eidos.*' --exclude='.*isi.*'
         --with-coverage --cover-inclusive --cover-package=indra
         --with-doctest --with-doctest-ignore-unicode
         --with-timer --timer-top-n 10 --slack_hook $SLACK_NOTIFY_HOOK
-        --label "INDRA $TRAVIS_BRANCH"
+        --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH"
   # Run NL model examples only when the environmental variable
   # RUN_NL_MODELS is set to true in the Travis build
   # NOTE: if blocks in Travis DO NOT FAIL even if there is

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ cache:
 python:
   - "2.7"
   - "3.5"
-script:
-  # Credit: https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
-  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
-  - echo "$TRAVIS_EVENT_TYPE"
 before_install:
   - sudo add-apt-repository --yes ppa:webupd8team/java
   - sudo apt-get update
@@ -59,7 +54,8 @@ install:
   - export EIDOSPATH=$TRAVIS_BUILD_DIR/eidos.jar
   - pip install pycodestyle
   # TEES
-  - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+  - |
+    if [[ $TRAVIS_EVENT_TYPE == "cron" ]]; then
         export RUN_SLOW=true;
     fi
   - |
@@ -77,6 +73,10 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3
 script:
+  # Credit: https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
+  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
+  - echo "$TRAVIS_EVENT_TYPE"
   - export TEES_SETTINGS=~/TEES/tees_local_settings.py
   - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR
   - export _JAVA_OPTIONS="-Xmx4g -Xms1g"
@@ -113,7 +113,7 @@ script:
   # successful. Rather, the log needs to be inspected and compared
   # to desired behavior.
   - |
-    if [ $RUN_NL_MODELS == "true" ]; then
+    if [[ $RUN_NL_MODELS == "true" ]]; then
         cd $TRAVIS_BUILD_DIR/models
         python hello_indra.py
         cd $TRAVIS_BUILD_DIR/models/p53_model
@@ -125,7 +125,8 @@ script:
      fi
   # Run assembly benchmarks
   - cd $TRAVIS_BUILD_DIR/indra/benchmarks/assembly_eval/batch4
-  - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+  - |
+    if [[ $TRAVIS_EVENT_TYPE == "cron" ]]; then
         python run_combined.py
     fi
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - pip install awscli
   - mkdir -p $HOME/.pybel/data
   - aws s3 cp s3://bigmech/travis/pybel_cache.db $HOME/.pybel/data/
-  - wget http://sorger.med.harvard.edu/data/bachman/Phosphorylation_site_dataset.tsv --directory-prefix=indra/resources/ -nv
+  - aws s3 cp s3://bigmech/travis/Phosphorylation_site_dataset.tsv indra/resources/
   # PySB and dependencies
   - wget "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable_Linux.tar.gz" -O bionetgen.tar.gz -nv
   - tar xzf bionetgen.tar.gz
@@ -45,17 +45,17 @@ install:
   - pip install .[all]
   - cd indra/benchmarks/assembly_eval/batch4
   # Download a number of useful resource files for testing purposes
-  - wget http://sorger.med.harvard.edu/data/bachman/trips_reach_batch4.gz -nv
+  - aws s3 cp s3://bigmech/travis/trips_reach_batch4.gz .
   - tar -xf trips_reach_batch4.gz
   - cd $TRAVIS_BUILD_DIR
-  - wget http://sorger.med.harvard.edu/data/bachman/reach-82631d-biores-e9ee36.jar -nv
+  - aws s3 cp s3://bigmech/travis/reach-82631d-biores-e9ee36.jar .
   - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
   # Get nose notify.
   - mkdir $HOME/.nose_notify
   - git clone https://github.com/pagreene/nose-notify.git $HOME/.nose_notify
   - export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify
   # Get a daily updated Eidos jar for testing
-  - wget http://sorger.med.harvard.edu/data/bgyori/eidos.jar -nv
+  - aws s3 cp s3://bigmech/travis/eidos.jar .
   - export EIDOSPATH=$TRAVIS_BUILD_DIR/eidos.jar
   - pip install pycodestyle
   # TEES
@@ -66,7 +66,7 @@ install:
   - |
     if [[ $RUN_SLOW == "true" ]]; then
         sudo apt-get --yes install ruby;
-        wget -nv http://sorger.med.harvard.edu/data/bgyori/TEES.tar.bz2;
+        aws s3 cp s3://bigmech/travis/TEES.tar.bz2 .;
         tar xjf TEES.tar.bz2;
         mv TEES ~/TEES;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,9 @@ install:
   - pip install git+https://github.com/bgyori/paths_graph.git@networkx2
   - pip install doctest-ignore-unicode
   - pip install pybel
+  - pip install awscli
   - mkdir -p $HOME/.pybel/data
-  - wget -nv http://sorger.med.harvard.edu/data/bgyori/pybel_cache.db --directory-prefix=$HOME/.pybel/data
+  - aws s3 cp s3://bigmech/travis/pybel_cache.db $HOME/.pybel/data/
   - wget http://sorger.med.harvard.edu/data/bachman/Phosphorylation_site_dataset.tsv --directory-prefix=indra/resources/ -nv
   # PySB and dependencies
   - wget "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable_Linux.tar.gz" -O bionetgen.tar.gz -nv

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/.pybel
-    - $HOME/.nose_notify
 python:
   - "2.7"
   - "3.5"
@@ -51,7 +50,9 @@ install:
   - cd $TRAVIS_BUILD_DIR
   - wget http://sorger.med.harvard.edu/data/bachman/reach-82631d-biores-e9ee36.jar -nv
   - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
-  - [ "$(ls -A $HOME/.nose_notify)" ] && git clone https://github.come/pagreene/nose-notify.git $HOME/.nose_notify || echo "nose-notify already installed."
+  # Get nose notify.
+  - mkdir $HOME/.nose_notify
+  - git clone https://github.come/pagreene/nose-notify.git $HOME/.nose_notify
   - export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify
   # Get a daily updated Eidos jar for testing
   - wget http://sorger.med.harvard.edu/data/bgyori/eidos.jar -nv

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,10 @@ install:
   # Get nose notify.
   - |
     if [[ -z "${SLACK_NOTIFY_HOOK}" ]]; then
+      echo "test is nosetests.";
       alias test='nosetests';
     else
+      echo "test is nose_notify.";
       mkdir $HOME/.nose_notify;
       git clone https://github.com/pagreene/nose-notify.git $HOME/.nose_notify;
       export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ cache:
 python:
   - "2.7"
   - "3.5"
+script:
+  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
+  - echo "$TRAVIS_EVENT_TYPE"
 before_install:
   - sudo add-apt-repository --yes ppa:webupd8team/java
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,15 @@ install:
   - aws s3 cp s3://bigmech/travis/reach-82631d-biores-e9ee36.jar . --no-sign-request
   - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
   # Get nose notify.
-  - mkdir $HOME/.nose_notify
-  - git clone https://github.com/pagreene/nose-notify.git $HOME/.nose_notify
-  - export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify
+  - |
+    if [[ -z "${SLACK_NOTIFY_HOOK}" ]]; then
+      alias test='nosetests';
+    else
+      mkdir $HOME/.nose_notify;
+      git clone https://github.com/pagreene/nose-notify.git $HOME/.nose_notify;
+      export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify;
+      alias test='python -m nose_notify --slack_hook $SLACK_NOTIFY_HOOK --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH"';
+    fi
   # Get a daily updated Eidos jar for testing
   - aws s3 cp s3://bigmech/travis/eidos.jar . --no-sign-request
   - export EIDOSPATH=$TRAVIS_BUILD_DIR/eidos.jar
@@ -102,17 +108,14 @@ script:
       export NOSEATTR="!slow,$NOSEATTR";
     fi
   # First run TEES and Eidos tests separately for technical reasons
-  - python -m nose_notify -v -a $NOSEATTR --process-restartworker indra/tests/test_tees.py
-        --slack_hook $SLACK_NOTIFY_HOOK --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH ~ TEES"
-  - python -m nose_notify -v -a $NOSEATTR indra/tests/test_eidos.py
-        --slack_hook $SLACK_NOTIFY_HOOK --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH ~ EIDOS"
+  - test indra/tests/test_tees.py -v -a $NOSEATTR --process-restartworker
+  - test indra/tests/test_eidos.py -v -a $NOSEATTR
   # Now run all INDRA tests
-  - python -m nose_notify indra -v -a $NOSEATTR
+  - test indra -v -a $NOSEATTR
         --exclude='.*tees.*' --exclude='.*eidos.*' --exclude='.*isi.*'
         --with-coverage --cover-inclusive --cover-package=indra
         --with-doctest --with-doctest-ignore-unicode
-        --with-timer --timer-top-n 10 --slack_hook $SLACK_NOTIFY_HOOK
-        --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH"
+        --with-timer --timer-top-n 10
   # Run NL model examples only when the environmental variable
   # RUN_NL_MODELS is set to true in the Travis build
   # NOTE: if blocks in Travis DO NOT FAIL even if there is

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,17 +50,15 @@ install:
   - cd $TRAVIS_BUILD_DIR
   - aws s3 cp s3://bigmech/travis/reach-82631d-biores-e9ee36.jar . --no-sign-request  --source-region us-east-1
   - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
-  # Get nose notify.
+  # Get nose notify, if needed.
   - |
     if [[ -z "${SLACK_NOTIFY_HOOK}" ]]; then
-      echo "run_tests is nosetests.";
-      alias run_tests='nosetests';
+      echo "NOT installing nose-notify.";
     else
-      echo "run_tests is nose_notify.";
+      echo "Installing nose-notify.";
       mkdir $HOME/.nose_notify;
       git clone https://github.com/pagreene/nose-notify.git $HOME/.nose_notify;
       export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify;
-      alias run_tests='python -m nose_notify --slack_hook $SLACK_NOTIFY_HOOK --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH"';
     fi
   # Get a daily updated Eidos jar for testing
   - aws s3 cp s3://bigmech/travis/eidos.jar . --no-sign-request --source-region us-east-1
@@ -86,6 +84,15 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3
 script:
+  # Choose which test code to use.
+  - |
+    if [[ -z "${SLACK_NOTIFY_HOOK}" ]]; then
+      echo "run_tests is nosetests.";
+      alias run_tests='nosetests';
+    else
+      echo "run_tests is nose_notify.";
+      alias run_tests='python -m nose_notify --slack_hook $SLACK_NOTIFY_HOOK --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH"';
+    fi
   # Credit: https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/.pybel
+    - $HOME/.nose_notify
 python:
   - "2.7"
   - "3.5"
@@ -50,6 +51,8 @@ install:
   - cd $TRAVIS_BUILD_DIR
   - wget http://sorger.med.harvard.edu/data/bachman/reach-82631d-biores-e9ee36.jar -nv
   - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
+  - git clone git@github.com:pagreene/nose-notify.git $HOME/.nose_notify
+  - export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify
   # Get a daily updated Eidos jar for testing
   - wget http://sorger.med.harvard.edu/data/bgyori/eidos.jar -nv
   - export EIDOSPATH=$TRAVIS_BUILD_DIR/eidos.jar
@@ -98,14 +101,16 @@ script:
       export NOSEATTR="!slow,$NOSEATTR";
     fi
   # First run TEES and Eidos tests separately for technical reasons
-  - nosetests -v -a $NOSEATTR --process-restartworker indra/tests/test_tees.py
-  - nosetests -v -a $NOSEATTR indra/tests/test_eidos.py
+  - python -m nose_notify -v -a $NOSEATTR --process-restartworker indra/tests/test_tees.py
+        --slack_hook $SLACK_NOTIFY_HOOK
+  - python -m nose_notify -v -a $NOSEATTR indra/tests/test_eidos.py
+        --slack_hook $SLACK_NOTIFY_HOOK
   # Now run all INDRA tests
-  - nosetests indra -v -a $NOSEATTR
+  - python -m nose_notify indra -v -a $NOSEATTR
         --exclude='.*tees.*' --exclude='.*eidos.*' --exclude='.*isi.*'
         --with-coverage --cover-inclusive --cover-package=indra
         --with-doctest --with-doctest-ignore-unicode
-        --with-timer --timer-top-n 10
+        --with-timer --timer-top-n 10 --slack_hook $SLACK_NOTIFY_HOOK
   # Run NL model examples only when the environmental variable
   # RUN_NL_MODELS is set to true in the Travis build
   # NOTE: if blocks in Travis DO NOT FAIL even if there is

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,14 +53,14 @@ install:
   # Get nose notify.
   - |
     if [[ -z "${SLACK_NOTIFY_HOOK}" ]]; then
-      echo "test is nosetests.";
-      alias test='nosetests';
+      echo "run_tests is nosetests.";
+      alias run_tests='nosetests';
     else
-      echo "test is nose_notify.";
+      echo "run_tests is nose_notify.";
       mkdir $HOME/.nose_notify;
       git clone https://github.com/pagreene/nose-notify.git $HOME/.nose_notify;
       export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify;
-      alias test='python -m nose_notify --slack_hook $SLACK_NOTIFY_HOOK --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH"';
+      alias run_tests='python -m nose_notify --slack_hook $SLACK_NOTIFY_HOOK --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH"';
     fi
   # Get a daily updated Eidos jar for testing
   - aws s3 cp s3://bigmech/travis/eidos.jar . --no-sign-request --source-region us-east-1
@@ -110,10 +110,10 @@ script:
       export NOSEATTR="!slow,$NOSEATTR";
     fi
   # First run TEES and Eidos tests separately for technical reasons
-  - test indra/tests/test_tees.py -v -a $NOSEATTR --process-restartworker
-  - test indra/tests/test_eidos.py -v -a $NOSEATTR
+  - run_tests indra/tests/test_tees.py -v -a $NOSEATTR --process-restartworker
+  - run_tests indra/tests/test_eidos.py -v -a $NOSEATTR
   # Now run all INDRA tests
-  - test indra -v -a $NOSEATTR
+  - run_tests indra -v -a $NOSEATTR
         --exclude='.*tees.*' --exclude='.*eidos.*' --exclude='.*isi.*'
         --with-coverage --cover-inclusive --cover-package=indra
         --with-doctest --with-doctest-ignore-unicode

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
   - pip install .[all]
   - cd indra/benchmarks/assembly_eval/batch4
   # Download a number of useful resource files for testing purposes
-  - aws s3 cp s3://bigmech/travis/trips_reach_batch4.gz .  --source-region us-east-1
+  - aws s3 cp s3://bigmech/travis/trips_reach_batch4.gz .  --no-sign-request  --source-region us-east-1
   - tar -xf trips_reach_batch4.gz
   - cd $TRAVIS_BUILD_DIR
   - aws s3 cp s3://bigmech/travis/reach-82631d-biores-e9ee36.jar . --no-sign-request  --source-region us-east-1


### PR DESCRIPTION
Update Travis to:
- Use nose-notify to send notifications when tests fail
- Draw resources from s3 instead of O2.