### PR TITLE
Medscan fixes

### DIFF
--- a/indra/sources/medscan/api.py
+++ b/indra/sources/medscan/api.py
@@ -81,7 +81,7 @@ def process_file_sorted_by_pmid(file_name):
     return s_dict
 
 
-def process_file(filename, num_documents=None, lazy=False):
+def process_file(filename, interval=None, lazy=False):
     """Process a CSXML file for its relevant information.
 
     Consider running the fix_csxml_character_encoding.py script in
@@ -92,9 +92,12 @@ def process_file(filename, num_documents=None, lazy=False):
     ----------
     filename : str
         The csxml file, containing Medscan XML, to process
-    num_documents : int
-        The number of documents to process, or None to process all of the
-        documents within the csxml file.
+    interval : (start, end) or None
+        Select the interval of documents to read, starting with the
+        `start`th document and ending before the `end`th document. If
+        either is None, the value is considered undefined. If the value
+        exceeds the bounds of available documents, it will simply be
+        ignored.
     lazy : bool
         If True, the statements will not be generated immediately, but rather
         a generator will be formulated, and statements can be retrieved by
@@ -107,5 +110,5 @@ def process_file(filename, num_documents=None, lazy=False):
         A MedscanProcessor object containing extracted statements
     """
     mp = MedscanProcessor()
-    mp.process_csxml_file(filename, num_documents, lazy)
+    mp.process_csxml_file(filename, interval, lazy)
     return mp

--- a/indra/sources/medscan/api.py
+++ b/indra/sources/medscan/api.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+
 from .processor import *
 
 

--- a/indra/sources/medscan/api.py
+++ b/indra/sources/medscan/api.py
@@ -76,7 +76,7 @@ def process_directory(directory_name):
     start_time_s = time.time()
 
     for filename in files:
-        logger.info('Processing', filename)
+        logger.info('Processing %s' % filename)
         fix_character_encoding(filename, tmp_file)
         mp_file = process_file(tmp_file, None)
 

--- a/indra/sources/medscan/api.py
+++ b/indra/sources/medscan/api.py
@@ -1,16 +1,5 @@
-import os
-import glob
-import time
-import shutil
-import codecs
-import pickle
-import tempfile
-import logging
-import lxml.etree
-from math import floor
-from collections import namedtuple, defaultdict
+from collections import defaultdict
 from .processor import *
-from .fix_csxml_character_encoding import fix_character_encoding
 
 
 logger = logging.getLogger(__name__)
@@ -33,14 +22,14 @@ def process_directory_statements_sorted_by_pmid(directory_name):
         that pmid
     """
     s_dict = defaultdict(list)
-    mp = process_directory(directory_name)
+    mp = process_directory(directory_name, lazy=True)
 
-    for statement in mp.statements:
+    for statement in mp.iter_statements():
         s_dict[statement.evidence[0].pmid].append(statement)
     return s_dict
 
 
-def process_directory(directory_name):
+def process_directory(directory_name, lazy=False):
     """Processes a directory filled with CSXML files, first normalizing the
     character encodings to utf-8, and then processing into a list of INDRA
     statements.
@@ -49,6 +38,11 @@ def process_directory(directory_name):
     ----------
     directory_name : str
         The name of a directory filled with csxml files to process
+    lazy : bool
+        If True, the statements will not be generated immediately, but rather
+        a generator will be formulated, and statements can be retrieved by
+        using `iter_statements`. If False, the `statements` attribute will be
+        populated immediately. Default is False.
 
     Returns
     -------
@@ -59,48 +53,7 @@ def process_directory(directory_name):
 
     # Parent Medscan processor containing extractions from all files
     mp = MedscanProcessor()
