### PR TITLE
Small PR to fix and test for bug introduced in previous PR.

### DIFF
--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -287,7 +287,7 @@ def get_metadata_from_xml_tree(tree, get_issns_from_nlm=False,
         pmcid = find_elem_text(pm_article, './/ArticleId[@IdType="pmc"]')
         # Title
         medline_article = \
-            pm_article.find('MedlineCitation/Article/ArticleTitle')
+            pm_article.find('MedlineCitation/Article')
         title = _get_title_from_article_element(medline_article)
 
         # Author list
@@ -373,7 +373,6 @@ def get_metadata_for_ids(pmid_list, get_issns_from_nlm=False,
     """
     if len(pmid_list) > 200:
         raise ValueError("Metadata query is limited to 200 PMIDs at a time.")
-    query_string=','.join(pmid_list)
     params = {'db': 'pubmed',
               'retmode': 'xml',
               'id': pmid_list}

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -122,5 +122,9 @@ def test_abstract_with_html_embedded():
 
 @attr('webservice')
 def test_pmid_27821631():
-    res = pubmed_client.get_abstract('27821631')
+    pmid = '27821631'
+    res = pubmed_client.get_abstract(pmid)
     assert len(res) > 50, res
+    res = pubmed_client.get_metadata_for_ids([pmid], get_abstracts=True)
+    assert res[pmid]['title'] is not None
+    assert len(res[pmid]['abstract']) > 50


### PR DESCRIPTION
Add a test of the `get_metadata_for_ids` and corresponding `get_metadata_from_xml_tree` functions in the pubmed client, which it seems were previously untested with regard to actually extracting titles and abstracts.