### PR TITLE
Optimize pickle protocols

### DIFF
--- a/indra/benchmarks/assembly_eval/batch4/assembly_eval.py
+++ b/indra/benchmarks/assembly_eval/batch4/assembly_eval.py
@@ -150,7 +150,7 @@ def run_assembly(stmts, folder, pmcid, background_assertions=None):
 
     # Dump top-level statements in a pickle
     with open(otherout_prefix + '.pkl', 'wb') as fh:
-        pickle.dump(nonbg_stmts, fh, protocol=2)
+        pickle.dump(nonbg_stmts, fh)
 
     # Flatten evidence for statements
     flattened_evidence_stmts = flatten_evidence(nonbg_stmts)

--- a/indra/benchmarks/phosphorylations/__init__.py
+++ b/indra/benchmarks/phosphorylations/__init__.py
@@ -44,7 +44,7 @@ def phosphosite_to_indra():
         stmts.append(st)
     logger.info('%d human-human phosphorylations in Phosphosite' % len(stmts))
     with open('phosphosite_indra.pkl', 'wb') as fh:
-        pickle.dump(stmts, fh, protocol=2)
+        pickle.dump(stmts, fh)
     return stmts
 
 def extract_phos():
@@ -79,7 +79,7 @@ def extract_phos():
     logger.info('%d top-level phosphorylations in RAS Machine' % len(stmts_unique))
 
     with open('mapped_unique_phos.pkl', 'wb') as fh:
-        pickle.dump(stmts_unique, fh, protocol=2)
+        pickle.dump(stmts_unique, fh)
 
     # Filter RAS Machine statements for direct and not hypothesis
     stmts = filter_direct(stmts_unique)
@@ -88,7 +88,7 @@ def extract_phos():
     logger.info('%d non-hypothesis phosphorylations in RAS Machine' % len(stmts))
 
     with open('filtered_phos.pkl', 'wb') as fh:
-        pickle.dump(stmts, fh, protocol=2)
+        pickle.dump(stmts, fh)
 
     return stmts
 

--- a/indra/resources/update_resources.py
+++ b/indra/resources/update_resources.py
@@ -122,7 +122,7 @@ def update_uniprot_entries():
     entries = uniprot_client._build_uniprot_entries(from_pickle=False)
     fname = os.path.join(path, 'uniprot_entries.pkl')
     with open(fname, 'wb') as fh:
-        pickle.dump(entries, fh, protocol=2)
+        pickle.dump(entries, fh, protocol=4)
 
 
 def update_uniprot_sec_ac():
@@ -136,7 +136,7 @@ def update_uniprot_sec_ac():
     entries = uniprot_client._build_uniprot_sec()
     fname = os.path.join(path, 'uniprot_sec_ac.pkl')
     with open(fname, 'wb') as fh:
-        pickle.dump(entries, fh, protocol=2)
+        pickle.dump(entries, fh, protocol=4)
 
 
 def update_uniprot_subcell_loc():
@@ -446,7 +446,7 @@ def update_hierarchy_pickle():
     fname = os.path.join(path, 'bio_hierarchies.pkl')
     hierarchies = get_bio_hierarchies(from_pickle=False)
     with open(fname, 'wb') as fh:
-        pickle.dump(hierarchies, fh, protocol=2)
+        pickle.dump(hierarchies, fh, protocol=4)
 
 
 def update_lincs_small_molecules():

--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -54,7 +54,7 @@ st3.belief = 0.7
 
 def test_load_stmts():
     with open('_test.pkl', 'wb') as fh:
-        pickle.dump([st1], fh, protocol=2)
+        pickle.dump([st1], fh)
     st_loaded = ac.load_statements('_test.pkl')
     assert len(st_loaded) == 1
     assert st_loaded[0].equals(st1)

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -24,20 +24,20 @@ def _filter(kwargs, arg_list):
     return dict(filter(lambda x: x[0] in arg_list, kwargs.items()))
 
 