-    mp.log_entities = defaultdict(int)
-
-    # Create temporary directory into which to put the csxml files with
-    # normalized character encodings
-    tmp_dir = tempfile.mkdtemp('indra_medscan_processor')
-    tmp_file = os.path.join(tmp_dir, 'fixed_char_encoding')
-
-    # Process each file
-    glob_pattern = os.path.join(directory_name, '*.csxml')
-    files = glob.glob(glob_pattern)
-    num_files = float(len(files))
-    logger.info("%d files to read" % int(num_files))
-    percent_done = 0
-    files_processed = 0
-    start_time_s = time.time()
-
-    for filename in files:
-        logger.info('Processing %s' % filename)
-        fix_character_encoding(filename, tmp_file)
-        mp_file = process_file(tmp_file, None)
-
-        mp.statements.extend(mp_file.statements)
-        mp.num_entities += mp_file.num_entities
-        mp.num_entities_not_found += mp_file.num_entities_not_found
-
-        for k in mp_file.log_entities:
-            mp.log_entities[k] = mp.log_entities[k] + mp_file.log_entities[k]
-
-        percent_done_now = floor(100.0 * files_processed / num_files)
-        if percent_done_now > percent_done:
-            percent_done = percent_done_now
-            ellapsed_s = time.time() - start_time_s
-            ellapsed_min = ellapsed_s / 60.0
-
-            msg = 'Processed %d of %d files (%f%% complete, %f minutes)' % \
-                    (files_processed, num_files, percent_done, ellapsed_min)
-            logger.info(msg)
-        files_processed += 1
-
-    # Delete the temporary directory
-    shutil.rmtree(tmp_dir)
-
+    mp.process_directory(directory_name, lazy)
     return mp
 
 
@@ -120,14 +73,14 @@ def process_file_sorted_by_pmid(file_name):
         that pmid
     """
     s_dict = defaultdict(list)
-    mp = process_file(file_name)
+    mp = process_file(file_name, lazy=True)
 
-    for statement in mp.statements:
+    for statement in mp.iter_statements():
         s_dict[statement.evidence[0].pmid].append(statement)
     return s_dict
 
 
-def process_file(filename, num_documents=None):
+def process_file(filename, num_documents=None, lazy=False):
     """Process a CSXML file for its relevant information.
 
     Consider running the fix_csxml_character_encoding.py script in
@@ -141,6 +94,11 @@ def process_file(filename, num_documents=None):
     num_documents : int
         The number of documents to process, or None to process all of the
         documents within the csxml file.
+    lazy : bool
+        If True, the statements will not be generated immediately, but rather
+        a generator will be formulated, and statements can be retrieved by
+        using `iter_statements`. If False, the `statements` attribute will be
+        populated immediately. Default is False.
 
     Returns
     -------
@@ -148,7 +106,5 @@ def process_file(filename, num_documents=None):
         A MedscanProcessor object containing extracted statements
     """
     mp = MedscanProcessor()
-
-    with open(filename, 'rb') as f:
-        mp.process_csxml_from_file_handle(f, num_documents)
+    mp.process_csxml_file(filename, num_documents, lazy)
     return mp

--- a/indra/sources/medscan/fix_csxml_character_encoding.py
+++ b/indra/sources/medscan/fix_csxml_character_encoding.py
@@ -1,5 +1,4 @@
 import sys
-import codecs
 import logging
 
 

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -512,6 +512,10 @@ class MedscanProcessor(object):
                 self._pmids_handled.add(pmid_num)
                 self._sentences_handled = set()
 
+            # Solution for memory leak found here:
+            # https://stackoverflow.com/questions/12160418/why-is-lxml-etree-iterparse-eating-up-all-my-memory?lq=1
+            elem.clear()
+
         self.files_processed += 1
         self.__f.close()
         return

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -10,7 +10,7 @@ from math import floor
 import lxml.etree
 import collections
 
-from indra.databases import go_client
+from indra.databases import go_client, mesh_client
 from indra.statements import *
 from indra.databases.chebi_client import get_chebi_id_from_cas
 from indra.databases.hgnc_client import get_hgnc_from_entrez, get_uniprot_id, \
@@ -939,7 +939,9 @@ def _urn_to_db_refs(urn):
         db_refs['MESH'] = urn_id
     elif urn_type == 'agi-meshdis':
         # Identifier is MESH: Actually MESH names
-        db_refs['MESHDIS'] = urn_id
+        mesh_id, mesh_name = mesh_client.get_mesh_id_name(urn_id)
+        db_refs['MESH'] = mesh_id
+        db_name = mesh_name
     elif urn_type == 'agi-gocomplex':
         # Identifier is GO
         db_refs['GO'] = 'GO:%s' % urn_id

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -845,7 +845,7 @@ def _parse_mod_string(s):
     """
     m = re.match('([A-Za-z])+([0-9]+)', s)
     assert(m is not None)
