### PR TITLE
Fix signor test

### DIFF
--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -60,7 +60,7 @@ def test_parse_csv_from_web():
     assert isinstance(sp.complex_map, dict)
     assert 'SIGNOR-C1' in sp.complex_map
     assert isinstance(sp.complex_map['SIGNOR-C1'], list)
-    assert sp.complex_map['SIGNOR-C1'] == ['P23511', 'P25208', 'Q13952']
+    assert set(sp.complex_map['SIGNOR-C1']) == set('P23511', 'P25208', 'Q13952')
     # Make sure we don't error if Complexes data is not provided
 
 


### PR DESCRIPTION
This PR changes a test of list vs list to set vs set, in order to not have to rely on the list order. Previous parts of the same test checks for the that the object is a list, so this change will not make the overall test more lenient.

This PR resolves issue https://github.com/sorgerlab/indra/issues/804