-def dump_statements(stmts, fname):
+def dump_statements(stmts, fname, protocol=4):
     """Dump a list of statements into a pickle file.
 
     Parameters
     ----------
     fname : str
         The name of the pickle file to dump statements into.
+    protocol : Optional[int]
+        The pickle protocol to use (use 2 for Python 2 compatibility).
+        Default: 4
     """
-    if sys.version_info[0] < 3:
-        logger.warning('Files pickled in Python 2 may be incompatible with '
-                       'Python 3')
     logger.info('Dumping %d statements into %s...' % (len(stmts), fname))
     with open(fname, 'wb') as fh:
-        pickle.dump(stmts, fh, protocol=2)
+        pickle.dump(stmts, fh, protocol=protocol)
 
 
 def load_statements(fname, as_dict=False):

--- a/indra/tools/gene_network.py
+++ b/indra/tools/gene_network.py
@@ -85,7 +85,7 @@ class GeneNetwork(object):
             # Save to pickle file if we're caching
             if self.basename is not None:
                 with open(bel_stmt_path, 'wb') as f:
-                    pickle.dump(bel_statements, f, protocol=2)
+                    pickle.dump(bel_statements, f)
         # Optionally filter out statements not involving only our gene set
         if filter:
             if len(self.gene_list) > 1:
@@ -165,7 +165,7 @@ class GeneNetwork(object):
         # Save statements to pickle file if we're caching
         if self.basename is not None:
             with open(biopax_stmt_path, 'wb') as f:
-                pickle.dump(bp.statements, f, protocol=2)
+                pickle.dump(bp.statements, f)
         # Optionally filter out statements not involving only our gene set
         if filter:
             policy = 'one' if len(self.gene_list) > 1 else 'all'
@@ -272,6 +272,6 @@ class GeneNetwork(object):
         if self.basename is not None:
             results_filename = '%s_results.pkl' % self.basename
             with open(results_filename, 'wb') as f:
-                pickle.dump(self.results, f, protocol=2)
+                pickle.dump(self.results, f)
         return self.results
 

--- a/indra/tools/incremental_model.py
+++ b/indra/tools/incremental_model.py
@@ -52,7 +52,7 @@ class IncrementalModel(object):
             IncrementalModel in. Default: model.pkl
         """
         with open(model_fname, 'wb') as fh:
-            pickle.dump(self.stmts, fh, protocol=2)
+            pickle.dump(self.stmts, fh, protocol=4)
 
     def add_statements(self, pmid, stmts):
         """Add INDRA Statements to the incremental model indexed by PMID.

--- a/indra/tools/reading/pmid_reading/read_pmids.py
+++ b/indra/tools/reading/pmid_reading/read_pmids.py
@@ -335,7 +335,7 @@ def get_content_to_read(pmid_list, start_index, end_index, tmp_dir, num_cores,
     logger.info('Saving text sources...')
     text_source_file = os.path.join(base_dir, 'content_types.pkl')
     with open(text_source_file, 'wb') as f:
-        pickle.dump(pmids_unread, f, protocol)
+        pickle.dump(pmids_unread, f, protocol=4)
     logger.info('Text sources saved.')
 
     return base_dir, input_dir, output_dir, pmids_read, pmids_unread, num_found
@@ -789,7 +789,7 @@ def main():
                 )
             pickle_file = '%s_stmts.pkl' % args.basename
             with open(pickle_file, 'wb') as f:
-                pickle.dump(stmts, f, protocol)
+                pickle.dump(stmts, f, protocol=4)
             sys.exit()
 
         # Option -r <reader>: actually read the content.
@@ -846,7 +846,7 @@ def main():
             args.end_index
             )
         with open(pickle_file, 'wb') as f:
-            pickle.dump(stmts, f, protocol)
+            pickle.dump(stmts, f, protocol=4)
         ret = pickle_file
     finally:
         time_taken = datetime.now() - now