-    return (m.group(1), m.group(2))
+    return m.groups()
 
 
 def _parse_mut_string(s):
@@ -1054,10 +1054,7 @@ def _extract_sentence_tags(tagged_sentence):
         text = text.replace('CONTEXT', '')
         text = text.replace('GLOSSARY', '')
         text = text.strip()
-        try:
-            start = untagged_sentence.index(text)
-        except ValueError as e:
-            print(e)
+        start = untagged_sentence.index(text)
         stop = start + len(text)
 
         tag_key = match.group(1)

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -370,7 +370,10 @@ class MedscanProcessor(object):
         if interval is None:
             interval = (None, None)
 
-        self.__f = open(filename, 'rb')
+        tmp_fname = tempfile.mktemp(filename)
+        fix_character_encoding(filename, tmp_fname)
+
+        self.__f = open(tmp_fname, 'rb')
         self._gen = self._iter_through_csxml_file_from_handle(*interval)
         if not lazy:
             for stmt in self._gen:

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -70,6 +70,17 @@ def is_statement_in_list(statement, statement_list):
         if s.equals(statement):
             return True
         elif s.get_hash(shallow=False) == statement.get_hash(shallow=False):
+            for ag_old, ag_new in zip(s.agent_list(), statement.agent_list()):
+                s_old = set(ag_old.db_refs.items())
+                s_new = set(ag_new.db_refs.items())
+                if s_old == s_new:
+                    continue
+                if s_old > s_new:
+                    return True
+                if s_new > s_old:
+                    ag_new.db_refs.update(ag_old.db_refs)
+                    return True
+
             print("Weird.")
     return False
 
@@ -846,7 +857,7 @@ def _parse_mut_string(s):
         # currently supported
         return None, None, None
     else:
-        return m.group(1), m.group(2), m.group(3)
+        return m.groups()
 
 
 def _urn_to_db_refs(urn):
@@ -906,10 +917,10 @@ def _urn_to_db_refs(urn):
         # Identifier is MESH
         db_refs['MESH'] = urn_id
     elif urn_type == 'agi-ncimcelltype':
-        # Identifier is MESH
+        # Identifier is MESH: Actually from UMLS
         db_refs['MESH'] = urn_id
     elif urn_type == 'agi-meshdis':
-        # Identifier is MESH
+        # Identifier is MESH: Actually MESH names
         db_refs['MESHDIS'] = urn_id
     elif urn_type == 'agi-gocomplex':
         # Identifier is GO
@@ -1038,7 +1049,6 @@ def _extract_sentence_tags(tagged_sentence):
                 if sub_key == '0':
                     continue
                 tags[sub_key] = {'text': text, 'bounds': (start, stop)}
-            print("That's interesting...")
         else:
             tags[tag_key] = {'text': text, 'bounds': (start, stop)}
     return tags

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -960,8 +960,13 @@ def _extract_sentence_tags(tagged_sentence):
             break
         endpos = match.end()
         text = match.group(2)
+        text = text.replace('CONTEXT', '')
+        text = text.replace('GLOSSARY', '')
         text = text.strip()
-        start = untagged_sentence.index(text)
+        try:
+            start = untagged_sentence.index(text)
+        except ValueError as e:
+            print(e)
         stop = start + len(text)
 
         tags[match.group(1)] = {'text': text, 'bounds': (start, stop)}

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -81,6 +81,13 @@ def is_statement_in_list(statement, statement_list):
                     ag_new.db_refs.update(ag_old.db_refs)
                     return True
 
