### PR TITLE
Create a simple client to get CHEBI names from a rest api.

### DIFF
--- a/indra/databases/chebi_client.py
+++ b/indra/databases/chebi_client.py
@@ -158,7 +158,7 @@ def _read_relative_csv(rel_path):
     return csv_reader
 
 
-@lru_cache(maxsize=50)
+@lru_cache(maxsize=5000)
 def get_chebi_name_from_id_web(chebi_id):
     """Return a ChEBI mame corresponding to a given ChEBI ID using a REST API.
 

--- a/indra/databases/chebi_client.py
+++ b/indra/databases/chebi_client.py
@@ -182,6 +182,7 @@ def get_chebi_name_from_id_web(chebi_id):
     tree = etree.fromstring(resp.content)
 
     # Get rid of the namespaces.
+    # Credit: https://stackoverflow.com/questions/18159221/remove-namespace-and-prefix-from-xml-in-python-using-lxml
     for elem in tree.getiterator():
         if not hasattr(elem.tag, 'find'):
             continue  # (1)

--- a/indra/databases/chebi_client.py
+++ b/indra/databases/chebi_client.py
@@ -83,13 +83,15 @@ def get_chebi_id_from_cas(cas_id):
     return cas_chebi.get(cas_id)
 
 
-def get_chebi_name_from_id(chebi_id):
+def get_chebi_name_from_id(chebi_id, offline=False):
     """Return a ChEBI mame corresponding to the given ChEBI ID.
 
     Parameters
     ----------
     chebi_id : str
         The ChEBI ID whose name is to be returned.
+    offline : bool
+        Choose whether to allow an online lookup if the local lookup fails.
 
     Returns
     -------
@@ -97,7 +99,10 @@ def get_chebi_name_from_id(chebi_id):
         The name corresponding to the given ChEBI ID. If the lookup
         fails, None is returned.
     """
-    return chebi_id_to_name.get(chebi_id)
+    chebi_name = chebi_id_to_name.get(chebi_id)
+    if chebi_name is None and not offline:
+        chebi_name = get_chebi_name_from_id_web(chebi_id)
+    return chebi_name
 
 
 def _read_chebi_to_pubchem():

--- a/indra/databases/chebi_client.py
+++ b/indra/databases/chebi_client.py
@@ -154,7 +154,7 @@ def _read_relative_csv(rel_path):
 
 
 @lru_cache(maxsize=50)
-def get_chebi_data_from_web(chebi_id):
+def get_chebi_name_from_id_web(chebi_id):
     url_base = 'http://www.ebi.ac.uk/webservices/chebi/2.0/test/'
     url_fmt = url_base + 'getCompleteEntity?chebiId=%s'
     resp = requests.get(url_fmt % chebi_id)

--- a/indra/databases/chebi_client.py
+++ b/indra/databases/chebi_client.py
@@ -74,8 +74,8 @@ def get_chebi_id_from_cas(cas_id):
     cas_id : str
         The CAS ID to be converted.
 
-    Parameters
-    ----------
+    Returns
+    -------
     chebi_id : str
         The ChEBI ID corresponding to the given CAS ID. If the lookup
         fails, None is returned.
@@ -91,9 +91,9 @@ def get_chebi_name_from_id(chebi_id):
     chebi_id : str
         The ChEBI ID whose name is to be returned.
 
-    Parameters
-    ----------
-    str
+    Returns
+    -------
+    chebi_name : str
         The name corresponding to the given ChEBI ID. If the lookup
         fails, None is returned.
     """
@@ -155,6 +155,19 @@ def _read_relative_csv(rel_path):
 
 @lru_cache(maxsize=50)
 def get_chebi_name_from_id_web(chebi_id):
+    """Return a ChEBI mame corresponding to a given ChEBI ID using a REST API.
+
+    Parameters
+    ----------
+    chebi_id : str
+        The ChEBI ID whose name is to be returned.
+
+    Returns
+    ----------
+    chebi_name : str
+        The name corresponding to the given ChEBI ID. If the lookup
+        fails, None is returned.
+    """
     url_base = 'http://www.ebi.ac.uk/webservices/chebi/2.0/test/'
     url_fmt = url_base + 'getCompleteEntity?chebiId=%s'
     resp = requests.get(url_fmt % chebi_id)

--- a/indra/tests/test_chebi_client.py
+++ b/indra/tests/test_chebi_client.py
@@ -23,7 +23,8 @@ def test_cas_to_chebi():
 
 
 def test_chebi_id_to_name():
-    assert chebi_client.get_chebi_name_from_id('63637') == 'vemurafenib'
+    name = chebi_client.get_chebi_name_from_id('63637', offline=True)
+    assert name == 'vemurafenib', name
 
 
 @attr('webservice')

--- a/indra/tests/test_chebi_client.py
+++ b/indra/tests/test_chebi_client.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str
 from indra.databases import chebi_client
 from indra.util import unicode_strs
 from nose.plugins.attrib import attr
@@ -28,6 +26,7 @@ def test_chebi_id_to_name():
     assert chebi_client.get_chebi_name_from_id('63637') == 'vemurafenib'
 
 
+@attr('webservice')
 def test_chebi_name_from_web():
     name = chebi_client.get_chebi_name_from_id_web('63637')
     assert name == 'vemurafenib'

--- a/indra/tests/test_chebi_client.py
+++ b/indra/tests/test_chebi_client.py
@@ -29,7 +29,7 @@ def test_chebi_id_to_name():
 
 
 def test_chebi_name_from_web():
-    name = chebi_client.get_chebi_data_from_web('63637')
+    name = chebi_client.get_chebi_name_from_id_web('63637')
     assert name == 'vemurafenib'
-    name = chebi_client.get_chebi_data_from_web('44215')
+    name = chebi_client.get_chebi_name_from_id_web('44215')
     assert name == 'NAD zwitterion'

--- a/indra/tests/test_chebi_client.py
+++ b/indra/tests/test_chebi_client.py
@@ -27,3 +27,9 @@ def test_cas_to_chebi():
 def test_chebi_id_to_name():
     assert chebi_client.get_chebi_name_from_id('63637') == 'vemurafenib'
 
+
+def test_chebi_name_from_web():
+    name = chebi_client.get_chebi_data_from_web('63637')
+    assert name == 'vemurafenib'
+    name = chebi_client.get_chebi_data_from_web('44215')
+    assert name == 'NAD zwitterion'


### PR DESCRIPTION
The name says it all. There are other things we could extract from this REST endpoint, if we wanted. Of the various possible choices, I found this to be the fastest to respond by far, and has the level of information we really need. It is also confirmed to get names that are not picked up by the TSV.