### PR TITLE
Bayesian belief scorer and real-time curation service

### DIFF
--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -100,6 +100,10 @@ class SimpleScorer(BeliefScorer):
     """
     def __init__(self, prior_probs=None, subtype_probs=None):
         self.prior_probs = load_default_probs()
+        self.subtype_probs = {}
+        self._update_probs(prior_probs, subtype_probs)
+
+    def update_probs(prior_probs=None, subtype_probs=None)
         if prior_probs:
             for key in ('rand', 'syst'):
                 self.prior_probs[key].update(prior_probs.get(key, {}))
@@ -107,7 +111,6 @@ class SimpleScorer(BeliefScorer):
             logger.debug("Prior probabilities for %s errors: %s"
                          % (err_type, source_dict))
         self.subtype_probs = subtype_probs
-        return
 
     def score_evidence_list(self, evidences):
         def _score(evidences):

--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -103,7 +103,7 @@ class SimpleScorer(BeliefScorer):
         self.subtype_probs = {}
         self._update_probs(prior_probs, subtype_probs)
 
-    def update_probs(prior_probs=None, subtype_probs=None)
+    def update_probs(prior_probs=None, subtype_probs=None):
         if prior_probs:
             for key in ('rand', 'syst'):
                 self.prior_probs[key].update(prior_probs.get(key, {}))

--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -259,6 +259,8 @@ class BayesianScorer(SimpleScorer):
                     self.subtype_counts[source][subtype] = [0, 0]
                 self.subtype_counts[source][subtype][0] += pos
                 self.subtype_counts[source][subtype][1] += neg
+            print(self.prior_probs)
+            print(self.prior_counts)
         self.update_probs()
 
 

--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -104,6 +104,9 @@ class SimpleScorer(BeliefScorer):
         self.update_probs(prior_probs, subtype_probs)
 
     def update_probs(self, prior_probs=None, subtype_probs=None):
+        print(self.prior_probs)
+        print(self.subtype_probs)
+        print('--------------')
         if prior_probs:
             for key in ('rand', 'syst'):
                 self.prior_probs[key].update(prior_probs.get(key, {}))
@@ -111,6 +114,8 @@ class SimpleScorer(BeliefScorer):
             logger.debug("Prior probabilities for %s errors: %s"
                          % (err_type, source_dict))
         self.subtype_probs = subtype_probs
+        print(self.prior_probs)
+        print(self.subtype_probs)
 
     def score_evidence_list(self, evidences):
         def _score(evidences):
@@ -198,6 +203,7 @@ class SimpleScorer(BeliefScorer):
             List of statements to check
         """
         sources = set()
+        print(statements)
         for stmt in statements:
             sources |= set([ev.source_api for ev in stmt.evidence])
         for err_type in ('rand', 'syst'):

--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -251,10 +251,10 @@ class BayesianScorer(SimpleScorer):
                 self.prior_counts[source] = [0, 0]
             self.prior_counts[source][0] += pos
             self.prior_counts[source][1] += neg
-        for source, subtype in subtype_counts.items():
+        for source, subtype_dict in subtype_counts.items():
             if source not in self.subtype_counts:
                 self.subtype_counts[source] = {}
-            for subtype, (pos, neg) in subtype_counts.items():
+            for subtype, (pos, neg) in subtype_dict.items():
                 if subtype not in self.subtype_counts[source]:
                     self.subtype_counts[source][subtype] = [0, 0]
                 self.subtype_counts[source][subtype][0] += pos

--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -259,7 +259,7 @@ class BayesianScorer(SimpleScorer):
                     1 - min((p / (n + p), 1-syst_error)) - syst_error
         # Finally we propagate this into the full probability
         # data structures of the parent class