+                if all('CHEBI' in ag.db_refs for ag in [ag_old, ag_new]) \
+                        and ag_new.db_refs['CHEBI'] != ag_old.db_refs['CHEBI']:
+                    print("The CHEBI case.")
+                    ag_new.name = ag_new.db_refs['CHEBI']
+                    ag_old.name = ag_old.db_refs['CHEBI']
+                    return False
+
             print("Weird.")
     return False
 

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -160,7 +160,7 @@ class MedscanProcessor(object):
         self.__tmp_dir = None
         return
 
-    def iter_statements(self):
+    def iter_statements(self, populate=True):
         if self.__gen is None and not self.statements:
             raise InputError("No generator has been initialized. Use "
                              "`process_directory` or `process_file` first.")
@@ -169,7 +169,8 @@ class MedscanProcessor(object):
                 yield stmt
         else:
             for stmt in self.__gen:
-                self.statements.append(stmt)
+                if populate:
+                    self.statements.append(stmt)
                 yield stmt
 
     def process_directory(self, directory_name, lazy=False):
@@ -578,6 +579,7 @@ class MedscanProcessor(object):
             self.last_site_info_in_sentence = \
                     ProteinSiteInfo(site_text=subj.name,
                                     object_text=obj.db_refs['TEXT'])
+        return
 
     def agent_from_entity(self, relation, entity_id):
         """Create a (potentially grounded) INDRA Agent object from a given

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -10,6 +10,7 @@ from math import floor
 import lxml.etree
 import collections
 
+from indra.databases import go_client
 from indra.statements import *
 from indra.databases.chebi_client import get_chebi_id_from_cas
 from indra.databases.hgnc_client import get_hgnc_from_entrez, get_uniprot_id, \
@@ -975,6 +976,8 @@ def _urn_to_db_refs(urn):
     # If there is a Famplex grounding, use Famplex for entity name
     if 'FPLX' in db_refs:
         db_name = db_refs['FPLX']
+    elif 'GO' in db_refs:
+        db_name = go_client.get_go_label(db_refs['GO'])
 
     return db_refs, db_name
 

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -963,8 +963,11 @@ def _urn_to_db_refs(urn):
         # Identifier is MESH
         urn_mesh_name = unquote(urn_id)
         mesh_id, mesh_name = mesh_client.get_mesh_id_name(urn_mesh_name)
-        db_refs['MESH'] = mesh_id
-        db_name = mesh_name
+        if mesh_id:
+            db_refs['MESH'] = mesh_id
+            db_name = mesh_name
+        else:
+            db_name = urn_mesh_name
     elif urn_type == 'agi-gocomplex':
         # Identifier is GO
         db_refs['GO'] = 'GO:%s' % urn_id

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -1017,7 +1017,8 @@ def _urn_to_db_refs(urn):
 
             # Convert the HGNC ID to a Uniprot ID
             uniprot_id = get_uniprot_id(hgnc_id)
-            db_refs['UP'] = uniprot_id
+            if uniprot_id is not None:
+                db_refs['UP'] = uniprot_id
 
             # Try to lookup HGNC name; if it's available, set it to the
             # agent name

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -370,7 +370,7 @@ class MedscanProcessor(object):
         if interval is None:
             interval = (None, None)
 
-        tmp_fname = tempfile.mktemp(filename)
+        tmp_fname = tempfile.mktemp(os.path.basename(filename))
         fix_character_encoding(filename, tmp_fname)
 
         self.__f = open(tmp_fname, 'rb')

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -391,8 +391,6 @@ class MedscanProcessor(object):
             # If opening up a new doc, set the PMID
             if event == 'start' and elem.tag == 'doc':
                 pmid = elem.attrib.get('uri')
-                if '26872462' in pmid:
-                    print("Take a look at this...")
             # If getting a section, set the section type
             elif event == 'start' and elem.tag == 'sec':
                 sec = elem.attrib.get('type')

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -79,7 +79,7 @@ def _is_statement_in_list(statement, statement_list):
     for s in statement_list:
         if s.equals(statement):
             return True
-        elif s.get_hash(shallow=False) == statement.get_hash(shallow=False):
+        elif s.get_hash(False, True) == statement.get_hash(False, True):
             for ag_old, ag_new in zip(s.agent_list(), statement.agent_list()):
                 s_old = set(ag_old.db_refs.items())
                 s_new = set(ag_new.db_refs.items())

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -73,14 +73,24 @@ def is_statement_in_list(statement, statement_list):
             for ag_old, ag_new in zip(s.agent_list(), statement.agent_list()):
                 s_old = set(ag_old.db_refs.items())
                 s_new = set(ag_new.db_refs.items())
+
+                # If they're equal this isn't the one we're interested in.
                 if s_old == s_new:
                     continue
+
+                # If the new statement has nothing new to offer, just ignore it
                 if s_old > s_new:
                     return True
+
+                # If the new statement does have something new, add it to the
+                # existing statement. And then ignore it.
                 if s_new > s_old:
                     ag_new.db_refs.update(ag_old.db_refs)
                     return True
 
+                # If this is a case where different CHEBI ids were mapped to
+                # the same entity, set the agent name to the CHEBI id.
+                # TODO: Ideally we should get the CHEBI name.
                 if all('CHEBI' in ag.db_refs for ag in [ag_old, ag_new]) \
                         and ag_new.db_refs['CHEBI'] != ag_old.db_refs['CHEBI']:
                     print("The CHEBI case.")

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -1,3 +1,5 @@
+from urllib.parse import unquote
+
 import re
 import os
 import glob
@@ -959,7 +961,8 @@ def _urn_to_db_refs(urn):
         db_refs['UMLS'] = urn_id
     elif urn_type in ['agi-meshdis', 'agi-ncimorgan']:
         # Identifier is MESH
-        mesh_id, mesh_name = mesh_client.get_mesh_id_name(urn_id)
+        urn_mesh_name = unquote(urn_id)
+        mesh_id, mesh_name = mesh_client.get_mesh_id_name(urn_mesh_name)
         db_refs['MESH'] = mesh_id
         db_name = mesh_name
     elif urn_type == 'agi-gocomplex':

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -304,7 +304,6 @@ class MedscanProcessor(object):
                 if num_documents is not None and doc_counter >= num_documents:
                     break
 
-
     def process_relation(self, relation, last_relation):
         """Process a relation into an INDRA statement.
 
