### PR TITLE
Add Gene Assembler

### DIFF
--- a/doc/modules/assemblers/gene_assembler.rst
+++ b/doc/modules/assemblers/gene_assembler.rst
@@ -1,0 +1,4 @@
+Gene Set Assembler (:py:mod:`indra.assemblers.genes.assembler`)
+===============================================================
+.. automodule:: indra.assemblers.genes.assembler
+    :members:

--- a/doc/modules/assemblers/index.rst
+++ b/doc/modules/assemblers/index.rst
@@ -18,3 +18,4 @@ Assemblers of model output (:py:mod:`indra.assemblers`)
    pybel_assembler
    kami_assembler
    indranet_assembler
+   gene_assembler

--- a/indra/assemblers/genes/__init__.py
+++ b/indra/assemblers/genes/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+"""An assembler for gene lists and related gene-centric outputs."""
+
+from .assembler import GeneAssembler
+
+__all__ = [
+    "GeneAssembler",
+]

--- a/indra/assemblers/genes/assembler.py
+++ b/indra/assemblers/genes/assembler.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+"""An assembler for gene lists and related gene-centric outputs."""
+
+from pathlib import Path
+from typing import List, Optional, Set, Union
+
+from indra.statements import Statement
+
+__all__ = [
+    "GeneAssembler",
+]
+
+
+class GeneAssembler:
+    """The Gene assembler assembles INDRA Statements into a gene list.
+
+    This graph can then be used with the GSEA software from the Broad
+    Institute, or output as a visualization with Ideogram.
+
+    Parameters
+    ----------
+    stmts :
+        A list of INDRA Statements to be added to the assembler's list
+        of Statements.
+
+    Example
+    -------
+    To create an ideogram HTML file, use the following code:
+
+    .. code-block:: python
+
+        stmts = ...
+        assembler = GeneAssembler(stmts)
+        assembler.make_model()
+        assembler.save_model('ideogram.html', format='ideogram')
+    """
+
+    stmts: List[Statement]
+    #: A set of strings representing gene names in the model.
+    genes: Set[str]
+
+    def __init__(self, stmts: Optional[List[Statement]] = None):
+        self.stmts = stmts or []
+        self.genes = set()
+
+    def make_model(self):
+        """Assemble the graph from the assembler's list of INDRA Statements."""
+        for statement in self.stmts:
+            try:
+                agents = statement.agent_list()
+            except Exception:
+                continue
+            else:
+                for agent in agents:
+                    if agent is None:
+                        continue
+                    if "HGNC" in agent.db_refs:
+                        self.genes.add(agent.name)
+
+        return self.genes
+
+    def save_model(self, path: Union[str, Path], format="gsea"):
+        """Save the assembled model's string into a file.
+
+        Parameters
+        ----------
+        path :
+            The name of the file to save the SIF into.
+        """
+        with open(path, "w") as file:
+            if format == "gsea":
+                print(self.to_gsea_str(), file=file)
+            elif format == "ideogram":
+                print(self.to_ideogram_html_str(), file=file)
+            else:
+                raise ValueError(f"Unsupported format: {format}")
+
+    def to_gsea_str(self, first: Optional[str] = "# INDRA Genes") -> str:
+        """Get a gene list string of the assembled model."""
+        return first + "\n" + "\n".join(sorted(self.genes))
+
+    def to_ideogram_html_str(self) -> str:
+        """Get an Ideogram HTML document string of the assembled model."""
+        import pydeogram
+
+        return pydeogram.to_html_str(self.genes)

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ def main():
                               'docstring-parser', 'gunicorn'],
                       'sklearn_belief': ['scikit-learn'],
                       'owl': ['pronto'],
+                      'ideogram': ['pydeogram'],
                       }
     extras_require['all'] = list({dep for deps in extras_require.values()
                                   for dep in deps})
@@ -60,6 +61,7 @@ def main():
                     'indra.assemblers.kami', 'indra.assemblers.pybel',
                     'indra.assemblers.pysb', 'indra.assemblers.sbgn',
                     'indra.assemblers.sif', 'indra.assemblers.tsv',
+                    'indra.assemblers.gene',
                     'indra.belief',
                     'indra.benchmarks', 'indra.databases',
                     'indra.explanation', 'indra.explanation.model_checker',

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def main():
                     'indra.assemblers.kami', 'indra.assemblers.pybel',
                     'indra.assemblers.pysb', 'indra.assemblers.sbgn',
                     'indra.assemblers.sif', 'indra.assemblers.tsv',
-                    'indra.assemblers.gene',
+                    'indra.assemblers.genes',
                     'indra.belief',
                     'indra.benchmarks', 'indra.databases',
                     'indra.explanation', 'indra.explanation.model_checker',


### PR DESCRIPTION
This assembler extracts a list of genes that have HGNC database references and can be used for:

1. Generating a gene list file, useful for Broad Institute's GSEA software
2. Generating an Ideogram visualization that shows what genes are represented and with what density. See example below generated using the `hbp_knowledge` graph: 

```python
import hbp_knowledge
from indra.assemblers.genes import GeneAssembler

statements = hbp_knowledge.repository.get_indra_statements()
ga = GeneAssembler(statements)
ga.make_model()
ga.save_model('statements_ideogram.html', format='ideogram')
```

<img width="961" alt="screenshot 2019-02-10 18 42 14" src="https://user-images.githubusercontent.com/5069736/52537160-a2ed8c80-2d63-11e9-91fa-9659e8fc8560.png">

To Do:

- [x] How should RefSeq data be stored? Should it live in the repository, and if so, how should it get updated? Otherwise I'll include a downloader for it.
- [x] What about chromosome numbers?