-        super().update_probs(prior_probs, subtype_probs)
+        super(BayesianScorer, self).update_probs(prior_probs, subtype_probs)
 
     def update_counts(self, prior_counts, subtype_counts):
         """Update the internal counts based on given new counts.

--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -245,7 +245,7 @@ class BayesianScorer(SimpleScorer):
                 continue
             prior_probs['syst'][source] = syst_error
             prior_probs['rand'][source] = \
-                1 - min((p / (n + p), 1-syst_error)) - syst_error
+                1 - min((float(p) / (n + p), 1-syst_error)) - syst_error
         # Next we deal with subtype probs based on counts
         subtype_probs = {}
         for source, entry in self.subtype_counts.items():
@@ -256,7 +256,7 @@ class BayesianScorer(SimpleScorer):
                 if source not in subtype_probs:
                     subtype_probs[source] = {}
                 subtype_probs[source][rule] = \
-                    1 - min((p / (n + p), 1-syst_error)) - syst_error
+                    1 - min((float(p) / (n + p), 1-syst_error)) - syst_error
         # Finally we propagate this into the full probability
         # data structures of the parent class
         super(BayesianScorer, self).update_probs(prior_probs, subtype_probs)

--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -225,7 +225,7 @@ class BayesianScorer(SimpleScorer):
     def update_probs(self):
         # This is a fixed assumed value for systematic error
         syst_error = 0.05
-        prior_probs = {'syst': [], 'rand': []}
+        prior_probs = {'syst': {}, 'rand': {}}
         for source, (p, n) in self.prior_counts.items():
             # Skip if there are no actual counts
             if n + p == 0:
@@ -247,11 +247,19 @@ class BayesianScorer(SimpleScorer):
 
     def update_counts(self, prior_counts, subtype_counts):
         for source, (pos, neg) in prior_counts.items():
-            # FIXME: handle subtypes
+            if source not in self.prior_counts:
+                self.prior_counts[source] = [0, 0]
             self.prior_counts[source][0] += pos
             self.prior_counts[source][1] += neg
-
-
+        for source, subtype in subtype_counts.items():
+            if source not in self.subtype_counts:
+                self.subtype_counts[source] = {}
+            for subtype, (pos, neg) in subtype_counts.items():
+                if subtype not in self.subtype_counts[source]:
+                    self.subtype_counts[source][subtype] = [0, 0]
+                self.subtype_counts[source][subtype][0] += pos
+                self.subtype_counts[source][subtype][1] += neg
+        self.update_probs()
 
 
 default_scorer = SimpleScorer()

--- a/indra/belief/wm_scorer.py
+++ b/indra/belief/wm_scorer.py
@@ -4,6 +4,60 @@ import requests
 from . import SimpleScorer
 
 
+class BayesianScorer(SimpleScorer):
+    def __init__(self, prior_counts, subtype_counts):
+        self.prior_counts = prior_counts
+        self.subtype_counts = subtype_counts
+        self._update_probs()
+
+    def update_probs(self):
+        prior_probs = {source: (p / (n + p)) for source, (p, n) in
+                       self.prior_counts.items()}
+        # FIXME: this will need to be fixed
+        subtype_probs = {source: {rule: (p / (n + p)} for rule, (p, n)
+                         in st.items() for st, rule in
+                         self.subtype_counts.items()}
+        super()._update_probs(prior_probs, subtype_probs)
+
+    def update_counts(self, counts):
+        for source, (pos, neg) in counts.items():
+            # FIXME: handle subtypes
+            self.prior_counts[source][0] += pos
+            self.prior_counts[source][1] += neg
+
+
+def get_eidos_counts():
+    url = 'https://raw.githubusercontent.com/clulab/eidos/master/' + \
+        'src/main/resources/org/clulab/wm/eidos/english/confidence/' + \
+        'rule_summary.tsv'
+    # Load the table of scores from the URL above into a data frame
+    res = StringIO(requests.get(url).text)
+    table = pandas.read_table(res, sep='\t')
+    # Drop the last "Grant total" row
+    table = table.drop(table.index[len(table)-1])
+
+    # Get the overall precision
+    total_corr = table['Num correct'].sum()
+    total_incorr = table['Num incorrect'].sum()
+    precision = total_corr / (total_corr + total_incorr)
+    prior_probs = {'rand': {'eidos': rand_error},
+                   'syst': {'eidos': syst_error}}
+
+    prior_counts = {'eidos': {r: [c, i] for r, c, i
+                              zip(table['RULE'], table['Num correct'],
+                              table['Num incorrect'])}}
+
+    # We have to divide this into a random and systematic component, for now
+    # in an ad-hoc manner
+    syst_error = 0.05
+    rand_error = 1 - precision - syst_error
+    prior_probs = {'rand': {'eidos': rand_error}, 'syst': {'eidos': syst_error}}
+
+    # Get a dict of rule-specific errors.
+    subtype_probs = {'eidos':
+                     {k: 1.0-min(v, 0.95)-syst_error for k, v
+                      in zip(table['RULE'], table['% correct'])}}
+
 def get_eidos_scorer():
     url = 'https://raw.githubusercontent.com/clulab/eidos/master/' + \
         'src/main/resources/org/clulab/wm/eidos/english/confidence/' + \

--- a/indra/belief/wm_scorer.py
+++ b/indra/belief/wm_scorer.py
@@ -4,7 +4,8 @@ import requests
 from . import SimpleScorer, BayesianScorer
 
 
-def get_eidos_counts():
+def get_eidos_bayesian_scorer():
+    """Return a BayesianScorer based on Eidos curation counts."""
     url = 'https://raw.githubusercontent.com/clulab/eidos/master/' + \
         'src/main/resources/org/clulab/wm/eidos/english/confidence/' + \
         'rule_summary.tsv'
@@ -14,32 +15,16 @@ def get_eidos_counts():
     # Drop the last "Grant total" row
     table = table.drop(table.index[len(table)-1])
 
-    # Get the overall precision
-    total_corr = table['Num correct'].sum()
-    total_incorr = table['Num incorrect'].sum()
-    precision = total_corr / (total_corr + total_incorr)
-
-    # We have to divide this into a random and systematic component, for now
-    # in an ad-hoc manner
-    syst_error = 0.05
-    rand_error = 1 - precision - syst_error
-
-    prior_probs = {'rand': {'eidos': rand_error},
-                   'syst': {'eidos': syst_error}}
-
-    prior_counts = {'eidos': {r: [c, i] for r, c, i in
+    subtype_counts = {'eidos': {r: [c, i] for r, c, i in
                               zip(table['RULE'], table['Num correct'],
                                   table['Num incorrect'])}}
 
-    # Get a dict of rule-specific errors.
-    subtype_probs = {'eidos':
-                     {k: 1.0-min(v, 0.95)-syst_error for k, v
-                      in zip(table['RULE'], table['% correct'])}}
-    scorer = BayesianScorer(prior_counts={}, subtype_counts=prior_counts)
+    scorer = BayesianScorer(prior_counts={}, subtype_counts=subtype_counts)
     return scorer
 
 
 def get_eidos_scorer():
+    """Return a SimpleScorer based on Eidos curated precision estimates."""
     url = 'https://raw.githubusercontent.com/clulab/eidos/master/' + \
         'src/main/resources/org/clulab/wm/eidos/english/confidence/' + \
         'rule_summary.tsv'

--- a/indra/belief/wm_scorer.py
+++ b/indra/belief/wm_scorer.py
@@ -18,12 +18,6 @@ def get_eidos_counts():
     total_corr = table['Num correct'].sum()
     total_incorr = table['Num incorrect'].sum()
     precision = total_corr / (total_corr + total_incorr)
-    prior_probs = {'rand': {'eidos': rand_error},
-                   'syst': {'eidos': syst_error}}
-
-    prior_counts = {'eidos': {r: [c, i] for r, c, i
-                              zip(table['RULE'], table['Num correct'],
-                              table['Num incorrect'])}}
 
     # We have to divide this into a random and systematic component, for now
     # in an ad-hoc manner
@@ -31,10 +25,19 @@ def get_eidos_counts():
     rand_error = 1 - precision - syst_error
     prior_probs = {'rand': {'eidos': rand_error}, 'syst': {'eidos': syst_error}}
 
+    prior_probs = {'rand': {'eidos': rand_error},
+                   'syst': {'eidos': syst_error}}
+
+    prior_counts = {'eidos': {r: [c, i] for r, c, i in
+                              zip(table['RULE'], table['Num correct'],
+                                  table['Num incorrect'])}}
+
     # Get a dict of rule-specific errors.
     subtype_probs = {'eidos':
                      {k: 1.0-min(v, 0.95)-syst_error for k, v
                       in zip(table['RULE'], table['% correct'])}}
+    scorer = BayesianScorer(prior_counts={}, subtype_counts=prior_counts)
+    return scorer
 
 def get_eidos_scorer():
     url = 'https://raw.githubusercontent.com/clulab/eidos/master/' + \

--- a/indra/belief/wm_scorer.py
+++ b/indra/belief/wm_scorer.py
@@ -36,8 +36,6 @@ def get_eidos_counts():
                      {k: 1.0-min(v, 0.95)-syst_error for k, v
                       in zip(table['RULE'], table['% correct'])}}
     scorer = BayesianScorer(prior_counts={}, subtype_counts=prior_counts)
-    print(scorer.prior_probs)
-    print(scorer.subtype_probs)
     return scorer
 
 

--- a/indra/belief/wm_scorer.py
+++ b/indra/belief/wm_scorer.py
@@ -46,6 +46,5 @@ def get_eidos_scorer():
     subtype_probs = {'eidos':
                      {k: 1.0-min(v, 0.95)-syst_error for k, v
                       in zip(table['RULE'], table['% correct'])}}
-    print(subtype_probs)
     scorer = SimpleScorer(prior_probs, subtype_probs)
     return scorer

--- a/indra/belief/wm_scorer.py
+++ b/indra/belief/wm_scorer.py
@@ -23,7 +23,6 @@ def get_eidos_counts():
     # in an ad-hoc manner
     syst_error = 0.05
     rand_error = 1 - precision - syst_error
-    prior_probs = {'rand': {'eidos': rand_error}, 'syst': {'eidos': syst_error}}
 
     prior_probs = {'rand': {'eidos': rand_error},
                    'syst': {'eidos': syst_error}}
@@ -37,7 +36,10 @@ def get_eidos_counts():
                      {k: 1.0-min(v, 0.95)-syst_error for k, v
                       in zip(table['RULE'], table['% correct'])}}
     scorer = BayesianScorer(prior_counts={}, subtype_counts=prior_counts)
+    print(scorer.prior_probs)
+    print(scorer.subtype_probs)
     return scorer
+
 
 def get_eidos_scorer():
     url = 'https://raw.githubusercontent.com/clulab/eidos/master/' + \
@@ -64,6 +66,6 @@ def get_eidos_scorer():
     subtype_probs = {'eidos':
                      {k: 1.0-min(v, 0.95)-syst_error for k, v
                       in zip(table['RULE'], table['% correct'])}}
-
+    print(subtype_probs)
     scorer = SimpleScorer(prior_probs, subtype_probs)
     return scorer

--- a/indra/belief/wm_scorer.py
+++ b/indra/belief/wm_scorer.py
@@ -1,29 +1,7 @@
 from io import StringIO
 import pandas
 import requests
-from . import SimpleScorer
-
-
-class BayesianScorer(SimpleScorer):
-    def __init__(self, prior_counts, subtype_counts):
-        self.prior_counts = prior_counts
-        self.subtype_counts = subtype_counts
-        self._update_probs()
-
-    def update_probs(self):
-        prior_probs = {source: (p / (n + p)) for source, (p, n) in
-                       self.prior_counts.items()}
-        # FIXME: this will need to be fixed
-        subtype_probs = {source: {rule: (p / (n + p)} for rule, (p, n)
-                         in st.items() for st, rule in
-                         self.subtype_counts.items()}
-        super()._update_probs(prior_probs, subtype_probs)
-
-    def update_counts(self, counts):
-        for source, (pos, neg) in counts.items():
-            # FIXME: handle subtypes
-            self.prior_counts[source][0] += pos
-            self.prior_counts[source][1] += neg
+from . import SimpleScorer, BayesianScorer
 
 
 def get_eidos_counts():

--- a/indra/belief/wm_scorer.py
+++ b/indra/belief/wm_scorer.py
@@ -4,8 +4,8 @@ import requests
 from . import SimpleScorer, BayesianScorer
 
 
-def get_eidos_bayesian_scorer():
-    """Return a BayesianScorer based on Eidos curation counts."""
+def load_eidos_curation_table():
+    """Return a pandas table of Eidos curation data."""
     url = 'https://raw.githubusercontent.com/clulab/eidos/master/' + \
         'src/main/resources/org/clulab/wm/eidos/english/confidence/' + \
         'rule_summary.tsv'
@@ -14,7 +14,12 @@ def get_eidos_bayesian_scorer():
     table = pandas.read_table(res, sep='\t')
     # Drop the last "Grant total" row
     table = table.drop(table.index[len(table)-1])
+    return table
 
+
+def get_eidos_bayesian_scorer():
+    """Return a BayesianScorer based on Eidos curation counts."""
+    table = load_eidos_curation_table()
     subtype_counts = {'eidos': {r: [c, i] for r, c, i in
                               zip(table['RULE'], table['Num correct'],
                                   table['Num incorrect'])}}
@@ -25,15 +30,7 @@ def get_eidos_bayesian_scorer():
 
 def get_eidos_scorer():
     """Return a SimpleScorer based on Eidos curated precision estimates."""
-    url = 'https://raw.githubusercontent.com/clulab/eidos/master/' + \
-        'src/main/resources/org/clulab/wm/eidos/english/confidence/' + \
-        'rule_summary.tsv'
-
-    # Load the table of scores from the URL above into a data frame
-    res = StringIO(requests.get(url).text)
-    table = pandas.read_table(res, sep='\t')
-    # Drop the last "Grant total" row
-    table = table.drop(table.index[len(table)-1])
+    table = load_eidos_curation_table()
 
     # Get the overall precision
     total_num = table['COUNT of RULE'].sum()

--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -418,6 +418,6 @@ def _get_time_stamp(entry):
     try:
         dt = datetime.datetime.strptime(entry, '%Y-%m-%dT%H:%M')
     except Exception as e:
-        logger.warning('Could not parse %s format' % entry)
+        logger.debug('Could not parse %s format' % entry)
         return None
     return dt

--- a/indra/tests/test_belief_engine.py
+++ b/indra/tests/test_belief_engine.py
@@ -5,7 +5,7 @@ from indra.statements import *
 from indra.belief import BeliefEngine, load_default_probs, _get_belief_package,\
     sample_statements, evidence_random_noise_prior, tag_evidence_subtype, \
     SimpleScorer
-from indra.belief import wm_scorer
+from indra.belief import wm_scorer, BayesianScorer
 
 default_probs = load_default_probs()
 
@@ -350,6 +350,22 @@ def test_wm_scorer():
     assert 'biopax' in scorer.prior_probs['syst']
     engine = BeliefEngine(scorer)
     engine.set_prior_probs([stmt])
+
+
+def test_bayesian_scorer():
+    prior_counts = {'hume': [3, 1]}
+    subtype_counts = {'eidos': {'rule1': [2, 2], 'rule2': [1, 4]}}
+    scorer = BayesianScorer(prior_counts, subtype_counts)
+    # Check initial probability assignment
+    assert scorer.prior_probs['rand']['hume'] == 0.2
+    assert scorer.prior_probs['syst']['hume'] == 0.05
+    assert scorer.subtype_probs['eidos']['rule1'] == 0.45
+    assert scorer.subtype_probs['eidos']['rule2'] == 0.75
+    # Now try to do some updates
+    scorer.update_counts({'hume': [0, 2]}, {})
+    assert scorer.prior_counts['hume'] == [3, 3]
+    scorer.update_counts({}, {'eidos': {'rule1': [6, 0]}})
+    assert scorer.subtype_counts['eidos']['rule1'] == [8, 2]
 
 
 @raises(AssertionError)

--- a/indra/tests/test_belief_engine.py
+++ b/indra/tests/test_belief_engine.py
@@ -366,6 +366,12 @@ def test_bayesian_scorer():
     assert scorer.prior_counts['hume'] == [3, 3]
     scorer.update_counts({}, {'eidos': {'rule1': [6, 0]}})
     assert scorer.subtype_counts['eidos']['rule1'] == [8, 2]
+    # Now check that the probabilities are up to date
+    assert scorer.prior_probs['rand']['hume'] == 0.45
+    assert scorer.prior_probs['syst']['hume'] == 0.05
+    assert_close_enough(scorer.subtype_probs['eidos']['rule1'],
+                        0.15)
+    assert scorer.subtype_probs['eidos']['rule2'] == 0.75
 
 
 @raises(AssertionError)

--- a/indra/tools/live_curation.py
+++ b/indra/tools/live_curation.py
@@ -1,0 +1,13 @@
+from flask import Flask, request, abort, Response
+from indra.belief import wm_scorer
+
+scorer = wm_scorer.get_eidos_counts()
+
+
+app = Flask(__name__)
+Compress(app)
+CORS(app)
+
+
+if __name__ == '__main__':
+    app.run()

--- a/indra/tools/live_curation.py
+++ b/indra/tools/live_curation.py
@@ -29,9 +29,12 @@ class Corpus(object):
 
 @app.route('/update_beliefs', methods=['POST'])
 def update_beliefs():
+    if request.json is None:
+        abort(Response('Missing application/json header.', 415))
+
     # Get input parameters
     corpus_id = request.json.get('corpus_id')
-    curations = request.json.get('curations')
+    curations = request.json.get('curations', {})
     return_beliefs = request.json.get('return_beliefs', False)
 
     # Get the right corpus

--- a/indra/tools/live_curation.py
+++ b/indra/tools/live_curation.py
@@ -25,7 +25,9 @@ def update_beliefs():
     for uuid, correct in curations.items():
         stmt = corpus.get(uuid)
         for ev in stmt.evidence:
-            extraction_rule = ev.epistemics.get('found_by')
+            print(ev)
+            extraction_rule = ev.annotations.get('found_by')
+            print(extraction_rule)
             if not extraction_rule:
                 try:
                     prior_counts[ev.source_api][correct] += 1
@@ -34,12 +36,15 @@ def update_beliefs():
                     prior_counts[ev.source_api][correct] += 1
             else:
                 try:
-                    prior_counts[ev.source_api][extraction_rule][correct] += 1
+                    subtype_counts[ev.source_api][extraction_rule][correct] += 1
                 except KeyError:
-                    prior_counts[ev.source_api][extraction_rule] = [0, 0]
-                    prior_counts[ev.source_api][extraction_rule][correct] += 1
-
+                    if ev.source_api not in subtype_counts:
+                        subtype_counts[ev.source_api] = {}
+                    subtype_counts[ev.source_api][extraction_rule] = [0, 0]
+                    subtype_counts[ev.source_api][extraction_rule][correct] += 1
+    print(scorer.subtype_counts)
     scorer.update_counts(prior_counts, subtype_counts)
+    print(scorer.subtype_counts)
     if not return_beliefs:
         return jsonify({})
     else:

--- a/indra/tools/live_curation.py
+++ b/indra/tools/live_curation.py
@@ -1,4 +1,5 @@
 import sys
+import pickle
 from flask import Flask, request, abort, Response
 from indra.belief import wm_scorer, BeliefEngine
 
@@ -55,5 +56,5 @@ def _get_belief_dict(stmts):
 if __name__ == '__main__':
     corpus_path = sys.argv[1]
     with open(corpus_path, 'rb') as fh:
-        corpus['1'] = pickle.load(fh)
+        corpora['1'] = pickle.load(fh)
     app.run()

--- a/indra/tools/live_curation.py
+++ b/indra/tools/live_curation.py
@@ -9,9 +9,19 @@ scorer = wm_scorer.get_eidos_counts()
 app = Flask(__name__)
 
 
-corpora = {
-    '1': {}
-    }
+corpora = {}
+
+
+class Corpus(object):
+    def __init__(self, statements):
+        self.statements = {st.uuid: st for st in statements}
+        self.curations = {}
+
+    def __str__(self):
+        return 'Corpus(%s -> %s)' % (str(self.statements), str(self.curations))
+
+    def __repr__(self):
+        return str(self)
 
 
 @app.route('/update_beliefs', methods=['POST'])
@@ -23,7 +33,8 @@ def update_beliefs():
     subtype_counts = {}
     corpus = corpora.get(corpus_id)
     for uuid, correct in curations.items():
-        stmt = corpus.get(uuid)
+        corpus.curations[uuid] = correct
+        stmt = corpus.statements.get(uuid)
         for ev in stmt.evidence:
             print(ev)
             extraction_rule = ev.annotations.get('found_by')
@@ -49,8 +60,12 @@ def update_beliefs():
         return jsonify({})
     else:
         be = BeliefEngine(scorer)
-        stmts = list(corpus.values())
+        stmts = list(corpus.statements.values())
         be.set_prior_probs(stmts)
+        # Here we set beliefs based on actual curation
+        for uuid, correct in corpus.curations.items():
+            stmt = corpus.statements.get(uuid)
+            stmt.belief = correct
         belief_dict = _get_belief_dict(stmts)
         print(belief_dict)
         return jsonify(belief_dict)
@@ -64,6 +79,6 @@ if __name__ == '__main__':
     corpus_path = sys.argv[1]
     with open(corpus_path, 'rb') as fh:
         stmts = pickle.load(fh)
-        corpora['1'] = {st.uuid: st for st in stmts}
+        corpora['1'] = Corpus(stmts)
     print(corpora)
     app.run()

--- a/indra/tools/live_curation.py
+++ b/indra/tools/live_curation.py
@@ -39,20 +39,21 @@ def update_beliefs():
             print(ev)
             extraction_rule = ev.annotations.get('found_by')
             print(extraction_rule)
+            idx = 0 if correct else 1
             if not extraction_rule:
                 try:
-                    prior_counts[ev.source_api][correct] += 1
+                    prior_counts[ev.source_api][idx] += 1
                 except KeyError:
                     prior_counts[ev.source_api] = [0, 0]
-                    prior_counts[ev.source_api][correct] += 1
+                    prior_counts[ev.source_api][idx] += 1
             else:
                 try:
-                    subtype_counts[ev.source_api][extraction_rule][correct] += 1
+                    subtype_counts[ev.source_api][extraction_rule][idx] += 1
                 except KeyError:
                     if ev.source_api not in subtype_counts:
                         subtype_counts[ev.source_api] = {}
                     subtype_counts[ev.source_api][extraction_rule] = [0, 0]
-                    subtype_counts[ev.source_api][extraction_rule][correct] += 1
+                    subtype_counts[ev.source_api][extraction_rule][idx] += 1
     print(scorer.subtype_counts)
     scorer.update_counts(prior_counts, subtype_counts)
     print(scorer.subtype_counts)

--- a/indra/tools/live_curation.py
+++ b/indra/tools/live_curation.py
@@ -5,7 +5,7 @@ import pickle
 from flask import Flask, request, jsonify, abort, Response
 from indra.belief import wm_scorer, BeliefEngine
 
-scorer = wm_scorer.get_eidos_counts()
+scorer = wm_scorer.get_eidos_bayesian_scorer()
 
 
 app = Flask(__name__)

--- a/indra/tools/live_curation.py
+++ b/indra/tools/live_curation.py
@@ -1,5 +1,5 @@
 from flask import Flask, request, abort, Response
-from indra.belief import wm_scorer
+from indra.belief import wm_scorer, BeliefEngine
 
 scorer = wm_scorer.get_eidos_counts()
 
@@ -7,6 +7,49 @@ scorer = wm_scorer.get_eidos_counts()
 app = Flask(__name__)
 Compress(app)
 CORS(app)
+
+
+corpora = {
+    '1': {}
+    }
+
+
+@app.route('/update_beliefs', methods=['POST'])
+def update_beliefs():
+    corpus_id = request.get('corpus_id')
+    curations = request.get('curations')
+    return_beliefs = request.get('return_beliefs', False)
+    prior_counts = {}
+    subtype_counts = {}
+    corpus = corpora.get(corpus_id)
+    for uuid, correct in curations:
+        stmt = corpus.get(uuid)
+        for ev in stmt.evidence:
+            extraction_rule = ev.epistemics.get('found_by')
+            if not extraction_rule:
+                try:
+                    prior_counts[ev.source_api][correct] += 1
+                except KeyError:
+                    prior_counts[ev.source_api] = [0, 0]
+                    prior_counts[ev.source_api][correct] += 1
+            else:
+                try:
+                    prior_counts[ev.source_api][extraction_rule][correct] += 1
+                except KeyError:
+                    prior_counts[ev.source_api][extraction_rule] = [0, 0]
+                    prior_counts[ev.source_api][extraction_rule][correct] += 1
+
+    scorer.update_counts(prior_counts, subtype_counts)
+    if not return_beliefs:
+        return {}
+    else:
+        be = BeliefEngine(scorer)
+        be.set_prior_probs(list(corpus.items()))
+        return _get_belief_dict(stmts)
+
+
+def _get_belief_dict(stmts):
+    return {st.uuid: st.belief for st in stmts}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR implements a new belief scorer class called BayesianScorer (which inherits from SimpleScorer) that is built around a set of curation counts of positive and negative examples from each source or subtype. The Scorer can also accept updates during runtime to the positive/negative counts to update its probability estimates.

The PR also adds a new tool, implemented as a Flask app which allows loading a corpus of Statements and accepting positive/negative (i.e. correct/incorrect) curations on Statements in the corpus. Depending on the input arguments, the tool can re-run belief calculation with the updated counts and return an updated set of belief scores for the corpus.