@@ -426,7 +425,6 @@ class MedscanProcessor(object):
                 return
 
             # Map the unnormalized verb to an INDRA statement type
-            statement_type = None
             if last_relation.verb == 'TK{phosphorylate}':
                 statement_type = Phosphorylation
             elif last_relation.verb == 'TK{dephosphorylate}':

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -11,7 +11,8 @@ import collections
 
 from indra.databases import go_client, mesh_client
 from indra.statements import *
-from indra.databases.chebi_client import get_chebi_id_from_cas
+from indra.databases.chebi_client import get_chebi_id_from_cas, \
+    get_chebi_name_from_id
 from indra.databases.hgnc_client import get_hgnc_from_entrez, get_uniprot_id, \
         get_hgnc_name
 from indra.util import read_unicode_csv
@@ -939,6 +940,7 @@ def _urn_to_db_refs(urn):
         chebi_id = get_chebi_id_from_cas(urn_id)
         if chebi_id:
             db_refs['CHEBI'] = 'CHEBI:%s' % chebi_id
+            db_name = get_chebi_name_from_id(chebi_id)
     elif urn_type == 'agi-llid':
         # This is an Entrez ID, convert to HGNC
         hgnc_id = get_hgnc_from_entrez(urn_id)
@@ -953,10 +955,10 @@ def _urn_to_db_refs(urn):
             # agent name
             db_name = get_hgnc_name(hgnc_id)
     elif urn_type == 'agi-ncimcelltype':
