### PR TITLE
Travis update for nonpublic tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,9 @@ script:
   - if [[ $RUN_SLOW != "true" ]]; then
       export NOSEATTR="!slow,$NOSEATTR";
     fi
+  - if [[ $TRAVIS_EVENT_TYPE != "cron" ]]; then
+      export NOSEATTR="!cron,$NOSEATTR";
+    fi
   - echo $NOSEATTR
   # First run TEES and Eidos tests separately for technical reasons
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ script:
   - export NOSE_IGNORE_FILES="find_full_text_sentence.py";
   # Set nose attributes based on the context in which we are running
   - export NOSEATTR="";
+  - echo $TRAVIS_PULL_REQUEST
   - if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
       export NOSEATTR="!nonpublic";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,14 +65,14 @@ script:
   # These are files that are ignored so that doctests don't fail
   - export NOSE_IGNORE_FILES="find_full_text_sentence.py";
   # Set nose attributes based on the context in which we are running
-  - export NOSEATTR="";
-  - echo $TRAVIS_PULL_REQUEST
+  - export NOSEATTR="!notravis";
   - if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
-      export NOSEATTR="!nonpublic";
+      export NOSEATTR="!nonpublic,$NOSEATTR";
     fi
   - if [[ $RUN_SLOW != "true" ]]; then
       export NOSEATTR="!slow,$NOSEATTR";
     fi
+  - echo $NOSEATTR
   # First run TEES and Eidos tests separately for technical reasons
   - cd $TRAVIS_BUILD_DIR
   - python -m nose_notify indra/tests/test_tees.py --slack_hook $SLACK_NOTIFY_HOOK

--- a/indra/databases/cbio_client.py
+++ b/indra/databases/cbio_client.py
@@ -213,6 +213,8 @@ def get_num_sequenced(study_id):
     data = {'cmd': 'getCaseLists',
             'cancer_study_id': study_id}
     df = send_request(**data)
+    if df.empty:
+        return 0
     row_filter = df['case_list_id'].str.contains('sequenced', case=False)
     num_case = len(df[row_filter]['case_ids'].tolist()[0].split(' '))
     return num_case

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -66,7 +66,7 @@ def test_timeout_no_persist_agent():
     resp = dbr.get_statements(agents=[agent], persist=False, timeout=0)
     assert resp.is_working(), "Lookup resolved too fast."
     resp.wait_until_done(70)
-    assert len(resp.statements) == 1000, len(resp.statements)
+    assert len(resp.statements) == 500, len(resp.statements)
 
 
 @attr('nonpublic')
@@ -78,7 +78,7 @@ def test_timeout_no_persist_type_object():
                               persist=False, timeout=0)
     assert resp.is_working(), "Lookup resolved too fast."
     resp.wait_until_done(70)
-    assert len(resp.statements) == 1000, len(resp.statements)
+    assert len(resp.statements) == 500, len(resp.statements)
 
 
 @attr('nonpublic')

--- a/indra/tests/test_reading_scripts_aws.py
+++ b/indra/tests/test_reading_scripts_aws.py
@@ -14,7 +14,7 @@ s3 = boto3.client('s3')
 HERE = path.dirname(path.abspath(__file__))
 
 
-@attr('nonpublic')
+@attr('nonpublic', 'notravis')
 def test_normal_pmid_reading_call():
     chdir(path.expanduser('~'))
     # Put an id file on s3
@@ -36,7 +36,7 @@ def test_normal_pmid_reading_call():
     return
 
 
-@attr('nonpublic')
+@attr('nonpublic', 'notravis')
 def test_bad_sparser():
     txt = ('Disruption of the AP-1 binding site reversed the transcriptional '
            'responses seen with Fos and Jun.')

--- a/indra/tests/test_reading_scripts_old.py
+++ b/indra/tests/test_reading_scripts_old.py
@@ -103,7 +103,7 @@ def test_reach_two_core():
     assert not len(pmids_unread2), "Didn't use cache."
 
 
-@attr('nonpublic')
+@attr('nonpublic', 'notravis')
 def test_sparser_one_core():
     stmts, pmids_unread = _call_reader('sparser', 1, True)
     _check_result(stmts)
@@ -113,7 +113,7 @@ def test_sparser_one_core():
     assert not len(pmids_unread2), "Didn't use cache."
 
 
-@attr('nonpublic')
+@attr('nonpublic', 'notravis')
 def test_sparser_two_core():
     if get_proc_num() <= 2:
         raise SkipTest("Not enough processes.")

--- a/indra/tests/test_s3_client.py
+++ b/indra/tests/test_s3_client.py
@@ -6,7 +6,7 @@ import zlib
 from nose.plugins.attrib import attr
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice', 'nonpublic', 'cron')
 def test_check_pmid():
     pmid = s3_client.check_pmid(12345)
     assert pmid == 'PMID12345'
@@ -19,7 +19,7 @@ def test_check_pmid():
     assert unicode_strs(pmid)
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice', 'nonpublic', 'cron')
 def test_get_pmid_key():
     pmid = '12345'
     pmid_key = s3_client.get_pmid_key(pmid)
@@ -27,14 +27,14 @@ def test_get_pmid_key():
     assert unicode_strs(pmid_key)
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice', 'nonpublic', 'cron')
 def test_filter_keys():
     pmid_key = s3_client.get_pmid_key('1001287')
     key_list = s3_client.filter_keys(pmid_key)
     assert len(key_list) == 4
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice', 'nonpublic', 'cron')
 def test_get_gz_object():
     # Get XML
     key = 'papers/PMID27297883/fulltext/txt'
@@ -46,13 +46,13 @@ def test_get_gz_object():
     assert unicode_strs(obj)
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice', 'nonpublic', 'cron')
 def test_get_gz_object_nosuchkey():
     obj = s3_client.get_gz_object('foobar')
     assert obj is None
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice', 'nonpublic', 'cron')
 def test_get_full_text():
     (content, content_type) = s3_client.get_full_text('27297883')
     assert unicode_strs((content, content_type))
@@ -68,7 +68,7 @@ def test_get_full_text():
     assert content is None and content_type is None
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice', 'nonpublic', 'cron')
 def test_put_full_text():
     full_text = 'test_put_full_text'
     pmid_test = 'PMID000test1'
@@ -80,7 +80,7 @@ def test_put_full_text():
     assert unicode_strs(content)
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice', 'nonpublic', 'cron')
 def test_put_abstract():
     abstract = 'test_put_abstract'
     pmid_test = 'PMID000test2'
@@ -92,7 +92,7 @@ def test_put_abstract():
     assert unicode_strs(content)
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice', 'nonpublic', 'cron')
 def test_reach_output():
     # Test put_reach_output
     reach_data = {'foo': 1, 'bar': {'baz': 2}}
@@ -120,7 +120,7 @@ def test_gzip_string():
     assert content == content_dec_uni
 
 
-@attr('webservice', 'nonpublic')
+@attr('webservice', 'nonpublic', 'cron')
 def test_get_upload_content():
     pmid_s3_no_content = 'PMID000foobar'
     (ct, ct_type) = s3_client.get_upload_content(pmid_s3_no_content)


### PR DESCRIPTION
This PR adds a new `notravis` attribute that can be attached to tests that we never want to run on Travis. It also adds a `cron` attribute which can be applied to tests that we want to run only on daily cron jobs and not on every push. It also fixes some bugs and test conditions that were failing since we haven't run them for a while due to an issue with which the `nonpublic` flag was set on Travis.