### PR TITLE
Mesh client update

### DIFF
--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -93,7 +93,7 @@ def get_mesh_id_name(mesh_term, offline=False):
         Returns a 2-tuple of the form `(id, name)` with the ID of the
         descriptor corresponding to the MESH label, and the descriptor name
         (which may not exactly match the name provided as an argument if it is
-        a Concept name. If the query failed, or no descriptor corresponding to
+        a Concept name). If the query failed, or no descriptor corresponding to
         the name was found, returns a tuple of (None, None).
     """
     indra_mesh_id = mesh_name_to_id.get(mesh_term)
@@ -120,7 +120,7 @@ def get_mesh_id_name_from_web(mesh_term):
         Returns a 2-tuple of the form `(id, name)` with the ID of the
         descriptor corresponding to the MESH label, and the descriptor name
         (which may not exactly match the name provided as an argument if it is
-        a Concept name. If the query failed, or no descriptor corresponding to
+        a Concept name). If the query failed, or no descriptor corresponding to
         the name was found, returns a tuple of (None, None).
     """
     url = mesh_url + 'sparql'

--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -1,18 +1,15 @@
-from os.path import abspath, dirname, join
+import re
 import csv
+from functools import lru_cache
+from urllib.parse import urlencode
+from os.path import abspath, dirname, join
 import requests
 from indra.util import read_unicode_csv
 
-mesh_url = 'http://id.nlm.nih.gov/mesh/'
+mesh_url = 'https://id.nlm.nih.gov/mesh/'
 mesh_file = join(dirname(abspath(__file__)), '..', 'resources',
                  'mesh_id_label_mappings.tsv')
 
-# Python3
-try:
-    from functools import lru_cache
-# Python2
-except ImportError:
-    from functools32 import lru_cache
 
 mesh_id_to_name = {}
 mesh_name_to_id = {}
@@ -75,30 +72,98 @@ def get_mesh_name(mesh_id, offline=False):
     return get_mesh_name_from_web(mesh_id)
 
 
-def get_mesh_id(mesh_name, offline=False):
-    """Get the MESH ID for the given MESH label.
+def get_mesh_id_name(mesh_term, offline=False):
+    """Get the MESH ID and name for the given MESH term.
 
-    Uses the mappings table in `indra/resources`; if the MESH label is not
+    Uses the mappings table in `indra/resources`; if the MESH term is not
     listed there, falls back on the NLM REST API.
 
     Parameters
     ----------
-    mesh_name : str
-        MESH Identifier, e.g. 'Glucosylceramides'.
+    mesh_term : str
+        MESH Descriptor or Concept name, e.g. 'Breast Cancer'.
     offline : bool
-        Whether to allow queries to the NLM REST API if the given MESH label is
+        Whether to allow queries to the NLM REST API if the given MESH term is
         not contained in INDRA's internal MESH mappings file. Default is False
         (allows REST API queries).
 
     Returns
     -------