-        # Identifier is MESH: Actually from UMLS
+        # Identifier is UMLS
         db_refs['UMLS'] = urn_id
-    elif urn_type == 'agi-meshdis':
-        # Identifier is MESH: Actually MESH names
+    elif urn_type in ['agi-meshdis', 'agi-ncimorgan']:
+        # Identifier is MESH
         mesh_id, mesh_name = mesh_client.get_mesh_id_name(urn_id)
         db_refs['MESH'] = mesh_id
         db_name = mesh_name

--- a/indra/sources/medscan/processor.py
+++ b/indra/sources/medscan/processor.py
@@ -30,6 +30,7 @@ MedscanEntity = collections.namedtuple('MedscanEntity', ['name', 'urn', 'type',
 MedscanProperty = collections.namedtuple('MedscanProperty',
                                          ['type', 'name', 'urn'])
 
+
 def _read_famplex_map():
     fname = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                          '../../resources/famplex_map.tsv')
@@ -807,7 +808,6 @@ def normalize_medscan_name(name):
         if name.endswith(suffix):
             name = name[:-len(suffix)]
     return name
-
 
 
 def _parse_mod_string(s):

--- a/indra/tests/test_medscan.py
+++ b/indra/tests/test_medscan.py
@@ -393,10 +393,3 @@ def test_site_text_parser():
     assert sites[0].position == '10'
     assert sites[1].residue == 'S'
     assert sites[1].position == '20'
-
-
-def test_full_corpus():
-    here = os.path.dirname(os.path.abspath(__file__))
-    mp = process_directory(os.path.join(here, os.path.pardir, os.path.pardir,
-                                        'medscan_inputs/harvard_csxml/HARVARD_CSXML'))
-    return

--- a/indra/tests/test_medscan.py
+++ b/indra/tests/test_medscan.py
@@ -96,7 +96,7 @@ def test_agent_from_entity():
 
     # Test relation
     tagged_sentence = '{ID{321=BRAF} is a protein, not a type of car.'
-    relation = MedscanRelation(uri=None,
+    relation = MedscanRelation(pmid=None,
                                sec=None,
                                entities={'123': entity},
                                tagged_sentence=tagged_sentence,

--- a/indra/tests/test_medscan.py
+++ b/indra/tests/test_medscan.py
@@ -393,3 +393,10 @@ def test_site_text_parser():
     assert sites[0].position == '10'
     assert sites[1].residue == 'S'
     assert sites[1].position == '20'
+
+
+def test_full_corpus():
+    here = os.path.dirname(os.path.abspath(__file__))
+    mp = process_directory(os.path.join(here, os.path.pardir, os.path.pardir,
+                                        'medscan_inputs/harvard_csxml/HARVARD_CSXML'))
+    return

--- a/indra/tests/test_medscan.py
+++ b/indra/tests/test_medscan.py
@@ -106,17 +106,17 @@ def test_agent_from_entity():
                                svo_type=None)
 
     # Test for when an entity is in the grounded entities list
-    agent1 = mp.agent_from_entity(relation, 'ID{123}')
+    agent1, bounds = mp.agent_from_entity(relation, 'ID{123}')
     assert agent1.db_refs == {'TEXT': 'kinesin-I', 'GO': 'GO:0016938'}
 
     # Test for when an entity is in the tagged sentence but not the entity list
-    agent2 = mp.agent_from_entity(relation, 'ID{321}')
+    agent2, bounds = mp.agent_from_entity(relation, 'ID{321}')
     assert agent2.db_refs == {'TEXT': 'BRAF'}  # No grounding
 
     # Test for when an entity is neither tagged in the sentence nor in the
     # grounded entities list
-    agent3 = mp.agent_from_entity(relation, 'ID{444}')
-    assert agent3 is None
+    agent3_res = mp.agent_from_entity(relation, 'ID{444}')
+    assert agent3_res is None
 
 
 def test_expressioncontrol_positive():
@@ -151,13 +151,13 @@ def test_evidence():
                                   ' display a significant reduction in the' + \
                                   ' circulating hypoxia-induced ' + \
                                   'erythropoietin levels, number of ' + \
-                                  'red cells and hemoglobin concentration. ', \
+                                  'red cells and hemoglobin concentration.', \
         s0.evidence[0].text
     coords = s0.evidence[0].annotations['agents']['coords']
     assert isinstance(coords, list), type(coords)
-    assert len(coords) == 2
-    assert coords[0] == [90, 97]
-    assert coords[1] == [106, 120]
+    assert len(coords) == 2, len(coords)
+    assert coords[0] == (90, 97), coords[0]
+    assert coords[1] == (106, 120), coords[1]
 
 
 def test_molsynthesis_positive():

--- a/indra/tests/test_medscan.py
+++ b/indra/tests/test_medscan.py
@@ -33,17 +33,17 @@ def test_urn_to_db_refs():
     # agi-ncimorgan
     urn3 = 'urn:agi-ncimorgan:C0012144'
     db_refs_3, _ = _urn_to_db_refs(urn3)
-    assert db_refs_3 == {'MESH': 'C0012144'}
+    assert db_refs_3 == {'UMLS': 'C0012144'}
 
     # agi-nicmcelltype
     urn4 = 'urn:agi-ncimcelltype:C0242633'
     db_refs_4, _ = _urn_to_db_refs(urn4)
-    assert db_refs_4 == {'MESH': 'C0242633'}
+    assert db_refs_4 == {'UMLS': 'C0242633'}
 
     # agi-meshdist
     urn5 = 'urn:agi-meshdis:Paramyotonia%20Congenita'
     db_refs_5, _ = _urn_to_db_refs(urn5)
-    assert db_refs_5 == {'MESHDIS': 'Paramyotonia%20Congenita'}
+    assert db_refs_5 == {'MESH': 'D020967'}
 
     # agi-gocomplex
     urn6 = 'urn:agi-gocomplex:0005610'
@@ -58,7 +58,7 @@ def test_urn_to_db_refs():
     # agi-ncimtissue
     urn8 = 'urn:agi-ncimtissue:C0007807'
     db_refs_8, _ = _urn_to_db_refs(urn8)
-    assert db_refs_8 == {'MESH': 'C0007807'}
+    assert db_refs_8 == {'UMLS': 'C0007807'}
 
     # Do we ground to Famplex when there is a correspondence between a GO
     # id and a Famplex id?
@@ -68,7 +68,7 @@ def test_urn_to_db_refs():
 
     # Do we ground to Famplex when there is a correspondence between a MESH
     # id and a Famplex id?
-    urn10 = 'urn:agi-ncimcelltype:D000199'
+    urn10 = 'urn:agi-ncimcelltype:Actins'
     db_refs_10, _ = _urn_to_db_refs(urn10)
     assert db_refs_10 == {'MESH': 'D000199', 'FPLX': 'Actin'}
 
@@ -97,6 +97,7 @@ def test_agent_from_entity():
     # Test relation
     tagged_sentence = '{ID{321=BRAF} is a protein, not a type of car.'
     relation = MedscanRelation(pmid=None,
+                               uri=None,
                                sec=None,
                                entities={'123': entity},
                                tagged_sentence=tagged_sentence,

--- a/indra/tests/test_medscan.py
+++ b/indra/tests/test_medscan.py
@@ -393,8 +393,3 @@ def test_site_text_parser():
     assert sites[0].position == '10'
     assert sites[1].residue == 'S'
     assert sites[1].position == '20'
-
-
-def test_special_cxml():
-    mp = process_file('PMID28270211.csxml')
-    assert len(mp.statements)

--- a/indra/tests/test_medscan.py
+++ b/indra/tests/test_medscan.py
@@ -394,3 +394,7 @@ def test_site_text_parser():
     assert sites[1].residue == 'S'
     assert sites[1].position == '20'
 
+
+def test_special_cxml():
+    mp = process_file('PMID28270211.csxml')
+    assert len(mp.statements)

--- a/indra/util/__init__.py
+++ b/indra/util/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, \
-                       unicode_literals
 import sys
 import csv
 import gzip

--- a/indra/util/perm_cache.py
+++ b/indra/util/perm_cache.py
@@ -1,0 +1,70 @@
+__all__ = ['perm_cache']
+
+import json
+import pickle
+from functools import update_wrapper
+from os.path import exists
+
+
+def perm_cache(cache_type='pkl', cache_file=None):
+    class PermCache(object):
+        _cache_type = cache_type
+        _cache_file = cache_file
+
+        def __init__(self, func):
+            if self._cache_type not in ['pkl', 'json']:
+                raise ValueError("Invalid cache type: %s" % self._cache_type)
+            self._cache_type = self._cache_type
+            self.func = func
+            if self._cache_file is None:
+                self._cache_file = (func.__code__.co_filename
+                                    .replace('.py', '.' + self.func.__name__))
+                self._cache_file += '.cache'
+            if self._cache_file.endswith('.py'):
+                self._cache_file = self._cache_file.replace('.py',
+                                                          '.' + self._cache_type)
+            else:
+                self._cache_file += '.' + self._cache_type
+
+            if exists(self._cache_file):
+                if self._cache_type == 'pkl':
+                    with open(self._cache_file, 'rb') as f:
+                        self.cache = pickle.load(f)
+                elif self._cache_type == 'json':
+                    with open(self._cache_file, 'r') as f:
+                        self.cache = json.load(f)
+            else:
+                self.cache = {}
+            self.__cache_info = dict.fromkeys(['added', 'read', 'total'], 0)
+            update_wrapper(self, func)
+            return
+
+        def __call__(self, *args, **kwargs):
+            key = ' '.join(args) \
+                  + ' '.join(['%s=%s' % (k, v) for k, v in kwargs.items()])
+            self.__cache_info['total'] += 1
+            try:
+                res = self.cache[key]
+                self.__cache_info['read'] += 1
+                print("Retrieving old value %s=%s" % (key, res))
+            except KeyError:
+                res = self.func(*args, **kwargs)
+                self.cache[key] = res
+                self.__cache_info['added'] += 1
+                print("Adding %s=%s to the cache." % (key, res))
+            return res
+
+        def cache_info(self):
+            return self.__cache_info.copy()
+
+        def stash_cache(self):
+            if self._cache_type == 'pkl':
+                with open(self._cache_file, 'wb') as f:
+                    pickle.dump(self.cache, f)
+            elif self._cache_type == 'json':
+                with open(self._cache_file, 'w') as f:
+                    json.dump(self.cache, f, indent=2)
+            print("Stashed %s." % self._cache_file)
+            return
+
+    return PermCache

--- a/indra/util/perm_cache.py
+++ b/indra/util/perm_cache.py
@@ -46,12 +46,10 @@ def perm_cache(cache_type='pkl', cache_file=None):
             try:
                 res = self.cache[key]
                 self.__cache_info['read'] += 1
-                print("Retrieving old value %s=%s" % (key, res))
             except KeyError:
                 res = self.func(*args, **kwargs)
                 self.cache[key] = res
                 self.__cache_info['added'] += 1
-                print("Adding %s=%s to the cache." % (key, res))
             return res
 
         def cache_info(self):
@@ -64,7 +62,6 @@ def perm_cache(cache_type='pkl', cache_file=None):
             elif self._cache_type == 'json':
                 with open(self._cache_file, 'w') as f:
                     json.dump(self.cache, f, indent=2)
-            print("Stashed %s." % self._cache_file)
             return
 
     return PermCache


### PR DESCRIPTION
Fix handling of entity name boundaries to be compatible with the case that there is no entity, but only a tag (TEXT only db_refs).

This PR now also implements the ability, via the `lazy` argument in the api endpoints, to merely create a generator of statements rather than extract the statements all at once. This should allow statements to be processed and dumped in batches more easily.

These changes have been stress tested on our entire corpus of Medscan reading outputs, which had been failing previously.