### PR TITLE
Activate the sub items of the table of contents

### DIFF
--- a/indra/assemblers/html/curationFunctions.js
+++ b/indra/assemblers/html/curationFunctions.js
@@ -1,5 +1,10 @@
 // CURATION FUNCTIONS
 
+// Force activate the sub items of the table of contents after page load
+$(document).ready(function(){
+    $('a[href="#statements"]').addClass('active')
+})
+
 // Variables
 var pubmed_fetch = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
 var latestSubmission = {


### PR DESCRIPTION
This PR adds jQuery code to curationFunctions.js that add the attribute `active` after page load to the `<a>` tag in the table of contents that contains the statement items. This makes the sub items visible once the page is fully loaded.

This resolves #774 