-    str
-        ID corresponding to the MESH label, or None if the query failed or no
-        label was found.
+    tuple of strs
+        Returns a 2-tuple of the form `(id, name)` with the ID of the
+        descriptor corresponding to the MESH label, and the descriptor name
+        (which may not exactly match the name provided as an argument if it is
+        a Concept name. If the query failed, or no descriptor corresponding to
+        the name was found, returns a tuple of (None, None).
     """
-    indra_mesh_mapping = mesh_name_to_id.get(mesh_name)
-    if offline or indra_mesh_mapping is not None:
-        return indra_mesh_mapping
+    indra_mesh_id = mesh_name_to_id.get(mesh_term)
+    if offline and indra_mesh_id is None:
+        return (None, None)
+    elif offline:
+        return (indra_mesh_id, mesh_term)
     # Look up the MESH mapping from NLM if we don't have it locally
-    return get_mesh_id_from_web(mesh_id)
+    return get_mesh_id_name_from_web(mesh_term)
+
+
+@lru_cache(maxsize=1000)
+def get_mesh_id_name_from_web(mesh_term):
+    """Get the MESH ID and name for the given MESH term using the NLM REST API.
+
+    Parameters
+    ----------
+    mesh_term : str
+        MESH Descriptor or Concept name, e.g. 'Breast Cancer'.
+
+    Returns
+    -------
+    tuple of strs
+        Returns a 2-tuple of the form `(id, name)` with the ID of the
+        descriptor corresponding to the MESH label, and the descriptor name
+        (which may not exactly match the name provided as an argument if it is
+        a Concept name. If the query failed, or no descriptor corresponding to
+        the name was found, returns a tuple of (None, None).
+    """
+    url = mesh_url + 'sparql'
+    query = """
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+        PREFIX owl: <http://www.w3.org/2002/07/owl#>
+        PREFIX meshv: <http://id.nlm.nih.gov/mesh/vocab#>
+        PREFIX mesh: <http://id.nlm.nih.gov/mesh/>
+        PREFIX mesh2019: <http://id.nlm.nih.gov/mesh/2019/>
+        PREFIX mesh2018: <http://id.nlm.nih.gov/mesh/2018/>
+        PREFIX mesh2017: <http://id.nlm.nih.gov/mesh/2017/>
+
+        SELECT ?d ?dName ?c ?cName 
+        FROM <http://id.nlm.nih.gov/mesh>
+        WHERE {
+          ?d a meshv:Descriptor .
+          ?d meshv:concept ?c .
+          ?d rdfs:label ?dName .
+          ?c rdfs:label ?cName
+          FILTER (REGEX(?cName,'^%s$','i') || REGEX(?cName,'^%s$','i'))
+        }
+        ORDER BY ?d
+    """ % (mesh_term, mesh_term)
+    args = {'query': query, 'format': 'JSON', 'inference': 'true'}
+    query_string = '%s?%s' % (url, urlencode(args))
+    resp = requests.get(query_string)
+    #resp = requests.get(url, data={'query': query, 'format': 'JSON',
+    #                               'inference': True})
+    if resp.status_code != 200:
+        return (None, None)
+    mesh_json = resp.json()
+    try:
+        # Choose the first entry (should usually be only one)
+        id_uri = mesh_json['results']['bindings'][0]['d']['value']
+        name = mesh_json['results']['bindings'][0]['dName']['value']
+    except (KeyError, IndexError) as e:
+        return (None, None)
+    # Strip the MESH prefix off the ID URI
+    m = re.match('http://id.nlm.nih.gov/mesh/([A-Za-z0-9]*)', id_uri)
+    assert m is not None
+    id = m.groups()[0]
+    return (id, name)
+
 

--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -147,10 +147,13 @@ def get_mesh_id_name_from_web(mesh_term):
         ORDER BY ?d
     """ % (mesh_term, mesh_term)
     args = {'query': query, 'format': 'JSON', 'inference': 'true'}
+    # Interestingly, the following call using requests.get to package the
+    # query does not work:
+    # resp = requests.get(url, data=args)
+    # But if the query string is explicitly urlencoded using urllib, it works:
     query_string = '%s?%s' % (url, urlencode(args))
     resp = requests.get(query_string)
-    #resp = requests.get(url, data={'query': query, 'format': 'JSON',
-    #                               'inference': True})
+    # Check status
     if resp.status_code != 200:
         return (None, None)
     mesh_json = resp.json()

--- a/indra/tests/test_mesh.py
+++ b/indra/tests/test_mesh.py
@@ -30,4 +30,8 @@ def test_mesh_id_fallback_to_rest():
     assert mesh_name == 'Ofloxacin'
 
 
+def test_mesh_name_lookup_local():
+    mesh_name = 'Glucosylceramides'
+    mesh_id = mesh_client.get_mesh_id(mesh_name, offline=True)
+    assert mesh_id == 'D005963'
 

--- a/indra/tests/test_mesh.py
+++ b/indra/tests/test_mesh.py
@@ -30,19 +30,36 @@ def test_mesh_id_fallback_to_rest():
     assert mesh_name == 'Ofloxacin'
 
 
-def test_mesh_name_lookup_local():
-    mesh_name = 'Glucosylceramides'
-    mesh_id = mesh_client.get_mesh_id(mesh_name, offline=True)
+def test_mesh_term_lookup_local():
+    mesh_term = 'Glucosylceramides'
+    (mesh_id, mesh_name) = mesh_client.get_mesh_id_name(mesh_term, offline=True)
     assert mesh_id == 'D005963'
+    assert mesh_name == mesh_term
 
 
-def test_mesh_name_lookup_local():
-    mesh_name = 'Glucosylceramides'
-    mesh_id = mesh_client.get_mesh_id(mesh_name, offline=True)
-    assert mesh_id == 'D005963'
-
-
-def test_mesh_name_local_missing():
-    mesh_name = 'Prostate Cancer'
-    mesh_id = mesh_client.get_mesh_id(mesh_name, offline=True)
+def test_mesh_term_local_missing():
+    mesh_term = 'Prostate Cancer'
+    mesh_id, mesh_name = mesh_client.get_mesh_id_name(mesh_term, offline=True)
     assert mesh_id is None
+    assert mesh_name is None
+
+
+def test_mesh_term_name_norm():
+    # For this one, the corresponding descriptor is D016922, which is in the
+    # INDRA resource file; however, the descriptor name is "Cellular
+    # Senescence".  This test verifies the expected behavior that in
+    # offline-only mode, "Cellular Senescence" will return the correct
+    # descriptor ID, but "Cell Aging" will not, unless using the REST service.
+    query_name = 'Cellular Senescence'
+    mesh_id, mesh_name = mesh_client.get_mesh_id_name(query_name, offline=True)
+    assert mesh_id == 'D016922'
+    assert mesh_name == query_name
+    query_name = 'Cell Aging'
+    mesh_id, mesh_name = mesh_client.get_mesh_id_name(query_name, offline=True)
+    assert mesh_id is None
+    assert mesh_name is None
+    mesh_id, mesh_name = mesh_client.get_mesh_id_name(query_name, offline=False)
+    assert mesh_id == 'D016922'
+    assert mesh_name == 'Cellular Senescence'
+
+

--- a/indra/tests/test_mesh.py
+++ b/indra/tests/test_mesh.py
@@ -35,3 +35,14 @@ def test_mesh_name_lookup_local():
     mesh_id = mesh_client.get_mesh_id(mesh_name, offline=True)
     assert mesh_id == 'D005963'
 
+
+def test_mesh_name_lookup_local():
+    mesh_name = 'Glucosylceramides'
+    mesh_id = mesh_client.get_mesh_id(mesh_name, offline=True)
+    assert mesh_id == 'D005963'
+
+
+def test_mesh_name_local_missing():
+    mesh_name = 'Prostate Cancer'
+    mesh_id = mesh_client.get_mesh_id(mesh_name, offline=True)
+    assert mesh_id is None

--- a/indra/tests/test_mesh.py
+++ b/indra/tests/test_mesh.py
@@ -63,3 +63,15 @@ def test_mesh_term_name_norm():
     assert mesh_name == 'Cellular Senescence'
 
 
+def test_mesh_term_lookups():
+    queries = {'Breast Cancer': ('D001943', 'Breast Neoplasms'),
+               'Neoplasms': ('D009369', 'Neoplasms'),
+               'Colorectal Cancer': ('D015179', 'Colorectal Neoplasms'),
+               'Intestinal Neoplasms': ('D007414', 'Intestinal Neoplasms'),
+               'Carcinoma, Non-Small-Cell Lung':
+                                ('D002289', 'Carcinoma, Non-Small-Cell Lung'),
+               'Prostate Cancer': ('D011471', 'Prostatic Neoplasms')}
+    for query_term, (correct_id, correct_name) in queries.items():
+        mesh_id, mesh_name = mesh_client.get_mesh_id_name(query_term)
+        assert mesh_id == correct_id
+        assert mesh_name == correct_name


### PR DESCRIPTION
As it turns out in certain cases (in particular Medscan) it is important to be able to query MeSH for terms and get back canonical IDs and names. This PR adds a feature to the MeSH client to retrieve IDs and names from the MeSH resource file (already in indra/resources) or connect to the MESH SPARQL endpoint for terms not found in the resource file. 