--- a/indra/tools/reading/pmid_reading/read_pmids.py
+++ b/indra/tools/reading/pmid_reading/read_pmids.py
@@ -335,7 +335,7 @@ def get_content_to_read(pmid_list, start_index, end_index, tmp_dir, num_cores,
     logger.info('Saving text sources...')
     text_source_file = os.path.join(base_dir, 'content_types.pkl')
     with open(text_source_file, 'wb') as f:
-        pickle.dump(pmids_unread, f, protocol=2)
+        pickle.dump(pmids_unread, f, protocol)
     logger.info('Text sources saved.')
 
     return base_dir, input_dir, output_dir, pmids_read, pmids_unread, num_found
@@ -789,7 +789,7 @@ def main():
                 )
             pickle_file = '%s_stmts.pkl' % args.basename
             with open(pickle_file, 'wb') as f:
-                pickle.dump(stmts, f, protocol=2)
+                pickle.dump(stmts, f, protocol)
             sys.exit()
 
         # Option -r <reader>: actually read the content.
@@ -846,7 +846,7 @@ def main():
             args.end_index
             )
         with open(pickle_file, 'wb') as f:
-            pickle.dump(stmts, f, protocol=2)
+            pickle.dump(stmts, f, protocol)
         ret = pickle_file
     finally:
         time_taken = datetime.now() - now

--- a/indra/tools/reading/run_drum_reading.py
+++ b/indra/tools/reading/run_drum_reading.py
@@ -113,7 +113,7 @@ def read_pmc(pmcid, **drum_args):
 
 def save_results(statements, out_fname):
     with open(out_fname, 'wb') as fh:
-        pickle.dump(statements, fh)
+        pickle.dump(statements, fh, protocol=4)
 
 
 def make_parser():

--- a/indra/tools/reading/starcluster_reading/assemble_reading_stmts.py
+++ b/indra/tools/reading/starcluster_reading/assemble_reading_stmts.py
@@ -31,4 +31,4 @@ if __name__ == '__main__':
             all_stmts[reader].update(stmts[reader])
 
     with open('reading_stmts.pkl', 'wb') as f:
-        pickle.dump(all_stmts, f, protocol=2)
+        pickle.dump(all_stmts, f)

--- a/indra/tools/reading/starcluster_reading/process_reach_from_s3.py
+++ b/indra/tools/reading/starcluster_reading/process_reach_from_s3.py
@@ -45,4 +45,4 @@ if __name__ == '__main__':
         stmts[pmid] = reach_proc.statements
 
     with open('reach_stmts_%d_%d.pkl' % (start_ix, end_ix), 'wb') as f:
-        pickle.dump(stmts, f, protocol=2)
+        pickle.dump(stmts, f)

--- a/indra/tools/reading/util/export_stmts_by_reach_rule.py
+++ b/indra/tools/reading/util/export_stmts_by_reach_rule.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
                 stmt_list.append(stmt)
 
     with open('reach_stmts_by_rule.pkl', 'wb') as f:
-        pickle.dump(stmts_by_rule, f, protocol=2)
+        pickle.dump(stmts_by_rule, f)
 
     frequencies = [(k, len(v)) for k, v in stmts_by_rule.items()]
     frequencies.sort(key=lambda x: x[1], reverse=True)

--- a/indra/tools/reading/util/sample_stmt_subset.py
+++ b/indra/tools/reading/util/sample_stmt_subset.py
@@ -28,5 +28,5 @@ if __name__ == '__main__':
 
     print("Pickling paper subset...")
     with open('%s_subset.pkl' % sys.argv[1], 'wb') as f:
-        pickle.dump(subset, f, protocol=2)
+        pickle.dump(subset, f)
 

--- a/indra/util/repickle_stmts.py
+++ b/indra/util/repickle_stmts.py
@@ -11,4 +11,4 @@ if __name__ == '__main__':
         stmts = pickle.load(f)
 
     with open('%s.new' % filename, 'wb') as f:
-        pickle.dump(stmts, f, protocol=2)
+        pickle.dump(stmts, f)


### PR DESCRIPTION
Now that INDRA is Python 3 only, I got rid of all the protocol=2 arguments to pickle.dump. In many places, I just left the argument out which defaults to 3 currently. In some places where very large files are expected to be pickled (e.g., in assemble_corpus), I set protocol=4, which is supposed to be better than 3, as the default. In a follow up PR I'll remove the UniProt downloads from update_resources since they are not needed anymore.