### PR TITLE
Fix the pubmed client handling of a corner case

### DIFF
--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -37,6 +37,8 @@ def send_request(url, data):
         logger.error(e)
         return None
     if not res.status_code == 200:
+        logger.error('Got return code %d from pubmed client.'
+                     % res.status_code)
         return None
     tree = ET.XML(res.content, parser=UTB())
     return tree

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -286,8 +286,10 @@ def get_metadata_from_xml_tree(tree, get_issns_from_nlm=False,
         # Try to get the PMCID
         pmcid = find_elem_text(pm_article, './/ArticleId[@IdType="pmc"]')
         # Title
-        title = find_elem_text(pm_article,
-                               'MedlineCitation/Article/ArticleTitle')
+        medline_article = \
+            pm_article.find('MedlineCitation/Article/ArticleTitle')
+        title = _get_title_from_article_element(medline_article)
+
         # Author list
         author_elems = pm_article.findall('MedlineCitation/Article/'
                                           'AuthorList/Author/LastName')
@@ -336,7 +338,6 @@ def get_metadata_from_xml_tree(tree, get_issns_from_nlm=False,
                   'page': page}
         # Get the abstracts if requested
         if get_abstracts:
-            medline_article = pm_article.find('MedlineCitation/Article')
             abstract = _abstract_from_article_element(
                                 medline_article, prepend_title=prepend_title)
             result['abstract'] = abstract

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -206,9 +206,6 @@ def _get_title_from_article_element(article):
         title = title_tag.text
         if title is None and hasattr(title_tag, 'itertext'):
             title = ' '.join(list(title_tag.itertext()))
-        if title is not None:
-            if not title.endswith('.'):
-                title += '.'
     return title
 
 
@@ -222,6 +219,8 @@ def _abstract_from_article_element(article, prepend_title=False):
     if prepend_title:
         title = _get_title_from_article_element(article)
         if title is not None:
+            if not title.endswith('.'):
+                title += '.'
             abstract_text = title + ' ' + abstract_text
 
     return abstract_text

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -118,3 +118,9 @@ def test_send_request_invalid():
 def test_abstract_with_html_embedded():
     res = pubmed_client.get_abstract('25484845')
     assert len(res) > 4, res
+
+
+@attr('webservice')
+def test_pmid_27821631():
+    res = pubmed_client.get_abstract('27821631')
+    assert len(res) > 50, res


### PR DESCRIPTION
We found a corner case where text was not being extracted from the xml, despite being present.