### PR TITLE
Handle new one-member complexes from Signor

### DIFF
--- a/indra/sources/signor/api.py
+++ b/indra/sources/signor/api.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import sys
 import logging
+import requests
 from io import StringIO, BytesIO
 from collections import namedtuple
-import requests
 from .processor import SignorProcessor
 from indra.util import read_unicode_csv, read_unicode_csv_fileobj
 
@@ -75,8 +75,8 @@ def process_from_file(signor_data_file, signor_complexes_file=None):
 def process_from_web():
     # Get interaction data
     data_url = 'https://signor.uniroma2.it/download_entity.php'
-    res = requests.post(data_url, data={'organism':'human', 'format':'csv',
-                                        'submit':'Download'})
+    res = requests.post(data_url, data={'organism': 'human', 'format': 'csv',
+                                        'submit': 'Download'})
     data_iter = _handle_response(res, '\t')
     # Get complexes
     complexes_url = 'https://signor.uniroma2.it/download_complexes.php'
@@ -101,6 +101,7 @@ def _handle_response(res, delimiter):
         raise Exception('Could not download Signor data.')
     return data_iter
 
+
 def _processor_from_data(data_iter, complexes_iter):
     # Process into a list of SignorRow namedtuples
     # Strip off any funky \xa0 whitespace characters
@@ -110,5 +111,3 @@ def _processor_from_data(data_iter, complexes_iter):
         for crow in complexes_iter:
             complex_map[crow[0]] = crow[2].split(',  ')
     return SignorProcessor(data, complex_map)
-
-

--- a/indra/sources/signor/processor.py
+++ b/indra/sources/signor/processor.py
@@ -155,9 +155,14 @@ class SignorProcessor(object):
 
         # Add a Complex statement for each Signor complex
         for complex_id in sorted(self.complex_map.keys()):
-            print(complex_id)
             agents = self._get_complex_agents(complex_id)
-            print(agents)
+            if len(agents) < 2:
+                logger.info('Skipping Complex %s with less than 2 members' %
+                            complex_id)
+                continue
+            # If we returned with None, we skip this complex
+            if not agents:
+                continue
             ev = Evidence(source_api='signor', source_id=complex_id,
                           text='Inferred from SIGNOR complex %s' % complex_id)
             s = Complex(agents, evidence=[ev])
@@ -170,7 +175,6 @@ class SignorProcessor(object):
         if database == 'SIGNOR' and id in self.complex_map:
             components = self.complex_map[id]
             agents = self._get_complex_agents(id)
-
             # Return the first agent with the remaining agents as a bound
             # condition
             agent = agents[0]
@@ -220,7 +224,7 @@ class SignorProcessor(object):
         """Looks up the constitutents of a complex. If any constituent is
         itself a complex, recursively expands until all constituents are
         not complexes."""
-        assert(complex_id in self.complex_map)
+        assert complex_id in self.complex_map
 
         expanded_agent_strings = []
         expand_these_next = [complex_id]
@@ -231,7 +235,7 @@ class SignorProcessor(object):
 
             # If a complex, add expanding it to the end of the queue
             # If an agent string, add it to the agent string list immediately
-            assert(c in self.complex_map)
+            assert c in self.complex_map
             for s in self.complex_map[c]:
                 if s in self.complex_map:
                     expand_these_next.append(s)

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -62,6 +62,11 @@ def test_parse_csv_from_web():
     assert isinstance(sp.complex_map['SIGNOR-C1'], list)
     assert set(sp.complex_map['SIGNOR-C1']) == {'P23511', 'P25208', 'Q13952'}
     # Make sure we don't error if Complexes data is not provided
+    for stmt in sp.statements:
+        if isinstance(stmt, Complex):
+            if len(stmt.members) < 2:
+                assert False, 'Found a complex with less than 2 members: %s' %\
+                    stmt
 
 
 def test_get_agent():


### PR DESCRIPTION
This PR fixes the handling of complexes reported by Signor that only have one member. We skip these when it comes to constructing Complex Statements but still use them if they appear as arguments of regular Statements.