### PR TITLE
Add and utilize a resource file built while running Medscan processor.

### DIFF
--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -108,7 +108,7 @@ def get_mesh_id_name(mesh_term, offline=False):
         return indra_mesh_id, mesh_term
 
     indra_mesh_id, new_term = \
-        mesh_name_to_id_NAME.get(mesh_term, (None, None))
+        mesh_name_to_id_name.get(mesh_term, (None, None))
     if indra_mesh_id is not None:
         return indra_mesh_id, new_term
 

--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -160,11 +160,16 @@ def get_mesh_id_name_from_web(mesh_term):
         return None, None
 
     try:
+        # Try to parse the json response (this can raise exceptions if we
+        # got no response).
+        mesh_json = resp.json()
+
         # Choose the first entry (should usually be only one)
         id_uri = mesh_json['results']['bindings'][0]['d']['value']
         name = mesh_json['results']['bindings'][0]['dName']['value']
-    except (KeyError, IndexError) as e:
-        return (None, None)
+    except (KeyError, IndexError, json.decoder.JSONDecodeError) as e:
+        return None, None
+
     # Strip the MESH prefix off the ID URI
     m = re.match('http://id.nlm.nih.gov/mesh/([A-Za-z0-9]*)', id_uri)
     assert m is not None

--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -20,8 +20,8 @@ for mesh_id, mesh_label in read_unicode_csv(MESH_FILE, delimiter='\t'):
     mesh_id_to_name[mesh_id] = mesh_label
     mesh_name_to_id[mesh_label] = mesh_id
 
-with open(mesh_rev_lookups, 'r') as f:
-    mesh_name_to_id_NAME = json.load(f)
+with open(MESH_REV_LOOKUPS, 'r') as f:
+    mesh_name_to_id_name = json.load(f)
 
 
 @lru_cache(maxsize=1000)

--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -3,20 +3,21 @@ import json
 import re
 from functools import lru_cache
 from urllib.parse import urlencode
-from os.path import abspath, dirname, join
+from os.path import abspath, dirname, join, pardir
 import requests
 from indra.util import read_unicode_csv
 
-mesh_url = 'https://id.nlm.nih.gov/mesh/'
-mesh_file = join(dirname(abspath(__file__)), '..', 'resources',
-                 'mesh_id_label_mappings.tsv')
+MESH_URL = 'https://id.nlm.nih.gov/mesh/'
+HERE = dirname(abspath(__file__))
+RESOURCES = join(HERE, pardir, 'resources')
+MESH_FILE = join(RESOURCES, 'mesh_id_label_mappings.tsv')
 
 
-mesh_id_to_name = {}
-mesh_name_to_id = {}
-for mesh_id, mesh_label in read_unicode_csv(mesh_file, delimiter='\t'):
-    mesh_id_to_name[mesh_id] = mesh_label
-    mesh_name_to_id[mesh_label] = mesh_id
+MESH_ID_TO_NAME = {}
+MESH_NAME_TO_ID = {}
+for mesh_id, mesh_label in read_unicode_csv(MESH_FILE, delimiter='\t'):
+    MESH_ID_TO_NAME[mesh_id] = mesh_label
+    MESH_NAME_TO_ID[mesh_label] = mesh_id
 
 
 @lru_cache(maxsize=1000)
@@ -34,7 +35,7 @@ def get_mesh_name_from_web(mesh_id):
         Label for the MESH ID, or None if the query failed or no label was
         found.
     """
-    url = mesh_url + mesh_id + '.json'
+    url = MESH_URL + mesh_id + '.json'
     resp = requests.get(url)
     if resp.status_code != 200:
         return None
@@ -67,7 +68,7 @@ def get_mesh_name(mesh_id, offline=False):
         Label for the MESH ID, or None if the query failed or no label was
         found.
     """
-    indra_mesh_mapping = mesh_id_to_name.get(mesh_id)
+    indra_mesh_mapping = MESH_ID_TO_NAME.get(mesh_id)
     if offline or indra_mesh_mapping is not None:
         return indra_mesh_mapping
     # Look up the MESH mapping from NLM if we don't have it locally
@@ -98,7 +99,7 @@ def get_mesh_id_name(mesh_term, offline=False):
         a Concept name). If the query failed, or no descriptor corresponding to
         the name was found, returns a tuple of (None, None).
     """
-    indra_mesh_id = mesh_name_to_id.get(mesh_term)
+    indra_mesh_id = MESH_NAME_TO_ID.get(mesh_term)
     if offline and indra_mesh_id is None:
         return None, None
     elif offline:
@@ -125,7 +126,7 @@ def get_mesh_id_name_from_web(mesh_term):
         a Concept name). If the query failed, or no descriptor corresponding to
         the name was found, returns a tuple of (None, None).
     """
-    url = mesh_url + 'sparql'
+    url = MESH_URL + 'sparql'
     query = """
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -14,14 +14,14 @@ MESH_FILE = join(RESOURCES, 'mesh_id_label_mappings.tsv')
 MESH_REV_LOOKUPS = join(RESOURCES, 'mesh_name_id_maps.json')
 
 
-MESH_ID_TO_NAME = {}
-MESH_NAME_TO_ID = {}
+mesh_id_to_name = {}
+mesh_name_to_id = {}
 for mesh_id, mesh_label in read_unicode_csv(MESH_FILE, delimiter='\t'):
-    MESH_ID_TO_NAME[mesh_id] = mesh_label
-    MESH_NAME_TO_ID[mesh_label] = mesh_id
+    mesh_id_to_name[mesh_id] = mesh_label
+    mesh_name_to_id[mesh_label] = mesh_id
 
-with open(MESH_REV_LOOKUPS, 'r') as f:
-    MESH_NAME_TO_ID_NAME = json.load(f)
+with open(mesh_rev_lookups, 'r') as f:
+    mesh_name_to_id_NAME = json.load(f)
 
 
 @lru_cache(maxsize=1000)
@@ -72,7 +72,7 @@ def get_mesh_name(mesh_id, offline=False):
         Label for the MESH ID, or None if the query failed or no label was
         found.
     """
-    indra_mesh_mapping = MESH_ID_TO_NAME.get(mesh_id)
+    indra_mesh_mapping = mesh_id_to_name.get(mesh_id)
     if offline or indra_mesh_mapping is not None:
         return indra_mesh_mapping
     # Look up the MESH mapping from NLM if we don't have it locally
@@ -103,12 +103,12 @@ def get_mesh_id_name(mesh_term, offline=False):
         a Concept name). If the query failed, or no descriptor corresponding to
         the name was found, returns a tuple of (None, None).
     """
-    indra_mesh_id = MESH_NAME_TO_ID.get(mesh_term)
+    indra_mesh_id = mesh_name_to_id.get(mesh_term)
     if indra_mesh_id is not None:
         return indra_mesh_id, mesh_term
 
     indra_mesh_id, new_term = \
-        MESH_NAME_TO_ID_NAME.get(mesh_term, (None, None))
+        mesh_name_to_id_NAME.get(mesh_term, (None, None))
     if indra_mesh_id is not None:
         return indra_mesh_id, new_term
 

--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -21,7 +21,7 @@ for mesh_id, mesh_label in read_unicode_csv(MESH_FILE, delimiter='\t'):
     MESH_NAME_TO_ID[mesh_label] = mesh_id
 
 with open(MESH_REV_LOOKUPS, 'r') as f:
-    MESH_NAME_TO_ID_NAME = json.loads(f)
+    MESH_NAME_TO_ID_NAME = json.load(f)
 
 
 @lru_cache(maxsize=1000)

--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -1,5 +1,6 @@
+import json
+
 import re
-import csv
 from functools import lru_cache
 from urllib.parse import urlencode
 from os.path import abspath, dirname, join
@@ -16,6 +17,7 @@ mesh_name_to_id = {}
 for mesh_id, mesh_label in read_unicode_csv(mesh_file, delimiter='\t'):
     mesh_id_to_name[mesh_id] = mesh_label
     mesh_name_to_id[mesh_label] = mesh_id
+
 
 @lru_cache(maxsize=1000)
 def get_mesh_name_from_web(mesh_id):
@@ -98,9 +100,9 @@ def get_mesh_id_name(mesh_term, offline=False):
     """
     indra_mesh_id = mesh_name_to_id.get(mesh_term)
     if offline and indra_mesh_id is None:
-        return (None, None)
+        return None, None
     elif offline:
-        return (indra_mesh_id, mesh_term)
+        return indra_mesh_id, mesh_term
     # Look up the MESH mapping from NLM if we don't have it locally
     return get_mesh_id_name_from_web(mesh_term)
 
@@ -155,8 +157,8 @@ def get_mesh_id_name_from_web(mesh_term):
     resp = requests.get(query_string)
     # Check status
     if resp.status_code != 200:
-        return (None, None)
-    mesh_json = resp.json()
+        return None, None
+
     try:
         # Choose the first entry (should usually be only one)
         id_uri = mesh_json['results']['bindings'][0]['d']['value']
@@ -167,6 +169,6 @@ def get_mesh_id_name_from_web(mesh_term):
     m = re.match('http://id.nlm.nih.gov/mesh/([A-Za-z0-9]*)', id_uri)
     assert m is not None
     id = m.groups()[0]
-    return (id, name)
+    return id, name
 
 

--- a/indra/resources/mesh_name_id_maps.json
+++ b/indra/resources/mesh_name_id_maps.json
@@ -1,0 +1,14942 @@
+{
+  "Neoplasms": [
+    "D009369",
+    "Neoplasms"
+  ],
+  "Cancer of Colon": [
+    "D003110",
+    "Colonic Neoplasms"
+  ],
+  "Carcinoma, Non-Small-Cell Lung": [
+    "D002289",
+    "Carcinoma, Non-Small-Cell Lung"
+  ],
+  "Diabetes Mellitus": [
+    "D003920",
+    "Diabetes Mellitus"
+  ],
+  "Breast Cancer": [
+    "D001943",
+    "Breast Neoplasms"
+  ],
+  "Cancer of Esophagus": [
+    "D004938",
+    "Esophageal Neoplasms"
+  ],
+  "Neoplasm Metastasis": [
+    "D009362",
+    "Neoplasm Metastasis"
+  ],
+  "Wounds": [
+    "D014947",
+    "Wounds and Injuries"
+  ],
+  "Ischemia": [
+    "D007511",
+    "Ischemia"
+  ],
+  "Glioblastoma": [
+    "D005909",
+    "Glioblastoma"
+  ],
+  "Cancer": [
+    "D009369",
+    "Neoplasms"
+  ],
+  "Carcinoma": [
+    "D002277",
+    "Carcinoma"
+  ],
+  "Leukemia, Myeloid, Acute": [
+    "D015470",
+    "Leukemia, Myeloid, Acute"
+  ],
+  "Precursor Cell Lymphoblastic Leukemia-Lymphoma": [
+    "D054198",
+    "Precursor Cell Lymphoblastic Leukemia-Lymphoma"
+  ],
+  "Carcinoma, Hepatocellular": [
+    "D006528",
+    "Carcinoma, Hepatocellular"
+  ],
+  "Prostate Cancer": [
+    "D011471",
+    "Prostatic Neoplasms"
+  ],
+  "Nerve Degeneration": [
+    "D009410",
+    "Nerve Degeneration"
+  ],
+  "Herpes Simplex": [
+    "D006561",
+    "Herpes Simplex"
+  ],
+  "Influenza, Human": [
+    "D007251",
+    "Influenza, Human"
+  ],
+  "Cancer of Stomach": [
+    "D013274",
+    "Stomach Neoplasms"
+  ],
+  "Colorectal Neoplasms": [
+    "D015179",
+    "Colorectal Neoplasms"
+  ],
+  "Respiratory Syncytial Virus Infections": [
+    "D018357",
+    "Respiratory Syncytial Virus Infections"
+  ],
+  "Infection": [
+    "D007239",
+    "Infection"
+  ],
+  "Leukemia": [
+    "D007938",
+    "Leukemia"
+  ],
+  "Colorectal Cancer": [
+    "D015179",
+    "Colorectal Neoplasms"
+  ],
+  "Intestinal Neoplasms": [
+    "D007414",
+    "Intestinal Neoplasms"
+  ],
+  "Cancer of Testis": [
+    "D013736",
+    "Testicular Neoplasms"
+  ],
+  "Depression, Involutional": [
+    "D003865",
+    "Depressive Disorder, Major"
+  ],
+  "Depression": [
+    "D003863",
+    "Depression"
+  ],
+  "Epilepsy, Generalized": [
+    "D004829",
+    "Epilepsy, Generalized"
+  ],
+  "Schizophrenia": [
+    "D012559",
+    "Schizophrenia"
+  ],
+  "Fibrodysplasia Ossificans Progressiva": [
+    "D009221",
+    "Myositis Ossificans"
+  ],
+  "Teratoma": [
+    "D013724",
+    "Teratoma"
+  ],
+  "Anemia": [
+    "D000740",
+    "Anemia"
+  ],
+  "Carcinogenesis": [
+    "D063646",
+    "Carcinogenesis"
+  ],
+  "Glomerulonephritis, IGA": [
+    "D005922",
+    "Glomerulonephritis, IGA"
+  ],
+  "Melanoma": [
+    "D008545",
+    "Melanoma"
+  ],
+  "Hepatitis B": [
+    "D006509",
+    "Hepatitis B"
+  ],
+  "Ovary Cancer": [
+    "D010051",
+    "Ovarian Neoplasms"
+  ],
+  "Inflammation": [
+    "D007249",
+    "Inflammation"
+  ],
+  "Anxiety": [
+    "D001007",
+    "Anxiety"
+  ],
+  "Colonic Neoplasms": [
+    "D003110",
+    "Colonic Neoplasms"
+  ],
+  "Cancer of Pancreas": [
+    "D010190",
+    "Pancreatic Neoplasms"
+  ],
+  "Injuries": [
+    "D014947",
+    "Wounds and Injuries"
+  ],
+  "Diabetic Nephropathies": [
+    "D003928",
+    "Diabetic Nephropathies"
+  ],
+  "Alzheimer Disease": [
+    "D000544",
+    "Alzheimer Disease"
+  ],
+  "Hyperkinesis": [
+    "D006948",
+    "Hyperkinesis"
+  ],
+  "Amyotrophic Lateral Sclerosis": [
+    "D000690",
+    "Amyotrophic Lateral Sclerosis"
+  ],
+  "Necrosis": [
+    "D009336",
+    "Necrosis"
+  ],
+  "Tuberculosis": [
+    "D014376",
+    "Tuberculosis"
+  ],
+  "Hepatitis C": [
+    "D006526",
+    "Hepatitis C"
+  ],
+  "Immunologic Deficiency Syndromes": [
+    "D007153",
+    "Immunologic Deficiency Syndromes"
+  ],
+  "Precancerous Conditions": [
+    "D011230",
+    "Precancerous Conditions"
+  ],
+  "Dementia": [
+    "D003704",
+    "Dementia"
+  ],
+  "Diabetes Mellitus, Type 1": [
+    "D003922",
+    "Diabetes Mellitus, Type 1"
+  ],
+  "Insulin Resistance": [
+    "D007333",
+    "Insulin Resistance"
+  ],
+  "Androgenization": [
+    "D014770",
+    "Virilism"
+  ],
+  "Pain": [
+    "D010146",
+    "Pain"
+  ],
+  "Lung Cancer": [
+    "D008175",
+    "Lung Neoplasms"
+  ],
+  "Inflammatory Breast Neoplasms": [
+    "D058922",
+    "Inflammatory Breast Neoplasms"
+  ],
+  "Prostatic Neoplasms": [
+    "D011471",
+    "Prostatic Neoplasms"
+  ],
+  "Benign Prostatic Hyperplasia": [
+    "D011470",
+    "Prostatic Hyperplasia"
+  ],
+  "Cancer of Liver": [
+    "D008113",
+    "Liver Neoplasms"
+  ],
+  "Steatohepatitis": [
+    "D005234",
+    "Fatty Liver"
+  ],
+  "Small Cell Lung Carcinoma": [
+    "D055752",
+    "Small Cell Lung Carcinoma"
+  ],
+  "Cell Transformation, Neoplastic": [
+    "D002471",
+    "Cell Transformation, Neoplastic"
+  ],
+  "Colitis, Ulcerative": [
+    "D003093",
+    "Colitis, Ulcerative"
+  ],
+  "Pneumonia, Pneumocystis": [
+    "D011020",
+    "Pneumonia, Pneumocystis"
+  ],
+  "Lupus Erythematosus, Systemic": [
+    "D008180",
+    "Lupus Erythematosus, Systemic"
+  ],
+  "Arthritis, Rheumatoid": [
+    "D001172",
+    "Arthritis, Rheumatoid"
+  ],
+  "Breast Neoplasms": [
+    "D001943",
+    "Breast Neoplasms"
+  ],
+  "Obesity": [
+    "D009765",
+    "Obesity"
+  ],
+  "Virus Diseases": [
+    "D014777",
+    "Virus Diseases"
+  ],
+  "Lupus Nephritis": [
+    "D008181",
+    "Lupus Nephritis"
+  ],
+  "Liver Failure, Acute": [
+    "D017114",
+    "Liver Failure, Acute"
+  ],
+  "Death": [
+    "D003643",
+    "Death"
+  ],
+  "Cystadenocarcinoma, Serous": [
+    "D018284",
+    "Cystadenocarcinoma, Serous"
+  ],
+  "Fibrosis": [
+    "D005355",
+    "Fibrosis"
+  ],
+  "Papillary Renal Cell Carcinoma": [
+    "D002292",
+    "Carcinoma, Renal Cell"
+  ],
+  "Aortic Aneurysm, Thoracic": [
+    "D017545",
+    "Aortic Aneurysm, Thoracic"
+  ],
+  "Carcinoma, Transitional Cell": [
+    "D002295",
+    "Carcinoma, Transitional Cell"
+  ],
+  "Carcinoma, Renal Cell": [
+    "D002292",
+    "Carcinoma, Renal Cell"
+  ],
+  "Retinal Degeneration": [
+    "D012162",
+    "Retinal Degeneration"
+  ],
+  "Osteosarcoma": [
+    "D012516",
+    "Osteosarcoma"
+  ],
+  "Ovarian Neoplasms": [
+    "D010051",
+    "Ovarian Neoplasms"
+  ],
+  "Dermatitis, Atopic": [
+    "D003876",
+    "Dermatitis, Atopic"
+  ],
+  "Glioma": [
+    "D005910",
+    "Glioma"
+  ],
+  "Pregnancy, Ectopic": [
+    "D011271",
+    "Pregnancy, Ectopic"
+  ],
+  "Cardiovascular Diseases": [
+    "D002318",
+    "Cardiovascular Diseases"
+  ],
+  "Osteopenia": [
+    "D001851",
+    "Bone Diseases, Metabolic"
+  ],
+  "Behcet Syndrome": [
+    "D001528",
+    "Behcet Syndrome"
+  ],
+  "Sarcoma": [
+    "D012509",
+    "Sarcoma"
+  ],
+  "Hyperplasia": [
+    "D006965",
+    "Hyperplasia"
+  ],
+  "Acute Radiation Syndrome": [
+    "D054508",
+    "Acute Radiation Syndrome"
+  ],
+  "Atherosclerosis": [
+    "D050197",
+    "Atherosclerosis"
+  ],
+  "Aneuploidy": [
+    "D000782",
+    "Aneuploidy"
+  ],
+  "Hematologic Neoplasms": [
+    "D019337",
+    "Hematologic Neoplasms"
+  ],
+  "Hereditary Diseases": [
+    "D030342",
+    "Genetic Diseases, Inborn"
+  ],
+  "Thrombocytopenia": [
+    "D013921",
+    "Thrombocytopenia"
+  ],
+  "Inflammatory Bowel Diseases": [
+    "D015212",
+    "Inflammatory Bowel Diseases"
+  ],
+  "Hypertrophy": [
+    "D006984",
+    "Hypertrophy"
+  ],
+  "Gliosis": [
+    "D005911",
+    "Gliosis"
+  ],
+  "Optic Nerve Transection": [
+    "D020221",
+    "Optic Nerve Injuries"
+  ],
+  "Wounds and Injuries": [
+    "D014947",
+    "Wounds and Injuries"
+  ],
+  "Hearing Loss, Sensorineural": [
+    "D006319",
+    "Hearing Loss, Sensorineural"
+  ],
+  "Liver Cirrhosis": [
+    "D008103",
+    "Liver Cirrhosis"
+  ],
+  "Stroke": [
+    "D020521",
+    "Stroke"
+  ],
+  "Peripheral Arterial Disease": [
+    "D058729",
+    "Peripheral Arterial Disease"
+  ],
+  "Hypertension": [
+    "D006973",
+    "Hypertension"
+  ],
+  "Myopia": [
+    "D009216",
+    "Myopia"
+  ],
+  "Neuroblastoma": [
+    "D009447",
+    "Neuroblastoma"
+  ],
+  "Leukemia, Lymphocytic, Chronic, B-Cell": [
+    "D015451",
+    "Leukemia, Lymphocytic, Chronic, B-Cell"
+  ],
+  "Urticaria": [
+    "D014581",
+    "Urticaria"
+  ],
+  "Type III Mucolipidosis": [
+    "D009081",
+    "Mucolipidoses"
+  ],
+  "Marfan Syndrome": [
+    "D008382",
+    "Marfan Syndrome"
+  ],
+  "Obesity, Abdominal": [
+    "D056128",
+    "Obesity, Abdominal"
+  ],
+  "Arrhythmias, Cardiac": [
+    "D001145",
+    "Arrhythmias, Cardiac"
+  ],
+  "Kidney Failure, Chronic": [
+    "D007676",
+    "Kidney Failure, Chronic"
+  ],
+  "Asthma": [
+    "D001249",
+    "Asthma"
+  ],
+  "Cancer of Kidney": [
+    "D007680",
+    "Kidney Neoplasms"
+  ],
+  "Dyslexia": [
+    "D004410",
+    "Dyslexia"
+  ],
+  "Hyperlipidemias": [
+    "D006949",
+    "Hyperlipidemias"
+  ],
+  "Muscular Dystrophy, Oculopharyngeal": [
+    "D039141",
+    "Muscular Dystrophy, Oculopharyngeal"
+  ],
+  "Muscle Weakness": [
+    "D018908",
+    "Muscle Weakness"
+  ],
+  "Precursor T-Cell Lymphoblastic Leukemia-Lymphoma": [
+    "D054218",
+    "Precursor T-Cell Lymphoblastic Leukemia-Lymphoma"
+  ],
+  "Prostatic Hyperplasia": [
+    "D011470",
+    "Prostatic Hyperplasia"
+  ],
+  "Prostatic Intraepithelial Neoplasia": [
+    "D019048",
+    "Prostatic Intraepithelial Neoplasia"
+  ],
+  "Pituitary Adenoma": [
+    "D010911",
+    "Pituitary Neoplasms"
+  ],
+  "Pituitary Neoplasms": [
+    "D010911",
+    "Pituitary Neoplasms"
+  ],
+  "Growth Hormone-Secreting Pituitary Adenoma": [
+    "D049912",
+    "Growth Hormone-Secreting Pituitary Adenoma"
+  ],
+  "Carcinoma, Basal Cell": [
+    "D002280",
+    "Carcinoma, Basal Cell"
+  ],
+  "Carcinoma, Squamous Cell": [
+    "D002294",
+    "Carcinoma, Squamous Cell"
+  ],
+  "Diabetic Retinopathy": [
+    "D003930",
+    "Diabetic Retinopathy"
+  ],
+  "Vasculitis": [
+    "D014657",
+    "Vasculitis"
+  ],
+  "Dengue": [
+    "D003715",
+    "Dengue"
+  ],
+  "Retinal Diseases": [
+    "D012164",
+    "Retinal Diseases"
+  ],
+  "Smoking": [
+    "D012907",
+    "Smoking"
+  ],
+  "Carcinoma, Pancreatic Ductal": [
+    "D021441",
+    "Carcinoma, Pancreatic Ductal"
+  ],
+  "Fibrosarcoma": [
+    "D005354",
+    "Fibrosarcoma"
+  ],
+  "Vitreoretinopathy, Proliferative": [
+    "D018630",
+    "Vitreoretinopathy, Proliferative"
+  ],
+  "Cardiac Hypertrophy": [
+    "D006332",
+    "Cardiomegaly"
+  ],
+  "Coronary Artery Disease": [
+    "D003324",
+    "Coronary Artery Disease"
+  ],
+  "Giant Axonal Neuropathy": [
+    "D056768",
+    "Giant Axonal Neuropathy"
+  ],
+  "Myocardial Ischemia": [
+    "D017202",
+    "Myocardial Ischemia"
+  ],
+  "Vascular Diseases": [
+    "D014652",
+    "Vascular Diseases"
+  ],
+  "Adenocarcinoma": [
+    "D000230",
+    "Adenocarcinoma"
+  ],
+  "Endometrial Carcinoma": [
+    "D016889",
+    "Endometrial Neoplasms"
+  ],
+  "Purpura, Thrombotic Thrombocytopenic": [
+    "D011697",
+    "Purpura, Thrombotic Thrombocytopenic"
+  ],
+  "Neoplasms, Multiple Primary": [
+    "D009378",
+    "Neoplasms, Multiple Primary"
+  ],
+  "Vesicular Stomatitis": [
+    "D054243",
+    "Vesicular Stomatitis"
+  ],
+  "Familial Mediterranean Fever": [
+    "D010505",
+    "Familial Mediterranean Fever"
+  ],
+  "Depressive Disorder, Major": [
+    "D003865",
+    "Depressive Disorder, Major"
+  ],
+  "Leukemia, Myelogenous, Chronic, BCR-ABL Positive": [
+    "D015464",
+    "Leukemia, Myelogenous, Chronic, BCR-ABL Positive"
+  ],
+  "Cancer of Mouth": [
+    "D009062",
+    "Mouth Neoplasms"
+  ],
+  "Seizures": [
+    "D012640",
+    "Seizures"
+  ],
+  "Memory Deficits": [
+    "D008569",
+    "Memory Disorders"
+  ],
+  "Atrophy": [
+    "D001284",
+    "Atrophy"
+  ],
+  "Myocardial Reperfusion Injury": [
+    "D015428",
+    "Myocardial Reperfusion Injury"
+  ],
+  "Parkinson Disease": [
+    "D010300",
+    "Parkinson Disease"
+  ],
+  "Mitochondrial Diseases": [
+    "D028361",
+    "Mitochondrial Diseases"
+  ],
+  "Lymphoma": [
+    "D008223",
+    "Lymphoma"
+  ],
+  "Periodontal Diseases": [
+    "D010510",
+    "Periodontal Diseases"
+  ],
+  "Frontotemporal Lobar Degeneration": [
+    "D057174",
+    "Frontotemporal Lobar Degeneration"
+  ],
+  "Bloom Syndrome": [
+    "D001816",
+    "Bloom Syndrome"
+  ],
+  "Pulmonary Disease, Chronic Obstructive": [
+    "D029424",
+    "Pulmonary Disease, Chronic Obstructive"
+  ],
+  "Lung Diseases": [
+    "D008171",
+    "Lung Diseases"
+  ],
+  "Cancer of Gastrointestinal Tract": [
+    "D005770",
+    "Gastrointestinal Neoplasms"
+  ],
+  "Mental Disorders": [
+    "D001523",
+    "Mental Disorders"
+  ],
+  "Alcoholism": [
+    "D000437",
+    "Alcoholism"
+  ],
+  "Irritable Bowel Syndrome": [
+    "D043183",
+    "Irritable Bowel Syndrome"
+  ],
+  "Multiple Myeloma": [
+    "D009101",
+    "Multiple Myeloma"
+  ],
+  "Retinal Neovascularization": [
+    "D015861",
+    "Retinal Neovascularization"
+  ],
+  "Leukostasis": [
+    "D018921",
+    "Leukostasis"
+  ],
+  "Sarcoma, Myeloid": [
+    "D023981",
+    "Sarcoma, Myeloid"
+  ],
+  "Vitiligo": [
+    "D014820",
+    "Vitiligo"
+  ],
+  "Melanoma, B16": [
+    "D008546",
+    "Melanoma, Experimental"
+  ],
+  "Hepatitis C, Chronic": [
+    "D019698",
+    "Hepatitis C, Chronic"
+  ],
+  "Hepatitis": [
+    "D006505",
+    "Hepatitis"
+  ],
+  "Hepatitis B, Chronic": [
+    "D019694",
+    "Hepatitis B, Chronic"
+  ],
+  "Endomyocardial Fibrosis": [
+    "D004719",
+    "Endomyocardial Fibrosis"
+  ],
+  "Congestive Heart Failure": [
+    "D006333",
+    "Heart Failure"
+  ],
+  "Bipolar Disorder": [
+    "D001714",
+    "Bipolar Disorder"
+  ],
+  "Psychotic Disorders": [
+    "D011618",
+    "Psychotic Disorders"
+  ],
+  "tardive dyskinesia": [
+    "D000071057",
+    "Tardive Dyskinesia"
+  ],
+  "Idiopathic Pulmonary Fibrosis": [
+    "D054990",
+    "Idiopathic Pulmonary Fibrosis"
+  ],
+  "Lung Injury": [
+    "D055370",
+    "Lung Injury"
+  ],
+  "Viremia": [
+    "D014766",
+    "Viremia"
+  ],
+  "Mild Cognitive Impairment": [
+    "D060825",
+    "Cognitive Dysfunction"
+  ],
+  "Neoplasm Invasiveness": [
+    "D009361",
+    "Neoplasm Invasiveness"
+  ],
+  "Lewy Body Disease": [
+    "D020961",
+    "Lewy Body Disease"
+  ],
+  "Brain Injuries": [
+    "D001930",
+    "Brain Injuries"
+  ],
+  "Brain Ischemia": [
+    "D002545",
+    "Brain Ischemia"
+  ],
+  "X-Linked Combined Immunodeficiency Diseases": [
+    "D053632",
+    "X-Linked Combined Immunodeficiency Diseases"
+  ],
+  "Adenocarcinoma, Mucinous": [
+    "D002288",
+    "Adenocarcinoma, Mucinous"
+  ],
+  "Eosinophilia": [
+    "D004802",
+    "Eosinophilia"
+  ],
+  "Lymphoma, Large B-Cell, Diffuse": [
+    "D016403",
+    "Lymphoma, Large B-Cell, Diffuse"
+  ],
+  "Vaccinia": [
+    "D014615",
+    "Vaccinia"
+  ],
+  "Cytomegalovirus Infections": [
+    "D003586",
+    "Cytomegalovirus Infections"
+  ],
+  "Metabolic Diseases": [
+    "D008659",
+    "Metabolic Diseases"
+  ],
+  "Cervical Intraepithelial Neoplasia": [
+    "D018290",
+    "Cervical Intraepithelial Neoplasia"
+  ],
+  "Heart Failure": [
+    "D006333",
+    "Heart Failure"
+  ],
+  "Urinary Bladder Cancer": [
+    "D001749",
+    "Urinary Bladder Neoplasms"
+  ],
+  "Cancer of Intestines": [
+    "D007414",
+    "Intestinal Neoplasms"
+  ],
+  "Scleroderma, Systemic": [
+    "D012595",
+    "Scleroderma, Systemic"
+  ],
+  "Pneumonia, Bacterial": [
+    "D018410",
+    "Pneumonia, Bacterial"
+  ],
+  "Weight Loss": [
+    "D015431",
+    "Weight Loss"
+  ],
+  "Stress Disorders, Post-Traumatic": [
+    "D013313",
+    "Stress Disorders, Post-Traumatic"
+  ],
+  "Communicable Diseases": [
+    "D003141",
+    "Communicable Diseases"
+  ],
+  "Psoriasis": [
+    "D011565",
+    "Psoriasis"
+  ],
+  "Metaplasia": [
+    "D008679",
+    "Metaplasia"
+  ],
+  "Retinoblastoma": [
+    "D012175",
+    "Retinoblastoma"
+  ],
+  "Cancer of Digestive System": [
+    "D004067",
+    "Digestive System Neoplasms"
+  ],
+  "Granulomatous Disease, Chronic": [
+    "D006105",
+    "Granulomatous Disease, Chronic"
+  ],
+  "Liver Diseases": [
+    "D008107",
+    "Liver Diseases"
+  ],
+  "Cerebral Hemorrhage": [
+    "D002543",
+    "Cerebral Hemorrhage"
+  ],
+  "Atrial Fibrillation": [
+    "D001281",
+    "Atrial Fibrillation"
+  ],
+  "Diarrhea": [
+    "D003967",
+    "Diarrhea"
+  ],
+  "Peritoneal Fibrosis": [
+    "D056627",
+    "Peritoneal Fibrosis"
+  ],
+  "Blast Crisis": [
+    "D001752",
+    "Blast Crisis"
+  ],
+  "Depressive Symptoms": [
+    "D003863",
+    "Depression"
+  ],
+  "Depressive Disorder": [
+    "D003866",
+    "Depressive Disorder"
+  ],
+  "Cryptococcosis": [
+    "D003453",
+    "Cryptococcosis"
+  ],
+  "Leukemia, Erythroblastic, Acute": [
+    "D004915",
+    "Leukemia, Erythroblastic, Acute"
+  ],
+  "Cysticercosis": [
+    "D003551",
+    "Cysticercosis"
+  ],
+  "Neurocysticercosis": [
+    "D020019",
+    "Neurocysticercosis"
+  ],
+  "Central Nervous System Cysts": [
+    "D020863",
+    "Central Nervous System Cysts"
+  ],
+  "Cholangiocarcinoma": [
+    "D018281",
+    "Cholangiocarcinoma"
+  ],
+  "Hemorrhage": [
+    "D006470",
+    "Hemorrhage"
+  ],
+  "Fetal Growth Retardation": [
+    "D005317",
+    "Fetal Growth Retardation"
+  ],
+  "Pre-Eclampsia": [
+    "D011225",
+    "Pre-Eclampsia"
+  ],
+  "Glaucoma, Open-Angle": [
+    "D005902",
+    "Glaucoma, Open-Angle"
+  ],
+  "Neurodegenerative Diseases": [
+    "D019636",
+    "Neurodegenerative Diseases"
+  ],
+  "Lentivirus Infections": [
+    "D016180",
+    "Lentivirus Infections"
+  ],
+  "Osteoporosis": [
+    "D010024",
+    "Osteoporosis"
+  ],
+  "Osteolysis": [
+    "D010014",
+    "Osteolysis"
+  ],
+  "Fractures, Compression": [
+    "D050815",
+    "Fractures, Compression"
+  ],
+  "Poisoning": [
+    "D011041",
+    "Poisoning"
+  ],
+  "Senile Plaques": [
+    "D058225",
+    "Plaque, Amyloid"
+  ],
+  "Autoimmune Diseases": [
+    "D001327",
+    "Autoimmune Diseases"
+  ],
+  "De Lange Syndrome": [
+    "D003635",
+    "De Lange Syndrome"
+  ],
+  "Congenital Abnormalities": [
+    "D000013",
+    "Congenital Abnormalities"
+  ],
+  "Hepatolenticular Degeneration": [
+    "D006527",
+    "Hepatolenticular Degeneration"
+  ],
+  "Glucose Intolerance": [
+    "D018149",
+    "Glucose Intolerance"
+  ],
+  "Hyperinsulinism": [
+    "D006946",
+    "Hyperinsulinism"
+  ],
+  "Carcinoma, Adenoid Cystic": [
+    "D003528",
+    "Carcinoma, Adenoid Cystic"
+  ],
+  "Vascular Calcification": [
+    "D061205",
+    "Vascular Calcification"
+  ],
+  "Indolent Systemic Mastocytosis": [
+    "D034721",
+    "Mastocytosis, Systemic"
+  ],
+  "HIV Infections": [
+    "D015658",
+    "HIV Infections"
+  ],
+  "Solitary Pulmonary Nodule": [
+    "D003074",
+    "Solitary Pulmonary Nodule"
+  ],
+  "Leukodystrophy, Globoid Cell": [
+    "D007965",
+    "Leukodystrophy, Globoid Cell"
+  ],
+  "Epilepsy, Temporal Lobe": [
+    "D004833",
+    "Epilepsy, Temporal Lobe"
+  ],
+  "Astrocytoma": [
+    "D001254",
+    "Astrocytoma"
+  ],
+  "Cancer of the Uterine Cervix": [
+    "D002583",
+    "Uterine Cervical Neoplasms"
+  ],
+  "Epidermal Cyst": [
+    "D004814",
+    "Epidermal Cyst"
+  ],
+  "Ulcer": [
+    "D014456",
+    "Ulcer"
+  ],
+  "Colitis": [
+    "D003092",
+    "Colitis"
+  ],
+  "Acute Coronary Syndrome": [
+    "D054058",
+    "Acute Coronary Syndrome"
+  ],
+  "Sepsis": [
+    "D018805",
+    "Sepsis"
+  ],
+  "Glaucoma": [
+    "D005901",
+    "Glaucoma"
+  ],
+  "Osteoarthritis": [
+    "D010003",
+    "Osteoarthritis"
+  ],
+  "Sleep Apnea, Obstructive": [
+    "D020181",
+    "Sleep Apnea, Obstructive"
+  ],
+  "Fibrosis, Liver": [
+    "D008103",
+    "Liver Cirrhosis"
+  ],
+  "Leukemia, Promyelocytic, Acute": [
+    "D015473",
+    "Leukemia, Promyelocytic, Acute"
+  ],
+  "Epstein-Barr Virus Infections": [
+    "D020031",
+    "Epstein-Barr Virus Infections"
+  ],
+  "Myocardial Infarction": [
+    "D009203",
+    "Myocardial Infarction"
+  ],
+  "Tauopathies": [
+    "D024801",
+    "Tauopathies"
+  ],
+  "Neurofibrillary Tangles": [
+    "D016874",
+    "Neurofibrillary Tangles"
+  ],
+  "Heart Failure, Right-Sided": [
+    "D006333",
+    "Heart Failure"
+  ],
+  "Mouth Neoplasms": [
+    "D009062",
+    "Mouth Neoplasms"
+  ],
+  "Huntington Disease": [
+    "D006816",
+    "Huntington Disease"
+  ],
+  "Hyperalgesia, Thermal": [
+    "D006930",
+    "Hyperalgesia"
+  ],
+  "Mechanical Allodynia": [
+    "D006930",
+    "Hyperalgesia"
+  ],
+  "Tendon Injuries": [
+    "D013708",
+    "Tendon Injuries"
+  ],
+  "Glioblastoma Multiforme": [
+    "D005909",
+    "Glioblastoma"
+  ],
+  "Nervous System Diseases": [
+    "D009422",
+    "Nervous System Diseases"
+  ],
+  "Pancreatic Neoplasms": [
+    "D010190",
+    "Pancreatic Neoplasms"
+  ],
+  "Sarcoma, Kaposi": [
+    "D012514",
+    "Sarcoma, Kaposi"
+  ],
+  "Liposarcoma, Myxoid": [
+    "D018208",
+    "Liposarcoma, Myxoid"
+  ],
+  "Ascites": [
+    "D001201",
+    "Ascites"
+  ],
+  "Retroviridae Infections": [
+    "D012192",
+    "Retroviridae Infections"
+  ],
+  "Trichothiodystrophy Syndromes": [
+    "D054463",
+    "Trichothiodystrophy Syndromes"
+  ],
+  "Obesity, Morbid": [
+    "D009767",
+    "Obesity, Morbid"
+  ],
+  "Severe Combined Immunodeficiency": [
+    "D016511",
+    "Severe Combined Immunodeficiency"
+  ],
+  "Hemophilia A": [
+    "D006467",
+    "Hemophilia A"
+  ],
+  "Cadmium Poisoning": [
+    "D002105",
+    "Cadmium Poisoning"
+  ],
+  "Adrenocortical Carcinoma": [
+    "D018268",
+    "Adrenocortical Carcinoma"
+  ],
+  "Adrenal Cortex Neoplasms": [
+    "D000306",
+    "Adrenal Cortex Neoplasms"
+  ],
+  "Fistula": [
+    "D005402",
+    "Fistula"
+  ],
+  "Muscular Atrophy, Spinal": [
+    "D009134",
+    "Muscular Atrophy, Spinal"
+  ],
+  "Fraser syndrome": [
+    "D058497",
+    "Fraser Syndrome"
+  ],
+  "Alcohol Drinking": [
+    "D000428",
+    "Alcohol Drinking"
+  ],
+  "Eye Diseases": [
+    "D005128",
+    "Eye Diseases"
+  ],
+  "Leukemia, Myeloid": [
+    "D007951",
+    "Leukemia, Myeloid"
+  ],
+  "Plasmacytoma": [
+    "D010954",
+    "Plasmacytoma"
+  ],
+  "Lymphoma, Non-Hodgkin": [
+    "D008228",
+    "Lymphoma, Non-Hodgkin"
+  ],
+  "Periodontitis": [
+    "D010518",
+    "Periodontitis"
+  ],
+  "Chronic Periodontitis": [
+    "D055113",
+    "Chronic Periodontitis"
+  ],
+  "Dermatomyositis": [
+    "D003882",
+    "Dermatomyositis"
+  ],
+  "Pseudoxanthoma Elasticum": [
+    "D011561",
+    "Pseudoxanthoma Elasticum"
+  ],
+  "Cysts": [
+    "D003560",
+    "Cysts"
+  ],
+  "Emphysema": [
+    "D004646",
+    "Emphysema"
+  ],
+  "Venous Thromboembolism": [
+    "D054556",
+    "Venous Thromboembolism"
+  ],
+  "Multiple Sclerosis": [
+    "D009103",
+    "Multiple Sclerosis"
+  ],
+  "Gastritis, Atrophic": [
+    "D005757",
+    "Gastritis, Atrophic"
+  ],
+  "Anorexia": [
+    "D000855",
+    "Anorexia"
+  ],
+  "Intracranial Aneurysm": [
+    "D002532",
+    "Intracranial Aneurysm"
+  ],
+  "Hypopigmentation": [
+    "D017496",
+    "Hypopigmentation"
+  ],
+  "Leishmaniasis, Visceral": [
+    "D007898",
+    "Leishmaniasis, Visceral"
+  ],
+  "Thrombosis": [
+    "D013927",
+    "Thrombosis"
+  ],
+  "Aggression": [
+    "D000374",
+    "Aggression"
+  ],
+  "Lymphatic Metastasis": [
+    "D008207",
+    "Lymphatic Metastasis"
+  ],
+  "Hypersensitivity": [
+    "D006967",
+    "Hypersensitivity"
+  ],
+  "Ileitis": [
+    "D007079",
+    "Ileitis"
+  ],
+  "Obstetric Labor, Premature": [
+    "D007752",
+    "Obstetric Labor, Premature"
+  ],
+  "Liposarcoma, Dedifferentiated": [
+    "D008080",
+    "Liposarcoma"
+  ],
+  "Lymphoma, T-Cell": [
+    "D016399",
+    "Lymphoma, T-Cell"
+  ],
+  "Pulmonary Emphysema": [
+    "D011656",
+    "Pulmonary Emphysema"
+  ],
+  "Airway Obstruction": [
+    "D000402",
+    "Airway Obstruction"
+  ],
+  "Hearing Loss": [
+    "D034381",
+    "Hearing Loss"
+  ],
+  "Erythrokeratodermia Variabilis": [
+    "D056266",
+    "Erythrokeratodermia Variabilis"
+  ],
+  "Paralysis": [
+    "D010243",
+    "Paralysis"
+  ],
+  "Kidney Failure": [
+    "D051437",
+    "Renal Insufficiency"
+  ],
+  "Kidney Failure, Acute": [
+    "D058186",
+    "Acute Kidney Injury"
+  ],
+  "Acute Kidney Injury": [
+    "D058186",
+    "Acute Kidney Injury"
+  ],
+  "Adenocarcinoma, Follicular": [
+    "D018263",
+    "Adenocarcinoma, Follicular"
+  ],
+  "Thyroid Nodule": [
+    "D016606",
+    "Thyroid Nodule"
+  ],
+  "Tuberous Sclerosis": [
+    "D014402",
+    "Tuberous Sclerosis"
+  ],
+  "Brain Neoplasms": [
+    "D001932",
+    "Brain Neoplasms"
+  ],
+  "Cystadenoma": [
+    "D003537",
+    "Cystadenoma"
+  ],
+  "Lymphangioleiomyomatosis": [
+    "D018192",
+    "Lymphangioleiomyomatosis"
+  ],
+  "Fatigue Syndrome, Chronic": [
+    "D015673",
+    "Fatigue Syndrome, Chronic"
+  ],
+  "Acidosis": [
+    "D000138",
+    "Acidosis"
+  ],
+  "Neoplastic Processes": [
+    "D009385",
+    "Neoplastic Processes"
+  ],
+  "Colorectal Carcinoma": [
+    "D015179",
+    "Colorectal Neoplasms"
+  ],
+  "Abortion, Spontaneous": [
+    "D000022",
+    "Abortion, Spontaneous"
+  ],
+  "Reperfusion Injury": [
+    "D015427",
+    "Reperfusion Injury"
+  ],
+  "Blindness": [
+    "D001766",
+    "Blindness"
+  ],
+  "Hypertension, Portal": [
+    "D006975",
+    "Hypertension, Portal"
+  ],
+  "Yellow Fever": [
+    "D015004",
+    "Yellow Fever"
+  ],
+  "Bovine Virus Diarrhea-Mucosal Disease": [
+    "D001912",
+    "Bovine Virus Diarrhea-Mucosal Disease"
+  ],
+  "Skin Neoplasms": [
+    "D012878",
+    "Skin Neoplasms"
+  ],
+  "Overweight": [
+    "D050177",
+    "Overweight"
+  ],
+  "Spinal Cord Injuries": [
+    "D013119",
+    "Spinal Cord Injuries"
+  ],
+  "Creutzfeldt-Jakob Syndrome": [
+    "D007562",
+    "Creutzfeldt-Jakob Syndrome"
+  ],
+  "Nephrosis, Lipoid": [
+    "D009402",
+    "Nephrosis, Lipoid"
+  ],
+  "Sclerosis": [
+    "D012598",
+    "Sclerosis"
+  ],
+  "Hypospadias": [
+    "D007021",
+    "Hypospadias"
+  ],
+  "Heart Diseases": [
+    "D006331",
+    "Heart Diseases"
+  ],
+  "Endotoxemia": [
+    "D019446",
+    "Endotoxemia"
+  ],
+  "Fanconi Anemia": [
+    "D005199",
+    "Fanconi Anemia"
+  ],
+  "Carcinoma, Mammary Ductal": [
+    "D018270",
+    "Carcinoma, Ductal, Breast"
+  ],
+  "Arthritis": [
+    "D001168",
+    "Arthritis"
+  ],
+  "Hepatitis, Chronic": [
+    "D006521",
+    "Hepatitis, Chronic"
+  ],
+  "Glomerulonephritis, Membranous": [
+    "D015433",
+    "Glomerulonephritis, Membranous"
+  ],
+  "Migraine Disorders": [
+    "D008881",
+    "Migraine Disorders"
+  ],
+  "Cone-Rod Dystrophies": [
+    "D000071700",
+    "Cone-Rod Dystrophies"
+  ],
+  "Monosomy": [
+    "D009006",
+    "Monosomy"
+  ],
+  "Skin Diseases": [
+    "D012871",
+    "Skin Diseases"
+  ],
+  "Cancer of Gallbladder": [
+    "D005706",
+    "Gallbladder Neoplasms"
+  ],
+  "Dermatosclerosis": [
+    "D012594",
+    "Scleroderma, Localized"
+  ],
+  "Pulmonary Fibrosis": [
+    "D011658",
+    "Pulmonary Fibrosis"
+  ],
+  "Hypoparathyroidism": [
+    "D007011",
+    "Hypoparathyroidism"
+  ],
+  "Long QT Syndrome": [
+    "D008133",
+    "Long QT Syndrome"
+  ],
+  "Otitis Media": [
+    "D010033",
+    "Otitis Media"
+  ],
+  "Cancer of Uterus": [
+    "D014594",
+    "Uterine Neoplasms"
+  ],
+  "Hyperglycemia": [
+    "D006943",
+    "Hyperglycemia"
+  ],
+  "Aortic Aneurysm, Abdominal": [
+    "D017544",
+    "Aortic Aneurysm, Abdominal"
+  ],
+  "Arteriosclerosis": [
+    "D001161",
+    "Arteriosclerosis"
+  ],
+  "Fatty Liver": [
+    "D005234",
+    "Fatty Liver"
+  ],
+  "Joint Diseases": [
+    "D007592",
+    "Joint Diseases"
+  ],
+  "Enterocolitis, Necrotizing": [
+    "D020345",
+    "Enterocolitis, Necrotizing"
+  ],
+  "Malignant Glioma": [
+    "D005910",
+    "Glioma"
+  ],
+  "Precursor B-Cell Lymphoblastic Leukemia-Lymphoma": [
+    "D015452",
+    "Precursor B-Cell Lymphoblastic Leukemia-Lymphoma"
+  ],
+  "Hepatitis, Chronic Active": [
+    "D006521",
+    "Hepatitis, Chronic"
+  ],
+  "Lymphoproliferative Disorders": [
+    "D008232",
+    "Lymphoproliferative Disorders"
+  ],
+  "Premature Birth": [
+    "D047928",
+    "Premature Birth"
+  ],
+  "Leprosy": [
+    "D007918",
+    "Leprosy"
+  ],
+  "Skin Diseases, Bacterial": [
+    "D017192",
+    "Skin Diseases, Bacterial"
+  ],
+  "Wound Infection": [
+    "D014946",
+    "Wound Infection"
+  ],
+  "Staphylococcal Infections": [
+    "D013203",
+    "Staphylococcal Infections"
+  ],
+  "DiGeorge Syndrome": [
+    "D004062",
+    "DiGeorge Syndrome"
+  ],
+  "Histiocytoma, Malignant Fibrous": [
+    "D051677",
+    "Histiocytoma, Malignant Fibrous"
+  ],
+  "Contracture": [
+    "D003286",
+    "Contracture"
+  ],
+  "Urinary Bladder, Overactive": [
+    "D053201",
+    "Urinary Bladder, Overactive"
+  ],
+  "Leukemia, Lymphocytic, Acute, L1": [
+    "D054198",
+    "Precursor Cell Lymphoblastic Leukemia-Lymphoma"
+  ],
+  "Rhabdomyosarcoma": [
+    "D012208",
+    "Rhabdomyosarcoma"
+  ],
+  "Muscular Atrophy": [
+    "D009133",
+    "Muscular Atrophy"
+  ],
+  "Whooping Cough": [
+    "D014917",
+    "Whooping Cough"
+  ],
+  "Heart Defects, Congenital": [
+    "D006330",
+    "Heart Defects, Congenital"
+  ],
+  "Muscular Diseases": [
+    "D009135",
+    "Muscular Diseases"
+  ],
+  "Edema": [
+    "D004487",
+    "Edema"
+  ],
+  "Congenital Hypothyroidism": [
+    "D003409",
+    "Congenital Hypothyroidism"
+  ],
+  "Polyps": [
+    "D011127",
+    "Polyps"
+  ],
+  "Lung Neoplasms": [
+    "D008175",
+    "Lung Neoplasms"
+  ],
+  "Osteoarthrosis Deformans": [
+    "D010003",
+    "Osteoarthritis"
+  ],
+  "Celiac Disease": [
+    "D002446",
+    "Celiac Disease"
+  ],
+  "Hypoglycemia": [
+    "D007003",
+    "Hypoglycemia"
+  ],
+  "Shivering": [
+    "D012768",
+    "Shivering"
+  ],
+  "Leukemia, Myeloid, Chronic-Phase": [
+    "D015466",
+    "Leukemia, Myeloid, Chronic-Phase"
+  ],
+  "Lymphoma, B-Cell": [
+    "D016393",
+    "Lymphoma, B-Cell"
+  ],
+  "Drug Dependence": [
+    "D019966",
+    "Substance-Related Disorders"
+  ],
+  "Polymyositis": [
+    "D017285",
+    "Polymyositis"
+  ],
+  "Liver Neoplasms": [
+    "D008113",
+    "Liver Neoplasms"
+  ],
+  "Urinary Bladder Neoplasms": [
+    "D001749",
+    "Urinary Bladder Neoplasms"
+  ],
+  "Pheochromocytoma": [
+    "D010673",
+    "Pheochromocytoma"
+  ],
+  "Nervous System Malformations": [
+    "D009421",
+    "Nervous System Malformations"
+  ],
+  "Brain Diseases": [
+    "D001927",
+    "Brain Diseases"
+  ],
+  "Cancer of Skin": [
+    "D012878",
+    "Skin Neoplasms"
+  ],
+  "Exfoliation Syndrome": [
+    "D017889",
+    "Exfoliation Syndrome"
+  ],
+  "Adenoma": [
+    "D000236",
+    "Adenoma"
+  ],
+  "Borderline Personality Disorder": [
+    "D001883",
+    "Borderline Personality Disorder"
+  ],
+  "Substance Abuse": [
+    "D019966",
+    "Substance-Related Disorders"
+  ],
+  "Arthritis, Psoriatic": [
+    "D015535",
+    "Arthritis, Psoriatic"
+  ],
+  "Spondylitis, Ankylosing": [
+    "D013167",
+    "Spondylitis, Ankylosing"
+  ],
+  "Diabetes, Gestational": [
+    "D016640",
+    "Diabetes, Gestational"
+  ],
+  "Diabetes Complications": [
+    "D048909",
+    "Diabetes Complications"
+  ],
+  "Pneumococcal Infections": [
+    "D011008",
+    "Pneumococcal Infections"
+  ],
+  "Cognition Disorders": [
+    "D003072",
+    "Cognition Disorders"
+  ],
+  "Mycoses": [
+    "D009181",
+    "Mycoses"
+  ],
+  "Alzheimer Disease, Late Onset": [
+    "D000544",
+    "Alzheimer Disease"
+  ],
+  "Vascular Malformations": [
+    "D054079",
+    "Vascular Malformations"
+  ],
+  "Neovascularization, Pathologic": [
+    "D009389",
+    "Neovascularization, Pathologic"
+  ],
+  "Hemangioma": [
+    "D006391",
+    "Hemangioma"
+  ],
+  "Wiskott-Aldrich Syndrome": [
+    "D014923",
+    "Wiskott-Aldrich Syndrome"
+  ],
+  "Urinary Tract Infections": [
+    "D014552",
+    "Urinary Tract Infections"
+  ],
+  "Astrocytoma, Grade II": [
+    "D001254",
+    "Astrocytoma"
+  ],
+  "Cocaine Dependence": [
+    "D019970",
+    "Cocaine-Related Disorders"
+  ],
+  "Ataxia Telangiectasia": [
+    "D001260",
+    "Ataxia Telangiectasia"
+  ],
+  "Cancer of Neck": [
+    "D006258",
+    "Head and Neck Neoplasms"
+  ],
+  "Osteoarthritis, Hip": [
+    "D015207",
+    "Osteoarthritis, Hip"
+  ],
+  "Cerebral Ischemia": [
+    "D002545",
+    "Brain Ischemia"
+  ],
+  "Epilepsy": [
+    "D004827",
+    "Epilepsy"
+  ],
+  "Endometriosis": [
+    "D004715",
+    "Endometriosis"
+  ],
+  "Myelodysplastic Syndromes": [
+    "D009190",
+    "Myelodysplastic Syndromes"
+  ],
+  "Spinocerebellar Ataxia Type 1": [
+    "D020754",
+    "Spinocerebellar Ataxias"
+  ],
+  "Ataxia": [
+    "D001259",
+    "Ataxia"
+  ],
+  "Clear Cell Renal Cell Carcinoma": [
+    "D002292",
+    "Carcinoma, Renal Cell"
+  ],
+  "Retinoschisis, Juvenile, X-Linked": [
+    "D041441",
+    "Retinoschisis"
+  ],
+  "Osteoarthritis, Knee": [
+    "D020370",
+    "Osteoarthritis, Knee"
+  ],
+  "Foot-and-Mouth Disease": [
+    "D005536",
+    "Foot-and-Mouth Disease"
+  ],
+  "Pulmonary Edema": [
+    "D011654",
+    "Pulmonary Edema"
+  ],
+  "Meningioma": [
+    "D008579",
+    "Meningioma"
+  ],
+  "Conn Syndrome": [
+    "D006929",
+    "Hyperaldosteronism"
+  ],
+  "Lymphoma, Mantle-Cell": [
+    "D020522",
+    "Lymphoma, Mantle-Cell"
+  ],
+  "Sleep Disorders": [
+    "D012893",
+    "Sleep Wake Disorders"
+  ],
+  "Behavior, Addictive": [
+    "D016739",
+    "Behavior, Addictive"
+  ],
+  "Thyroiditis, Autoimmune": [
+    "D013967",
+    "Thyroiditis, Autoimmune"
+  ],
+  "Hyperthyroidism": [
+    "D006980",
+    "Hyperthyroidism"
+  ],
+  "Thymoma": [
+    "D013945",
+    "Thymoma"
+  ],
+  "Puberty, Precocious": [
+    "D011629",
+    "Puberty, Precocious"
+  ],
+  "Acute Lung Injury": [
+    "D055371",
+    "Acute Lung Injury"
+  ],
+  "Granuloma": [
+    "D006099",
+    "Granuloma"
+  ],
+  "Meningitis": [
+    "D008581",
+    "Meningitis"
+  ],
+  "Hypertension, Pulmonary": [
+    "D006976",
+    "Hypertension, Pulmonary"
+  ],
+  "Fractures, Spontaneous": [
+    "D005598",
+    "Fractures, Spontaneous"
+  ],
+  "Microangiopathy, Diabetic": [
+    "D003925",
+    "Diabetic Angiopathies"
+  ],
+  "Kidney Diseases": [
+    "D007674",
+    "Kidney Diseases"
+  ],
+  "Neoplasms, Second Primary": [
+    "D016609",
+    "Neoplasms, Second Primary"
+  ],
+  "Aortic Aneurysm": [
+    "D001014",
+    "Aortic Aneurysm"
+  ],
+  "Plaque, Atherosclerotic": [
+    "D058226",
+    "Plaque, Atherosclerotic"
+  ],
+  "Aortic Aneurysm, Ruptured": [
+    "D001019",
+    "Aortic Rupture"
+  ],
+  "Rupture": [
+    "D012421",
+    "Rupture"
+  ],
+  "Cataract": [
+    "D002386",
+    "Cataract"
+  ],
+  "Hypoxemia": [
+    "D000860",
+    "Hypoxia"
+  ],
+  "Hepatitis E": [
+    "D016751",
+    "Hepatitis E"
+  ],
+  "Carcinoma, Intraductal, Noninfiltrating": [
+    "D002285",
+    "Carcinoma, Intraductal, Noninfiltrating"
+  ],
+  "Porokeratosis": [
+    "D017499",
+    "Porokeratosis"
+  ],
+  "Ventricular Remodeling": [
+    "D020257",
+    "Ventricular Remodeling"
+  ],
+  "Encephalomyelitis": [
+    "D004679",
+    "Encephalomyelitis"
+  ],
+  "Helminthiasis": [
+    "D006373",
+    "Helminthiasis"
+  ],
+  "Autoimmunity": [
+    "D015551",
+    "Autoimmunity"
+  ],
+  "Rhabdoid Tumor": [
+    "D018335",
+    "Rhabdoid Tumor"
+  ],
+  "Cancer of Rectum": [
+    "D012004",
+    "Rectal Neoplasms"
+  ],
+  "Malignant Meningioma": [
+    "D008579",
+    "Meningioma"
+  ],
+  "Foot Ulcer, Diabetic": [
+    "D017719",
+    "Diabetic Foot"
+  ],
+  "Polycystic Ovary Syndrome": [
+    "D011085",
+    "Polycystic Ovary Syndrome"
+  ],
+  "Acquired Immunodeficiency Syndrome": [
+    "D000163",
+    "Acquired Immunodeficiency Syndrome"
+  ],
+  "Malaria, Vivax": [
+    "D016780",
+    "Malaria, Vivax"
+  ],
+  "Pneumonia": [
+    "D011014",
+    "Pneumonia"
+  ],
+  "Leiomyosarcoma": [
+    "D007890",
+    "Leiomyosarcoma"
+  ],
+  "Gastrointestinal Stromal Tumors": [
+    "D046152",
+    "Gastrointestinal Stromal Tumors"
+  ],
+  "Fibromatosis, Aggressive": [
+    "D018222",
+    "Fibromatosis, Aggressive"
+  ],
+  "Brain Infarction": [
+    "D020520",
+    "Brain Infarction"
+  ],
+  "Muscular Dystrophy, Duchenne": [
+    "D020388",
+    "Muscular Dystrophy, Duchenne"
+  ],
+  "Mood Disorders": [
+    "D019964",
+    "Mood Disorders"
+  ],
+  "Conduct Disorder": [
+    "D019955",
+    "Conduct Disorder"
+  ],
+  "Adenomatous Polyposis Coli": [
+    "D011125",
+    "Adenomatous Polyposis Coli"
+  ],
+  "Intestinal Polyps": [
+    "D007417",
+    "Intestinal Polyps"
+  ],
+  "Charcot-Marie-Tooth Disease": [
+    "D002607",
+    "Charcot-Marie-Tooth Disease"
+  ],
+  "Tetanus": [
+    "D013742",
+    "Tetanus"
+  ],
+  "Nephrotic Syndrome": [
+    "D009404",
+    "Nephrotic Syndrome"
+  ],
+  "Schistosomiasis": [
+    "D012552",
+    "Schistosomiasis"
+  ],
+  "Cerebrovascular Disorders": [
+    "D002561",
+    "Cerebrovascular Disorders"
+  ],
+  "Sexually Transmitted Diseases": [
+    "D012749",
+    "Sexually Transmitted Diseases"
+  ],
+  "Pelvic Inflammatory Disease": [
+    "D000292",
+    "Pelvic Inflammatory Disease"
+  ],
+  "Genital Diseases, Female": [
+    "D005831",
+    "Genital Diseases, Female"
+  ],
+  "Cannabis Dependence": [
+    "D002189",
+    "Marijuana Abuse"
+  ],
+  "Thyroid Carcinoma": [
+    "D013964",
+    "Thyroid Neoplasms"
+  ],
+  "Carcinoma, Bronchogenic": [
+    "D002283",
+    "Carcinoma, Bronchogenic"
+  ],
+  "Demyelination": [
+    "D003711",
+    "Demyelinating Diseases"
+  ],
+  "Liver Diseases, Alcoholic": [
+    "D008108",
+    "Liver Diseases, Alcoholic"
+  ],
+  "Hepatitis, Alcoholic": [
+    "D006519",
+    "Hepatitis, Alcoholic"
+  ],
+  "Hepatoblastoma": [
+    "D018197",
+    "Hepatoblastoma"
+  ],
+  "Muscular Dystrophy, Facioscapulohumeral": [
+    "D020391",
+    "Muscular Dystrophy, Facioscapulohumeral"
+  ],
+  "Albuminuria": [
+    "D000419",
+    "Albuminuria"
+  ],
+  "Hyperalgesia, Secondary": [
+    "D006930",
+    "Hyperalgesia"
+  ],
+  "Hyperalgesia": [
+    "D006930",
+    "Hyperalgesia"
+  ],
+  "Cholestasis": [
+    "D002779",
+    "Cholestasis"
+  ],
+  "Hematologic Diseases": [
+    "D006402",
+    "Hematologic Diseases"
+  ],
+  "Respiratory Distress Syndrome, Adult": [
+    "D012128",
+    "Respiratory Distress Syndrome, Adult"
+  ],
+  "Diabetes Mellitus, Experimental": [
+    "D003921",
+    "Diabetes Mellitus, Experimental"
+  ],
+  "Giant Cell Arteritis": [
+    "D013700",
+    "Giant Cell Arteritis"
+  ],
+  "Leishmaniasis, Cutaneous": [
+    "D016773",
+    "Leishmaniasis, Cutaneous"
+  ],
+  "Leishmaniasis": [
+    "D007896",
+    "Leishmaniasis"
+  ],
+  "Ischemic Attack, Transient": [
+    "D002546",
+    "Ischemic Attack, Transient"
+  ],
+  "Respiratory Depression": [
+    "D012131",
+    "Respiratory Insufficiency"
+  ],
+  "Critical Illness": [
+    "D016638",
+    "Critical Illness"
+  ],
+  "Crohn Disease": [
+    "D003424",
+    "Crohn Disease"
+  ],
+  "Urologic Neoplasms": [
+    "D014571",
+    "Urologic Neoplasms"
+  ],
+  "Cancer of Urinary Tract": [
+    "D014571",
+    "Urologic Neoplasms"
+  ],
+  "Necrosis, Avascular, of Femur Head": [
+    "D005271",
+    "Femur Head Necrosis"
+  ],
+  "Malaria, Cerebral": [
+    "D016779",
+    "Malaria, Cerebral"
+  ],
+  "Spinocerebellar Ataxia Type 2": [
+    "D020754",
+    "Spinocerebellar Ataxias"
+  ],
+  "Spinocerebellar Ataxia Type 6": [
+    "D020754",
+    "Spinocerebellar Ataxias"
+  ],
+  "Graft vs Host Disease": [
+    "D006086",
+    "Graft vs Host Disease"
+  ],
+  "Leukemia, T-Cell": [
+    "D015458",
+    "Leukemia, T-Cell"
+  ],
+  "Neurologic Deficits": [
+    "D009461",
+    "Neurologic Manifestations"
+  ],
+  "Lens Opacities": [
+    "D002386",
+    "Cataract"
+  ],
+  "Sarcoidosis": [
+    "D012507",
+    "Sarcoidosis"
+  ],
+  "Amyloidosis": [
+    "D000686",
+    "Amyloidosis"
+  ],
+  "Hyperpigmentation": [
+    "D017495",
+    "Hyperpigmentation"
+  ],
+  "Down Syndrome": [
+    "D004314",
+    "Down Syndrome"
+  ],
+  "Hypertriglyceridemia": [
+    "D015228",
+    "Hypertriglyceridemia"
+  ],
+  "Microphthalmos": [
+    "D008850",
+    "Microphthalmos"
+  ],
+  "Infertility": [
+    "D007246",
+    "Infertility"
+  ],
+  "Leukemia, Myelomonocytic, Acute": [
+    "D015479",
+    "Leukemia, Myelomonocytic, Acute"
+  ],
+  "Radiation Injuries": [
+    "D011832",
+    "Radiation Injuries"
+  ],
+  "Inclusion Body Myopathy, Sporadic": [
+    "D018979",
+    "Myositis, Inclusion Body"
+  ],
+  "Parkinsonian Disorders": [
+    "D020734",
+    "Parkinsonian Disorders"
+  ],
+  "Fever": [
+    "D005334",
+    "Fever"
+  ],
+  "Primary Myelofibrosis": [
+    "D055728",
+    "Primary Myelofibrosis"
+  ],
+  "Anaphylaxis": [
+    "D000707",
+    "Anaphylaxis"
+  ],
+  "Barrett Esophagus": [
+    "D001471",
+    "Barrett Esophagus"
+  ],
+  "Birt-Hogg-Dube Syndrome": [
+    "D058249",
+    "Birt-Hogg-Dube Syndrome"
+  ],
+  "Niemann-Pick Disease, Type C": [
+    "D052556",
+    "Niemann-Pick Disease, Type C"
+  ],
+  "Tuberculosis, Pulmonary": [
+    "D014397",
+    "Tuberculosis, Pulmonary"
+  ],
+  "Seasonal Affective Disorder": [
+    "D016574",
+    "Seasonal Affective Disorder"
+  ],
+  "Brain Cancer": [
+    "D001932",
+    "Brain Neoplasms"
+  ],
+  "Respiratory Hypersensitivity": [
+    "D012130",
+    "Respiratory Hypersensitivity"
+  ],
+  "Blister": [
+    "D001768",
+    "Blister"
+  ],
+  "Muscular Dystrophies": [
+    "D009136",
+    "Muscular Dystrophies"
+  ],
+  "Cancer of Head and Neck": [
+    "D006258",
+    "Head and Neck Neoplasms"
+  ],
+  "Prolidase Deficiency": [
+    "D056732",
+    "Prolidase Deficiency"
+  ],
+  "Arthritis, Collagen-Induced": [
+    "D001169",
+    "Arthritis, Experimental"
+  ],
+  "Microcephaly": [
+    "D008831",
+    "Microcephaly"
+  ],
+  "Multiple Organ Failure": [
+    "D009102",
+    "Multiple Organ Failure"
+  ],
+  "Malaria": [
+    "D008288",
+    "Malaria"
+  ],
+  "Multiple Epiphyseal Dysplasia": [
+    "D010009",
+    "Osteochondrodysplasias"
+  ],
+  "Liver Dysfunction": [
+    "D008107",
+    "Liver Diseases"
+  ],
+  "Breast Diseases": [
+    "D001941",
+    "Breast Diseases"
+  ],
+  "Fibrocystic Breast Disease": [
+    "D005348",
+    "Fibrocystic Breast Disease"
+  ],
+  "Hemimegalencephaly": [
+    "D065705",
+    "Hemimegalencephaly"
+  ],
+  "Respiratory Chain Deficiencies, Mitochondrial": [
+    "D028361",
+    "Mitochondrial Diseases"
+  ],
+  "Frontotemporal Dementia": [
+    "D057180",
+    "Frontotemporal Dementia"
+  ],
+  "Bulimia Nervosa": [
+    "D052018",
+    "Bulimia Nervosa"
+  ],
+  "Heredodegenerative Disorders, Nervous System": [
+    "D020271",
+    "Heredodegenerative Disorders, Nervous System"
+  ],
+  "Tuberculosis, Central Nervous System": [
+    "D020306",
+    "Tuberculosis, Central Nervous System"
+  ],
+  "Hyperkalemia": [
+    "D006947",
+    "Hyperkalemia"
+  ],
+  "Cholelithiasis": [
+    "D002769",
+    "Cholelithiasis"
+  ],
+  "Anemia, Dyserythropoietic, Congenital, Type II": [
+    "D000742",
+    "Anemia, Dyserythropoietic, Congenital"
+  ],
+  "Malaria, Falciparum": [
+    "D016778",
+    "Malaria, Falciparum"
+  ],
+  "Dehydration": [
+    "D003681",
+    "Dehydration"
+  ],
+  "Osteogenesis Imperfecta": [
+    "D010013",
+    "Osteogenesis Imperfecta"
+  ],
+  "Synovitis": [
+    "D013585",
+    "Synovitis"
+  ],
+  "Gastritis, Hypertrophic": [
+    "D005758",
+    "Gastritis, Hypertrophic"
+  ],
+  "Bone Marrow Neoplasms": [
+    "D019046",
+    "Bone Marrow Neoplasms"
+  ],
+  "Medulloblastoma": [
+    "D008527",
+    "Medulloblastoma"
+  ],
+  "Neisseriaceae Infections": [
+    "D016870",
+    "Neisseriaceae Infections"
+  ],
+  "Sarcoma, Epithelioid": [
+    "D012509",
+    "Sarcoma"
+  ],
+  "Corneal Dystrophies, Hereditary": [
+    "D003317",
+    "Corneal Dystrophies, Hereditary"
+  ],
+  "Salmonella Infections": [
+    "D012480",
+    "Salmonella Infections"
+  ],
+  "Pyelonephritis": [
+    "D011704",
+    "Pyelonephritis"
+  ],
+  "Cystitis": [
+    "D003556",
+    "Cystitis"
+  ],
+  "Burkitt Lymphoma": [
+    "D002051",
+    "Burkitt Lymphoma"
+  ],
+  "Spinal Curvatures": [
+    "D013121",
+    "Spinal Curvatures"
+  ],
+  "Aging, Premature": [
+    "D019588",
+    "Aging, Premature"
+  ],
+  "Hemoglobin F Disease": [
+    "D017086",
+    "beta-Thalassemia"
+  ],
+  "Lymphopenia": [
+    "D008231",
+    "Lymphopenia"
+  ],
+  "Leukodystrophy, Metachromatic": [
+    "D007966",
+    "Leukodystrophy, Metachromatic"
+  ],
+  "Paraganglioma": [
+    "D010235",
+    "Paraganglioma"
+  ],
+  "Arteritis": [
+    "D001167",
+    "Arteritis"
+  ],
+  "Rhabdomyosarcoma, Alveolar": [
+    "D018232",
+    "Rhabdomyosarcoma, Alveolar"
+  ],
+  "Lymphoma, T-Cell, Cutaneous": [
+    "D016410",
+    "Lymphoma, T-Cell, Cutaneous"
+  ],
+  "Arthritis, Experimental": [
+    "D001169",
+    "Arthritis, Experimental"
+  ],
+  "Pancreatitis, Chronic": [
+    "D050500",
+    "Pancreatitis, Chronic"
+  ],
+  "Keratoconus": [
+    "D007640",
+    "Keratoconus"
+  ],
+  "Candidiasis": [
+    "D002177",
+    "Candidiasis"
+  ],
+  "Chorioamnionitis": [
+    "D002821",
+    "Chorioamnionitis"
+  ],
+  "Carney Complex": [
+    "D056733",
+    "Carney Complex"
+  ],
+  "Purpura, Thrombocytopenic": [
+    "D011696",
+    "Purpura, Thrombocytopenic"
+  ],
+  "Severe Acute Respiratory Syndrome": [
+    "D045169",
+    "Severe Acute Respiratory Syndrome"
+  ],
+  "Dental Caries": [
+    "D003731",
+    "Dental Caries"
+  ],
+  "Gammopathy, Monoclonal": [
+    "D010265",
+    "Paraproteinemias"
+  ],
+  "Pregnancy, Prolonged": [
+    "D011273",
+    "Pregnancy, Prolonged"
+  ],
+  "Splenomegaly": [
+    "D013163",
+    "Splenomegaly"
+  ],
+  "Hyperhomocysteinemia": [
+    "D020138",
+    "Hyperhomocysteinemia"
+  ],
+  "Deafness": [
+    "D003638",
+    "Deafness"
+  ],
+  "Diabetic Glomerulosclerosis": [
+    "D003928",
+    "Diabetic Nephropathies"
+  ],
+  "Hyperlipoproteinemia Type II": [
+    "D006938",
+    "Hyperlipoproteinemia Type II"
+  ],
+  "Neoplasm, Residual": [
+    "D018365",
+    "Neoplasm, Residual"
+  ],
+  "Meniere Disease": [
+    "D008575",
+    "Meniere Disease"
+  ],
+  "Dermatitis": [
+    "D003872",
+    "Dermatitis"
+  ],
+  "Gastrointestinal Diseases": [
+    "D005767",
+    "Gastrointestinal Diseases"
+  ],
+  "Smooth Muscle Tumor": [
+    "D018235",
+    "Smooth Muscle Tumor"
+  ],
+  "Leiomyoma": [
+    "D007889",
+    "Leiomyoma"
+  ],
+  "Fibroid Uterus": [
+    "D007889",
+    "Leiomyoma"
+  ],
+  "Uterine Neoplasms": [
+    "D014594",
+    "Uterine Neoplasms"
+  ],
+  "Neoplasms, Epithelial": [
+    "D009375",
+    "Neoplasms, Glandular and Epithelial"
+  ],
+  "Hereditary Nonpolyposis Colorectal Cancer": [
+    "D003123",
+    "Colorectal Neoplasms, Hereditary Nonpolyposis"
+  ],
+  "Coronary Restenosis": [
+    "D023903",
+    "Coronary Restenosis"
+  ],
+  "Vitamin D Deficiency": [
+    "D014808",
+    "Vitamin D Deficiency"
+  ],
+  "Developmental Disabilities": [
+    "D002658",
+    "Developmental Disabilities"
+  ],
+  "Fibromyalgia": [
+    "D005356",
+    "Fibromyalgia"
+  ],
+  "Intellectual Disability": [
+    "D008607",
+    "Intellectual Disability"
+  ],
+  "Disseminated Intravascular Coagulation": [
+    "D004211",
+    "Disseminated Intravascular Coagulation"
+  ],
+  "Anger": [
+    "D000786",
+    "Anger"
+  ],
+  "Connective Tissue Diseases": [
+    "D003240",
+    "Connective Tissue Diseases"
+  ],
+  "Semantic Dementia": [
+    "D057180",
+    "Frontotemporal Dementia"
+  ],
+  "Dementia, Vascular": [
+    "D015140",
+    "Dementia, Vascular"
+  ],
+  "Meningitis, Pneumococcal": [
+    "D008586",
+    "Meningitis, Pneumococcal"
+  ],
+  "Choriocarcinoma": [
+    "D002822",
+    "Choriocarcinoma"
+  ],
+  "Hyperuricemia": [
+    "D033461",
+    "Hyperuricemia"
+  ],
+  "Chronic Disease": [
+    "D002908",
+    "Chronic Disease"
+  ],
+  "Stomach Neoplasms": [
+    "D013274",
+    "Stomach Neoplasms"
+  ],
+  "Angina Pectoris": [
+    "D000787",
+    "Angina Pectoris"
+  ],
+  "Myeloproliferative Disorders": [
+    "D009196",
+    "Myeloproliferative Disorders"
+  ],
+  "Hypertrophy, Left Ventricular": [
+    "D017379",
+    "Hypertrophy, Left Ventricular"
+  ],
+  "Rett Syndrome": [
+    "D015518",
+    "Rett Syndrome"
+  ],
+  "Thyroid Neoplasms": [
+    "D013964",
+    "Thyroid Neoplasms"
+  ],
+  "Idiopathic Inflammatory Myopathies": [
+    "D009220",
+    "Myositis"
+  ],
+  "Mesothelioma": [
+    "D008654",
+    "Mesothelioma"
+  ],
+  "Seminoma": [
+    "D018239",
+    "Seminoma"
+  ],
+  "Granulosa Cell Tumor": [
+    "D006106",
+    "Granulosa Cell Tumor"
+  ],
+  "Peritoneal Neoplasms": [
+    "D010534",
+    "Peritoneal Neoplasms"
+  ],
+  "Proteinuria": [
+    "D011507",
+    "Proteinuria"
+  ],
+  "Polyploidy": [
+    "D011123",
+    "Polyploidy"
+  ],
+  "RNA Virus Infections": [
+    "D012327",
+    "RNA Virus Infections"
+  ],
+  "Pancreatitis": [
+    "D010195",
+    "Pancreatitis"
+  ],
+  "Ossification, Heterotopic": [
+    "D009999",
+    "Ossification, Heterotopic"
+  ],
+  "Tachycardia": [
+    "D013610",
+    "Tachycardia"
+  ],
+  "Gram-Negative Bacterial Infections": [
+    "D016905",
+    "Gram-Negative Bacterial Infections"
+  ],
+  "Carcinoma, Embryonal": [
+    "D018236",
+    "Carcinoma, Embryonal"
+  ],
+  "Cystic Fibrosis": [
+    "D003550",
+    "Cystic Fibrosis"
+  ],
+  "Autosomal Recessive Juvenile Parkinson Disease": [
+    "D020734",
+    "Parkinsonian Disorders"
+  ],
+  "Anemia, Iron-Deficiency": [
+    "D018798",
+    "Anemia, Iron-Deficiency"
+  ],
+  "Chromosome Aberrations": [
+    "D002869",
+    "Chromosome Aberrations"
+  ],
+  "Altitude Sickness": [
+    "D000532",
+    "Altitude Sickness"
+  ],
+  "Bacterial Infections": [
+    "D001424",
+    "Bacterial Infections"
+  ],
+  "Allergic Reaction": [
+    "D006967",
+    "Hypersensitivity"
+  ],
+  "Islet Cell Tumor": [
+    "D007516",
+    "Adenoma, Islet Cell"
+  ],
+  "Li-Fraumeni Syndrome": [
+    "D016864",
+    "Li-Fraumeni Syndrome"
+  ],
+  "Nicotine Dependence": [
+    "D014029",
+    "Tobacco Use Disorder"
+  ],
+  "Hyperandrogenism": [
+    "D017588",
+    "Hyperandrogenism"
+  ],
+  "Anemia, Aplastic": [
+    "D000741",
+    "Anemia, Aplastic"
+  ],
+  "Collagen Diseases": [
+    "D003095",
+    "Collagen Diseases"
+  ],
+  "Myositis, Inclusion Body": [
+    "D018979",
+    "Myositis, Inclusion Body"
+  ],
+  "Aggressive Periodontitis": [
+    "D010520",
+    "Aggressive Periodontitis"
+  ],
+  "General Paralysis": [
+    "D009494",
+    "Neurosyphilis"
+  ],
+  "Alcohol Abuse": [
+    "D000437",
+    "Alcoholism"
+  ],
+  "Liposarcoma": [
+    "D008080",
+    "Liposarcoma"
+  ],
+  "Chylothorax": [
+    "D002916",
+    "Chylothorax"
+  ],
+  "Dwarfism": [
+    "D004392",
+    "Dwarfism"
+  ],
+  "Translocation, Genetic": [
+    "D014178",
+    "Translocation, Genetic"
+  ],
+  "Malignant Peripheral Nerve Sheath Tumors": [
+    "D018319",
+    "Neurofibrosarcoma"
+  ],
+  "Alkaptonuria": [
+    "D000474",
+    "Alkaptonuria"
+  ],
+  "Food Poisoning": [
+    "D005517",
+    "Foodborne Diseases"
+  ],
+  "Respiratory Distress Syndrome, Newborn": [
+    "D012127",
+    "Respiratory Distress Syndrome, Newborn"
+  ],
+  "Hypoxic-Ischemic Encephalopathy": [
+    "D020925",
+    "Hypoxia-Ischemia, Brain"
+  ],
+  "Macular Degeneration": [
+    "D008268",
+    "Macular Degeneration"
+  ],
+  "Stuttering": [
+    "D013342",
+    "Stuttering"
+  ],
+  "Scleroderma, Diffuse": [
+    "D045743",
+    "Scleroderma, Diffuse"
+  ],
+  "Constriction, Pathologic": [
+    "D003251",
+    "Constriction, Pathologic"
+  ],
+  "Centronuclear Myopathy": [
+    "D020914",
+    "Myopathies, Structural, Congenital"
+  ],
+  "Lymphoma, Follicular": [
+    "D008224",
+    "Lymphoma, Follicular"
+  ],
+  "Hirschsprung Disease": [
+    "D006627",
+    "Hirschsprung Disease"
+  ],
+  "alpha 1-Antitrypsin Deficiency": [
+    "D019896",
+    "alpha 1-Antitrypsin Deficiency"
+  ],
+  "Panacinar Emphysema": [
+    "D011656",
+    "Pulmonary Emphysema"
+  ],
+  "Mycobacterium Infections": [
+    "D009164",
+    "Mycobacterium Infections"
+  ],
+  "Arthritis, Gouty": [
+    "D015210",
+    "Arthritis, Gouty"
+  ],
+  "Gastritis": [
+    "D005756",
+    "Gastritis"
+  ],
+  "Stomach Diseases": [
+    "D013272",
+    "Stomach Diseases"
+  ],
+  "Gram-Positive Bacterial Infections": [
+    "D016908",
+    "Gram-Positive Bacterial Infections"
+  ],
+  "Respiratory Tract Diseases": [
+    "D012140",
+    "Respiratory Tract Diseases"
+  ],
+  "Bardet-Biedl Syndrome": [
+    "D020788",
+    "Bardet-Biedl Syndrome"
+  ],
+  "Calculi": [
+    "D002137",
+    "Calculi"
+  ],
+  "Nystagmus, Congenital": [
+    "D020417",
+    "Nystagmus, Congenital"
+  ],
+  "Metabolic Acidosis": [
+    "D000138",
+    "Acidosis"
+  ],
+  "Mastocytosis": [
+    "D008415",
+    "Mastocytosis"
+  ],
+  "Balkan Nephropathy": [
+    "D001449",
+    "Balkan Nephropathy"
+  ],
+  "Cerebral Infarction": [
+    "D002544",
+    "Cerebral Infarction"
+  ],
+  "Smoke Inhalation Injury": [
+    "D015208",
+    "Smoke Inhalation Injury"
+  ],
+  "Severe Sepsis": [
+    "D018805",
+    "Sepsis"
+  ],
+  "Neuritis, Motor": [
+    "D009443",
+    "Neuritis"
+  ],
+  "Choroidal Neovascularization": [
+    "D020256",
+    "Choroidal Neovascularization"
+  ],
+  "Central Nervous System Neoplasms": [
+    "D016543",
+    "Central Nervous System Neoplasms"
+  ],
+  "Immune System Diseases": [
+    "D007154",
+    "Immune System Diseases"
+  ],
+  "Cardiomyopathy, Dilated": [
+    "D002311",
+    "Cardiomyopathy, Dilated"
+  ],
+  "Hyperalgesia, Primary": [
+    "D006930",
+    "Hyperalgesia"
+  ],
+  "Blood Platelet Disorders": [
+    "D001791",
+    "Blood Platelet Disorders"
+  ],
+  "Ovarian Hyperstimulation Syndrome": [
+    "D016471",
+    "Ovarian Hyperstimulation Syndrome"
+  ],
+  "Infarction": [
+    "D007238",
+    "Infarction"
+  ],
+  "Atherogenesis": [
+    "D050197",
+    "Atherosclerosis"
+  ],
+  "Lymphoma, Primary Effusion": [
+    "D054685",
+    "Lymphoma, Primary Effusion"
+  ],
+  "Leukemia, Myelomonocytic, Chronic": [
+    "D015477",
+    "Leukemia, Myelomonocytic, Chronic"
+  ],
+  "Antibody Deficiency Syndrome": [
+    "D007153",
+    "Immunologic Deficiency Syndromes"
+  ],
+  "Trichiasis": [
+    "D058457",
+    "Trichiasis"
+  ],
+  "Hematochezia": [
+    "D006471",
+    "Gastrointestinal Hemorrhage"
+  ],
+  "Low Birth Weight": [
+    "D007230",
+    "Infant, Low Birth Weight"
+  ],
+  "Leprosy, Lepromatous": [
+    "D015440",
+    "Leprosy, Lepromatous"
+  ],
+  "Carcinoma, Neuroendocrine": [
+    "D018278",
+    "Carcinoma, Neuroendocrine"
+  ],
+  "Peripheral Nervous System Diseases": [
+    "D010523",
+    "Peripheral Nervous System Diseases"
+  ],
+  "Adenomatosis, Pulmonary": [
+    "D018255",
+    "Adenomatosis, Pulmonary"
+  ],
+  "Papilloma": [
+    "D010212",
+    "Papilloma"
+  ],
+  "Carcinoma, Ductal, Breast": [
+    "D018270",
+    "Carcinoma, Ductal, Breast"
+  ],
+  "Neoplasms, Germ Cell": [
+    "D009373",
+    "Neoplasms, Germ Cell and Embryonal"
+  ],
+  "Adenocarcinoma, Clear Cell": [
+    "D018262",
+    "Adenocarcinoma, Clear Cell"
+  ],
+  "Fractures, Stress": [
+    "D015775",
+    "Fractures, Stress"
+  ],
+  "Leber Congenital Amaurosis": [
+    "D057130",
+    "Leber Congenital Amaurosis"
+  ],
+  "Asthma, Aspirin-Induced": [
+    "D055963",
+    "Asthma, Aspirin-Induced"
+  ],
+  "Pleural Effusion, Malignant": [
+    "D016066",
+    "Pleural Effusion, Malignant"
+  ],
+  "Pancreatic Diseases": [
+    "D010182",
+    "Pancreatic Diseases"
+  ],
+  "Hyperemia": [
+    "D006940",
+    "Hyperemia"
+  ],
+  "Dyslipidemias": [
+    "D050171",
+    "Dyslipidemias"
+  ],
+  "Insulinoma": [
+    "D007340",
+    "Insulinoma"
+  ],
+  "Neutropenia": [
+    "D009503",
+    "Neutropenia"
+  ],
+  "Tetraploidy": [
+    "D057891",
+    "Tetraploidy"
+  ],
+  "Postoperative Complications": [
+    "D011183",
+    "Postoperative Complications"
+  ],
+  "Systemic Inflammatory Response Syndrome": [
+    "D018746",
+    "Systemic Inflammatory Response Syndrome"
+  ],
+  "Autosomal Recessive Parkinsonism": [
+    "D020734",
+    "Parkinsonian Disorders"
+  ],
+  "Cerebral Amyloid Angiopathy": [
+    "D016657",
+    "Cerebral Amyloid Angiopathy"
+  ],
+  "Plague": [
+    "D010930",
+    "Plague"
+  ],
+  "Neuroectodermal Tumors, Primitive": [
+    "D018242",
+    "Neuroectodermal Tumors, Primitive"
+  ],
+  "Cachexia": [
+    "D002100",
+    "Cachexia"
+  ],
+  "Arthralgia": [
+    "D018771",
+    "Arthralgia"
+  ],
+  "Low Tension Glaucoma": [
+    "D057066",
+    "Low Tension Glaucoma"
+  ],
+  "Tumor Escape": [
+    "D019139",
+    "Tumor Escape"
+  ],
+  "Infertility, Male": [
+    "D007248",
+    "Infertility, Male"
+  ],
+  "Sleep Deprivation": [
+    "D012892",
+    "Sleep Deprivation"
+  ],
+  "Neoplasm Micrometastasis": [
+    "D061206",
+    "Neoplasm Micrometastasis"
+  ],
+  "Pseudomonas Infections": [
+    "D011552",
+    "Pseudomonas Infections"
+  ],
+  "Helicobacter Infections": [
+    "D016481",
+    "Helicobacter Infections"
+  ],
+  "Brain Injuries, Traumatic": [
+    "D000070642",
+    "Brain Injuries, Traumatic"
+  ],
+  "chronic traumatic encephalopathy": [
+    "D000070627",
+    "Chronic Traumatic Encephalopathy"
+  ],
+  "Carcinoma, Lewis Lung": [
+    "D018827",
+    "Carcinoma, Lewis Lung"
+  ],
+  "Cancer, Second Primary": [
+    "D016609",
+    "Neoplasms, Second Primary"
+  ],
+  "Polycystic Kidney, Autosomal Dominant": [
+    "D016891",
+    "Polycystic Kidney, Autosomal Dominant"
+  ],
+  "Biliary Atresia": [
+    "D001656",
+    "Biliary Atresia"
+  ],
+  "Primary Sclerosing Cholangitis": [
+    "D015209",
+    "Cholangitis, Sclerosing"
+  ],
+  "Glomerulonephritis": [
+    "D005921",
+    "Glomerulonephritis"
+  ],
+  "Influenza in Birds": [
+    "D005585",
+    "Influenza in Birds"
+  ],
+  "Aneurysm": [
+    "D000783",
+    "Aneurysm"
+  ],
+  "Fasting Hypoglycemia": [
+    "D007003",
+    "Hypoglycemia"
+  ],
+  "Hyperammonemia": [
+    "D022124",
+    "Hyperammonemia"
+  ],
+  "Neuromuscular Diseases": [
+    "D009468",
+    "Neuromuscular Diseases"
+  ],
+  "Ectodermal Dysplasia": [
+    "D004476",
+    "Ectodermal Dysplasia"
+  ],
+  "Chickenpox": [
+    "D002644",
+    "Chickenpox"
+  ],
+  "Cataplexy": [
+    "D002385",
+    "Cataplexy"
+  ],
+  "Niemann-Pick Diseases": [
+    "D009542",
+    "Niemann-Pick Diseases"
+  ],
+  "Memory Disorders": [
+    "D008569",
+    "Memory Disorders"
+  ],
+  "Cardiomyopathies": [
+    "D009202",
+    "Cardiomyopathies"
+  ],
+  "Osteopetrosis": [
+    "D010022",
+    "Osteopetrosis"
+  ],
+  "Parasitemia": [
+    "D018512",
+    "Parasitemia"
+  ],
+  "Arthritis, Adjuvant-Induced": [
+    "D001169",
+    "Arthritis, Experimental"
+  ],
+  "Hyperlipoproteinemia Type IIa": [
+    "D006938",
+    "Hyperlipoproteinemia Type II"
+  ],
+  "Renal Tubular Acidosis, Type I": [
+    "D000141",
+    "Acidosis, Renal Tubular"
+  ],
+  "Carcinoma, Small Cell": [
+    "D018288",
+    "Carcinoma, Small Cell"
+  ],
+  "Pituitary ACTH Hypersecretion": [
+    "D047748",
+    "Pituitary ACTH Hypersecretion"
+  ],
+  "MPS III B": [
+    "D009084",
+    "Mucopolysaccharidosis III"
+  ],
+  "Endometrial Neoplasms": [
+    "D016889",
+    "Endometrial Neoplasms"
+  ],
+  "Adenocarcinoma, Papillary": [
+    "D000231",
+    "Adenocarcinoma, Papillary"
+  ],
+  "Hemolytic-Uremic Syndrome": [
+    "D006463",
+    "Hemolytic-Uremic Syndrome"
+  ],
+  "Glomerulosclerosis, Focal Segmental": [
+    "D005923",
+    "Glomerulosclerosis, Focal Segmental"
+  ],
+  "Walker-Warburg Syndrome": [
+    "D058494",
+    "Walker-Warburg Syndrome"
+  ],
+  "Menkes Kinky Hair Syndrome": [
+    "D007706",
+    "Menkes Kinky Hair Syndrome"
+  ],
+  "Alcoholic Intoxication": [
+    "D000435",
+    "Alcoholic Intoxication"
+  ],
+  "Hypophosphatemic Rickets, X-Linked Dominant": [
+    "D053098",
+    "Familial Hypophosphatemic Rickets"
+  ],
+  "DNA Virus Infections": [
+    "D004266",
+    "DNA Virus Infections"
+  ],
+  "Delayed Graft Function": [
+    "D051799",
+    "Delayed Graft Function"
+  ],
+  "Neurofibromatosis 2": [
+    "D016518",
+    "Neurofibromatosis 2"
+  ],
+  "Carditis": [
+    "D009205",
+    "Myocarditis"
+  ],
+  "Postoperative Nausea and Vomiting": [
+    "D020250",
+    "Postoperative Nausea and Vomiting"
+  ],
+  "Iron Overload": [
+    "D019190",
+    "Iron Overload"
+  ],
+  "Leriche Syndrome": [
+    "D007925",
+    "Leriche Syndrome"
+  ],
+  "Hemoglobinopathies": [
+    "D006453",
+    "Hemoglobinopathies"
+  ],
+  "Cicatrix, Hypertrophic": [
+    "D017439",
+    "Cicatrix, Hypertrophic"
+  ],
+  "Mucocutaneous Lymph Node Syndrome": [
+    "D009080",
+    "Mucocutaneous Lymph Node Syndrome"
+  ],
+  "Burns": [
+    "D002056",
+    "Burns"
+  ],
+  "X-Linked Lymphoproliferative Disorder": [
+    "D008232",
+    "Lymphoproliferative Disorders"
+  ],
+  "Epilepsy, Rolandic": [
+    "D019305",
+    "Epilepsy, Rolandic"
+  ],
+  "Osteomalacia": [
+    "D010018",
+    "Osteomalacia"
+  ],
+  "Ureteral Obstruction": [
+    "D014517",
+    "Ureteral Obstruction"
+  ],
+  "Apraxias": [
+    "D001072",
+    "Apraxias"
+  ],
+  "Cholecystolithiasis": [
+    "D041761",
+    "Cholecystolithiasis"
+  ],
+  "Hypocalcemia": [
+    "D006996",
+    "Hypocalcemia"
+  ],
+  "Hyperphosphatemia": [
+    "D054559",
+    "Hyperphosphatemia"
+  ],
+  "Rheumatic Diseases": [
+    "D012216",
+    "Rheumatic Diseases"
+  ],
+  "Pancytopenia": [
+    "D010198",
+    "Pancytopenia"
+  ],
+  "Protein Deficiency": [
+    "D011488",
+    "Protein Deficiency"
+  ],
+  "Hydrops Fetalis": [
+    "D015160",
+    "Hydrops Fetalis"
+  ],
+  "Spondylarthritis": [
+    "D025241",
+    "Spondylarthritis"
+  ],
+  "Bronchogenic Cyst": [
+    "D001994",
+    "Bronchogenic Cyst"
+  ],
+  "Kidney Neoplasms": [
+    "D007680",
+    "Kidney Neoplasms"
+  ],
+  "Hematuria": [
+    "D006417",
+    "Hematuria"
+  ],
+  "Lymphoma, Large-Cell, Anaplastic": [
+    "D017728",
+    "Lymphoma, Large-Cell, Anaplastic"
+  ],
+  "Fatigue": [
+    "D005221",
+    "Fatigue"
+  ],
+  "Hypophosphatemia": [
+    "D017674",
+    "Hypophosphatemia"
+  ],
+  "Rickets, Hypophosphatemic": [
+    "D063730",
+    "Rickets, Hypophosphatemic"
+  ],
+  "Airway Remodeling": [
+    "D056151",
+    "Airway Remodeling"
+  ],
+  "Dermatitis, Allergic Contact": [
+    "D017449",
+    "Dermatitis, Allergic Contact"
+  ],
+  "Hypercalcemia": [
+    "D006934",
+    "Hypercalcemia"
+  ],
+  "Gingivitis": [
+    "D005891",
+    "Gingivitis"
+  ],
+  "Bronchitis, Chronic": [
+    "D029481",
+    "Bronchitis, Chronic"
+  ],
+  "Germ Cell Cancer": [
+    "D009373",
+    "Neoplasms, Germ Cell and Embryonal"
+  ],
+  "Carcinoma in Situ": [
+    "D002278",
+    "Carcinoma in Situ"
+  ],
+  "Papilloma, Inverted": [
+    "D018308",
+    "Papilloma, Inverted"
+  ],
+  "Protein-Losing Enteropathies": [
+    "D011504",
+    "Protein-Losing Enteropathies"
+  ],
+  "Cancer of Tongue": [
+    "D014062",
+    "Tongue Neoplasms"
+  ],
+  "Adrenocortical Adenoma": [
+    "D018246",
+    "Adrenocortical Adenoma"
+  ],
+  "Diabetes Mellitus, Type 2": [
+    "D003924",
+    "Diabetes Mellitus, Type 2"
+  ],
+  "Optic Atrophy, Hereditary, Leber": [
+    "D029242",
+    "Optic Atrophy, Hereditary, Leber"
+  ],
+  "Temporomandibular Joint Disorders": [
+    "D013705",
+    "Temporomandibular Joint Disorders"
+  ],
+  "Glaucoma, Neovascular": [
+    "D015355",
+    "Glaucoma, Neovascular"
+  ],
+  "Cardiovascular Abnormalities": [
+    "D018376",
+    "Cardiovascular Abnormalities"
+  ],
+  "Stress, Psychological": [
+    "D013315",
+    "Stress, Psychological"
+  ],
+  "Hypesthesia": [
+    "D006987",
+    "Hypesthesia"
+  ],
+  "Rectal Neoplasms": [
+    "D012004",
+    "Rectal Neoplasms"
+  ],
+  "Shock, Hemorrhagic": [
+    "D012771",
+    "Shock, Hemorrhagic"
+  ],
+  "Polycythemia Vera": [
+    "D011087",
+    "Polycythemia Vera"
+  ],
+  "Tinea": [
+    "D014005",
+    "Tinea"
+  ],
+  "Attention Deficit Disorder with Hyperactivity": [
+    "D001289",
+    "Attention Deficit Disorder with Hyperactivity"
+  ],
+  "Phobia, Social": [
+    "D000072861",
+    "Phobia, Social"
+  ],
+  "Acromegaly": [
+    "D000172",
+    "Acromegaly"
+  ],
+  "Osteomyelitis": [
+    "D010019",
+    "Osteomyelitis"
+  ],
+  "Lyme Disease": [
+    "D008193",
+    "Lyme Disease"
+  ],
+  "Coronary Disease": [
+    "D003327",
+    "Coronary Disease"
+  ],
+  "Neurogenic Inflammation": [
+    "D020078",
+    "Neurogenic Inflammation"
+  ],
+  "Lysosomal Storage Diseases": [
+    "D016464",
+    "Lysosomal Storage Diseases"
+  ],
+  "Arrhythmogenic Right Ventricular Dysplasia": [
+    "D019571",
+    "Arrhythmogenic Right Ventricular Dysplasia"
+  ],
+  "Spinocerebellar Ataxias": [
+    "D020754",
+    "Spinocerebellar Ataxias"
+  ],
+  "Fibrillary Astrocytoma": [
+    "D001254",
+    "Astrocytoma"
+  ],
+  "Cough": [
+    "D003371",
+    "Cough"
+  ],
+  "Fragile X Syndrome": [
+    "D005600",
+    "Fragile X Syndrome"
+  ],
+  "Chondrosarcoma": [
+    "D002813",
+    "Chondrosarcoma"
+  ],
+  "Neurologic Symptoms": [
+    "D009461",
+    "Neurologic Manifestations"
+  ],
+  "Agammaglobulinemia": [
+    "D000361",
+    "Agammaglobulinemia"
+  ],
+  "Malnutrition": [
+    "D044342",
+    "Malnutrition"
+  ],
+  "Skin Ulcer": [
+    "D012883",
+    "Skin Ulcer"
+  ],
+  "Optic Nerve Glioma": [
+    "D020339",
+    "Optic Nerve Glioma"
+  ],
+  "Hearing Loss, Noise-Induced": [
+    "D006317",
+    "Hearing Loss, Noise-Induced"
+  ],
+  "Pterygium": [
+    "D011625",
+    "Pterygium"
+  ],
+  "Newcastle Disease": [
+    "D009521",
+    "Newcastle Disease"
+  ],
+  "Thalassemia": [
+    "D013789",
+    "Thalassemia"
+  ],
+  "Amyloid Neuropathies, Familial": [
+    "D028227",
+    "Amyloid Neuropathies, Familial"
+  ],
+  "Anaplastic Oligodendroglioma": [
+    "D009837",
+    "Oligodendroglioma"
+  ],
+  "Diabetes, Autoimmune": [
+    "D003922",
+    "Diabetes Mellitus, Type 1"
+  ],
+  "Osteophyte": [
+    "D054850",
+    "Osteophyte"
+  ],
+  "Aortic Diseases": [
+    "D001018",
+    "Aortic Diseases"
+  ],
+  "Cocaine Abuse": [
+    "D019970",
+    "Cocaine-Related Disorders"
+  ],
+  "Spinocerebellar Ataxia Type 5": [
+    "D020754",
+    "Spinocerebellar Ataxias"
+  ],
+  "Simian Acquired Immunodeficiency Syndrome": [
+    "D016097",
+    "Simian Acquired Immunodeficiency Syndrome"
+  ],
+  "Keratosis, Actinic": [
+    "D055623",
+    "Keratosis, Actinic"
+  ],
+  "Branchio-Oto-Renal Syndrome": [
+    "D019280",
+    "Branchio-Oto-Renal Syndrome"
+  ],
+  "Musculoskeletal Abnormalities": [
+    "D009139",
+    "Musculoskeletal Abnormalities"
+  ],
+  "Uterine Cervical Neoplasms": [
+    "D002583",
+    "Uterine Cervical Neoplasms"
+  ],
+  "Polycystic Kidney Diseases": [
+    "D007690",
+    "Polycystic Kidney Diseases"
+  ],
+  "Autoimmune Response": [
+    "D015551",
+    "Autoimmunity"
+  ],
+  "Gastroparesis": [
+    "D018589",
+    "Gastroparesis"
+  ],
+  "Cerebral Thrombosis": [
+    "D020767",
+    "Intracranial Thrombosis"
+  ],
+  "Arterial Stiffness": [
+    "D059289",
+    "Vascular Stiffness"
+  ],
+  "Hashimoto Disease": [
+    "D050031",
+    "Hashimoto Disease"
+  ],
+  "Language Disorders": [
+    "D007806",
+    "Language Disorders"
+  ],
+  "Oral Mucositis": [
+    "D013280",
+    "Stomatitis"
+  ],
+  "Cicatrix": [
+    "D002921",
+    "Cicatrix"
+  ],
+  "Anemia, Sickle Cell": [
+    "D000755",
+    "Anemia, Sickle Cell"
+  ],
+  "Hypothyroidism": [
+    "D007037",
+    "Hypothyroidism"
+  ],
+  "Tuberculosis, Spinal": [
+    "D014399",
+    "Tuberculosis, Spinal"
+  ],
+  "Silicosis": [
+    "D012829",
+    "Silicosis"
+  ],
+  "Costello Syndrome": [
+    "D056685",
+    "Costello Syndrome"
+  ],
+  "Mucositis": [
+    "D052016",
+    "Mucositis"
+  ],
+  "Ventricular Premature Complexes": [
+    "D018879",
+    "Ventricular Premature Complexes"
+  ],
+  "Lymphadenopathy": [
+    "D000072281",
+    "Lymphadenopathy"
+  ],
+  "Autoimmune Lymphoproliferative Syndrome": [
+    "D056735",
+    "Autoimmune Lymphoproliferative Syndrome"
+  ],
+  "Prolactinoma": [
+    "D015175",
+    "Prolactinoma"
+  ],
+  "Mixed Oligodendroglioma-Astrocytoma": [
+    "D009837",
+    "Oligodendroglioma"
+  ],
+  "Nephritis": [
+    "D009393",
+    "Nephritis"
+  ],
+  "Ganglioneuroblastoma": [
+    "D018305",
+    "Ganglioneuroblastoma"
+  ],
+  "Ganglioneuroma": [
+    "D005729",
+    "Ganglioneuroma"
+  ],
+  "Erectile Dysfunction": [
+    "D007172",
+    "Erectile Dysfunction"
+  ],
+  "Decreased Libido": [
+    "D007989",
+    "Libido"
+  ],
+  "Narcolepsy": [
+    "D009290",
+    "Narcolepsy"
+  ],
+  "Dyskeratosis Congenita": [
+    "D019871",
+    "Dyskeratosis Congenita"
+  ],
+  "Embryo Death": [
+    "D020964",
+    "Embryo Loss"
+  ],
+  "Kartagener Syndrome": [
+    "D007619",
+    "Kartagener Syndrome"
+  ],
+  "Loeys-Dietz Aortic Aneurysm Syndrome": [
+    "D055947",
+    "Loeys-Dietz Syndrome"
+  ],
+  "Low Back Pain": [
+    "D017116",
+    "Low Back Pain"
+  ],
+  "Sciatica": [
+    "D012585",
+    "Sciatica"
+  ],
+  "Parasitic Diseases": [
+    "D010272",
+    "Parasitic Diseases"
+  ],
+  "Andersen Syndrome": [
+    "D050030",
+    "Andersen Syndrome"
+  ],
+  "Chlamydia Infections": [
+    "D002690",
+    "Chlamydia Infections"
+  ],
+  "Retinitis Pigmentosa": [
+    "D012174",
+    "Retinitis Pigmentosa"
+  ],
+  "Pulmonary Cystic Fibrosis": [
+    "D003550",
+    "Cystic Fibrosis"
+  ],
+  "Candidiasis, Vulvovaginal": [
+    "D002181",
+    "Candidiasis, Vulvovaginal"
+  ],
+  "Onychomycosis": [
+    "D014009",
+    "Onychomycosis"
+  ],
+  "Death, Sudden": [
+    "D003645",
+    "Death, Sudden"
+  ],
+  "Channelopathies": [
+    "D053447",
+    "Channelopathies"
+  ],
+  "Angina, Unstable": [
+    "D000789",
+    "Angina, Unstable"
+  ],
+  "Coronary Arteriosclerosis": [
+    "D003324",
+    "Coronary Artery Disease"
+  ],
+  "Hematopoietic Neoplasms": [
+    "D019337",
+    "Hematologic Neoplasms"
+  ],
+  "Middle Cerebral Artery Occlusion": [
+    "D020244",
+    "Infarction, Middle Cerebral Artery"
+  ],
+  "Sleeplessness": [
+    "D007319",
+    "Sleep Initiation and Maintenance Disorders"
+  ],
+  "Hamartoma": [
+    "D006222",
+    "Hamartoma"
+  ],
+  "Carcinoma, Endometrioid": [
+    "D018269",
+    "Carcinoma, Endometrioid"
+  ],
+  "Leukemia, B-Cell": [
+    "D015448",
+    "Leukemia, B-Cell"
+  ],
+  "Anthrax": [
+    "D000881",
+    "Anthrax"
+  ],
+  "Hyalinosis, Systemic": [
+    "D057770",
+    "Hyalinosis, Systemic"
+  ],
+  "Neurologic Manifestations": [
+    "D009461",
+    "Neurologic Manifestations"
+  ],
+  "Kidney Tubular Necrosis, Acute": [
+    "D007683",
+    "Kidney Tubular Necrosis, Acute"
+  ],
+  "Hypercholesterolemia": [
+    "D006937",
+    "Hypercholesterolemia"
+  ],
+  "Anemia, Diamond-Blackfan": [
+    "D029503",
+    "Anemia, Diamond-Blackfan"
+  ],
+  "Ileal Diseases": [
+    "D007077",
+    "Ileal Diseases"
+  ],
+  "Intestinal Diseases": [
+    "D007410",
+    "Intestinal Diseases"
+  ],
+  "Central Nervous System Diseases": [
+    "D002493",
+    "Centrala nervsystemets sjukdomar"
+  ],
+  "Myoepithelioma": [
+    "D009208",
+    "Myoepithelioma"
+  ],
+  "Uveomeningoencephalitic Syndrome": [
+    "D014607",
+    "Uveomeningoencephalitic Syndrome"
+  ],
+  "Pleural Effusion": [
+    "D010996",
+    "Pleural Effusion"
+  ],
+  "Gaucher Disease": [
+    "D005776",
+    "Gaucher Disease"
+  ],
+  "Hepatomegaly": [
+    "D006529",
+    "Hepatomegaly"
+  ],
+  "Measles": [
+    "D008457",
+    "Measles"
+  ],
+  "Convulsions": [
+    "D012640",
+    "Seizures"
+  ],
+  "Coma": [
+    "D003128",
+    "Coma"
+  ],
+  "Anaplasia": [
+    "D000708",
+    "Anaplasia"
+  ],
+  "Bone Diseases, Developmental": [
+    "D001848",
+    "Bone Diseases, Developmental"
+  ],
+  "Achondroplasia": [
+    "D000130",
+    "Achondroplasia"
+  ],
+  "Cancer of Nasopharynx": [
+    "D009303",
+    "Nasopharyngeal Neoplasms"
+  ],
+  "Hypovolemia": [
+    "D020896",
+    "Hypovolemia"
+  ],
+  "Carcinoma, Adenosquamous": [
+    "D018196",
+    "Carcinoma, Adenosquamous"
+  ],
+  "Astrocytosis": [
+    "D005911",
+    "Gliosis"
+  ],
+  "Peri-Implantitis": [
+    "D057873",
+    "Peri-Implantitis"
+  ],
+  "Hyperopia": [
+    "D006956",
+    "Hyperopia"
+  ],
+  "Addison Disease": [
+    "D000224",
+    "Addison Disease"
+  ],
+  "Holoprosencephaly": [
+    "D016142",
+    "Holoprosencephaly"
+  ],
+  "Hypogonadotropic Hypogonadism": [
+    "D007006",
+    "Hypogonadism"
+  ],
+  "Benign Neoplasms": [
+    "D009369",
+    "Neoplasms"
+  ],
+  "Uveitis": [
+    "D014605",
+    "Uveitis"
+  ],
+  "Leukemia, Lymphoid": [
+    "D007945",
+    "Leukemia, Lymphoid"
+  ],
+  "HTLV-I Infections": [
+    "D015490",
+    "HTLV-I Infections"
+  ],
+  "Hypoplastic Left Heart Syndrome": [
+    "D018636",
+    "Hypoplastic Left Heart Syndrome"
+  ],
+  "Pneumonia, Mycoplasma": [
+    "D011019",
+    "Pneumonia, Mycoplasma"
+  ],
+  "Autistic Disorder": [
+    "D001321",
+    "Autistic Disorder"
+  ],
+  "Neuronal Ceroid-Lipofuscinoses": [
+    "D009472",
+    "Neuronal Ceroid-Lipofuscinoses"
+  ],
+  "Pica": [
+    "D010842",
+    "Pica"
+  ],
+  "Hodgkin Disease": [
+    "D006689",
+    "Hodgkin Disease"
+  ],
+  "Peripheral Vascular Diseases": [
+    "D016491",
+    "Peripheral Vascular Diseases"
+  ],
+  "Obsessive-Compulsive Disorder": [
+    "D009771",
+    "Obsessive-Compulsive Disorder"
+  ],
+  "Xeroderma Pigmentosum": [
+    "D014983",
+    "Xeroderma Pigmentosum"
+  ],
+  "Hereditary Autoinflammatory Diseases": [
+    "D056660",
+    "Hereditary Autoinflammatory Diseases"
+  ],
+  "Juvenile-Onset Still Disease": [
+    "D001171",
+    "Arthritis, Juvenile"
+  ],
+  "Leukocytosis": [
+    "D007964",
+    "Leukocytosis"
+  ],
+  "Pregnancy Complications": [
+    "D011248",
+    "Pregnancy Complications"
+  ],
+  "Parkinsonism, Experimental": [
+    "D020734",
+    "Parkinsonian Disorders"
+  ],
+  "Acute-Phase Reaction": [
+    "D000210",
+    "Acute-Phase Reaction"
+  ],
+  "Cleft Palate": [
+    "D002972",
+    "Cleft Palate"
+  ],
+  "Pemphigus": [
+    "D010392",
+    "Pemphigus"
+  ],
+  "Hemangiosarcoma": [
+    "D006394",
+    "Hemangiosarcoma"
+  ],
+  "Atypical Endometrial Hyperplasia": [
+    "D004714",
+    "Endometrial Hyperplasia"
+  ],
+  "Melancholia": [
+    "D003866",
+    "Depressive Disorder"
+  ],
+  "Pain, Postoperative": [
+    "D010149",
+    "Pain, Postoperative"
+  ],
+  "Acute Disease": [
+    "D000208",
+    "Acute Disease"
+  ],
+  "Carcinoma, Mucoepidermoid": [
+    "D018277",
+    "Carcinoma, Mucoepidermoid"
+  ],
+  "Mesenchymoma": [
+    "D008637",
+    "Mesenchymoma"
+  ],
+  "Fractures, Bone": [
+    "D050723",
+    "Fractures, Bone"
+  ],
+  "Dyspepsia": [
+    "D004415",
+    "Dyspepsia"
+  ],
+  "Fatty Liver, Alcoholic": [
+    "D005235",
+    "Fatty Liver, Alcoholic"
+  ],
+  "Hypersensitivity, Contact": [
+    "D003877",
+    "Dermatitis, Contact"
+  ],
+  "Beckwith-Wiedemann Syndrome": [
+    "D001506",
+    "Beckwith-Wiedemann Syndrome"
+  ],
+  "Uveitis, Posterior": [
+    "D015866",
+    "Uveitis, Posterior"
+  ],
+  "Hermanski-Pudlak Syndrome": [
+    "D022861",
+    "Hermanski-Pudlak Syndrome"
+  ],
+  "Uveitis, Anterior": [
+    "D014606",
+    "Uveitis, Anterior"
+  ],
+  "Hepatitis, Autoimmune": [
+    "D019693",
+    "Hepatitis, Autoimmune"
+  ],
+  "Takayasu Arteritis": [
+    "D013625",
+    "Takayasu Arteritis"
+  ],
+  "Encephalitis": [
+    "D004660",
+    "Encephalitis"
+  ],
+  "Mucormycosis": [
+    "D009091",
+    "Mucormycosis"
+  ],
+  "Squamous Cell Cancer": [
+    "D018307",
+    "Neoplasms, Squamous Cell"
+  ],
+  "Shock, Endotoxic": [
+    "D012772",
+    "Shock, Septic"
+  ],
+  "Keloid": [
+    "D007627",
+    "Keloid"
+  ],
+  "Radiation Pneumonitis": [
+    "D017564",
+    "Radiation Pneumonitis"
+  ],
+  "Hypotension": [
+    "D007022",
+    "Hypotension"
+  ],
+  "Myasthenia Gravis": [
+    "D009157",
+    "Myasthenia Gravis"
+  ],
+  "Hyperphagia": [
+    "D006963",
+    "Hyperphagia"
+  ],
+  "Cherubism": [
+    "D002636",
+    "Cherubism"
+  ],
+  "Lupus Erythematosus, Discoid": [
+    "D008179",
+    "Lupus Erythematosus, Discoid"
+  ],
+  "Wilms Tumor": [
+    "D009396",
+    "Wilms Tumor"
+  ],
+  "Liver Failure": [
+    "D017093",
+    "Liver Failure"
+  ],
+  "Sudden Cardiac Arrest": [
+    "D016757",
+    "Death, Sudden, Cardiac"
+  ],
+  "Muscle Hypotonia": [
+    "D009123",
+    "Muscle Hypotonia"
+  ],
+  "Hypogonadism": [
+    "D007006",
+    "Hypogonadism"
+  ],
+  "Phosphaturia": [
+    "D007015",
+    "Hypophosphatemia, Familial"
+  ],
+  "Hyperparathyroidism, Secondary": [
+    "D006962",
+    "Hyperparathyroidism, Secondary"
+  ],
+  "Pulmonary Embolism": [
+    "D011655",
+    "Pulmonary Embolism"
+  ],
+  "Osteochondroma": [
+    "D015831",
+    "Osteochondroma"
+  ],
+  "Bile Duct Cancer": [
+    "D001650",
+    "Bile Duct Neoplasms"
+  ],
+  "Vascular Stiffness": [
+    "D059289",
+    "Vascular Stiffness"
+  ],
+  "Herpesviridae Infections": [
+    "D006566",
+    "Herpesviridae Infections"
+  ],
+  "Smith-Magenis Syndrome": [
+    "D058496",
+    "Smith-Magenis Syndrome"
+  ],
+  "Brain Edema": [
+    "D001929",
+    "Brain Edema"
+  ],
+  "Turner Syndrome": [
+    "D014424",
+    "Turner Syndrome"
+  ],
+  "Peptic Ulcer": [
+    "D010437",
+    "Peptic Ulcer"
+  ],
+  "Stomach Ulcer": [
+    "D013276",
+    "Stomach Ulcer"
+  ],
+  "von Hippel-Lindau Disease": [
+    "D006623",
+    "von Hippel-Lindau Disease"
+  ],
+  "Ehlers-Danlos Syndrome": [
+    "D004535",
+    "Ehlers-Danlos Syndrome"
+  ],
+  "Signs and Symptoms, Respiratory": [
+    "D012818",
+    "Signs and Symptoms, Respiratory"
+  ],
+  "Anorexia Nervosa": [
+    "D000856",
+    "Anorexia Nervosa"
+  ],
+  "Leg Ulcer": [
+    "D007871",
+    "Leg Ulcer"
+  ],
+  "Virilism": [
+    "D014770",
+    "Virilism"
+  ],
+  "Learning Disabilities": [
+    "D007859",
+    "Learning Disorders"
+  ],
+  "Bone Diseases": [
+    "D001847",
+    "Bone Diseases"
+  ],
+  "Graves Disease": [
+    "D006111",
+    "Graves Disease"
+  ],
+  "Nevus, Pigmented": [
+    "D009508",
+    "Nevus, Pigmented"
+  ],
+  "Neural Tube Defects": [
+    "D009436",
+    "Neural Tube Defects"
+  ],
+  "Hypertrichosis": [
+    "D006983",
+    "Hypertrichosis"
+  ],
+  "Hypothermia": [
+    "D007035",
+    "Hypothermia"
+  ],
+  "Color Blindness": [
+    "D003117",
+    "Color Vision Defects"
+  ],
+  "Cardiomyopathy, Alcoholic": [
+    "D002310",
+    "Cardiomyopathy, Alcoholic"
+  ],
+  "Dermatitis, Poison Ivy": [
+    "D011040",
+    "Dermatitis, Toxicodendron"
+  ],
+  "Escherichia coli Infections": [
+    "D004927",
+    "Escherichia coli Infections"
+  ],
+  "Lymphohistiocytosis, Hemophagocytic": [
+    "D051359",
+    "Lymphohistiocytosis, Hemophagocytic"
+  ],
+  "Androgenetic Alopecia": [
+    "D000505",
+    "Alopecia"
+  ],
+  "Spinal Fractures": [
+    "D016103",
+    "Spinal Fractures"
+  ],
+  "Carcinoma, Ductal": [
+    "D044584",
+    "Carcinoma, Ductal"
+  ],
+  "Prediabetic State": [
+    "D011236",
+    "Prediabetic State"
+  ],
+  "Cavernous Hemangioma of Brain": [
+    "D020786",
+    "Hemangioma, Cavernous, Central Nervous System"
+  ],
+  "Gastroesophageal Reflux": [
+    "D005764",
+    "Gastroesophageal Reflux"
+  ],
+  "Cholesterol Ester Storage Disease": [
+    "D015217",
+    "Cholesterol Ester Storage Disease"
+  ],
+  "Lymphoma, B-Cell, Marginal Zone": [
+    "D018442",
+    "Lymphoma, B-Cell, Marginal Zone"
+  ],
+  "Kidney Calculi": [
+    "D007669",
+    "Kidney Calculi"
+  ],
+  "Tobacco Dependence": [
+    "D014029",
+    "Tobacco Use Disorder"
+  ],
+  "AIDS-Associated Nephropathy": [
+    "D016263",
+    "AIDS-Associated Nephropathy"
+  ],
+  "Heart Failure, Systolic": [
+    "D054143",
+    "Heart Failure, Systolic"
+  ],
+  "Leptospirosis": [
+    "D007922",
+    "Leptospirosis"
+  ],
+  "Pervasive Development Disorders": [
+    "D002659",
+    "Child Development Disorders, Pervasive"
+  ],
+  "Tourette Syndrome": [
+    "D005879",
+    "Tourette Syndrome"
+  ],
+  "Trichotillomania": [
+    "D014256",
+    "Trichotillomania"
+  ],
+  "Adrenoleukodystrophy": [
+    "D000326",
+    "Adrenoleukodystrophy"
+  ],
+  "Acne Vulgaris": [
+    "D000152",
+    "Acne Vulgaris"
+  ],
+  "Pseudohypoparathyroidism": [
+    "D011547",
+    "Pseudohypoparathyroidism"
+  ],
+  "Porcine Reproductive and Respiratory Syndrome": [
+    "D019318",
+    "Porcine Reproductive and Respiratory Syndrome"
+  ],
+  "Encephalitis, Japanese": [
+    "D004672",
+    "Encephalitis, Japanese"
+  ],
+  "Myocarditis": [
+    "D009205",
+    "Myocarditis"
+  ],
+  "Angina, Stable": [
+    "D060050",
+    "Angina, Stable"
+  ],
+  "African Lymphoma": [
+    "D002051",
+    "Burkitt Lymphoma"
+  ],
+  "Dyspnea": [
+    "D004417",
+    "Dyspnea"
+  ],
+  "Binge-Eating Disorder": [
+    "D056912",
+    "Binge-Eating Disorder"
+  ],
+  "Abortion, Habitual": [
+    "D000026",
+    "Abortion, Habitual"
+  ],
+  "Glomus Tumor": [
+    "D005918",
+    "Glomus Tumor"
+  ],
+  "Neurofibroma": [
+    "D009455",
+    "Neurofibroma"
+  ],
+  "Leukemia, Myelomonocytic, Juvenile": [
+    "D054429",
+    "Leukemia, Myelomonocytic, Juvenile"
+  ],
+  "Erythrocytosis": [
+    "D011086",
+    "Polycythemia"
+  ],
+  "Puberty, Delayed": [
+    "D011628",
+    "Puberty, Delayed"
+  ],
+  "Conjunctivitis, Allergic": [
+    "D003233",
+    "Conjunctivitis, Allergic"
+  ],
+  "Alopecia": [
+    "D000505",
+    "Alopecia"
+  ],
+  "Rift Valley Fever": [
+    "D012295",
+    "Rift Valley Fever"
+  ],
+  "Seizures, Generalized": [
+    "D012640",
+    "Seizures"
+  ],
+  "Seizures, Febrile": [
+    "D003294",
+    "Seizures, Febrile"
+  ],
+  "Very Low Birth Weight": [
+    "D019102",
+    "Infant, Very Low Birth Weight"
+  ],
+  "Antiphospholipid Syndrome": [
+    "D016736",
+    "Antiphospholipid Syndrome"
+  ],
+  "Heart Injuries": [
+    "D006335",
+    "Heart Injuries"
+  ],
+  "Neurotic Disorders": [
+    "D009497",
+    "Neurotic Disorders"
+  ],
+  "Cockayne Syndrome, Type II": [
+    "D003057",
+    "Cockayne Syndrome"
+  ],
+  "Hypoxia-Ischemia, Brain": [
+    "D020925",
+    "Hypoxia-Ischemia, Brain"
+  ],
+  "Opiate Dependence": [
+    "D009293",
+    "Opioid-Related Disorders"
+  ],
+  "Sickle Cell Trait": [
+    "D012805",
+    "Sickle Cell Trait"
+  ],
+  "Thrombocythemia, Essential": [
+    "D013920",
+    "Thrombocythemia, Essential"
+  ],
+  "Neoplasms, Experimental": [
+    "D009374",
+    "Neoplasms, Experimental"
+  ],
+  "DNA Repair-Deficiency Disorders": [
+    "D049914",
+    "DNA Repair-Deficiency Disorders"
+  ],
+  "Chagas Disease": [
+    "D014355",
+    "Chagas Disease"
+  ],
+  "Ventricular Dysfunction, Left": [
+    "D018487",
+    "Ventricular Dysfunction, Left"
+  ],
+  "Neuroendocrine Tumors": [
+    "D018358",
+    "Neuroendocrine Tumors"
+  ],
+  "Graft Rejection": [
+    "D006084",
+    "Graft Rejection"
+  ],
+  "Papillomavirus Infections": [
+    "D030361",
+    "Papillomavirus Infections"
+  ],
+  "Epilepsy, Myoclonic, Infantile, Severe": [
+    "D004831",
+    "Epilepsies, Myoclonic"
+  ],
+  "Acantholysis": [
+    "D000051",
+    "Acantholysis"
+  ],
+  "Confusion, Post-Ictal": [
+    "D003221",
+    "Confusion"
+  ],
+  "Rhabdomyosarcoma, Embryonal": [
+    "D018233",
+    "Rhabdomyosarcoma, Embryonal"
+  ],
+  "Mania": [
+    "D001714",
+    "Bipolar Disorder"
+  ],
+  "Phenylketonurias": [
+    "D010661",
+    "Phenylketonurias"
+  ],
+  "Hemorrhagic Fever with Renal Syndrome": [
+    "D006480",
+    "Hemorrhagic Fever with Renal Syndrome"
+  ],
+  "Paranoid Disorders": [
+    "D010259",
+    "Paranoid Disorders"
+  ],
+  "Eye Abnormalities": [
+    "D005124",
+    "Eye Abnormalities"
+  ],
+  "Superinfection": [
+    "D015163",
+    "Superinfection"
+  ],
+  "Schistosomiasis mansoni": [
+    "D012555",
+    "Schistosomiasis mansoni"
+  ],
+  "Foreign-Body Reaction": [
+    "D005549",
+    "Foreign-Body Reaction"
+  ],
+  "Brain Tumor, Primary": [
+    "D001932",
+    "Brain Neoplasms"
+  ],
+  "Hyperlipoproteinemia Type I": [
+    "D008072",
+    "Hyperlipoproteinemia Type I"
+  ],
+  "Coronary Aneurysm": [
+    "D003323",
+    "Coronary Aneurysm"
+  ],
+  "Latent Tuberculosis": [
+    "D055985",
+    "Latent Tuberculosis"
+  ],
+  "Carcinoid Tumor": [
+    "D002276",
+    "Carcinoid Tumor"
+  ],
+  "Endocrine Gland Neoplasms": [
+    "D004701",
+    "Endocrine Gland Neoplasms"
+  ],
+  "Dihydropyrimidine Dehydrogenase Deficiency": [
+    "D054067",
+    "Dihydropyrimidine Dehydrogenase Deficiency"
+  ],
+  "Urolithiasis": [
+    "D052878",
+    "Urolithiasis"
+  ],
+  "Alzheimer Disease, Early Onset": [
+    "D000544",
+    "Alzheimer Disease"
+  ],
+  "Lesch-Nyhan Syndrome": [
+    "D007926",
+    "Lesch-Nyhan Syndrome"
+  ],
+  "Arteriovenous Malformations": [
+    "D001165",
+    "Arteriovenous Malformations"
+  ],
+  "Motor Neuron Disease": [
+    "D016472",
+    "Motor Neuron Disease"
+  ],
+  "Ameloblastoma": [
+    "D000564",
+    "Ameloblastoma"
+  ],
+  "Nephrotic Syndrome, Minimal Change": [
+    "D009402",
+    "Nephrosis, Lipoid"
+  ],
+  "Multiple System Atrophy": [
+    "D019578",
+    "Multiple System Atrophy"
+  ],
+  "Peritonitis": [
+    "D010538",
+    "Peritonitis"
+  ],
+  "Oropharyngeal Dysphagia": [
+    "D003680",
+    "Deglutition Disorders"
+  ],
+  "Xeroderma": [
+    "D007057",
+    "Ichthyosis"
+  ],
+  "Darier Disease": [
+    "D007644",
+    "Darier Disease"
+  ],
+  "Arthrogryposis": [
+    "D001176",
+    "Arthrogryposis"
+  ],
+  "Shock, Septic": [
+    "D012772",
+    "Shock, Septic"
+  ],
+  "Dermatitis Herpetiformis": [
+    "D003874",
+    "Dermatitis Herpetiformis"
+  ],
+  "Bacteremia": [
+    "D016470",
+    "Bacteremia"
+  ],
+  "Fibrous Dysplasia of Bone": [
+    "D005357",
+    "Fibrous Dysplasia of Bone"
+  ],
+  "Bronchiectasis": [
+    "D001987",
+    "Bronchiectasis"
+  ],
+  "Brugada Syndrome": [
+    "D053840",
+    "Brugada Syndrome"
+  ],
+  "Neuromyelitis Optica": [
+    "D009471",
+    "Neuromyelitis Optica"
+  ],
+  "Intracranial Hemorrhages": [
+    "D020300",
+    "Intracranial Hemorrhages"
+  ],
+  "Immunoblastic Lymphadenopathy": [
+    "D007119",
+    "Immunoblastic Lymphadenopathy"
+  ],
+  "Respiratory Insufficiency": [
+    "D012131",
+    "Respiratory Insufficiency"
+  ],
+  "Diabetes Insipidus": [
+    "D003919",
+    "Diabetes Insipidus"
+  ],
+  "Goiter": [
+    "D006042",
+    "Goiter"
+  ],
+  "Geographic Atrophy": [
+    "D057092",
+    "Geographic Atrophy"
+  ],
+  "Vomiting": [
+    "D014839",
+    "Vomiting"
+  ],
+  "Streptozotocin Diabetes": [
+    "D003921",
+    "Diabetes Mellitus, Experimental"
+  ],
+  "Nasal Polyps": [
+    "D009298",
+    "Nasal Polyps"
+  ],
+  "LEOPARD Syndrome": [
+    "D044542",
+    "LEOPARD Syndrome"
+  ],
+  "Tuberculosis, Meningeal": [
+    "D014390",
+    "Tuberculosis, Meningeal"
+  ],
+  "Teratocarcinoma": [
+    "D018243",
+    "Teratocarcinoma"
+  ],
+  "Sarcopenia": [
+    "D055948",
+    "Sarcopenia"
+  ],
+  "Skin Manifestations": [
+    "D012877",
+    "Skin Manifestations"
+  ],
+  "Adenomatous Polyps": [
+    "D018256",
+    "Adenomatous Polyps"
+  ],
+  "Hyperbilirubinemia": [
+    "D006932",
+    "Hyperbilirubinemia"
+  ],
+  "Hypogammaglobulinemia": [
+    "D000361",
+    "Agammaglobulinemia"
+  ],
+  "Carcinoma, Large Cell": [
+    "D018287",
+    "Carcinoma, Large Cell"
+  ],
+  "Fasciculation": [
+    "D005207",
+    "Fasciculation"
+  ],
+  "Photosensitization": [
+    "D010787",
+    "Photosensitivity Disorders"
+  ],
+  "Primary Peritonitis": [
+    "D010538",
+    "Peritonitis"
+  ],
+  "Status Epilepticus": [
+    "D013226",
+    "Status Epilepticus"
+  ],
+  "Night Blindness": [
+    "D009755",
+    "Night Blindness"
+  ],
+  "Renal Tubule Necrosis": [
+    "D007673",
+    "Kidney Cortex Necrosis"
+  ],
+  "Osteoporosis, Age-Related": [
+    "D010024",
+    "Osteoporosis"
+  ],
+  "Carcinoma, Merkel Cell": [
+    "D015266",
+    "Carcinoma, Merkel Cell"
+  ],
+  "Benign Meningioma": [
+    "D008579",
+    "Meningioma"
+  ],
+  "Common Variable Immunodeficiency": [
+    "D017074",
+    "Common Variable Immunodeficiency"
+  ],
+  "Duodenal Ulcer": [
+    "D004381",
+    "Duodenal Ulcer"
+  ],
+  "Arteriolosclerosis": [
+    "D050379",
+    "Arteriolosclerosis"
+  ],
+  "Gastrointestinal Neoplasms": [
+    "D005770",
+    "Gastrointestinal Neoplasms"
+  ],
+  "Cholera": [
+    "D002771",
+    "Cholera"
+  ],
+  "Flavivirus Infections": [
+    "D018177",
+    "Flavivirus Infections"
+  ],
+  "Fetal Alcohol Syndrome": [
+    "D063647",
+    "Fetal Alcohol Spectrum Disorders"
+  ],
+  "Anophthalmos": [
+    "D000853",
+    "Anophthalmos"
+  ],
+  "Coloboma": [
+    "D003103",
+    "Coloboma"
+  ],
+  "Neurofibromatosis 1": [
+    "D009456",
+    "Neurofibromatosis 1"
+  ],
+  "Corneal Edema": [
+    "D015715",
+    "Corneal Edema"
+  ],
+  "Corneal Diseases": [
+    "D003316",
+    "Corneal Diseases"
+  ],
+  "Rheumatic Heart Disease": [
+    "D012214",
+    "Rheumatic Heart Disease"
+  ],
+  "Rubella": [
+    "D012409",
+    "Rubella"
+  ],
+  "Venous Thrombosis": [
+    "D020246",
+    "Venous Thrombosis"
+  ],
+  "Hallopeau-Siemens Disease": [
+    "D016108",
+    "Epidermolysis Bullosa Dystrophica"
+  ],
+  "Hypereosinophilic Syndrome": [
+    "D017681",
+    "Hypereosinophilic Syndrome"
+  ],
+  "Purpura, Thrombocytopenic, Idiopathic": [
+    "D016553",
+    "Purpura, Thrombocytopenic, Idiopathic"
+  ],
+  "Waldenstrom Macroglobulinemia": [
+    "D008258",
+    "Waldenstrom Macroglobulinemia"
+  ],
+  "Atrioventricular Block": [
+    "D054537",
+    "Atrioventricular Block"
+  ],
+  "Nasal Obstruction": [
+    "D015508",
+    "Nasal Obstruction"
+  ],
+  "Sneezing": [
+    "D012912",
+    "Sneezing"
+  ],
+  "Airflow Obstruction, Chronic": [
+    "D029424",
+    "Pulmonary Disease, Chronic Obstructive"
+  ],
+  "Lipidoses": [
+    "D008064",
+    "Lipidoses"
+  ],
+  "beta-Thalassemia": [
+    "D017086",
+    "beta-Thalassemia"
+  ],
+  "Diabetic Foot": [
+    "D017719",
+    "Diabetic Foot"
+  ],
+  "Bradykinesia": [
+    "D018476",
+    "Hypokinesia"
+  ],
+  "Warts": [
+    "D014860",
+    "Warts"
+  ],
+  "Depression, Postpartum": [
+    "D019052",
+    "Depression, Postpartum"
+  ],
+  "Aphasia, Primary Progressive": [
+    "D018888",
+    "Aphasia, Primary Progressive"
+  ],
+  "Apraxia of Phonation": [
+    "D001072",
+    "Apraxias"
+  ],
+  "Optic Atrophy, Autosomal Dominant": [
+    "D029241",
+    "Optic Atrophy, Autosomal Dominant"
+  ],
+  "Optic Nerve Diseases": [
+    "D009901",
+    "Optic Nerve Diseases"
+  ],
+  "Papillon-Lefevre Disease": [
+    "D010214",
+    "Papillon-Lefevre Disease"
+  ],
+  "Gilbert Disease": [
+    "D005878",
+    "Gilbert Disease"
+  ],
+  "Tactile Allodynia": [
+    "D006930",
+    "Hyperalgesia"
+  ],
+  "Neurilemmoma": [
+    "D009442",
+    "Neurilemmoma"
+  ],
+  "Torsades de Pointes": [
+    "D016171",
+    "Torsades de Pointes"
+  ],
+  "Myoclonus": [
+    "D009207",
+    "Myoclonus"
+  ],
+  "Rhinitis": [
+    "D012220",
+    "Rhinitis"
+  ],
+  "Asthmatic Airway Remodeling": [
+    "D056151",
+    "Airway Remodeling"
+  ],
+  "Hearing Loss, Cochlear": [
+    "D006319",
+    "Hearing Loss, Sensorineural"
+  ],
+  "Pulmonary Eosinophilia": [
+    "D011657",
+    "Pulmonary Eosinophilia"
+  ],
+  "Encephalitis, Tick-Borne": [
+    "D004675",
+    "Encephalitis, Tick-Borne"
+  ],
+  "Spastic Paraplegia, Hereditary": [
+    "D015419",
+    "Spastic Paraplegia, Hereditary"
+  ],
+  "Bone Cysts": [
+    "D001845",
+    "Bone Cysts"
+  ],
+  "Dystonia": [
+    "D004421",
+    "Dystonia"
+  ],
+  "Elliptocytosis, Hereditary": [
+    "D004612",
+    "Elliptocytosis, Hereditary"
+  ],
+  "Ankylosis": [
+    "D000844",
+    "Ankylosis"
+  ],
+  "Carotid Artery Plaque": [
+    "D016893",
+    "Carotid Stenosis"
+  ],
+  "Leukemia, Monocytic, Acute": [
+    "D007948",
+    "Leukemia, Monocytic, Acute"
+  ],
+  "Ventilator-Induced Lung Injury": [
+    "D055397",
+    "Ventilator-Induced Lung Injury"
+  ],
+  "Spasms, Infantile": [
+    "D013036",
+    "Spasms, Infantile"
+  ],
+  "Trisomy": [
+    "D014314",
+    "Trisomy"
+  ],
+  "Tendinopathy": [
+    "D052256",
+    "Tendinopathy"
+  ],
+  "Polyglandular Type I Autoimmune Syndrome": [
+    "D016884",
+    "Polyendocrinopathies, Autoimmune"
+  ],
+  "Mycosis Fungoides": [
+    "D009182",
+    "Mycosis Fungoides"
+  ],
+  "Sezary Syndrome": [
+    "D012751",
+    "Sezary Syndrome"
+  ],
+  "Emotional Disturbances": [
+    "D000342",
+    "Affective Symptoms"
+  ],
+  "Multiple Endocrine Neoplasia Type 1": [
+    "D018761",
+    "Multiple Endocrine Neoplasia Type 1"
+  ],
+  "Leukemia, Large Granular Lymphocytic": [
+    "D054066",
+    "Leukemia, Large Granular Lymphocytic"
+  ],
+  "Prader-Willi Syndrome": [
+    "D011218",
+    "Prader-Willi Syndrome"
+  ],
+  "Irritable Mood": [
+    "D007508",
+    "Irritable Mood"
+  ],
+  "Compulsive Behavior": [
+    "D003192",
+    "Compulsive Behavior"
+  ],
+  "Acanthosis Nigricans": [
+    "D000052",
+    "Acanthosis Nigricans"
+  ],
+  "Hamartoma Syndrome, Multiple": [
+    "D006223",
+    "Hamartoma Syndrome, Multiple"
+  ],
+  "Attention Deficit Disorder": [
+    "D001289",
+    "Attention Deficit Disorder with Hyperactivity"
+  ],
+  "Drug Use Disorders": [
+    "D019966",
+    "Substance-Related Disorders"
+  ],
+  "Noonan Syndrome": [
+    "D009634",
+    "Noonan Syndrome"
+  ],
+  "Thinness": [
+    "D013851",
+    "Thinness"
+  ],
+  "Rhinitis, Allergic, Perennial": [
+    "D012221",
+    "Rhinitis, Allergic, Perennial"
+  ],
+  "Neuroma, Acoustic": [
+    "D009464",
+    "Neuroma, Acoustic"
+  ],
+  "Lymphedema": [
+    "D008209",
+    "Lymphedema"
+  ],
+  "Pelizaeus-Merzbacher Disease": [
+    "D020371",
+    "Pelizaeus-Merzbacher Disease"
+  ],
+  "Cardiomyopathy, Hypertrophic, Familial": [
+    "D024741",
+    "Cardiomyopathy, Hypertrophic, Familial"
+  ],
+  "DNA Repair-Deficiency": [
+    "D049914",
+    "DNA Repair-Deficiency Disorders"
+  ],
+  "Malabsorption Syndromes": [
+    "D008286",
+    "Malabsorption Syndromes"
+  ],
+  "Steatorrhea": [
+    "D045602",
+    "Steatorrhea"
+  ],
+  "Multiple Sclerosis, Relapsing-Remitting": [
+    "D020529",
+    "Multiple Sclerosis, Relapsing-Remitting"
+  ],
+  "Toxoplasmosis, Ocular": [
+    "D014126",
+    "Toxoplasmosis, Ocular"
+  ],
+  "Nephropathia Epidemica": [
+    "D006480",
+    "Hemorrhagic Fever with Renal Syndrome"
+  ],
+  "Tachycardia, Ventricular": [
+    "D017180",
+    "Tachycardia, Ventricular"
+  ],
+  "Hypernatremia": [
+    "D006955",
+    "Hypernatremia"
+  ],
+  "Anemia, Hemolytic": [
+    "D000743",
+    "Anemia, Hemolytic"
+  ],
+  "Hip Fractures": [
+    "D006620",
+    "Hip Fractures"
+  ],
+  "Testicular Neoplasms": [
+    "D013736",
+    "Testicular Neoplasms"
+  ],
+  "Leukemia, Hairy Cell": [
+    "D007943",
+    "Leukemia, Hairy Cell"
+  ],
+  "Neoplasm Seeding": [
+    "D009366",
+    "Neoplasm Seeding"
+  ],
+  "Cervical Intraepithelial Neoplasia, Grade III": [
+    "D018290",
+    "Cervical Intraepithelial Neoplasia"
+  ],
+  "von Willebrand Diseases": [
+    "D014842",
+    "von Willebrand Diseases"
+  ],
+  "Subarachnoid Hemorrhage, Aneurysmal": [
+    "D013345",
+    "Subarachnoid Hemorrhage"
+  ],
+  "Neoplasms, Neuroepithelial": [
+    "D018302",
+    "Neoplasms, Neuroepithelial"
+  ],
+  "Memory Loss": [
+    "D008569",
+    "Memory Disorders"
+  ],
+  "Purpura": [
+    "D011693",
+    "Purpura"
+  ],
+  "Erythromelalgia": [
+    "D004916",
+    "Erythromelalgia"
+  ],
+  "Panic Disorder": [
+    "D016584",
+    "Panic Disorder"
+  ],
+  "Ocular Hypertension": [
+    "D009798",
+    "Ocular Hypertension"
+  ],
+  "Parakeratosis": [
+    "D010241",
+    "Parakeratosis"
+  ],
+  "Blood Coagulation Disorders": [
+    "D001778",
+    "Blood Coagulation Disorders"
+  ],
+  "Rickets": [
+    "D012279",
+    "Rickets"
+  ],
+  "Allelic Imbalance": [
+    "D022981",
+    "Allelic Imbalance"
+  ],
+  "Campomelic Dysplasia": [
+    "D055036",
+    "Campomelic Dysplasia"
+  ],
+  "Meningomyelocele": [
+    "D008591",
+    "Meningomyelocele"
+  ],
+  "Hemangioma, Capillary": [
+    "D018324",
+    "Hemangioma, Capillary"
+  ],
+  "Reoviridae Infections": [
+    "D012088",
+    "Reoviridae Infections"
+  ],
+  "Lymphangioma": [
+    "D008202",
+    "Lymphangioma"
+  ],
+  "Lymphoma, T-Cell, Peripheral": [
+    "D016411",
+    "Lymphoma, T-Cell, Peripheral"
+  ],
+  "Cancer of Larynx": [
+    "D007822",
+    "Laryngeal Neoplasms"
+  ],
+  "Paratuberculosis": [
+    "D010283",
+    "Paratuberculosis"
+  ],
+  "Drug Abuse": [
+    "D019966",
+    "Substance-Related Disorders"
+  ],
+  "Essential Tremor": [
+    "D020329",
+    "Essential Tremor"
+  ],
+  "Lung Diseases, Obstructive": [
+    "D008173",
+    "Lung Diseases, Obstructive"
+  ],
+  "Hepatitis A": [
+    "D006506",
+    "Hepatitis A"
+  ],
+  "Reactive Hyperemia": [
+    "D006940",
+    "Hyperemia"
+  ],
+  "Exophthalmos": [
+    "D005094",
+    "Exophthalmos"
+  ],
+  "Myxedema": [
+    "D009230",
+    "Myxedema"
+  ],
+  "Heart Failure, Left-Sided": [
+    "D006333",
+    "Heart Failure"
+  ],
+  "Leukemia, Basophilic, Acute": [
+    "D015471",
+    "Leukemia, Basophilic, Acute"
+  ],
+  "Hepatic Insufficiency": [
+    "D048550",
+    "Hepatic Insufficiency"
+  ],
+  "Craniosynostoses": [
+    "D003398",
+    "Craniosynostoses"
+  ],
+  "Protein S Deficiency": [
+    "D018455",
+    "Protein S Deficiency"
+  ],
+  "Hernia": [
+    "D006547",
+    "Hernia"
+  ],
+  "Epidermolysis Bullosa": [
+    "D004820",
+    "Epidermolysis Bullosa"
+  ],
+  "Graves Ophthalmopathy": [
+    "D049970",
+    "Graves Ophthalmopathy"
+  ],
+  "Conjunctivitis, Inclusion": [
+    "D003235",
+    "Conjunctivitis, Inclusion"
+  ],
+  "Anoxia": [
+    "D000860",
+    "Hypoxia"
+  ],
+  "Adenoma, Liver Cell": [
+    "D018248",
+    "Adenoma, Liver Cell"
+  ],
+  "Thyrotoxicosis": [
+    "D013971",
+    "Thyrotoxicosis"
+  ],
+  "Neuroectodermal Tumors": [
+    "D017599",
+    "Neuroectodermal Tumors"
+  ],
+  "Heart Septal Defects, Ventricular": [
+    "D006345",
+    "Heart Septal Defects, Ventricular"
+  ],
+  "Double Outlet Right Ventricle": [
+    "D004310",
+    "Double Outlet Right Ventricle"
+  ],
+  "Saethre-Chotzen Syndrome": [
+    "D000168",
+    "Acrocephalosyndactylia"
+  ],
+  "Barth Syndrome": [
+    "D056889",
+    "Barth Syndrome"
+  ],
+  "Pneumonia, Ventilator-Associated": [
+    "D053717",
+    "Pneumonia, Ventilator-Associated"
+  ],
+  "Feminization": [
+    "D005262",
+    "Feminization"
+  ],
+  "Lipoma": [
+    "D008067",
+    "Lipoma"
+  ],
+  "Becker Muscular Dystrophy": [
+    "D020388",
+    "Muscular Dystrophy, Duchenne"
+  ],
+  "Endocrine System Diseases": [
+    "D004700",
+    "Endocrine System Diseases"
+  ],
+  "Biliary Tract Cancer": [
+    "D001661",
+    "Biliary Tract Neoplasms"
+  ],
+  "Machado-Joseph Disease": [
+    "D017827",
+    "Machado-Joseph Disease"
+  ],
+  "Colitis, Ischemic": [
+    "D017091",
+    "Colitis, Ischemic"
+  ],
+  "Intestinal Polyposis": [
+    "D044483",
+    "Intestinal Polyposis"
+  ],
+  "Pilocytic Astrocytoma": [
+    "D001254",
+    "Astrocytoma"
+  ],
+  "Spinal Dysraphism": [
+    "D016135",
+    "Spinal Dysraphism"
+  ],
+  "Pulmonary Stenosis": [
+    "D011666",
+    "Pulmonary Valve Stenosis"
+  ],
+  "Fetal Death": [
+    "D005313",
+    "Fetal Death"
+  ],
+  "Idiopathic Interstitial Pneumonias": [
+    "D054988",
+    "Idiopathic Interstitial Pneumonias"
+  ],
+  "Meningococcal Infections": [
+    "D008589",
+    "Meningococcal Infections"
+  ],
+  "Inflammatory Pseudotumor": [
+    "D006104",
+    "Granuloma, Plasma Cell"
+  ],
+  "Subarachnoid Hemorrhage": [
+    "D013345",
+    "Subarachnoid Hemorrhage"
+  ],
+  "Leukemia, Megakaryoblastic, Acute": [
+    "D007947",
+    "Leukemia, Megakaryoblastic, Acute"
+  ],
+  "Dandy-Walker Syndrome": [
+    "D003616",
+    "Dandy-Walker Syndrome"
+  ],
+  "Oral Submucous Fibrosis": [
+    "D009914",
+    "Oral Submucous Fibrosis"
+  ],
+  "Osteoporosis, Postmenopausal": [
+    "D015663",
+    "Osteoporosis, Postmenopausal"
+  ],
+  "Prion Diseases": [
+    "D017096",
+    "Prion Diseases"
+  ],
+  "Polyuria": [
+    "D011141",
+    "Polyuria"
+  ],
+  "Azoospermia": [
+    "D053713",
+    "Azoospermia"
+  ],
+  "Angioedemas, Hereditary": [
+    "D054179",
+    "Angioedemas, Hereditary"
+  ],
+  "Adenoma, Oxyphilic": [
+    "D018249",
+    "Adenoma, Oxyphilic"
+  ],
+  "Adrenal Insufficiency": [
+    "D000309",
+    "Adrenal Insufficiency"
+  ],
+  "Melioidosis": [
+    "D008554",
+    "Melioidosis"
+  ],
+  "Scoliosis": [
+    "D012600",
+    "Scoliosis"
+  ],
+  "Eosinophilic Esophagitis": [
+    "D057765",
+    "Eosinophilic Esophagitis"
+  ],
+  "Male Breast Cancer": [
+    "D018567",
+    "Breast Neoplasms, Male"
+  ],
+  "Vascular Neoplasms": [
+    "D019043",
+    "Vascular Neoplasms"
+  ],
+  "Antisocial Personality Disorder": [
+    "D000987",
+    "Antisocial Personality Disorder"
+  ],
+  "Pyruvate Dehydrogenase Complex Deficiency Disease": [
+    "D015325",
+    "Pyruvate Dehydrogenase Complex Deficiency Disease"
+  ],
+  "Spherocytosis, Hereditary": [
+    "D013103",
+    "Spherocytosis, Hereditary"
+  ],
+  "Hypophosphatasia": [
+    "D007014",
+    "Hypophosphatasia"
+  ],
+  "Cholesteatoma": [
+    "D002781",
+    "Cholesteatoma"
+  ],
+  "Calciphylaxis": [
+    "D002115",
+    "Calciphylaxis"
+  ],
+  "Tooth, Supernumerary": [
+    "D014096",
+    "Tooth, Supernumerary"
+  ],
+  "Dental Enamel Hypoplasia": [
+    "D003744",
+    "Dental Enamel Hypoplasia"
+  ],
+  "Kallmann Syndrome": [
+    "D017436",
+    "Kallmann Syndrome"
+  ],
+  "Root Resorption": [
+    "D012391",
+    "Root Resorption"
+  ],
+  "Candidiasis, Chronic Mucocutaneous": [
+    "D002178",
+    "Candidiasis, Chronic Mucocutaneous"
+  ],
+  "Constipation": [
+    "D003248",
+    "Constipation"
+  ],
+  "Limb Deformities, Congenital": [
+    "D017880",
+    "Limb Deformities, Congenital"
+  ],
+  "Mandibulofacial Dysostosis": [
+    "D008342",
+    "Mandibulofacial Dysostosis"
+  ],
+  "Necrosis, Avascular, of Bone": [
+    "D010020",
+    "Osteonecrosis"
+  ],
+  "Epidermolysis Bullosa Simplex": [
+    "D016110",
+    "Epidermolysis Bullosa Simplex"
+  ],
+  "Ventricular Dysfunction": [
+    "D018754",
+    "Ventricular Dysfunction"
+  ],
+  "Head and Neck Neoplasms": [
+    "D006258",
+    "Head and Neck Neoplasms"
+  ],
+  "Demyelinating Diseases": [
+    "D003711",
+    "Demyelinating Diseases"
+  ],
+  "Prolapse": [
+    "D011391",
+    "Prolapse"
+  ],
+  "Rothmund-Thomson Syndrome": [
+    "D011038",
+    "Rothmund-Thomson Syndrome"
+  ],
+  "Retinal Drusen": [
+    "D015593",
+    "Retinal Drusen"
+  ],
+  "Osteoarthropathy, Primary Hypertrophic": [
+    "D010004",
+    "Osteoarthropathy, Primary Hypertrophic"
+  ],
+  "Bronchopulmonary Dysplasia": [
+    "D001997",
+    "Bronchopulmonary Dysplasia"
+  ],
+  "Heroin Dependence": [
+    "D006556",
+    "Heroin Dependence"
+  ],
+  "Candidemia": [
+    "D058387",
+    "Candidemia"
+  ],
+  "Spinal Cord Transection": [
+    "D013119",
+    "Spinal Cord Injuries"
+  ],
+  "Hypertension, Pregnancy-Induced": [
+    "D046110",
+    "Hypertension, Pregnancy-Induced"
+  ],
+  "Myositis": [
+    "D009220",
+    "Myositis"
+  ],
+  "Left Ventricle Remodeling": [
+    "D020257",
+    "Ventricular Remodeling"
+  ],
+  "Neoplasms, Intraepithelial": [
+    "D002278",
+    "Carcinoma in Situ"
+  ],
+  "Hidradenitis": [
+    "D016575",
+    "Hidradenitis"
+  ],
+  "Heart Arrest": [
+    "D006323",
+    "Heart Arrest"
+  ],
+  "Chromosome Fragility": [
+    "D002873",
+    "Chromosome Fragility"
+  ],
+  "Hypersplenism": [
+    "D006971",
+    "Hypersplenism"
+  ],
+  "Hemopericardium": [
+    "D010490",
+    "Pericardial Effusion"
+  ],
+  "Angiomyolipoma": [
+    "D018207",
+    "Angiomyolipoma"
+  ],
+  "Hyperoxaluria, Primary": [
+    "D006960",
+    "Hyperoxaluria, Primary"
+  ],
+  "Alstrom Syndrome": [
+    "D056769",
+    "Alstrom Syndrome"
+  ],
+  "Hallucinations": [
+    "D006212",
+    "Hallucinations"
+  ],
+  "Kidney Diseases, Cystic": [
+    "D052177",
+    "Kidney Diseases, Cystic"
+  ],
+  "Polysyndactyly": [
+    "D013576",
+    "Syndactyly"
+  ],
+  "Keratoconjunctivitis, Vernal": [
+    "D003233",
+    "Conjunctivitis, Allergic"
+  ],
+  "Aganglionosis, Colonic": [
+    "D006627",
+    "Hirschsprung Disease"
+  ],
+  "Fabry Disease": [
+    "D000795",
+    "Fabry Disease"
+  ],
+  "Uniparental Disomy": [
+    "D024182",
+    "Uniparental Disomy"
+  ],
+  "Progeria": [
+    "D011371",
+    "Progeria"
+  ],
+  "Hand, Foot and Mouth Disease": [
+    "D006232",
+    "Hand, Foot and Mouth Disease"
+  ],
+  "Diabetes Insipidus, Neurogenic": [
+    "D020790",
+    "Diabetes Insipidus, Neurogenic"
+  ],
+  "Hypodontia": [
+    "D000848",
+    "Anodontia"
+  ],
+  "Hypertrophy, Right Ventricular": [
+    "D017380",
+    "Hypertrophy, Right Ventricular"
+  ],
+  "Cholestasis, Intrahepatic": [
+    "D002780",
+    "Cholestasis, Intrahepatic"
+  ],
+  "Linitis Plastica": [
+    "D008039",
+    "Linitis Plastica"
+  ],
+  "Rotavirus Infections": [
+    "D012400",
+    "Rotavirus Infections"
+  ],
+  "Death, Sudden, Cardiac": [
+    "D016757",
+    "Death, Sudden, Cardiac"
+  ],
+  "Wheezing": [
+    "D012135",
+    "Respiratory Sounds"
+  ],
+  "Visual Impairment": [
+    "D014786",
+    "Vision Disorders"
+  ],
+  "Thrombophilia": [
+    "D019851",
+    "Thrombophilia"
+  ],
+  "Cystinosis": [
+    "D003554",
+    "Cystinosis"
+  ],
+  "Maternal Death": [
+    "D063130",
+    "Maternal Death"
+  ],
+  "Toxoplasmosis, Congenital": [
+    "D014125",
+    "Toxoplasmosis, Congenital"
+  ],
+  "Diabetic Angiopathies": [
+    "D003925",
+    "Diabetic Angiopathies"
+  ],
+  "Cancer of Oropharnyx": [
+    "D009959",
+    "Oropharyngeal Neoplasms"
+  ],
+  "Dyskinesias, Paroxysmal": [
+    "D002819",
+    "Chorea"
+  ],
+  "Chronic Daily Headache": [
+    "D020773",
+    "Headache Disorders"
+  ],
+  "Dyskinesias": [
+    "D020820",
+    "Dyskinesias"
+  ],
+  "Respiratory Failure": [
+    "D012131",
+    "Respiratory Insufficiency"
+  ],
+  "Chordoma": [
+    "D002817",
+    "Chordoma"
+  ],
+  "Granulosa Cell Cancer": [
+    "D006106",
+    "Granulosa Cell Tumor"
+  ],
+  "Brain Concussion": [
+    "D001924",
+    "Brain Concussion"
+  ],
+  "Multiple Endocrine Neoplasia Type 2a": [
+    "D018813",
+    "Multiple Endocrine Neoplasia Type 2a"
+  ],
+  "Bradycardia": [
+    "D001919",
+    "Bradycardia"
+  ],
+  "Neoplastic Syndromes, Hereditary": [
+    "D009386",
+    "Neoplastic Syndromes, Hereditary"
+  ],
+  "Familial Retinoblastoma": [
+    "D012175",
+    "Retinoblastoma"
+  ],
+  "Metabolism, Inborn Errors": [
+    "D008661",
+    "Metabolism, Inborn Errors"
+  ],
+  "Trauma, Nervous System": [
+    "D020196",
+    "Trauma, Nervous System"
+  ],
+  "Homocystinuria": [
+    "D006712",
+    "Homocystinuria"
+  ],
+  "Retinitis": [
+    "D012173",
+    "Retinitis"
+  ],
+  "Folic Acid Deficiency": [
+    "D005494",
+    "Folic Acid Deficiency"
+  ],
+  "Osteosclerosis": [
+    "D010026",
+    "Osteosclerosis"
+  ],
+  "Hemorrhagic Fever, Ebola": [
+    "D019142",
+    "Hemorrhagic Fever, Ebola"
+  ],
+  "Pulmonary Alveolar Proteinosis": [
+    "D011649",
+    "Pulmonary Alveolar Proteinosis"
+  ],
+  "Pemphigoid, Bullous": [
+    "D010391",
+    "Pemphigoid, Bullous"
+  ],
+  "Guillain-Barre Syndrome": [
+    "D020275",
+    "Guillain-Barre Syndrome"
+  ],
+  "Neoplasms, Intracranial": [
+    "D001932",
+    "Brain Neoplasms"
+  ],
+  "Bone Neoplasms": [
+    "D001859",
+    "Bone Neoplasms"
+  ],
+  "Lithiasis": [
+    "D020347",
+    "Lithiasis"
+  ],
+  "Eating Disorders": [
+    "D001068",
+    "Feeding and Eating Disorders"
+  ],
+  "Gait Ataxia": [
+    "D020234",
+    "Gait Ataxia"
+  ],
+  "Polyarthritis": [
+    "D001168",
+    "Arthritis"
+  ],
+  "Respiratory Tract Infections": [
+    "D012141",
+    "Respiratory Tract Infections"
+  ],
+  "Hepatorenal Syndrome": [
+    "D006530",
+    "Hepatorenal Syndrome"
+  ],
+  "Hemangioendothelioma, Epithelioid": [
+    "D018323",
+    "Hemangioendothelioma, Epithelioid"
+  ],
+  "Hypersensitivity, Delayed": [
+    "D006968",
+    "Hypersensitivity, Delayed"
+  ],
+  "IgA Deficiency": [
+    "D017098",
+    "IgA Deficiency"
+  ],
+  "Lung Diseases, Interstitial": [
+    "D017563",
+    "Lung Diseases, Interstitial"
+  ],
+  "Pneumonia, Pneumococcal": [
+    "D011018",
+    "Pneumonia, Pneumococcal"
+  ],
+  "Exostoses, Multiple Hereditary": [
+    "D005097",
+    "Exostoses, Multiple Hereditary"
+  ],
+  "Exostoses": [
+    "D005096",
+    "Exostoses"
+  ],
+  "Bronchiolitis Obliterans": [
+    "D001989",
+    "Bronchiolitis Obliterans"
+  ],
+  "Epilepsy, Post-Traumatic": [
+    "D004834",
+    "Epilepsy, Post-Traumatic"
+  ],
+  "Carcinoma, Verrucous": [
+    "D018289",
+    "Carcinoma, Verrucous"
+  ],
+  "Familial Partial Lipodystrophy, Type 2": [
+    "D052496",
+    "Lipodystrophy, Familial Partial"
+  ],
+  "Anemia, Hemolytic, Autoimmune": [
+    "D000744",
+    "Anemia, Hemolytic, Autoimmune"
+  ],
+  "Vulvovaginitis": [
+    "D014848",
+    "Vulvovaginitis"
+  ],
+  "Growth Disorders": [
+    "D006130",
+    "Growth Disorders"
+  ],
+  "Schistosomiasis haematobia": [
+    "D012553",
+    "Schistosomiasis haematobia"
+  ],
+  "Pseudomyxoma Peritonei": [
+    "D011553",
+    "Pseudomyxoma Peritonei"
+  ],
+  "Sotos Syndrome": [
+    "D058495",
+    "Sotos Syndrome"
+  ],
+  "Wolf-Hirschhorn Syndrome": [
+    "D054877",
+    "Wolf-Hirschhorn Syndrome"
+  ],
+  "Gaucher Disease, Type 1": [
+    "D005776",
+    "Gaucher Disease"
+  ],
+  "Hyperthyroxinemia": [
+    "D006981",
+    "Hyperthyroxinemia"
+  ],
+  "Hyperthyroxinemia, Familial Dysalbuminemic": [
+    "D050010",
+    "Hyperthyroxinemia, Familial Dysalbuminemic"
+  ],
+  "Biliary Tract Neoplasms": [
+    "D001661",
+    "Biliary Tract Neoplasms"
+  ],
+  "Functional Gastrointestinal Disorders": [
+    "D005767",
+    "Gastrointestinal Diseases"
+  ],
+  "Tendinitis": [
+    "D052256",
+    "Tendinopathy"
+  ],
+  "Motor Neuron Disease, Lower": [
+    "D016472",
+    "Motor Neuron Disease"
+  ],
+  "Spinal Diseases": [
+    "D013122",
+    "Spinal Diseases"
+  ],
+  "Pneumonia, Interstitial": [
+    "D017563",
+    "Lung Diseases, Interstitial"
+  ],
+  "Moyamoya Disease": [
+    "D009072",
+    "Moyamoya Disease"
+  ],
+  "Telangiectasis": [
+    "D013684",
+    "Telangiectasis"
+  ],
+  "Tetralogy of Fallot": [
+    "D013771",
+    "Tetralogy of Fallot"
+  ],
+  "Cleft Lip": [
+    "D002971",
+    "Cleft Lip"
+  ],
+  "Morphine Dependence": [
+    "D009021",
+    "Morphine Dependence"
+  ],
+  "Cockayne Syndrome": [
+    "D003057",
+    "Cockayne Syndrome"
+  ],
+  "Carotid Stenosis": [
+    "D016893",
+    "Carotid Stenosis"
+  ],
+  "Lower Urinary Tract Symptoms": [
+    "D059411",
+    "Lower Urinary Tract Symptoms"
+  ],
+  "Tremor": [
+    "D014202",
+    "Tremor"
+  ],
+  "Leukemia-Lymphoma, Adult T-Cell": [
+    "D015459",
+    "Leukemia-Lymphoma, Adult T-Cell"
+  ],
+  "Thrombocytosis": [
+    "D013922",
+    "Thrombocytosis"
+  ],
+  "Borrelia Infections": [
+    "D001899",
+    "Borrelia Infections"
+  ],
+  "Muscle Cramp": [
+    "D009120",
+    "Muscle Cramp"
+  ],
+  "Gonadal Dysgenesis": [
+    "D006059",
+    "Gonadal Dysgenesis"
+  ],
+  "Congenital Disorders of Glycosylation": [
+    "D018981",
+    "Congenital Disorders of Glycosylation"
+  ],
+  "Sleep Apnea, Newborn, Primary": [
+    "D020182",
+    "Sleep Apnea, Central"
+  ],
+  "Epilepsies, Partial": [
+    "D004828",
+    "Epilepsies, Partial"
+  ],
+  "Activated Protein C Resistance": [
+    "D020016",
+    "Activated Protein C Resistance"
+  ],
+  "Meningitis, Bacterial": [
+    "D016920",
+    "Meningitis, Bacterial"
+  ],
+  "Toxoplasmosis": [
+    "D014123",
+    "Toxoplasmosis"
+  ],
+  "Friedreich Ataxia": [
+    "D005621",
+    "Friedreich Ataxia"
+  ],
+  "Affective Symptoms": [
+    "D000342",
+    "Affective Symptoms"
+  ],
+  "Endometrioma": [
+    "D004715",
+    "Endometriosis"
+  ],
+  "Adrenal Cancer": [
+    "D000310",
+    "Adrenal Gland Neoplasms"
+  ],
+  "Organophosphate Poisoning": [
+    "D062025",
+    "Organophosphate Poisoning"
+  ],
+  "Optic Atrophy": [
+    "D009896",
+    "Optic Atrophy"
+  ],
+  "Cervical Dystonia": [
+    "D014103",
+    "Torticollis"
+  ],
+  "Macular Edema": [
+    "D008269",
+    "Macular Edema"
+  ],
+  "Catalepsy": [
+    "D002375",
+    "Catalepsy"
+  ],
+  "Photophobia": [
+    "D020795",
+    "Photophobia"
+  ],
+  "Anxiety Disorders": [
+    "D001008",
+    "Anxiety Disorders"
+  ],
+  "Maxillary Sinusitis": [
+    "D015523",
+    "Maxillary Sinusitis"
+  ],
+  "Blepharophimosis": [
+    "D016569",
+    "Blepharophimosis"
+  ],
+  "Thoracic Diseases": [
+    "D013896",
+    "Thoracic Diseases"
+  ],
+  "Brain Hemorrhage": [
+    "D020300",
+    "Intracranial Hemorrhages"
+  ],
+  "Familial Hemophagocytic Lymphocytosis": [
+    "D051359",
+    "Lymphohistiocytosis, Hemophagocytic"
+  ],
+  "Overnutrition": [
+    "D044343",
+    "Overnutrition"
+  ],
+  "Angelman Syndrome": [
+    "D017204",
+    "Angelman Syndrome"
+  ],
+  "Aniridia": [
+    "D015783",
+    "Aniridia"
+  ],
+  "Leishmaniasis, Mucocutaneous": [
+    "D007897",
+    "Leishmaniasis, Mucocutaneous"
+  ],
+  "Rasmussen Syndrome": [
+    "D004660",
+    "Encephalitis"
+  ],
+  "Sertoli-Leydig Cell Tumor": [
+    "D018310",
+    "Sertoli-Leydig Cell Tumor"
+  ],
+  "Amenorrhea": [
+    "D000568",
+    "Amenorrhea"
+  ],
+  "Adrenal Hyperplasia, Congenital": [
+    "D000312",
+    "Adrenal Hyperplasia, Congenital"
+  ],
+  "Bare Lymphocyte Syndrome": [
+    "D016511",
+    "Severe Combined Immunodeficiency"
+  ],
+  "Underweight": [
+    "D013851",
+    "Thinness"
+  ],
+  "Opsoclonus-Myoclonus Syndrome": [
+    "D053578",
+    "Opsoclonus-Myoclonus Syndrome"
+  ],
+  "Werner Syndrome": [
+    "D014898",
+    "Werner Syndrome"
+  ],
+  "Encephalomyelitis, Autoimmune, Experimental": [
+    "D004681",
+    "Encephalomyelitis, Autoimmune, Experimental"
+  ],
+  "Hematoma, Subdural, Chronic": [
+    "D020200",
+    "Hematoma, Subdural, Chronic"
+  ],
+  "Osteitis Deformans": [
+    "D010001",
+    "Osteitis Deformans"
+  ],
+  "Cytomegalovirus Retinitis": [
+    "D017726",
+    "Cytomegalovirus Retinitis"
+  ],
+  "Postural Orthostatic Tachycardia Syndrome": [
+    "D054972",
+    "Postural Orthostatic Tachycardia Syndrome"
+  ],
+  "Paraparesis, Tropical Spastic": [
+    "D015493",
+    "Paraparesis, Tropical Spastic"
+  ],
+  "Hydrarthrosis": [
+    "D006833",
+    "Hydrarthrosis"
+  ],
+  "Atheroma": [
+    "D058226",
+    "Plaque, Atherosclerotic"
+  ],
+  "Pancreatitis, Alcoholic": [
+    "D019512",
+    "Pancreatitis, Alcoholic"
+  ],
+  "Carcinoma, Medullary": [
+    "D018276",
+    "Carcinoma, Medullary"
+  ],
+  "Retrograde Degeneration": [
+    "D012183",
+    "Retrograde Degeneration"
+  ],
+  "Oligodendroglioma": [
+    "D009837",
+    "Oligodendroglioma"
+  ],
+  "Autosomal Dominant Emery-Dreifuss Muscular Dystrophy": [
+    "D020389",
+    "Muscular Dystrophy, Emery-Dreifuss"
+  ],
+  "Mastitis": [
+    "D008413",
+    "Mastitis"
+  ],
+  "Arteriovenous Fistula": [
+    "D001164",
+    "Arteriovenous Fistula"
+  ],
+  "Uremia": [
+    "D014511",
+    "Uremia"
+  ],
+  "Pustulosis of Palms and Soles": [
+    "D011565",
+    "Psoriasis"
+  ],
+  "Cerebral Edema": [
+    "D001929",
+    "Brain Edema"
+  ],
+  "Prostatic Diseases": [
+    "D011469",
+    "Prostatic Diseases"
+  ],
+  "Cushing Syndrome": [
+    "D003480",
+    "Cushing Syndrome"
+  ],
+  "Albinism": [
+    "D000417",
+    "Albinism"
+  ],
+  "Fucosidosis": [
+    "D005645",
+    "Fucosidosis"
+  ],
+  "Leukopenia": [
+    "D007970",
+    "Leukopenia"
+  ],
+  "Vaginosis, Bacterial": [
+    "D016585",
+    "Vaginosis, Bacterial"
+  ],
+  "Hot Flashes": [
+    "D019584",
+    "Hot Flashes"
+  ],
+  "Denys-Drash Syndrome": [
+    "D030321",
+    "Denys-Drash Syndrome"
+  ],
+  "Myotonic Dystrophy": [
+    "D009223",
+    "Myotonic Dystrophy"
+  ],
+  "Blood Loss, Surgical": [
+    "D016063",
+    "Blood Loss, Surgical"
+  ],
+  "WAGR Syndrome": [
+    "D017624",
+    "WAGR Syndrome"
+  ],
+  "Schistosomiasis japonica": [
+    "D012554",
+    "Schistosomiasis japonica"
+  ],
+  "Renal Insufficiency, Chronic": [
+    "D051436",
+    "Renal Insufficiency, Chronic"
+  ],
+  "Prehypertension": [
+    "D058246",
+    "Prehypertension"
+  ],
+  "Coronary Stenosis": [
+    "D023921",
+    "Coronary Stenosis"
+  ],
+  "Carcinoma, Undifferentiated": [
+    "D002277",
+    "Carcinoma"
+  ],
+  "Dry Eye Syndromes": [
+    "D015352",
+    "Dry Eye Syndromes"
+  ],
+  "Stevens-Johnson Syndrome": [
+    "D013262",
+    "Stevens-Johnson Syndrome"
+  ],
+  "Leukocyte-Adhesion Deficiency Syndrome": [
+    "D018370",
+    "Leukocyte-Adhesion Deficiency Syndrome"
+  ],
+  "Persistent Fetal Circulation Syndrome": [
+    "D010547",
+    "Persistent Fetal Circulation Syndrome"
+  ],
+  "Pelvic Pain": [
+    "D017699",
+    "Pelvic Pain"
+  ],
+  "Dysmenorrhea": [
+    "D004412",
+    "Dysmenorrhea"
+  ],
+  "Cystitis, Interstitial": [
+    "D018856",
+    "Cystitis, Interstitial"
+  ],
+  "Dyssomnias": [
+    "D020920",
+    "Dyssomnias"
+  ],
+  "Spondylarthropathies": [
+    "D025242",
+    "Spondylarthropathies"
+  ],
+  "Nevus": [
+    "D009506",
+    "Nevus"
+  ],
+  "Amelogenesis Imperfecta": [
+    "D000567",
+    "Amelogenesis Imperfecta"
+  ],
+  "Adenomyosis": [
+    "D062788",
+    "Adenomyosis"
+  ],
+  "Heat Stroke": [
+    "D018883",
+    "Heat Stroke"
+  ],
+  "Paroxysmal Nocturnal Hemoglobinuria": [
+    "D006457",
+    "Hemoglobinuria, Paroxysmal"
+  ],
+  "Apraxia, Developmental Verbal": [
+    "D001072",
+    "Apraxias"
+  ],
+  "Arthritis, Reactive": [
+    "D016918",
+    "Arthritis, Reactive"
+  ],
+  "Mobius Syndrome": [
+    "D020331",
+    "Mobius Syndrome"
+  ],
+  "Fibroma": [
+    "D005350",
+    "Fibroma"
+  ],
+  "Bernard-Soulier Syndrome": [
+    "D001606",
+    "Bernard-Soulier Syndrome"
+  ],
+  "Neck Injuries": [
+    "D019838",
+    "Neck Injuries"
+  ],
+  "Renal Osteodystrophy": [
+    "D012080",
+    "Chronic Kidney Disease-Mineral and Bone Disorder"
+  ],
+  "Anovulation": [
+    "D000858",
+    "Anovulation"
+  ],
+  "Oculocerebrorenal Syndrome": [
+    "D009800",
+    "Oculocerebrorenal Syndrome"
+  ],
+  "Respiration Disorders": [
+    "D012120",
+    "Respiration Disorders"
+  ],
+  "Glaucoma, Angle-Closure": [
+    "D015812",
+    "Glaucoma, Angle-Closure"
+  ],
+  "Mental Retardation, X-Linked": [
+    "D038901",
+    "Mental Retardation, X-Linked"
+  ],
+  "Anhedonia": [
+    "D059445",
+    "Anhedonia"
+  ],
+  "Cerebral Aneurysm": [
+    "D002532",
+    "Intracranial Aneurysm"
+  ],
+  "Lipodystrophy": [
+    "D008060",
+    "Lipodystrophy"
+  ],
+  "Lymphoma, AIDS-Related": [
+    "D016483",
+    "Lymphoma, AIDS-Related"
+  ],
+  "Hyponatremia": [
+    "D007010",
+    "Hyponatremia"
+  ],
+  "Nesidioblastosis": [
+    "D046768",
+    "Nesidioblastosis"
+  ],
+  "Hepatic Encephalopathy": [
+    "D006501",
+    "Hepatic Encephalopathy"
+  ],
+  "Tay-Sachs Disease": [
+    "D013661",
+    "Tay-Sachs Disease"
+  ],
+  "Hemochromatosis": [
+    "D006432",
+    "Hemochromatosis"
+  ],
+  "Nutrition Disorders": [
+    "D009748",
+    "Nutrition Disorders"
+  ],
+  "Ileocolitis": [
+    "D003424",
+    "Crohn Disease"
+  ],
+  "Enterocolitis": [
+    "D004760",
+    "Enterocolitis"
+  ],
+  "Polycythemia": [
+    "D011086",
+    "Polycythemia"
+  ],
+  "Prostatitis": [
+    "D011472",
+    "Prostatitis"
+  ],
+  "Hand-Foot Syndrome": [
+    "D060831",
+    "Hand-Foot Syndrome"
+  ],
+  "Substance Dependence": [
+    "D019966",
+    "Substance-Related Disorders"
+  ],
+  "Type IV Mucolipidosis": [
+    "D009081",
+    "Mucolipidoses"
+  ],
+  "Myoclonic Epilepsy, Juvenile": [
+    "D020190",
+    "Myoclonic Epilepsy, Juvenile"
+  ],
+  "Shock, Toxic": [
+    "D012772",
+    "Shock, Septic"
+  ],
+  "Brain Death": [
+    "D001926",
+    "Brain Death"
+  ],
+  "Cleidocranial Dysplasia": [
+    "D002973",
+    "Cleidocranial Dysplasia"
+  ],
+  "Melanosis": [
+    "D008548",
+    "Melanosis"
+  ],
+  "Distal Spinal Muscular Atrophy": [
+    "D009134",
+    "Muscular Atrophy, Spinal"
+  ],
+  "Allodynia": [
+    "D006930",
+    "Hyperalgesia"
+  ],
+  "Adenoma, Pleomorphic": [
+    "D008949",
+    "Adenoma, Pleomorphic"
+  ],
+  "Carcinoma, Acinar Cell": [
+    "D018267",
+    "Carcinoma, Acinar Cell"
+  ],
+  "Thrombotic Microangiopathies": [
+    "D057049",
+    "Thrombotic Microangiopathies"
+  ],
+  "Marburg Virus Disease": [
+    "D008379",
+    "Marburg Virus Disease"
+  ],
+  "Ornithine Carbamoyltransferase Deficiency Disease": [
+    "D020163",
+    "Ornithine Carbamoyltransferase Deficiency Disease"
+  ],
+  "Tuberculosis, Multidrug-Resistant": [
+    "D018088",
+    "Tuberculosis, Multidrug-Resistant"
+  ],
+  "Albinism, Oculocutaneous": [
+    "D016115",
+    "Albinism, Oculocutaneous"
+  ],
+  "Carcinosarcoma": [
+    "D002296",
+    "Carcinosarcoma"
+  ],
+  "Polydactyly": [
+    "D017689",
+    "Polydactyly"
+  ],
+  "Headache": [
+    "D006261",
+    "Headache"
+  ],
+  "Histiocytosis, Langerhans-Cell": [
+    "D006646",
+    "Histiocytosis, Langerhans-Cell"
+  ],
+  "Anaplastic Astrocytoma": [
+    "D001254",
+    "Astrocytoma"
+  ],
+  "Congenital Nephrogenic Diabetes Insipidus": [
+    "D018500",
+    "Diabetes Insipidus, Nephrogenic"
+  ],
+  "Sarcoma, Synovial": [
+    "D013584",
+    "Sarcoma, Synovial"
+  ],
+  "Rous Sarcoma": [
+    "D001357",
+    "Sarcoma, Avian"
+  ],
+  "Hepatitis, Toxic": [
+    "D056486",
+    "Chemical and Drug Induced Liver Injury"
+  ],
+  "Dilatation, Pathologic": [
+    "D004108",
+    "Dilatation, Pathologic"
+  ],
+  "Bartter Syndrome": [
+    "D001477",
+    "Bartter Syndrome"
+  ],
+  "Tongue Neoplasms": [
+    "D014062",
+    "Tongue Neoplasms"
+  ],
+  "Dentin Dysplasia": [
+    "D003805",
+    "Dentin Dysplasia"
+  ],
+  "Cutis Laxa": [
+    "D003483",
+    "Cutis Laxa"
+  ],
+  "Hyperlipidemia, Familial Combined": [
+    "D006950",
+    "Hyperlipidemia, Familial Combined"
+  ],
+  "Pregnancy, Tubal": [
+    "D011274",
+    "Pregnancy, Tubal"
+  ],
+  "Malignant Hyperthermia": [
+    "D008305",
+    "Malignant Hyperthermia"
+  ],
+  "Malignant Meningeal Neoplasms": [
+    "D008577",
+    "Meningeal Neoplasms"
+  ],
+  "Corneal Neovascularization": [
+    "D016510",
+    "Corneal Neovascularization"
+  ],
+  "Dentinogenesis Imperfecta": [
+    "D003811",
+    "Dentinogenesis Imperfecta"
+  ],
+  "Lymphocytic Choriomeningitis": [
+    "D008216",
+    "Lymphocytic Choriomeningitis"
+  ],
+  "Melorheostosis": [
+    "D008557",
+    "Melorheostosis"
+  ],
+  "Sarcoma, Avian": [
+    "D001357",
+    "Sarcoma, Avian"
+  ],
+  "Pelger-Huet Anomaly": [
+    "D010381",
+    "Pelger-Huet Anomaly"
+  ],
+  "Gitelman Syndrome": [
+    "D053579",
+    "Gitelman Syndrome"
+  ],
+  "Intravenous Drug Abuse": [
+    "D015819",
+    "Substance Abuse, Intravenous"
+  ],
+  "Bone Diseases, Metabolic": [
+    "D001851",
+    "Bone Diseases, Metabolic"
+  ],
+  "Neurofibromatoses": [
+    "D017253",
+    "Neurofibromatoses"
+  ],
+  "Prurigo": [
+    "D011536",
+    "Prurigo"
+  ],
+  "Opportunistic Infections": [
+    "D009894",
+    "Opportunistic Infections"
+  ],
+  "Muckle-Wells Syndrome": [
+    "D056587",
+    "Cryopyrin-Associated Periodic Syndromes"
+  ],
+  "Charcot-Marie-Tooth Disease, Type Ia": [
+    "D002607",
+    "Charcot-Marie-Tooth Disease"
+  ],
+  "Sexual Infantilism": [
+    "D050035",
+    "Sexual Infantilism"
+  ],
+  "Genetic Diseases, X-Linked": [
+    "D040181",
+    "Genetic Diseases, X-Linked"
+  ],
+  "Acidosis, Lactic": [
+    "D000140",
+    "Acidosis, Lactic"
+  ],
+  "Asthma, Exercise-Induced": [
+    "D001250",
+    "Asthma, Exercise-Induced"
+  ],
+  "Gonorrhea": [
+    "D006069",
+    "Gonorrhea"
+  ],
+  "AIDS Dementia Complex": [
+    "D015526",
+    "AIDS Dementia Complex"
+  ],
+  "Sarcoma, Endometrial Stromal": [
+    "D018203",
+    "Sarcoma, Endometrial Stromal"
+  ],
+  "Chronic Infantile Neurological, Cutaneous, and Articular Syndrome": [
+    "D056587",
+    "Cryopyrin-Associated Periodic Syndromes"
+  ],
+  "Speech Disorders": [
+    "D013064",
+    "Speech Disorders"
+  ],
+  "Muscle Spasticity": [
+    "D009128",
+    "Muscle Spasticity"
+  ],
+  "Carcinoma, Islet Cell": [
+    "D018273",
+    "Carcinoma, Islet Cell"
+  ],
+  "Dermatomyositis, Childhood Type": [
+    "D003882",
+    "Dermatomyositis"
+  ],
+  "Galactosemias": [
+    "D005693",
+    "Galactosemias"
+  ],
+  "Myocardial Failure": [
+    "D006333",
+    "Heart Failure"
+  ],
+  "Flushing": [
+    "D005483",
+    "Flushing"
+  ],
+  "Synostosis": [
+    "D013580",
+    "Synostosis"
+  ],
+  "Exocrine Pancreatic Insufficiency": [
+    "D010188",
+    "Exocrine Pancreatic Insufficiency"
+  ],
+  "Neoplasms, Plasma Cell": [
+    "D054219",
+    "Neoplasms, Plasma Cell"
+  ],
+  "Dysautonomia, Familial": [
+    "D004402",
+    "Dysautonomia, Familial"
+  ],
+  "Lipid Metabolism Disorders": [
+    "D052439",
+    "Lipid Metabolism Disorders"
+  ],
+  "Drug Toxicity": [
+    "D064420",
+    "Drug-Related Side Effects and Adverse Reactions"
+  ],
+  "Peutz-Jeghers Syndrome": [
+    "D010580",
+    "Peutz-Jeghers Syndrome"
+  ],
+  "Lymphangioma, Cystic": [
+    "D018191",
+    "Lymphangioma, Cystic"
+  ],
+  "Cryptosporidiosis": [
+    "D003457",
+    "Cryptosporidiosis"
+  ],
+  "Carcinoma, Papillary": [
+    "D002291",
+    "Carcinoma, Papillary"
+  ],
+  "Chest Pain": [
+    "D002637",
+    "Chest Pain"
+  ],
+  "Fluoride Poisoning": [
+    "D005458",
+    "Fluoride Poisoning"
+  ],
+  "Mitochondrial Myopathies": [
+    "D017240",
+    "Mitochondrial Myopathies"
+  ],
+  "Leukoencephalopathies": [
+    "D056784",
+    "Leukoencephalopathies"
+  ],
+  "Pseudopelade": [
+    "D000505",
+    "Alopecia"
+  ],
+  "Hepatic Veno-Occlusive Disease": [
+    "D006504",
+    "Hepatic Veno-Occlusive Disease"
+  ],
+  "Muir-Torre Syndrome": [
+    "D055653",
+    "Muir-Torre Syndrome"
+  ],
+  "Equine Infectious Anemia": [
+    "D004859",
+    "Equine Infectious Anemia"
+  ],
+  "Cystadenoma, Mucinous": [
+    "D018291",
+    "Cystadenoma, Mucinous"
+  ],
+  "Anthracosis": [
+    "D055008",
+    "Anthracosis"
+  ],
+  "Pulmonary Atelectasis": [
+    "D001261",
+    "Pulmonary Atelectasis"
+  ],
+  "Craniocerebral Trauma": [
+    "D006259",
+    "Craniocerebral Trauma"
+  ],
+  "Lymphangiectasis": [
+    "D008200",
+    "Lymphangiectasis"
+  ],
+  "Glycogen Storage Disease Type IV": [
+    "D006011",
+    "Glycogen Storage Disease Type IV"
+  ],
+  "Leukoplakia, Oral": [
+    "D007972",
+    "Leukoplakia, Oral"
+  ],
+  "Williams Syndrome": [
+    "D018980",
+    "Williams Syndrome"
+  ],
+  "Splenic Neoplasms": [
+    "D013160",
+    "Splenic Neoplasms"
+  ],
+  "Poliomyelitis": [
+    "D011051",
+    "Poliomyelitis"
+  ],
+  "Salivary Gland Neoplasms": [
+    "D012468",
+    "Salivary Gland Neoplasms"
+  ],
+  "Cancer of Salivary Gland": [
+    "D012468",
+    "Salivary Gland Neoplasms"
+  ],
+  "Glucose Metabolism Disorders": [
+    "D044882",
+    "Glucose Metabolism Disorders"
+  ],
+  "Aura": [
+    "D004827",
+    "Epilepsy"
+  ],
+  "Pancreatic Cyst": [
+    "D010181",
+    "Pancreatic Cyst"
+  ],
+  "Alveolar Bone Loss": [
+    "D016301",
+    "Alveolar Bone Loss"
+  ],
+  "Scleroderma, Localized": [
+    "D012594",
+    "Scleroderma, Localized"
+  ],
+  "Vaginal Discharge": [
+    "D019522",
+    "Vaginal Discharge"
+  ],
+  "Fungemia": [
+    "D016469",
+    "Fungemia"
+  ],
+  "Sterility, Male": [
+    "D007248",
+    "Infertility, Male"
+  ],
+  "Musculoskeletal Diseases": [
+    "D009140",
+    "Musculoskeletal Diseases"
+  ],
+  "PTEN Hamartoma Tumor Syndrome": [
+    "D006223",
+    "Hamartoma Syndrome, Multiple"
+  ],
+  "Pain Disorder": [
+    "D013001",
+    "Somatoform Disorders"
+  ],
+  "Usher Syndrome, Type III": [
+    "D052245",
+    "Usher Syndromes"
+  ],
+  "Usher Syndromes": [
+    "D052245",
+    "Usher Syndromes"
+  ],
+  "Lyme Arthritis": [
+    "D008193",
+    "Lyme Disease"
+  ],
+  "Philadelphia Chromosome": [
+    "D010677",
+    "Philadelphia Chromosome"
+  ],
+  "Mouth Diseases": [
+    "D009059",
+    "Mouth Diseases"
+  ],
+  "Leigh Disease": [
+    "D007888",
+    "Leigh Disease"
+  ],
+  "Vestibulodynia": [
+    "D056650",
+    "Vulvodynia"
+  ],
+  "Insomnia, Fatal Familial": [
+    "D034062",
+    "Insomnia, Fatal Familial"
+  ],
+  "Neurologic Signs": [
+    "D009461",
+    "Neurologic Manifestations"
+  ],
+  "Epidermolysis Bullosa, Junctional": [
+    "D016109",
+    "Epidermolysis Bullosa, Junctional"
+  ],
+  "Pachyonychia Congenita": [
+    "D053549",
+    "Pachyonychia Congenita"
+  ],
+  "Nausea": [
+    "D009325",
+    "Nausea"
+  ],
+  "Deficiency, Vitamin": [
+    "D001361",
+    "Avitaminosis"
+  ],
+  "Leukemia, Prolymphocytic, T-Cell": [
+    "D015461",
+    "Leukemia, Prolymphocytic, T-Cell"
+  ],
+  "Angiolipoma": [
+    "D018206",
+    "Angiolipoma"
+  ],
+  "Carcinoma, Signet Ring Cell": [
+    "D018279",
+    "Carcinoma, Signet Ring Cell"
+  ],
+  "Cerebral Palsy": [
+    "D002547",
+    "Cerebral Palsy"
+  ],
+  "Pallister-Hall Syndrome": [
+    "D054975",
+    "Pallister-Hall Syndrome"
+  ],
+  "Scrapie": [
+    "D012608",
+    "Scrapie"
+  ],
+  "Coronavirus Infections": [
+    "D018352",
+    "Coronavirus Infections"
+  ],
+  "Multiple Endocrine Neoplasia": [
+    "D009377",
+    "Multiple Endocrine Neoplasia"
+  ],
+  "HELLP Syndrome": [
+    "D017359",
+    "HELLP Syndrome"
+  ],
+  "Hydronephrosis": [
+    "D006869",
+    "Hydronephrosis"
+  ],
+  "Glycogen Storage Disease Type IIb": [
+    "D052120",
+    "Glycogen Storage Disease Type IIb"
+  ],
+  "Glycogen Storage Disease Type II": [
+    "D006009",
+    "Glycogen Storage Disease Type II"
+  ],
+  "Idiopathic Hypereosinophilic Syndrome": [
+    "D017681",
+    "Hypereosinophilic Syndrome"
+  ],
+  "Cyanosis": [
+    "D003490",
+    "Cyanosis"
+  ],
+  "Neurobehavioral Manifestations": [
+    "D019954",
+    "Neurobehavioral Manifestations"
+  ],
+  "Tick Toxicoses": [
+    "D013986",
+    "Tick Toxicoses"
+  ],
+  "Oxidative Phosphorylation Deficiencies": [
+    "D028361",
+    "Mitochondrial Diseases"
+  ],
+  "Diabetic Neuropathies": [
+    "D003929",
+    "Diabetic Neuropathies"
+  ],
+  "Hookworm Infections": [
+    "D006725",
+    "Hookworm Infections"
+  ],
+  "Hypercalciuria": [
+    "D053565",
+    "Hypercalciuria"
+  ],
+  "Glycosuria": [
+    "D006029",
+    "Glycosuria"
+  ],
+  "Mastodynia": [
+    "D059373",
+    "Mastodynia"
+  ],
+  "Bronchiolitis": [
+    "D001988",
+    "Bronchiolitis"
+  ],
+  "Wasting Syndrome": [
+    "D019282",
+    "Wasting Syndrome"
+  ],
+  "Trigeminal Neuralgia": [
+    "D014277",
+    "Trigeminal Neuralgia"
+  ],
+  "Ossification of Posterior Longitudinal Ligament": [
+    "D017887",
+    "Ossification of Posterior Longitudinal Ligament"
+  ],
+  "Capillary Leak Syndrome": [
+    "D019559",
+    "Capillary Leak Syndrome"
+  ],
+  "Thyroid Hormone Resistance Syndrome": [
+    "D018382",
+    "Thyroid Hormone Resistance Syndrome"
+  ],
+  "Head Injuries, Closed": [
+    "D016489",
+    "Head Injuries, Closed"
+  ],
+  "Osteonecrosis": [
+    "D010020",
+    "Osteonecrosis"
+  ],
+  "CADASIL": [
+    "D046589",
+    "CADASIL"
+  ],
+  "Mycoplasma Infections": [
+    "D009175",
+    "Mycoplasma Infections"
+  ],
+  "Idiopathic Membranous Glomerulonephritis": [
+    "D015433",
+    "Glomerulonephritis, Membranous"
+  ],
+  "Calcinosis": [
+    "D002114",
+    "Calcinosis"
+  ],
+  "Tularemia": [
+    "D014406",
+    "Tularemia"
+  ],
+  "Renal Insufficiency": [
+    "D051437",
+    "Renal Insufficiency"
+  ],
+  "Esophagitis, Peptic": [
+    "D004942",
+    "Esophagitis, Peptic"
+  ],
+  "Adrenal Gland Neoplasms": [
+    "D000310",
+    "Adrenal Gland Neoplasms"
+  ],
+  "Rhabdomyolysis": [
+    "D012206",
+    "Rhabdomyolysis"
+  ],
+  "Coronaviridae Infections": [
+    "D003333",
+    "Coronaviridae Infections"
+  ],
+  "Protozoan Infections": [
+    "D011528",
+    "Protozoan Infections"
+  ],
+  "Cerebral Ischemia, Transient": [
+    "D002546",
+    "Ischemic Attack, Transient"
+  ],
+  "Varicose Veins": [
+    "D014648",
+    "Varicose Veins"
+  ],
+  "Raynaud Disease": [
+    "D011928",
+    "Raynaud Disease"
+  ],
+  "Favre-Racouchot Syndrome": [
+    "D005148",
+    "Facial Dermatoses"
+  ],
+  "Aortic Valve Stenosis": [
+    "D001024",
+    "Aortic Valve Stenosis"
+  ],
+  "Alpers Syndrome": [
+    "D002549",
+    "Diffuse Cerebral Sclerosis of Schilder"
+  ],
+  "Erythema": [
+    "D004890",
+    "Erythema"
+  ],
+  "Bone Cysts, Aneurysmal": [
+    "D017824",
+    "Bone Cysts, Aneurysmal"
+  ],
+  "Giant Cell Tumor of Bone": [
+    "D018212",
+    "Giant Cell Tumor of Bone"
+  ],
+  "Zenker Diverticulum": [
+    "D016672",
+    "Zenker Diverticulum"
+  ],
+  "Eczema": [
+    "D004485",
+    "Eczema"
+  ],
+  "Anemia, Hemolytic, Congenital": [
+    "D000745",
+    "Anemia, Hemolytic, Congenital"
+  ],
+  "Tendinosis": [
+    "D052256",
+    "Tendinopathy"
+  ],
+  "Neurofibroma, Plexiform": [
+    "D018318",
+    "Neurofibroma, Plexiform"
+  ],
+  "Thyroid Diseases": [
+    "D013959",
+    "Thyroid Diseases"
+  ],
+  "Respiratory Paralysis": [
+    "D012133",
+    "Respiratory Paralysis"
+  ],
+  "Sudden Infant Death": [
+    "D013398",
+    "Sudden Infant Death"
+  ],
+  "Exanthema": [
+    "D005076",
+    "Exanthema"
+  ],
+  "Anal Fistula": [
+    "D012003",
+    "Rectal Fistula"
+  ],
+  "Yersinia pseudotuberculosis Infections": [
+    "D015012",
+    "Yersinia pseudotuberculosis Infections"
+  ],
+  "Hydrocephalus": [
+    "D006849",
+    "Hydrocephalus"
+  ],
+  "Cystathionine beta-Synthase Deficiency Disease": [
+    "D006712",
+    "Homocystinuria"
+  ],
+  "Substance Use Disorders": [
+    "D019966",
+    "Substance-Related Disorders"
+  ],
+  "Carotid Artery Injuries": [
+    "D020212",
+    "Carotid Artery Injuries"
+  ],
+  "Sterility, Female": [
+    "D007247",
+    "Infertility, Female"
+  ],
+  "Esophageal Neoplasms": [
+    "D004938",
+    "Esophageal Neoplasms"
+  ],
+  "Emotional Stress": [
+    "D013315",
+    "Stress, Psychological"
+  ],
+  "Bone Cancer": [
+    "D001859",
+    "Bone Neoplasms"
+  ],
+  "Schizoaffective Disorder": [
+    "D011618",
+    "Psychotic Disorders"
+  ],
+  "Nephrocalcinosis": [
+    "D009397",
+    "Nephrocalcinosis"
+  ],
+  "Noma": [
+    "D009625",
+    "Noma"
+  ],
+  "Neuroacanthocytosis": [
+    "D054546",
+    "Neuroacanthocytosis"
+  ],
+  "Sandhoff Disease": [
+    "D012497",
+    "Sandhoff Disease"
+  ],
+  "Listeriosis": [
+    "D008088",
+    "Listeriosis"
+  ],
+  "Leukomalacia, Periventricular": [
+    "D007969",
+    "Leukomalacia, Periventricular"
+  ],
+  "Filariasis": [
+    "D005368",
+    "Filariasis"
+  ],
+  "Dermoid Cyst": [
+    "D003884",
+    "Dermoid Cyst"
+  ],
+  "Carotid Atherosclerosis": [
+    "D002340",
+    "Carotid Artery Diseases"
+  ],
+  "Carcinoma, Spindle-Cell": [
+    "D002277",
+    "Carcinoma"
+  ],
+  "Trypanosomiasis": [
+    "D014352",
+    "Trypanosomiasis"
+  ],
+  "Corneal Opacity": [
+    "D003318",
+    "Corneal Opacity"
+  ],
+  "Myxoma": [
+    "D009232",
+    "Myxoma"
+  ],
+  "Movement Disorders": [
+    "D009069",
+    "Movement Disorders"
+  ],
+  "Sarcoidosis, Pulmonary": [
+    "D017565",
+    "Sarcoidosis, Pulmonary"
+  ],
+  "Serum Sickness": [
+    "D012713",
+    "Serum Sickness"
+  ],
+  "Cestode Infections": [
+    "D002590",
+    "Cestode Infections"
+  ],
+  "Atrial Remodeling": [
+    "D064752",
+    "Atrial Remodeling"
+  ],
+  "Shock": [
+    "D012769",
+    "Shock"
+  ],
+  "Infectious Disease Transmission, Vertical": [
+    "D018445",
+    "Infectious Disease Transmission, Vertical"
+  ],
+  "Enchondroma": [
+    "D002812",
+    "Chondroma"
+  ],
+  "Hereditary Opalescent Dentin": [
+    "D003811",
+    "Dentinogenesis Imperfecta"
+  ],
+  "Ichthyosis": [
+    "D007057",
+    "Ichthyosis"
+  ],
+  "Restless Legs Syndrome": [
+    "D012148",
+    "Restless Legs Syndrome"
+  ],
+  "Dementia, Presenile": [
+    "D000544",
+    "Alzheimer Disease"
+  ],
+  "Spondyloepiphyseal Dysplasia": [
+    "D010009",
+    "Osteochondrodysplasias"
+  ],
+  "Tuberculosis, Pleural": [
+    "D014396",
+    "Tuberculosis, Pleural"
+  ],
+  "Severe Dengue": [
+    "D019595",
+    "Severe Dengue"
+  ],
+  "Chagas Cardiomyopathy": [
+    "D002598",
+    "Chagas Cardiomyopathy"
+  ],
+  "Protein-Energy Malnutrition": [
+    "D011502",
+    "Protein-Energy Malnutrition"
+  ],
+  "Communicating Hydrocephalus": [
+    "D006849",
+    "Hydrocephalus"
+  ],
+  "Tachypnea": [
+    "D059246",
+    "Tachypnea"
+  ],
+  "Cardiomyopathy, Familial Idiopathic": [
+    "D002311",
+    "Cardiomyopathy, Dilated"
+  ],
+  "Klippel-Feil Syndrome": [
+    "D007714",
+    "Klippel-Feil Syndrome"
+  ],
+  "Pemphigus, Benign Familial": [
+    "D016506",
+    "Pemphigus, Benign Familial"
+  ],
+  "Infarction, Lacunar": [
+    "D059409",
+    "Stroke, Lacunar"
+  ],
+  "Hyperlipoproteinemias": [
+    "D006951",
+    "Hyperlipoproteinemias"
+  ],
+  "Protoporphyria, Erythropoietic": [
+    "D046351",
+    "Protoporphyria, Erythropoietic"
+  ],
+  "Porphyrias": [
+    "D011164",
+    "Porphyrias"
+  ],
+  "Community-Acquired Infections": [
+    "D017714",
+    "Community-Acquired Infections"
+  ],
+  "Infections, Hospital": [
+    "D003428",
+    "Cross Infection"
+  ],
+  "Alport Syndrome": [
+    "D009394",
+    "Nephritis, Hereditary"
+  ],
+  "Nephrosis": [
+    "D009401",
+    "Nephrosis"
+  ],
+  "REM Sleep Behavior Disorder": [
+    "D020187",
+    "REM Sleep Behavior Disorder"
+  ],
+  "Adenocarcinoma in Situ": [
+    "D065311",
+    "Adenocarcinoma in Situ"
+  ],
+  "Smith-Lemli-Opitz Syndrome": [
+    "D019082",
+    "Smith-Lemli-Opitz Syndrome"
+  ],
+  "Hepatitis, Drug-Induced": [
+    "D056486",
+    "Chemical and Drug Induced Liver Injury"
+  ],
+  "Bannayan-Riley-Ruvalcaba Syndrome": [
+    "D006223",
+    "Hamartoma Syndrome, Multiple"
+  ],
+  "Glycogen Storage Disease Type I": [
+    "D005953",
+    "Glycogen Storage Disease Type I"
+  ],
+  "Clubfoot": [
+    "D003025",
+    "Clubfoot"
+  ],
+  "Foot Deformities": [
+    "D005530",
+    "Foot Deformities"
+  ],
+  "Endocarditis": [
+    "D004696",
+    "Endocarditis"
+  ],
+  "Fetal Diseases": [
+    "D005315",
+    "Fetal Diseases"
+  ],
+  "Raynaud Phenomenon": [
+    "D011928",
+    "Raynaud Disease"
+  ],
+  "Hypochlorhydria": [
+    "D000126",
+    "Achlorhydria"
+  ],
+  "Coronary Occlusion": [
+    "D054059",
+    "Coronary Occlusion"
+  ],
+  "Bronchial Neoplasms": [
+    "D001984",
+    "Bronchial Neoplasms"
+  ],
+  "Coronary Vasospasm": [
+    "D003329",
+    "Coronary Vasospasm"
+  ],
+  "Torsion Abnormality": [
+    "D014102",
+    "Torsion Abnormality"
+  ],
+  "Craniofacial Abnormalities": [
+    "D019465",
+    "Craniofacial Abnormalities"
+  ],
+  "Hereditary Sensory and Motor Neuropathy": [
+    "D015417",
+    "Hereditary Sensory and Motor Neuropathy"
+  ],
+  "Tangier Disease": [
+    "D013631",
+    "Tangier Disease"
+  ],
+  "Gastrointestinal Hemorrhage": [
+    "D006471",
+    "Gastrointestinal Hemorrhage"
+  ],
+  "Glucosephosphate Dehydrogenase Deficiency": [
+    "D005955",
+    "Glucosephosphate Dehydrogenase Deficiency"
+  ],
+  "Hemoglobinuria": [
+    "D006456",
+    "Hemoglobinuria"
+  ],
+  "Parkinsonism, Juvenile": [
+    "D020734",
+    "Parkinsonian Disorders"
+  ],
+  "Odontogenic Tumor, Squamous": [
+    "D051527",
+    "Odontogenic Tumor, Squamous"
+  ],
+  "Tooth Loss": [
+    "D016388",
+    "Tooth Loss"
+  ],
+  "Stroke, Acute": [
+    "D020521",
+    "Stroke"
+  ],
+  "Primary Ovarian Insufficiency": [
+    "D016649",
+    "Primary Ovarian Insufficiency"
+  ],
+  "New Variant Creutzfeldt-Jakob Disease": [
+    "D007562",
+    "Creutzfeldt-Jakob Syndrome"
+  ],
+  "Cardiomegaly": [
+    "D006332",
+    "Cardiomegaly"
+  ],
+  "Pemphigus Vulgaris": [
+    "D010392",
+    "Pemphigus"
+  ],
+  "Facial Nerve Diseases": [
+    "D005155",
+    "Facial Nerve Diseases"
+  ],
+  "Dental Plaque": [
+    "D003773",
+    "Dental Plaque"
+  ],
+  "Gangliosidosis, GM1": [
+    "D016537",
+    "Gangliosidosis, GM1"
+  ],
+  "Epidermolysis Bullosa Simplex Kobner": [
+    "D016110",
+    "Epidermolysis Bullosa Simplex"
+  ],
+  "Glossitis, Benign Migratory": [
+    "D005929",
+    "Glossitis, Benign Migratory"
+  ],
+  "Shigellosis": [
+    "D004405",
+    "Dysentery, Bacillary"
+  ],
+  "Carcinoma, Lobular": [
+    "D018275",
+    "Carcinoma, Lobular"
+  ],
+  "Lafora Disease": [
+    "D020192",
+    "Lafora Disease"
+  ],
+  "Nijmegen Breakage Syndrome": [
+    "D049932",
+    "Nijmegen Breakage Syndrome"
+  ],
+  "Paramyotonia Congenita": [
+    "D020967",
+    "Myotonic Disorders"
+  ],
+  "Otosclerosis": [
+    "D010040",
+    "Otosclerosis"
+  ],
+  "Rectal Prolapse": [
+    "D012005",
+    "Rectal Prolapse"
+  ],
+  "Protein C Deficiency": [
+    "D020151",
+    "Protein C Deficiency"
+  ],
+  "Epilepsies, Myoclonic": [
+    "D004831",
+    "Epilepsies, Myoclonic"
+  ],
+  "Adrenocortical Cancer": [
+    "D000306",
+    "Adrenal Cortex Neoplasms"
+  ],
+  "Mevalonate Kinase Deficiency": [
+    "D054078",
+    "Mevalonate Kinase Deficiency"
+  ],
+  "Cerebellar Ataxia": [
+    "D002524",
+    "Cerebellar Ataxia"
+  ],
+  "Neoplasms, Mesothelial": [
+    "D018301",
+    "Neoplasms, Mesothelial"
+  ],
+  "Bronchial Hyperreactivity": [
+    "D016535",
+    "Bronchial Hyperreactivity"
+  ],
+  "Mastocytoma": [
+    "D034801",
+    "Mastocytoma"
+  ],
+  "Muscle Rigidity": [
+    "D009127",
+    "Muscle Rigidity"
+  ],
+  "Sarcoma, Alveolar Soft Part": [
+    "D018234",
+    "Sarcoma, Alveolar Soft Part"
+  ],
+  "Medulloblastoma, Childhood": [
+    "D008527",
+    "Medulloblastoma"
+  ],
+  "Chromothripsis": [
+    "D000072837",
+    "Chromothripsis"
+  ],
+  "Histiocytic Sarcoma": [
+    "D054747",
+    "Histiocytic Sarcoma"
+  ],
+  "Glioma, Subependymal": [
+    "D018315",
+    "Glioma, Subependymal"
+  ],
+  "Rosacea": [
+    "D012393",
+    "Rosacea"
+  ],
+  "Neuralgia, Postherpetic": [
+    "D051474",
+    "Neuralgia, Postherpetic"
+  ],
+  "Spinocerebellar Degenerations": [
+    "D013132",
+    "Spinocerebellar Degenerations"
+  ],
+  "Invasive Pulmonary Aspergillosis": [
+    "D055744",
+    "Invasive Pulmonary Aspergillosis"
+  ],
+  "Phyllodes Tumor": [
+    "D003557",
+    "Phyllodes Tumor"
+  ],
+  "Rhabdomyoma": [
+    "D012207",
+    "Rhabdomyoma"
+  ],
+  "Angioedema": [
+    "D000799",
+    "Angioedema"
+  ],
+  "Cortical Dysplasia": [
+    "D054220",
+    "Malformations of Cortical Development"
+  ],
+  "Polyradiculoneuropathy, Chronic Inflammatory Demyelinating": [
+    "D020277",
+    "Polyradiculoneuropathy, Chronic Inflammatory Demyelinating"
+  ],
+  "Neuritis, Autoimmune, Experimental": [
+    "D009444",
+    "Neuritis, Autoimmune, Experimental"
+  ],
+  "Encephalomyelitis, Venezuelan Equine": [
+    "D004685",
+    "Encephalomyelitis, Venezuelan Equine"
+  ],
+  "Nephritis, Interstitial": [
+    "D009395",
+    "Nephritis, Interstitial"
+  ],
+  "Lichen Planus, Oral": [
+    "D017676",
+    "Lichen Planus, Oral"
+  ],
+  "Vitamin A Deficiency": [
+    "D014802",
+    "Vitamin A Deficiency"
+  ],
+  "Albinism, Ocular": [
+    "D016117",
+    "Albinism, Ocular"
+  ],
+  "Bone Malalignment": [
+    "D017760",
+    "Bone Malalignment"
+  ],
+  "Aphakia": [
+    "D001035",
+    "Aphakia"
+  ],
+  "Urethral Obstruction": [
+    "D014524",
+    "Urethral Obstruction"
+  ],
+  "Entamoebiasis": [
+    "D004749",
+    "Entamoebiasis"
+  ],
+  "Mycetoma": [
+    "D008271",
+    "Mycetoma"
+  ],
+  "Leukemia, Feline": [
+    "D016582",
+    "Leukemia, Feline"
+  ],
+  "Contusions": [
+    "D003288",
+    "Contusions"
+  ],
+  "Infective Endocarditis": [
+    "D004696",
+    "Endocarditis"
+  ],
+  "Uterine Diseases": [
+    "D014591",
+    "Uterine Diseases"
+  ],
+  "Hyperparathyroidism": [
+    "D006961",
+    "Hyperparathyroidism"
+  ],
+  "Hyperparathyroidism, Primary": [
+    "D049950",
+    "Hyperparathyroidism, Primary"
+  ],
+  "Lissencephaly": [
+    "D054082",
+    "Lissencephaly"
+  ],
+  "Upper Respiratory Tract Infections": [
+    "D012141",
+    "Respiratory Tract Infections"
+  ],
+  "Otitis": [
+    "D010031",
+    "Otitis"
+  ],
+  "Hyperbilirubinemia, Neonatal": [
+    "D051556",
+    "Hyperbilirubinemia, Neonatal"
+  ],
+  "Reading Disorder, Developmental": [
+    "D004410",
+    "Dyslexia"
+  ],
+  "Ceroid Lipofuscinosis, Neuronal, Parry Type": [
+    "D009472",
+    "Neuronal Ceroid-Lipofuscinoses"
+  ],
+  "Prostatic Hypertrophy, Benign": [
+    "D011470",
+    "Prostatic Hyperplasia"
+  ],
+  "Myelolipoma": [
+    "D018209",
+    "Myelolipoma"
+  ],
+  "Nail-Patella Syndrome": [
+    "D009261",
+    "Nail-Patella Syndrome"
+  ],
+  "Thromboembolism": [
+    "D013923",
+    "Thromboembolism"
+  ],
+  "Cardiomyopathy, Restrictive": [
+    "D002313",
+    "Cardiomyopathy, Restrictive"
+  ],
+  "Myopathies, Nemaline": [
+    "D017696",
+    "Myopathies, Nemaline"
+  ],
+  "Nephrolithiasis": [
+    "D053040",
+    "Nephrolithiasis"
+  ],
+  "Cecal Diseases": [
+    "D002429",
+    "Cecal Diseases"
+  ],
+  "Withdrawal Symptoms": [
+    "D013375",
+    "Substance Withdrawal Syndrome"
+  ],
+  "HTLV-II Infections": [
+    "D015491",
+    "HTLV-II Infections"
+  ],
+  "Pulmonary Thromboembolisms": [
+    "D011655",
+    "Pulmonary Embolism"
+  ],
+  "Eye Injuries": [
+    "D005131",
+    "Eye Injuries"
+  ],
+  "Kyphosis": [
+    "D007738",
+    "Kyphosis"
+  ],
+  "Pinealoma": [
+    "D010871",
+    "Pinealoma"
+  ],
+  "Disorders of Sex Development": [
+    "D012734",
+    "Disorders of Sex Development"
+  ],
+  "Hantavirus Infections": [
+    "D018778",
+    "Hantavirus Infections"
+  ],
+  "Parathyroid Adenoma": [
+    "D010282",
+    "Parathyroid Neoplasms"
+  ],
+  "Aspergillosis": [
+    "D001228",
+    "Aspergillosis"
+  ],
+  "Endometrial Hyperplasia": [
+    "D004714",
+    "Endometrial Hyperplasia"
+  ],
+  "Eye Neoplasms": [
+    "D005134",
+    "Eye Neoplasms"
+  ],
+  "Adenocarcinoma, Sebaceous": [
+    "D018266",
+    "Adenocarcinoma, Sebaceous"
+  ],
+  "Giant Cell Tumors": [
+    "D005870",
+    "Giant Cell Tumors"
+  ],
+  "Alveolitis, Extrinsic Allergic": [
+    "D000542",
+    "Alveolitis, Extrinsic Allergic"
+  ],
+  "Retinal Detachment": [
+    "D012163",
+    "Retinal Detachment"
+  ],
+  "Residual Tumor": [
+    "D018365",
+    "Neoplasm, Residual"
+  ],
+  "Nerve Compression Syndromes": [
+    "D009408",
+    "Nerve Compression Syndromes"
+  ],
+  "alpha-Dystroglycanopathies": [
+    "D058494",
+    "Walker-Warburg Syndrome"
+  ],
+  "Periaortitis, Chronic": [
+    "D012185",
+    "Retroperitoneal Fibrosis"
+  ],
+  "Trypanosomiasis, African": [
+    "D014353",
+    "Trypanosomiasis, African"
+  ],
+  "Tibial Fractures": [
+    "D013978",
+    "Tibial Fractures"
+  ],
+  "Mastocytosis, Systemic": [
+    "D034721",
+    "Mastocytosis, Systemic"
+  ],
+  "Marinesco-Sjogren Syndrome": [
+    "D013132",
+    "Spinocerebellar Degenerations"
+  ],
+  "Heart Rupture": [
+    "D006341",
+    "Heart Rupture"
+  ],
+  "Hypergammaglobulinemia": [
+    "D006942",
+    "Hypergammaglobulinemia"
+  ],
+  "Meningitis, Meningococcal": [
+    "D008585",
+    "Meningitis, Meningococcal"
+  ],
+  "Creutzfeldt-Jakob Disease, Familial": [
+    "D007562",
+    "Creutzfeldt-Jakob Syndrome"
+  ],
+  "Carcinoma of Endocrine Gland": [
+    "D004701",
+    "Endocrine Gland Neoplasms"
+  ],
+  "Intestinal Perforation": [
+    "D007416",
+    "Intestinal Perforation"
+  ],
+  "Oliguria": [
+    "D009846",
+    "Oliguria"
+  ],
+  "Myelitis": [
+    "D009187",
+    "Myelitis"
+  ],
+  "Convulsive Seizures": [
+    "D012640",
+    "Seizures"
+  ],
+  "Submandibular Gland Neoplasms": [
+    "D013365",
+    "Submandibular Gland Neoplasms"
+  ],
+  "Spinocerebellar Ataxia Type 7": [
+    "D020754",
+    "Spinocerebellar Ataxias"
+  ],
+  "Polycystic Kidney, Autosomal Recessive": [
+    "D017044",
+    "Polycystic Kidney, Autosomal Recessive"
+  ],
+  "Retinal Neoplasms": [
+    "D019572",
+    "Retinal Neoplasms"
+  ],
+  "Grand Mal Status Epilepticus": [
+    "D013226",
+    "Status Epilepticus"
+  ],
+  "Vision Disorders": [
+    "D014786",
+    "Vision Disorders"
+  ],
+  "Aneurysm, Ruptured": [
+    "D017542",
+    "Aneurysm, Ruptured"
+  ],
+  "Lactose Intolerance": [
+    "D007787",
+    "Lactose Intolerance"
+  ],
+  "Leukemia, Lymphocytic, Acute, L2": [
+    "D054198",
+    "Precursor Cell Lymphoblastic Leukemia-Lymphoma"
+  ],
+  "Hemorrhagic Fevers, Viral": [
+    "D006482",
+    "Hemorrhagic Fevers, Viral"
+  ],
+  "Angiomatosis": [
+    "D000798",
+    "Angiomatosis"
+  ],
+  "Placental Insufficiency": [
+    "D010927",
+    "Placental Insufficiency"
+  ],
+  "Chromophobe Renal Cell Carcinoma": [
+    "D002292",
+    "Carcinoma, Renal Cell"
+  ],
+  "Adenoviridae Infections": [
+    "D000257",
+    "Adenoviridae Infections"
+  ],
+  "Omphalocele": [
+    "D006554",
+    "Hernia, Umbilical"
+  ],
+  "Fetal Macrosomia": [
+    "D005320",
+    "Fetal Macrosomia"
+  ],
+  "Hepatitis D": [
+    "D003699",
+    "Hepatitis D"
+  ],
+  "Red-Cell Aplasia, Pure": [
+    "D012010",
+    "Red-Cell Aplasia, Pure"
+  ],
+  "Pneumoconiosis": [
+    "D011009",
+    "Pneumoconiosis"
+  ],
+  "Disease Transmission, Infectious": [
+    "D018562",
+    "Disease Transmission, Infectious"
+  ],
+  "Choroideremia": [
+    "D015794",
+    "Choroideremia"
+  ],
+  "Dermatofibrosarcoma": [
+    "D018223",
+    "Dermatofibrosarcoma"
+  ],
+  "Multiple Sulfatase Deficiency Disease": [
+    "D052517",
+    "Multiple Sulfatase Deficiency Disease"
+  ],
+  "Situs Inversus": [
+    "D012857",
+    "Situs Inversus"
+  ],
+  "Neurosyphilis": [
+    "D009494",
+    "Neurosyphilis"
+  ],
+  "Myasthenic Syndromes, Congenital": [
+    "D020294",
+    "Myasthenic Syndromes, Congenital"
+  ],
+  "Choristoma": [
+    "D002828",
+    "Choristoma"
+  ],
+  "Optic Neuritis": [
+    "D009902",
+    "Optic Neuritis"
+  ],
+  "Enteritis": [
+    "D004751",
+    "Enteritis"
+  ],
+  "Muscular Disorders, Atrophic": [
+    "D020966",
+    "Muscular Disorders, Atrophic"
+  ],
+  "Hypertension, Renal": [
+    "D006977",
+    "Hypertension, Renal"
+  ],
+  "Strabismus": [
+    "D013285",
+    "Strabismus"
+  ],
+  "Jaundice, Neonatal": [
+    "D007567",
+    "Jaundice, Neonatal"
+  ],
+  "Muscular Atrophy, Spinal, Type II": [
+    "D014897",
+    "Spinal Muscular Atrophies of Childhood"
+  ],
+  "Anuria": [
+    "D001002",
+    "Anuria"
+  ],
+  "Hepatoma, Morris": [
+    "D008114",
+    "Liver Neoplasms, Experimental"
+  ],
+  "Ganglioglioma": [
+    "D018303",
+    "Ganglioglioma"
+  ],
+  "Shock, Cardiogenic": [
+    "D012770",
+    "Shock, Cardiogenic"
+  ],
+  "Hyper-IgM Immunodeficiency Syndrome": [
+    "D053306",
+    "Hyper-IgM Immunodeficiency Syndrome"
+  ],
+  "Boutonneuse Fever": [
+    "D001907",
+    "Boutonneuse Fever"
+  ],
+  "Refsum Disease, Infantile": [
+    "D052919",
+    "Refsum Disease, Infantile"
+  ],
+  "Anemia, Refractory, with Excess of Blasts": [
+    "D000754",
+    "Anemia, Refractory, with Excess of Blasts"
+  ],
+  "Ellis-Van Creveld Syndrome": [
+    "D004613",
+    "Ellis-Van Creveld Syndrome"
+  ],
+  "Peripheral Nervous System Neoplasms": [
+    "D010524",
+    "Peripheral Nervous System Neoplasms"
+  ],
+  "Enterovirus Infections": [
+    "D004769",
+    "Enterovirus Infections"
+  ],
+  "Candidiasis, Invasive": [
+    "D058365",
+    "Candidiasis, Invasive"
+  ],
+  "Chromosome Deletion": [
+    "D002872",
+    "Chromosome Deletion"
+  ],
+  "Uveitis, Intermediate": [
+    "D015867",
+    "Uveitis, Intermediate"
+  ],
+  "Skin Wrinkling": [
+    "D015595",
+    "Skin Aging"
+  ],
+  "Netherton Syndrome": [
+    "D056770",
+    "Netherton Syndrome"
+  ],
+  "Odontogenic Tumors": [
+    "D009808",
+    "Odontogenic Tumors"
+  ],
+  "Dissociative Disorders": [
+    "D004213",
+    "Dissociative Disorders"
+  ],
+  "Extranodal NK-T-Cell Lymphoma, Nasal and Nasal-Type": [
+    "D054391",
+    "Lymphoma, Extranodal NK-T-Cell"
+  ],
+  "Migraine without Aura": [
+    "D020326",
+    "Migraine without Aura"
+  ],
+  "Macular Dystrophy, Corneal": [
+    "D003317",
+    "Corneal Dystrophies, Hereditary"
+  ],
+  "Keratosis, Seborrheic": [
+    "D017492",
+    "Keratosis, Seborrheic"
+  ],
+  "Bulimia": [
+    "D002032",
+    "Bulimia"
+  ],
+  "Aortic Valve Insufficiency": [
+    "D001022",
+    "Aortic Valve Insufficiency"
+  ],
+  "Heart Septal Defects, Atrial": [
+    "D006344",
+    "Heart Septal Defects, Atrial"
+  ],
+  "Digestive System Neoplasms": [
+    "D004067",
+    "Digestive System Neoplasms"
+  ],
+  "Tachycardia, Ectopic Atrial": [
+    "D013612",
+    "Tachycardia, Ectopic Atrial"
+  ],
+  "Urinary Calculi": [
+    "D014545",
+    "Urinary Calculi"
+  ],
+  "Wallerian Degeneration": [
+    "D014855",
+    "Wallerian Degeneration"
+  ],
+  "Rheumatic Fever": [
+    "D012213",
+    "Rheumatic Fever"
+  ],
+  "Vitamin E Deficiency": [
+    "D014811",
+    "Vitamin E Deficiency"
+  ],
+  "Asthenozoospermia": [
+    "D053627",
+    "Asthenozoospermia"
+  ],
+  "Dysplastic Nevi": [
+    "D004416",
+    "Dysplastic Nevus Syndrome"
+  ],
+  "Aspergillosis, Allergic Bronchopulmonary": [
+    "D001229",
+    "Aspergillosis, Allergic Bronchopulmonary"
+  ],
+  "Spina Bifida Cystica": [
+    "D016137",
+    "Spina Bifida Cystica"
+  ],
+  "Neoplasms, Embryonal": [
+    "D009373",
+    "Neoplasms, Germ Cell and Embryonal"
+  ],
+  "Dystonia, Primary": [
+    "D020821",
+    "Dystonic Disorders"
+  ],
+  "Liver Cirrhosis, Alcoholic": [
+    "D008104",
+    "Liver Cirrhosis, Alcoholic"
+  ],
+  "Hermaphroditism, True": [
+    "D050090",
+    "Ovotesticular Disorders of Sex Development"
+  ],
+  "Craniopharyngioma, Papillary": [
+    "D003397",
+    "Craniopharyngioma"
+  ],
+  "Craniopharyngioma, Adamantinous": [
+    "D003397",
+    "Craniopharyngioma"
+  ],
+  "Alport Syndrome, X-Linked": [
+    "D009394",
+    "Nephritis, Hereditary"
+  ],
+  "Femoral Fractures": [
+    "D005264",
+    "Femoral Fractures"
+  ],
+  "Nematode Infections": [
+    "D009349",
+    "Nematode Infections"
+  ],
+  "Behavior Disorders": [
+    "D001523",
+    "Mental Disorders"
+  ],
+  "Stereotyped Behavior": [
+    "D013239",
+    "Stereotyped Behavior"
+  ],
+  "Esophagitis": [
+    "D004941",
+    "Esophagitis"
+  ],
+  "Glomerular Necrosis": [
+    "D007673",
+    "Kidney Cortex Necrosis"
+  ],
+  "Laryngeal Neoplasms": [
+    "D007822",
+    "Laryngeal Neoplasms"
+  ],
+  "Diagnosis, Psychiatric": [
+    "D001523",
+    "Mental Disorders"
+  ],
+  "Episodic Cluster Headache": [
+    "D003027",
+    "Cluster Headache"
+  ],
+  "Barrett Epithelium": [
+    "D001471",
+    "Barrett Esophagus"
+  ],
+  "Myotonia": [
+    "D009222",
+    "Myotonia"
+  ],
+  "CHARGE Syndrome": [
+    "D058747",
+    "CHARGE Syndrome"
+  ],
+  "Muscular Dystrophies, Limb-Girdle": [
+    "D049288",
+    "Muscular Dystrophies, Limb-Girdle"
+  ],
+  "Sarcoglycanopathies": [
+    "D058088",
+    "Sarcoglycanopathies"
+  ],
+  "Anemia, Hypochromic": [
+    "D000747",
+    "Anemia, Hypochromic"
+  ],
+  "Asherman Syndrome": [
+    "D006175",
+    "Gynatresia"
+  ],
+  "Parathyroid Carcinoma": [
+    "D010282",
+    "Parathyroid Neoplasms"
+  ],
+  "Hypotrichosis": [
+    "D007039",
+    "Hypotrichosis"
+  ],
+  "Lymphoma, Extranodal NK-T-Cell": [
+    "D054391",
+    "Lymphoma, Extranodal NK-T-Cell"
+  ],
+  "Bronchitis": [
+    "D001991",
+    "Bronchitis"
+  ],
+  "Hydrophthalmos": [
+    "D006871",
+    "Hydrophthalmos"
+  ],
+  "Color Vision Defects": [
+    "D003117",
+    "Color Vision Defects"
+  ],
+  "Amnesia, Retrograde": [
+    "D000648",
+    "Amnesia, Retrograde"
+  ],
+  "Hyperglycinemia, Nonketotic": [
+    "D020158",
+    "Hyperglycinemia, Nonketotic"
+  ],
+  "Propionic Acidemia": [
+    "D056693",
+    "Propionic Acidemia"
+  ],
+  "Fetal Resorption": [
+    "D005327",
+    "Fetal Resorption"
+  ],
+  "Leukoencephalopathy, Progressive Multifocal": [
+    "D007968",
+    "Leukoencephalopathy, Progressive Multifocal"
+  ],
+  "Keratoacanthoma": [
+    "D007636",
+    "Keratoacanthoma"
+  ],
+  "Microvascular Angina": [
+    "D017566",
+    "Microvascular Angina"
+  ],
+  "Dermatitis, Exfoliative": [
+    "D003873",
+    "Dermatitis, Exfoliative"
+  ],
+  "Embolism": [
+    "D004617",
+    "Embolism"
+  ],
+  "Truncus Arteriosus, Persistent": [
+    "D014339",
+    "Truncus Arteriosus, Persistent"
+  ],
+  "Empyema, Pleural": [
+    "D016724",
+    "Empyema, Pleural"
+  ],
+  "Empyema": [
+    "D004653",
+    "Empyema"
+  ],
+  "alpha-Thalassemia": [
+    "D017085",
+    "alpha-Thalassemia"
+  ],
+  "Carcinomatosis": [
+    "D002277",
+    "Carcinoma"
+  ],
+  "Amebiasis": [
+    "D000562",
+    "Amebiasis"
+  ],
+  "Dysentery, Amebic": [
+    "D004404",
+    "Dysentery, Amebic"
+  ],
+  "Diabetic Ketoacidosis": [
+    "D016883",
+    "Diabetic Ketoacidosis"
+  ],
+  "Anemia, Neonatal": [
+    "D000751",
+    "Anemia, Neonatal"
+  ],
+  "Hydatidiform Mole": [
+    "D006828",
+    "Hydatidiform Mole"
+  ],
+  "Hydatidiform Mole, Complete": [
+    "D006828",
+    "Hydatidiform Mole"
+  ],
+  "Paranasal Sinus Diseases": [
+    "D010254",
+    "Paranasal Sinus Diseases"
+  ],
+  "Schizophreniform Disorders": [
+    "D011618",
+    "Psychotic Disorders"
+  ],
+  "Pregnancy, High-Risk": [
+    "D018566",
+    "Pregnancy, High-Risk"
+  ],
+  "De Quervain Disease": [
+    "D053684",
+    "De Quervain Disease"
+  ],
+  "Liposarcoma, Pleomorphic": [
+    "D008080",
+    "Liposarcoma"
+  ],
+  "Plasma Cell Dyscrasias": [
+    "D010265",
+    "Paraproteinemias"
+  ],
+  "Eosinophilia, Tropical": [
+    "D004802",
+    "Eosinophilia"
+  ],
+  "Gyrate Atrophy": [
+    "D015799",
+    "Gyrate Atrophy"
+  ],
+  "Hyperostosis Corticalis Generalisata": [
+    "D010009",
+    "Osteochondrodysplasias"
+  ],
+  "Lead Poisoning": [
+    "D007855",
+    "Lead Poisoning"
+  ],
+  "Heart Septal Defects": [
+    "D006343",
+    "Heart Septal Defects"
+  ],
+  "Distal Myopathies": [
+    "D049310",
+    "Distal Myopathies"
+  ],
+  "Dental Pulp Calcification": [
+    "D003784",
+    "Dental Pulp Calcification"
+  ],
+  "Pruritus": [
+    "D011537",
+    "Pruritus"
+  ],
+  "Gonadal Dysgenesis, 46,XY": [
+    "D006061",
+    "Gonadal Dysgenesis, 46,XY"
+  ],
+  "Tooth Attrition": [
+    "D019217",
+    "Tooth Attrition"
+  ],
+  "Alexithymia": [
+    "D000342",
+    "Affective Symptoms"
+  ],
+  "Keratitis": [
+    "D007634",
+    "Keratitis"
+  ],
+  "Compensatory Hyperinsulinemia": [
+    "D006946",
+    "Hyperinsulinism"
+  ],
+  "Communication Disorders": [
+    "D003147",
+    "Communication Disorders"
+  ],
+  "Kernicterus": [
+    "D007647",
+    "Kernicterus"
+  ],
+  "Nervousness": [
+    "D001007",
+    "Anxiety"
+  ],
+  "Uterine Cervical Dysplasia": [
+    "D002578",
+    "Uterine Cervical Dysplasia"
+  ],
+  "Pulmonary Veno-Occlusive Disease": [
+    "D011668",
+    "Pulmonary Veno-Occlusive Disease"
+  ],
+  "Mucopolysaccharidoses": [
+    "D009083",
+    "Mucopolysaccharidoses"
+  ],
+  "Neuritis": [
+    "D009443",
+    "Neuritis"
+  ],
+  "Spinal Cord Compression": [
+    "D013117",
+    "Spinal Cord Compression"
+  ],
+  "Hip Dislocation, Congenital": [
+    "D006618",
+    "Hip Dislocation, Congenital"
+  ],
+  "Tuberculosis, Cutaneous": [
+    "D014382",
+    "Tuberculosis, Cutaneous"
+  ],
+  "Tuberculid": [
+    "D014382",
+    "Tuberculosis, Cutaneous"
+  ],
+  "Bronchial Spasm": [
+    "D001986",
+    "Bronchial Spasm"
+  ],
+  "Leprosy, Cutaneous": [
+    "D015440",
+    "Leprosy, Lepromatous"
+  ],
+  "Endometrial Stromal Tumors": [
+    "D036821",
+    "Endometrial Stromal Tumors"
+  ],
+  "Nephrosclerosis": [
+    "D009400",
+    "Nephrosclerosis"
+  ],
+  "Mucopolysaccharidosis VI": [
+    "D009087",
+    "Mucopolysaccharidosis VI"
+  ],
+  "Osteitis": [
+    "D010000",
+    "Osteitis"
+  ],
+  "Chandler Syndrome": [
+    "D057129",
+    "Iridocorneal Endothelial Syndrome"
+  ],
+  "Retinal Vein Occlusion": [
+    "D012170",
+    "Retinal Vein Occlusion"
+  ],
+  "Amyotrophic Lateral Sclerosis, Guam Form": [
+    "D000690",
+    "Amyotrophic Lateral Sclerosis"
+  ],
+  "Usher Syndrome, Type I": [
+    "D052245",
+    "Usher Syndromes"
+  ],
+  "Wolman Disease": [
+    "D015223",
+    "Wolman Disease"
+  ],
+  "Prelingual Deafness": [
+    "D003638",
+    "Deafness"
+  ],
+  "Necrotizing Arteritis": [
+    "D010488",
+    "Polyarteritis Nodosa"
+  ],
+  "Eclampsia": [
+    "D004461",
+    "Eclampsia"
+  ],
+  "Central Nervous System Lyme Disease": [
+    "D020852",
+    "Lyme Neuroborreliosis"
+  ],
+  "Dysgerminoma": [
+    "D004407",
+    "Dysgerminoma"
+  ],
+  "Endodermal Sinus Tumor": [
+    "D018240",
+    "Endodermal Sinus Tumor"
+  ],
+  "Spasm": [
+    "D013035",
+    "Spasm"
+  ],
+  "Personality Disorders": [
+    "D010554",
+    "Personality Disorders"
+  ],
+  "Abscess": [
+    "D000038",
+    "Abscess"
+  ],
+  "Neoplasms, Radiation-Induced": [
+    "D009381",
+    "Neoplasms, Radiation-Induced"
+  ],
+  "Sinus Thrombosis, Intracranial": [
+    "D012851",
+    "Sinus Thrombosis, Intracranial"
+  ],
+  "Diastema": [
+    "D003970",
+    "Diastema"
+  ],
+  "Apnea": [
+    "D001049",
+    "Apnea"
+  ],
+  "Basal Ganglia Diseases": [
+    "D001480",
+    "Basal Ganglia Diseases"
+  ],
+  "Behavioral Symptoms": [
+    "D001526",
+    "Behavioral Symptoms"
+  ],
+  "Meningeal Carcinomatosis": [
+    "D055756",
+    "Meningeal Carcinomatosis"
+  ],
+  "mammary analogue secretory carcinoma": [
+    "D000069295",
+    "Mammary Analogue Secretory Carcinoma"
+  ],
+  "Cholangitis": [
+    "D002761",
+    "Cholangitis"
+  ],
+  "Follicular Cyst": [
+    "D005497",
+    "Follicular Cyst"
+  ],
+  "Cerebral Small Vessel Diseases": [
+    "D059345",
+    "Cerebral Small Vessel Diseases"
+  ],
+  "Delusions": [
+    "D003702",
+    "Delusions"
+  ],
+  "Dysthymic Disorder": [
+    "D019263",
+    "Dysthymic Disorder"
+  ],
+  "Smallpox": [
+    "D012899",
+    "Smallpox"
+  ],
+  "Deficiency, Mental": [
+    "D008607",
+    "Intellectual Disability"
+  ],
+  "Mucolipidoses": [
+    "D009081",
+    "Mucolipidoses"
+  ],
+  "Anemia, Megaloblastic": [
+    "D000749",
+    "Anemia, Megaloblastic"
+  ],
+  "Congenital Fiber Type Disproportion": [
+    "D020914",
+    "Myopathies, Structural, Congenital"
+  ],
+  "Aggressive Systemic Mastocytosis": [
+    "D034721",
+    "Mastocytosis, Systemic"
+  ],
+  "ACTH-Secreting Pituitary Adenoma": [
+    "D049913",
+    "ACTH-Secreting Pituitary Adenoma"
+  ],
+  "Parainfluenza": [
+    "D018184",
+    "Paramyxoviridae Infections"
+  ],
+  "Carotid Artery Diseases": [
+    "D002340",
+    "Carotid Artery Diseases"
+  ],
+  "Heart Valve Diseases": [
+    "D006349",
+    "Heart Valve Diseases"
+  ],
+  "Carcinoma, Ehrlich Tumor": [
+    "D002286",
+    "Carcinoma, Ehrlich Tumor"
+  ],
+  "Chromosome Instability Syndromes": [
+    "D049914",
+    "DNA Repair-Deficiency Disorders"
+  ],
+  "Niemann-Pick Disease, Type A": [
+    "D052536",
+    "Niemann-Pick Disease, Type A"
+  ],
+  "Pseudarthrosis": [
+    "D011542",
+    "Pseudarthrosis"
+  ],
+  "Biliary Fistula": [
+    "D001658",
+    "Biliary Fistula"
+  ],
+  "Hereditary Cerebral Amyloid Angiopathy, Icelandic Type": [
+    "D028243",
+    "Cerebral Amyloid Angiopathy, Familial"
+  ],
+  "Hypersensitivity, Immediate": [
+    "D006969",
+    "Hypersensitivity, Immediate"
+  ],
+  "Heart Block": [
+    "D006327",
+    "Heart Block"
+  ],
+  "Dupuytren Contracture": [
+    "D004387",
+    "Dupuytren Contracture"
+  ],
+  "Cataract, Membranous": [
+    "D002386",
+    "Cataract"
+  ],
+  "Stomatitis": [
+    "D013280",
+    "Stomatitis"
+  ],
+  "Cystinuria": [
+    "D003555",
+    "Cystinuria"
+  ],
+  "Skin Diseases, Infectious": [
+    "D012874",
+    "Skin Diseases, Infectious"
+  ],
+  "Pleocytosis": [
+    "D007964",
+    "Leukocytosis"
+  ],
+  "Urogenital Neoplasms": [
+    "D014565",
+    "Urogenital Neoplasms"
+  ],
+  "Tinnitus": [
+    "D014012",
+    "Tinnitus"
+  ],
+  "Weill-Marchesani Syndrome": [
+    "D056846",
+    "Weill-Marchesani Syndrome"
+  ],
+  "Lymphocytosis": [
+    "D008218",
+    "Lymphocytosis"
+  ],
+  "Pneumonia, Aspiration": [
+    "D011015",
+    "Pneumonia, Aspiration"
+  ],
+  "Diabetic Cardiomyopathies": [
+    "D058065",
+    "Diabetic Cardiomyopathies"
+  ],
+  "Ataxias, Hereditary": [
+    "D013132",
+    "Spinocerebellar Degenerations"
+  ],
+  "Anhidrosis": [
+    "D007007",
+    "Hypohidrosis"
+  ],
+  "Eczema Herpeticum": [
+    "D007617",
+    "Kaposi Varicelliform Eruption"
+  ],
+  "Tooth Abnormalities": [
+    "D014071",
+    "Tooth Abnormalities"
+  ],
+  "Placenta Diseases": [
+    "D010922",
+    "Placenta Diseases"
+  ],
+  "Acrocallosal Syndrome": [
+    "D055673",
+    "Acrocallosal Syndrome"
+  ],
+  "Postoperative Hemorrhage": [
+    "D019106",
+    "Postoperative Hemorrhage"
+  ],
+  "Gait, Spastic": [
+    "D020233",
+    "Gait Disorders, Neurologic"
+  ],
+  "Amyloidosis, Familial": [
+    "D028226",
+    "Amyloidosis, Familial"
+  ],
+  "Takotsubo Cardiomyopathy": [
+    "D054549",
+    "Takotsubo Cardiomyopathy"
+  ],
+  "Duane Retraction Syndrome": [
+    "D004370",
+    "Duane Retraction Syndrome"
+  ],
+  "Dentatorubral-Pallidoluysian Atrophy": [
+    "D020191",
+    "Myoclonic Epilepsies, Progressive"
+  ],
+  "Hydrocephalus, Normal Pressure": [
+    "D006850",
+    "Hydrocephalus, Normal Pressure"
+  ],
+  "Olfaction Disorders": [
+    "D000857",
+    "Olfaction Disorders"
+  ],
+  "Benign Familial Neonatal Epilepsy": [
+    "D020936",
+    "Epilepsy, Benign Neonatal"
+  ],
+  "Mammary Neoplasms, Experimental": [
+    "D008325",
+    "Mammary Neoplasms, Experimental"
+  ],
+  "Alexander Disease": [
+    "D038261",
+    "Alexander Disease"
+  ],
+  "Thanatophoric Dysplasia": [
+    "D013796",
+    "Thanatophoric Dysplasia"
+  ],
+  "Perivascular Epithelioid Cell Neoplasms": [
+    "D054973",
+    "Perivascular Epithelioid Cell Neoplasms"
+  ],
+  "Failure to Thrive": [
+    "D005183",
+    "Failure to Thrive"
+  ],
+  "Camurati-Engelmann Syndrome": [
+    "D003966",
+    "Camurati-Engelmann Syndrome"
+  ],
+  "Cholesteatoma, Middle Ear": [
+    "D018424",
+    "Cholesteatoma, Middle Ear"
+  ],
+  "Wounds, Stab": [
+    "D014951",
+    "Wounds, Stab"
+  ],
+  "Abdominal Pain": [
+    "D015746",
+    "Abdominal Pain"
+  ],
+  "Chloracne": [
+    "D054506",
+    "Chloracne"
+  ],
+  "Tic Disorders": [
+    "D013981",
+    "Tic Disorders"
+  ],
+  "Orofaciodigital Syndromes": [
+    "D009958",
+    "Orofaciodigital Syndromes"
+  ],
+  "Hypoalphalipoproteinemia, Familial": [
+    "D052456",
+    "Hypoalphalipoproteinemias"
+  ],
+  "Clear Cell Meningioma": [
+    "D008579",
+    "Meningioma"
+  ],
+  "Brucellosis": [
+    "D002006",
+    "Brucellosis"
+  ],
+  "Hereditary Autosomal Dominant Spastic Paraplegia": [
+    "D015419",
+    "Spastic Paraplegia, Hereditary"
+  ],
+  "Beryllium Disease": [
+    "D001607",
+    "Berylliosis"
+  ],
+  "Berylliosis": [
+    "D001607",
+    "Berylliosis"
+  ],
+  "Farber Lipogranulomatosis": [
+    "D055577",
+    "Farber Lipogranulomatosis"
+  ],
+  "Intestinal Obstruction": [
+    "D007415",
+    "Intestinal Obstruction"
+  ],
+  "Leprosy, Multibacillary": [
+    "D056006",
+    "Leprosy, Multibacillary"
+  ],
+  "Underage Drinking": [
+    "D000066608",
+    "Underage Drinking"
+  ],
+  "Embryo Resorption": [
+    "D020964",
+    "Embryo Loss"
+  ],
+  "Animal Diseases": [
+    "D000820",
+    "Animal Diseases"
+  ],
+  "Magnesium Deficiency": [
+    "D008275",
+    "Magnesium Deficiency"
+  ],
+  "Focal Infection": [
+    "D005490",
+    "Focal Infection"
+  ],
+  "Oligomenorrhea": [
+    "D009839",
+    "Oligomenorrhea"
+  ],
+  "Pseudohypoaldosteronism, Type II": [
+    "D011546",
+    "Pseudohypoaldosteronism"
+  ],
+  "HMSN Type II": [
+    "D002607",
+    "Charcot-Marie-Tooth Disease"
+  ],
+  "Infectious Mononucleosis": [
+    "D007244",
+    "Infectious Mononucleosis"
+  ],
+  "Cryopyrin-Associated Periodic Syndromes": [
+    "D056587",
+    "Cryopyrin-Associated Periodic Syndromes"
+  ],
+  "Foramen Ovale, Patent": [
+    "D054092",
+    "Foramen Ovale, Patent"
+  ],
+  "Proteus Syndrome": [
+    "D016715",
+    "Proteus Syndrome"
+  ],
+  "Renal Tubular Acidosis, Type II": [
+    "D000141",
+    "Acidosis, Renal Tubular"
+  ],
+  "Myocardial Stunning": [
+    "D017682",
+    "Myocardial Stunning"
+  ],
+  "Neck Neoplasms": [
+    "D006258",
+    "Head and Neck Neoplasms"
+  ],
+  "Neuroma": [
+    "D009463",
+    "Neuroma"
+  ],
+  "Catatonia": [
+    "D002389",
+    "Catatonia"
+  ],
+  "Focal Nodular Hyperplasia": [
+    "D020518",
+    "Focal Nodular Hyperplasia"
+  ],
+  "Pulmonary Aspergillosis": [
+    "D055732",
+    "Pulmonary Aspergillosis"
+  ],
+  "Ventricular Fibrillation": [
+    "D014693",
+    "Ventricular Fibrillation"
+  ],
+  "Status Asthmaticus": [
+    "D013224",
+    "Status Asthmaticus"
+  ],
+  "Focal Dermal Hypoplasia": [
+    "D005489",
+    "Focal Dermal Hypoplasia"
+  ],
+  "Complex Regional Pain Syndromes": [
+    "D020918",
+    "Complex Regional Pain Syndromes"
+  ],
+  "Lymphatic Diseases": [
+    "D008206",
+    "Lymphatic Diseases"
+  ],
+  "Subacute Sclerosing Panencephalitis": [
+    "D013344",
+    "Subacute Sclerosing Panencephalitis"
+  ],
+  "Phototoxicity": [
+    "D017484",
+    "Dermatitis, Phototoxic"
+  ],
+  "Nasopharyngeal Neoplasms": [
+    "D009303",
+    "Nasopharyngeal Neoplasms"
+  ],
+  "Osteochondrodysplasias": [
+    "D010009",
+    "Osteochondrodysplasias"
+  ],
+  "Pick Disease of the Brain": [
+    "D020774",
+    "Pick Disease of the Brain"
+  ],
+  "Microlissencephaly": [
+    "D008831",
+    "Microcephaly"
+  ],
+  "Retinal Artery Occlusion": [
+    "D015356",
+    "Retinal Artery Occlusion"
+  ],
+  "Telangiectasia, Hereditary Hemorrhagic": [
+    "D013683",
+    "Telangiectasia, Hereditary Hemorrhagic"
+  ],
+  "Thyroid Dysgenesis": [
+    "D050033",
+    "Thyroid Dysgenesis"
+  ],
+  "Lipodystrophy, Congenital Generalized": [
+    "D052497",
+    "Lipodystrophy, Congenital Generalized"
+  ],
+  "Zellweger Syndrome": [
+    "D015211",
+    "Zellweger Syndrome"
+  ],
+  "Lymphatic Vessel Tumors": [
+    "D018190",
+    "Lymphatic Vessel Tumors"
+  ],
+  "Vaginitis": [
+    "D014627",
+    "Vaginitis"
+  ],
+  "Pressure Ulcer": [
+    "D003668",
+    "Pressure Ulcer"
+  ],
+  "Jaundice": [
+    "D007565",
+    "Jaundice"
+  ],
+  "Cryptorchidism": [
+    "D003456",
+    "Cryptorchidism"
+  ],
+  "Q Fever": [
+    "D011778",
+    "Q Fever"
+  ],
+  "Basal Cell Nevus Syndrome": [
+    "D001478",
+    "Basal Cell Nevus Syndrome"
+  ],
+  "Neoplasms, Squamous Cell": [
+    "D018307",
+    "Neoplasms, Squamous Cell"
+  ],
+  "Dysostoses": [
+    "D004413",
+    "Dysostoses"
+  ],
+  "Supranuclear Palsy, Progressive": [
+    "D013494",
+    "Supranuclear Palsy, Progressive"
+  ],
+  "Euthyroid Sick Syndromes": [
+    "D005067",
+    "Euthyroid Sick Syndromes"
+  ],
+  "Language Delay": [
+    "D007805",
+    "Language Development Disorders"
+  ],
+  "Lymphatic Abnormalities": [
+    "D044148",
+    "Lymphatic Abnormalities"
+  ],
+  "Leukemic Infiltration": [
+    "D017254",
+    "Leukemic Infiltration"
+  ],
+  "Pseudopregnancy": [
+    "D011555",
+    "Pseudopregnancy"
+  ],
+  "Oppositional Defiant Disorder": [
+    "D019958",
+    "Attention Deficit and Disruptive Behavior Disorders"
+  ],
+  "Diplopia": [
+    "D004172",
+    "Diplopia"
+  ],
+  "Cockayne Syndrome, Type I": [
+    "D003057",
+    "Cockayne Syndrome"
+  ],
+  "Cancer of Eye": [
+    "D005134",
+    "Eye Neoplasms"
+  ],
+  "Histiocytosis": [
+    "D015614",
+    "Histiocytosis"
+  ],
+  "Coronary Thrombosis": [
+    "D003328",
+    "Coronary Thrombosis"
+  ],
+  "Radiation-Induced Cancer": [
+    "D009381",
+    "Neoplasms, Radiation-Induced"
+  ],
+  "Livedo Reticularis": [
+    "D054068",
+    "Livedo Reticularis"
+  ],
+  "Polyarteritis Nodosa": [
+    "D010488",
+    "Polyarteritis Nodosa"
+  ],
+  "Botulism": [
+    "D001906",
+    "Botulism"
+  ],
+  "Hyperglycemia, Postprandial": [
+    "D006943",
+    "Hyperglycemia"
+  ],
+  "Abortion, Missed": [
+    "D000030",
+    "Abortion, Missed"
+  ],
+  "Paracoccidioidomycosis": [
+    "D010229",
+    "Paracoccidioidomycosis"
+  ],
+  "Brachydactyly": [
+    "D059327",
+    "Brachydactyly"
+  ],
+  "Mitral Valve Prolapse": [
+    "D008945",
+    "Mitral Valve Prolapse"
+  ],
+  "Pycnodysostosis": [
+    "D058631",
+    "Pycnodysostosis"
+  ],
+  "Hypoalbuminemia": [
+    "D034141",
+    "Hypoalbuminemia"
+  ],
+  "Mucopolysaccharidosis I": [
+    "D008059",
+    "Mucopolysaccharidosis I"
+  ],
+  "Dental Calculus": [
+    "D003728",
+    "Dental Calculus"
+  ],
+  "Familial Hemiplegic Migraine": [
+    "D020325",
+    "Migraine with Aura"
+  ],
+  "Malocclusion": [
+    "D008310",
+    "Malocclusion"
+  ],
+  "Solitary Fibrous Tumors": [
+    "D054364",
+    "Solitary Fibrous Tumors"
+  ],
+  "Keratitis, Herpetic": [
+    "D016849",
+    "Keratitis, Herpetic"
+  ],
+  "Gestational Trophoblastic Disease": [
+    "D031901",
+    "Gestational Trophoblastic Disease"
+  ],
+  "Persistent Hyperplastic Primary Vitreous": [
+    "D054514",
+    "Persistent Hyperplastic Primary Vitreous"
+  ],
+  "Cerebral Vasospasm": [
+    "D020301",
+    "Vasospasm, Intracranial"
+  ],
+  "Meleda Disease": [
+    "D007645",
+    "Keratoderma, Palmoplantar"
+  ],
+  "Crigler-Najjar Syndrome": [
+    "D003414",
+    "Crigler-Najjar Syndrome"
+  ],
+  "Congenital Disorders": [
+    "D009358",
+    "Congenital, Hereditary, and Neonatal Diseases and Abnormalities"
+  ],
+  "Ventricular Dysfunction, Right": [
+    "D018497",
+    "Ventricular Dysfunction, Right"
+  ],
+  "Cytochrome-c Oxidase Deficiency": [
+    "D030401",
+    "Cytochrome-c Oxidase Deficiency"
+  ],
+  "Pleurisy": [
+    "D010998",
+    "Pleurisy"
+  ],
+  "Hemeralopia": [
+    "D014786",
+    "Vision Disorders"
+  ],
+  "Neonatal Abstinence Syndrome": [
+    "D009357",
+    "Neonatal Abstinence Syndrome"
+  ],
+  "Pantothenate Kinase-Associated Neurodegeneration": [
+    "D006211",
+    "Pantothenate Kinase-Associated Neurodegeneration"
+  ],
+  "Dermatitis, Contact": [
+    "D003877",
+    "Dermatitis, Contact"
+  ],
+  "Pharyngitis": [
+    "D010612",
+    "Pharyngitis"
+  ],
+  "Adenitis": [
+    "D008199",
+    "Lymphadenitis"
+  ],
+  "Adenocarcinoma, Bronchiolo-Alveolar": [
+    "D002282",
+    "Adenocarcinoma, Bronchiolo-Alveolar"
+  ],
+  "Epilepsy, Absence": [
+    "D004832",
+    "Epilepsy, Absence"
+  ],
+  "Skin Abnormalities": [
+    "D012868",
+    "Skin Abnormalities"
+  ],
+  "Cerebellar Diseases": [
+    "D002526",
+    "Cerebellar Diseases"
+  ],
+  "Hemorrhagic Fever, Argentinian": [
+    "D006478",
+    "Hemorrhagic Fever, American"
+  ],
+  "Fibroatheroma": [
+    "D058226",
+    "Plaque, Atherosclerotic"
+  ],
+  "Encephalitis, Herpes Simplex": [
+    "D020803",
+    "Encephalitis, Herpes Simplex"
+  ],
+  "Peanut Hypersensitivity": [
+    "D021183",
+    "Peanut Hypersensitivity"
+  ],
+  "Food Hypersensitivity": [
+    "D005512",
+    "Food Hypersensitivity"
+  ],
+  "Diabetes Insipidus, Nephrogenic": [
+    "D018500",
+    "Diabetes Insipidus, Nephrogenic"
+  ],
+  "Oligodendroglioma, Childhood": [
+    "D009837",
+    "Oligodendroglioma"
+  ],
+  "Pleural Diseases": [
+    "D010995",
+    "Pleural Diseases"
+  ],
+  "Typhoid Fever": [
+    "D014435",
+    "Typhoid Fever"
+  ],
+  "Narcolepsy-Cataplexy Syndrome": [
+    "D009290",
+    "Narcolepsy"
+  ],
+  "Cheilitis": [
+    "D002613",
+    "Cheilitis"
+  ],
+  "Keratoderma, Palmoplantar": [
+    "D007645",
+    "Keratoderma, Palmoplantar"
+  ],
+  "Thyroid Adenoma": [
+    "D013964",
+    "Thyroid Neoplasms"
+  ],
+  "Anosmia": [
+    "D000857",
+    "Olfaction Disorders"
+  ],
+  "Lateral Sclerosis": [
+    "D016472",
+    "Motor Neuron Disease"
+  ],
+  "Pericarditis": [
+    "D010493",
+    "Pericarditis"
+  ],
+  "Hypopituitarism": [
+    "D007018",
+    "Hypopituitarism"
+  ],
+  "Pulmonary Adenomatosis, Ovine": [
+    "D011648",
+    "Pulmonary Adenomatosis, Ovine"
+  ],
+  "Encapsulating Peritoneal Sclerosis": [
+    "D056627",
+    "Peritoneal Fibrosis"
+  ],
+  "Preterm Premature Rupture of Fetal Membranes": [
+    "D005322",
+    "Fetal Membranes, Premature Rupture"
+  ],
+  "Epidermolysis Bullosa Dystrophica": [
+    "D016108",
+    "Epidermolysis Bullosa Dystrophica"
+  ],
+  "Hypopharyngeal Cancer": [
+    "D007012",
+    "Hypopharyngeal Neoplasms"
+  ],
+  "Hyperprolactinemia": [
+    "D006966",
+    "Hyperprolactinemia"
+  ],
+  "Involuntary Movements": [
+    "D020820",
+    "Dyskinesias"
+  ],
+  "Gerstmann-Straussler-Scheinker Disease": [
+    "D016098",
+    "Gerstmann-Straussler-Scheinker Disease"
+  ],
+  "Choanal Atresia": [
+    "D002754",
+    "Choanal Atresia"
+  ],
+  "Hyperphenylalaninemia, Non-Phenylketonuric": [
+    "D010661",
+    "Phenylketonurias"
+  ],
+  "Leukoplakia": [
+    "D007971",
+    "Leukoplakia"
+  ],
+  "Onchocerciasis": [
+    "D009855",
+    "Onchocerciasis"
+  ],
+  "Lipomatosis": [
+    "D008068",
+    "Lipomatosis"
+  ],
+  "Chromosome Inversion": [
+    "D007446",
+    "Chromosome Inversion"
+  ],
+  "Sleep Apnea, Central": [
+    "D020182",
+    "Sleep Apnea, Central"
+  ],
+  "Scleroderma, Limited": [
+    "D045745",
+    "Scleroderma, Limited"
+  ],
+  "Ketosis": [
+    "D007662",
+    "Ketosis"
+  ],
+  "Common Cold": [
+    "D003139",
+    "Common Cold"
+  ],
+  "Leydig Cell Tumor": [
+    "D007984",
+    "Leydig Cell Tumor"
+  ],
+  "Keratoderma, Palmoplantar, Epidermolytic": [
+    "D053546",
+    "Keratoderma, Palmoplantar, Epidermolytic"
+  ],
+  "Oligospermia": [
+    "D009845",
+    "Oligospermia"
+  ],
+  "Ehlers-Danlos Syndrome, Type IV": [
+    "D004535",
+    "Ehlers-Danlos Syndrome"
+  ],
+  "Pituitary Carcinoma": [
+    "D010911",
+    "Pituitary Neoplasms"
+  ],
+  "Cardiac Complexes, Premature": [
+    "D005117",
+    "Cardiac Complexes, Premature"
+  ],
+  "Acidosis, Renal Tubular": [
+    "D000141",
+    "Acidosis, Renal Tubular"
+  ],
+  "Retinal Hemorrhage": [
+    "D012166",
+    "Retinal Hemorrhage"
+  ],
+  "Gambling, Pathological": [
+    "D005715",
+    "Gambling"
+  ],
+  "Epidermodysplasia Verruciformis": [
+    "D004819",
+    "Epidermodysplasia Verruciformis"
+  ],
+  "Rhinitis, Allergic, Seasonal": [
+    "D006255",
+    "Rhinitis, Allergic, Seasonal"
+  ],
+  "Pelvic Organ Prolapse": [
+    "D056887",
+    "Pelvic Organ Prolapse"
+  ],
+  "Otitis Media with Effusion": [
+    "D010034",
+    "Otitis Media with Effusion"
+  ],
+  "Agranulocytosis": [
+    "D000380",
+    "Agranulocytosis"
+  ],
+  "Sepsis-Associated Encephalopathy": [
+    "D065166",
+    "Sepsis-Associated Encephalopathy"
+  ],
+  "Labyrinth Diseases": [
+    "D007759",
+    "Labyrinth Diseases"
+  ],
+  "Milk Hypersensitivity": [
+    "D016269",
+    "Milk Hypersensitivity"
+  ],
+  "Hearing Loss, High-Frequency": [
+    "D006316",
+    "Hearing Loss, High-Frequency"
+  ],
+  "Eye Infections": [
+    "D015817",
+    "Eye Infections"
+  ],
+  "Herpes Zoster": [
+    "D006562",
+    "Herpes Zoster"
+  ],
+  "Pulmonary Valve Insufficiency": [
+    "D011665",
+    "Pulmonary Valve Insufficiency"
+  ],
+  "Carcinoid Heart Disease": [
+    "D002275",
+    "Carcinoid Heart Disease"
+  ],
+  "Neoplasms, Connective Tissue": [
+    "D009372",
+    "Neoplasms, Connective Tissue"
+  ],
+  "Silver-Russell Syndrome": [
+    "D056730",
+    "Silver-Russell Syndrome"
+  ],
+  "Hajdu-Cheney Syndrome": [
+    "D031845",
+    "Hajdu-Cheney Syndrome"
+  ],
+  "Leukemia, Plasma Cell": [
+    "D007952",
+    "Leukemia, Plasma Cell"
+  ],
+  "Thoracic Neoplasms": [
+    "D013899",
+    "Thoracic Neoplasms"
+  ],
+  "Polyneuropathies": [
+    "D011115",
+    "Polyneuropathies"
+  ],
+  "Surgical Adhesions": [
+    "D000267",
+    "Tissue Adhesions"
+  ],
+  "Corneal Ulcer": [
+    "D003320",
+    "Corneal Ulcer"
+  ],
+  "Seizure, Febrile, Simple": [
+    "D003294",
+    "Seizures, Febrile"
+  ],
+  "Craniorachischisis": [
+    "D009436",
+    "Neural Tube Defects"
+  ],
+  "Tics": [
+    "D020323",
+    "Tics"
+  ],
+  "Usher Syndrome, Type II": [
+    "D052245",
+    "Usher Syndromes"
+  ],
+  "Arterial Occlusive Diseases": [
+    "D001157",
+    "Arterial Occlusive Diseases"
+  ],
+  "Dermatitis, Seborrheic": [
+    "D012628",
+    "Dermatitis, Seborrheic"
+  ],
+  "Brain Tumor, Recurrent": [
+    "D001932",
+    "Brain Neoplasms"
+  ],
+  "Medullary Sponge Kidney": [
+    "D007691",
+    "Medullary Sponge Kidney"
+  ],
+  "Ichthyosiform Erythroderma, Congenital": [
+    "D016113",
+    "Ichthyosiform Erythroderma, Congenital"
+  ],
+  "Labor Pain": [
+    "D048949",
+    "Labor Pain"
+  ],
+  "Leukoaraiosis": [
+    "D049292",
+    "Leukoaraiosis"
+  ],
+  "Cardiomyopathy, Hypertrophic": [
+    "D002312",
+    "Cardiomyopathy, Hypertrophic"
+  ],
+  "Uniparental Isodisomy": [
+    "D024182",
+    "Uniparental Disomy"
+  ],
+  "Bacterial Infections and Mycoses": [
+    "D001423",
+    "Bacterial Infections and Mycoses"
+  ],
+  "Pemphigus Foliaceus": [
+    "D010392",
+    "Pemphigus"
+  ],
+  "Late-Infantile Neuronal Ceroid Lipofuscinosis": [
+    "D009472",
+    "Neuronal Ceroid-Lipofuscinoses"
+  ],
+  "Testicular Diseases": [
+    "D013733",
+    "Testicular Diseases"
+  ],
+  "Amputation, Traumatic": [
+    "D000673",
+    "Amputation, Traumatic"
+  ],
+  "Ataxia, Sensory": [
+    "D001259",
+    "Ataxia"
+  ],
+  "Ophthalmoparesis": [
+    "D009886",
+    "Ophthalmoplegia"
+  ],
+  "Infantile Neuronal Ceroid Lipofuscinosis": [
+    "D009472",
+    "Neuronal Ceroid-Lipofuscinoses"
+  ],
+  "Tubular Aggregate Myopathy": [
+    "D020914",
+    "Myopathies, Structural, Congenital"
+  ],
+  "Mitochondrial Encephalomyopathies": [
+    "D017237",
+    "Mitochondrial Encephalomyopathies"
+  ],
+  "Thalassemia Major": [
+    "D017086",
+    "beta-Thalassemia"
+  ],
+  "Autosomal Recessive Emery-Dreifuss Muscular Dystrophy": [
+    "D020389",
+    "Muscular Dystrophy, Emery-Dreifuss"
+  ],
+  "Hyperostosis": [
+    "D015576",
+    "Hyperostosis"
+  ],
+  "Glycogen Storage Disease": [
+    "D006008",
+    "Glycogen Storage Disease"
+  ],
+  "Graft Occlusion, Vascular": [
+    "D006083",
+    "Graft Occlusion, Vascular"
+  ],
+  "Colonic Polyps": [
+    "D003111",
+    "Colonic Polyps"
+  ],
+  "Pfeiffer Syndrome": [
+    "D000168",
+    "Acrocephalosyndactylia"
+  ],
+  "Porphyria, Hepatoerythropoietic": [
+    "D017121",
+    "Porphyria, Hepatoerythropoietic"
+  ],
+  "Porphyria Cutanea Tarda": [
+    "D017119",
+    "Porphyria Cutanea Tarda"
+  ],
+  "Chondrodysplasia Punctata": [
+    "D002806",
+    "Chondrodysplasia Punctata"
+  ],
+  "Leukemia, Neutrophilic, Chronic": [
+    "D015467",
+    "Leukemia, Neutrophilic, Chronic"
+  ],
+  "Hypobetalipoproteinemia, Familial, Apolipoprotein B": [
+    "D052476",
+    "Hypobetalipoproteinemia, Familial, Apolipoprotein B"
+  ],
+  "Ichthyosis, X-Linked": [
+    "D016114",
+    "Ichthyosis, X-Linked"
+  ],
+  "Odontogenic Cysts": [
+    "D009807",
+    "Odontogenic Cysts"
+  ],
+  "Lipodystrophy, Familial Partial": [
+    "D052496",
+    "Lipodystrophy, Familial Partial"
+  ],
+  "Endemic Cretinism": [
+    "D003409",
+    "Congenital Hypothyroidism"
+  ],
+  "Hypoventilation": [
+    "D007040",
+    "Hypoventilation"
+  ],
+  "Parathyroid Neoplasms": [
+    "D010282",
+    "Parathyroid Neoplasms"
+  ],
+  "Myotonia Congenita": [
+    "D009224",
+    "Myotonia Congenita"
+  ],
+  "Disorientation": [
+    "D003221",
+    "Confusion"
+  ],
+  "Aphasia": [
+    "D001037",
+    "Aphasia"
+  ],
+  "Achromatopsia": [
+    "D003117",
+    "Color Vision Defects"
+  ],
+  "Presbycusis": [
+    "D011304",
+    "Presbycusis"
+  ],
+  "Gingival Hyperplasia": [
+    "D005885",
+    "Gingival Hyperplasia"
+  ],
+  "Paraparesis, Spastic": [
+    "D020336",
+    "Paraparesis, Spastic"
+  ],
+  "Wolfram Syndrome": [
+    "D014929",
+    "Wolfram Syndrome"
+  ],
+  "Epidermal Necrolysis, Toxic": [
+    "D013262",
+    "Stevens-Johnson Syndrome"
+  ],
+  "Dermatitis, Irritant": [
+    "D017453",
+    "Dermatitis, Irritant"
+  ],
+  "Dent Disease": [
+    "D057973",
+    "Dent Disease"
+  ],
+  "Short Rib-Polydactyly Syndrome": [
+    "D012779",
+    "Short Rib-Polydactyly Syndrome"
+  ],
+  "Epiretinal Membrane": [
+    "D019773",
+    "Epiretinal Membrane"
+  ],
+  "Classical Lissencephalies and Subcortical Band Heterotopias": [
+    "D054221",
+    "Classical Lissencephalies and Subcortical Band Heterotopias"
+  ],
+  "Subcortical Band Heterotopia": [
+    "D054221",
+    "Classical Lissencephalies and Subcortical Band Heterotopias"
+  ],
+  "Chondrosarcoma, Mesenchymal": [
+    "D018211",
+    "Chondrosarcoma, Mesenchymal"
+  ],
+  "Cancer of Vulva": [
+    "D014846",
+    "Vulvar Neoplasms"
+  ],
+  "Flaccid Muscle Tone": [
+    "D009123",
+    "Muscle Hypotonia"
+  ],
+  "Leukemia, Mast-Cell": [
+    "D007946",
+    "Leukemia, Mast-Cell"
+  ],
+  "Sphingolipidoses": [
+    "D013106",
+    "Sphingolipidoses"
+  ],
+  "Canavan Disease": [
+    "D017825",
+    "Canavan Disease"
+  ],
+  "Factor XIII Deficiency": [
+    "D005177",
+    "Factor XIII Deficiency"
+  ],
+  "Autosomal Recessive Hereditary Spastic Paraplegia": [
+    "D015419",
+    "Spastic Paraplegia, Hereditary"
+  ],
+  "Ependymoma": [
+    "D004806",
+    "Ependymoma"
+  ],
+  "Anal Cancer": [
+    "D001005",
+    "Anus Neoplasms"
+  ],
+  "Hypokalemic Periodic Paralysis": [
+    "D020514",
+    "Hypokalemic Periodic Paralysis"
+  ],
+  "Hidradenitis Suppurativa": [
+    "D017497",
+    "Hidradenitis Suppurativa"
+  ],
+  "Thrombocytopenia, Neonatal Alloimmune": [
+    "D054098",
+    "Thrombocytopenia, Neonatal Alloimmune"
+  ],
+  "Chondrodysplasia Punctata, Rhizomelic": [
+    "D018902",
+    "Chondrodysplasia Punctata, Rhizomelic"
+  ],
+  "Purpura, Schoenlein-Henoch": [
+    "D011695",
+    "Purpura, Schoenlein-Henoch"
+  ],
+  "Epilepsy, Benign Neonatal": [
+    "D020936",
+    "Epilepsy, Benign Neonatal"
+  ],
+  "Osteoporotic Fractures": [
+    "D058866",
+    "Osteoporotic Fractures"
+  ],
+  "Pseudohypoaldosteronism": [
+    "D011546",
+    "Pseudohypoaldosteronism"
+  ],
+  "Goiter, Nodular": [
+    "D006044",
+    "Goiter, Nodular"
+  ],
+  "Scapuloperoneal Form of Spinal Muscular Atrophy": [
+    "D009134",
+    "Muscular Atrophy, Spinal"
+  ],
+  "Chondrocalcinosis": [
+    "D002805",
+    "Chondrocalcinosis"
+  ],
+  "Freckles": [
+    "D008548",
+    "Melanosis"
+  ],
+  "Porphyria, Variegate": [
+    "D046350",
+    "Porphyria, Variegate"
+  ],
+  "Amnionitis": [
+    "D002821",
+    "Chorioamnionitis"
+  ],
+  "Carpal Tunnel Syndrome": [
+    "D002349",
+    "Carpal Tunnel Syndrome"
+  ],
+  "Okihiro Syndrome": [
+    "D004370",
+    "Duane Retraction Syndrome"
+  ],
+  "Pyoderma": [
+    "D011711",
+    "Pyoderma"
+  ],
+  "Pityriasis Rubra Pilaris": [
+    "D010916",
+    "Pityriasis Rubra Pilaris"
+  ],
+  "Caroli Disease": [
+    "D016767",
+    "Caroli Disease"
+  ],
+  "Sialorrhea": [
+    "D012798",
+    "Sialorrhea"
+  ],
+  "Bone Diseases, Infectious": [
+    "D001850",
+    "Bone Diseases, Infectious"
+  ],
+  "Gliosarcoma": [
+    "D018316",
+    "Gliosarcoma"
+  ],
+  "Lambert-Eaton Myasthenic Syndrome": [
+    "D015624",
+    "Lambert-Eaton Myasthenic Syndrome"
+  ],
+  "Laurence-Moon Syndrome": [
+    "D007849",
+    "Laurence-Moon Syndrome"
+  ],
+  "Paraplegia, Spastic": [
+    "D010264",
+    "Paraplegia"
+  ],
+  "HSAN Type IV": [
+    "D009477",
+    "Hereditary Sensory and Autonomic Neuropathies"
+  ],
+  "Sarcoma, Endometrial Stromal, Low-Grade": [
+    "D036821",
+    "Endometrial Stromal Tumors"
+  ],
+  "Polyendocrinopathies, Autoimmune": [
+    "D016884",
+    "Polyendocrinopathies, Autoimmune"
+  ],
+  "Ectopia Lentis": [
+    "D004479",
+    "Ectopia Lentis"
+  ],
+  "Paraneoplastic Syndromes": [
+    "D010257",
+    "Paraneoplastic Syndromes"
+  ],
+  "Familial CHARGE Syndrome": [
+    "D058747",
+    "CHARGE Syndrome"
+  ],
+  "Hereditary Type I Motor and Sensory Neuropathy": [
+    "D002607",
+    "Charcot-Marie-Tooth Disease"
+  ],
+  "Hypercapnia": [
+    "D006935",
+    "Hypercapnia"
+  ],
+  "Pain Insensitivity, Congenital": [
+    "D000699",
+    "Pain Insensitivity, Congenital"
+  ],
+  "Esthesioneuroblastoma, Olfactory": [
+    "D018304",
+    "Esthesioneuroblastoma, Olfactory"
+  ],
+  "Olfactory Groove Meningioma": [
+    "D008579",
+    "Meningioma"
+  ],
+  "Cerebrovascular Trauma": [
+    "D020214",
+    "Cerebrovascular Trauma"
+  ],
+  "Adult Neuronal Ceroid Lipofuscinosis": [
+    "D009472",
+    "Neuronal Ceroid-Lipofuscinoses"
+  ],
+  "POR Deficiency": [
+    "D054882",
+    "Antley-Bixler Syndrome Phenotype"
+  ],
+  "Carcinoma, Thymic": [
+    "D013945",
+    "Thymoma"
+  ],
+  "Steatocystoma Multiplex": [
+    "D062685",
+    "Steatocystoma Multiplex"
+  ],
+  "Pachyonychia Congenita, Type 2": [
+    "D053549",
+    "Pachyonychia Congenita"
+  ],
+  "Aortic Stenosis, Supravalvular": [
+    "D021921",
+    "Aortic Stenosis, Supravalvular"
+  ],
+  "Welander Distal Myopathy": [
+    "D049310",
+    "Distal Myopathies"
+  ],
+  "Myoclonic Epilepsies, Progressive": [
+    "D020191",
+    "Myoclonic Epilepsies, Progressive"
+  ],
+  "Parkinson Disease, Secondary": [
+    "D010302",
+    "Parkinson Disease, Secondary"
+  ],
+  "Mumps": [
+    "D009107",
+    "Mumps"
+  ],
+  "von Willebrand Disease, Type 2B": [
+    "D056728",
+    "von Willebrand Disease, Type 2"
+  ],
+  "Fish-Eye Disease": [
+    "D007863",
+    "Lecithin Cholesterol Acyltransferase Deficiency"
+  ],
+  "Hyperkeratosis, Epidermolytic": [
+    "D017488",
+    "Hyperkeratosis, Epidermolytic"
+  ],
+  "Type I Mucolipidosis": [
+    "D009081",
+    "Mucolipidoses"
+  ],
+  "Myeloid Leukemia, Acute, M1": [
+    "D015470",
+    "Leukemia, Myeloid, Acute"
+  ],
+  "Hereditary Sensory and Autonomic Neuropathies": [
+    "D009477",
+    "Hereditary Sensory and Autonomic Neuropathies"
+  ],
+  "Diabetic Autonomic Neuropathy": [
+    "D003929",
+    "Diabetic Neuropathies"
+  ],
+  "Velocardiofacial Syndrome": [
+    "D004062",
+    "DiGeorge Syndrome"
+  ],
+  "Alagille Syndrome": [
+    "D016738",
+    "Alagille Syndrome"
+  ],
+  "Maple Syrup Urine Disease": [
+    "D008375",
+    "Maple Syrup Urine Disease"
+  ],
+  "Classic Maple Syrup Urine Disease": [
+    "D008375",
+    "Maple Syrup Urine Disease"
+  ],
+  "Ichthyosis, Lamellar": [
+    "D017490",
+    "Ichthyosis, Lamellar"
+  ],
+  "Sensory Neuropathy, Hereditary": [
+    "D009477",
+    "Hereditary Sensory and Autonomic Neuropathies"
+  ],
+  "Coffin-Lowry Syndrome": [
+    "D038921",
+    "Coffin-Lowry Syndrome"
+  ],
+  "Dermatomycoses": [
+    "D003881",
+    "Dermatomycoses"
+  ],
+  "Biotinidase Deficiency": [
+    "D028921",
+    "Biotinidase Deficiency"
+  ],
+  "Abetalipoproteinemia": [
+    "D000012",
+    "Abetalipoproteinemia"
+  ],
+  "Endocardial Cushion Defects": [
+    "D004694",
+    "Endocardial Cushion Defects"
+  ],
+  "Varicocele": [
+    "D014646",
+    "Varicocele"
+  ],
+  "X-Linked Emery-Dreifuss Muscular Dystrophy": [
+    "D020389",
+    "Muscular Dystrophy, Emery-Dreifuss"
+  ],
+  "Piebaldism": [
+    "D016116",
+    "Piebaldism"
+  ],
+  "Hypotension, Orthostatic": [
+    "D007024",
+    "Hypotension, Orthostatic"
+  ],
+  "Autosomal Chromosome Disorders": [
+    "D025063",
+    "Chromosome Disorders"
+  ],
+  "Hemangioma, Cavernous": [
+    "D006392",
+    "Hemangioma, Cavernous"
+  ],
+  "Argininosuccinic Aciduria": [
+    "D056807",
+    "Argininosuccinic Aciduria"
+  ],
+  "Leukemia, Myeloid, Accelerated Phase": [
+    "D015465",
+    "Leukemia, Myeloid, Accelerated Phase"
+  ],
+  "Urinary Incontinence": [
+    "D014549",
+    "Urinary Incontinence"
+  ],
+  "Factor VII Deficiency": [
+    "D005168",
+    "Factor VII Deficiency"
+  ],
+  "Ichthyosis Vulgaris": [
+    "D016112",
+    "Ichthyosis Vulgaris"
+  ],
+  "Fetal Hypoxia": [
+    "D005311",
+    "Fetal Hypoxia"
+  ],
+  "Pulmonary Heart Disease": [
+    "D011660",
+    "Pulmonary Heart Disease"
+  ],
+  "Vaginitis, Monilial": [
+    "D002181",
+    "Candidiasis, Vulvovaginal"
+  ],
+  "Infertility, Female": [
+    "D007247",
+    "Infertility, Female"
+  ],
+  "Myokymia": [
+    "D020385",
+    "Myokymia"
+  ],
+  "Anemia, Sideroblastic": [
+    "D000756",
+    "Anemia, Sideroblastic"
+  ],
+  "Corneal Dystrophy, Juvenile Epithelial of Meesmann": [
+    "D053559",
+    "Corneal Dystrophy, Juvenile Epithelial of Meesmann"
+  ],
+  "Mucopolysaccharidosis Type IV A": [
+    "D009085",
+    "Mucopolysaccharidosis IV"
+  ],
+  "Pineoblastoma": [
+    "D010871",
+    "Pinealoma"
+  ],
+  "Anemia, Hemolytic, Congenital Nonspherocytic": [
+    "D000746",
+    "Anemia, Hemolytic, Congenital Nonspherocytic"
+  ],
+  "Mineralocorticoid Excess Syndrome, Apparent": [
+    "D043204",
+    "Mineralocorticoid Excess Syndrome, Apparent"
+  ],
+  "Hypokalemia": [
+    "D007008",
+    "Hypokalemia"
+  ],
+  "Ventricular Outflow Obstruction, Left": [
+    "D014694",
+    "Ventricular Outflow Obstruction"
+  ],
+  "Fluorosis, Dental": [
+    "D009050",
+    "Fluorosis, Dental"
+  ],
+  "Male Pseudohermaphroditism": [
+    "D058490",
+    "Disorder of Sex Development, 46,XY"
+  ],
+  "von Willebrand Disease, Type 2": [
+    "D056728",
+    "von Willebrand Disease, Type 2"
+  ],
+  "Nevus, Sebaceous of Jadassohn": [
+    "D054000",
+    "Nevus, Sebaceous of Jadassohn"
+  ],
+  "Spastic": [
+    "D009128",
+    "Muscle Spasticity"
+  ],
+  "Struma Ovarii": [
+    "D013330",
+    "Struma Ovarii"
+  ],
+  "Cafe-au-Lait Spots": [
+    "D019080",
+    "Cafe-au-Lait Spots"
+  ],
+  "Skin Diseases, Viral": [
+    "D017193",
+    "Skin Diseases, Viral"
+  ],
+  "Parotid Neoplasms": [
+    "D010307",
+    "Parotid Neoplasms"
+  ],
+  "Autonomic Nervous System Diseases": [
+    "D001342",
+    "Autonomic Nervous System Diseases"
+  ],
+  "Afibrinogenemia": [
+    "D000347",
+    "Afibrinogenemia"
+  ],
+  "HMSN Type III": [
+    "D015417",
+    "Hereditary Sensory and Motor Neuropathy"
+  ],
+  "Mucopolysaccharidosis IV": [
+    "D009085",
+    "Mucopolysaccharidosis IV"
+  ],
+  "Adenoma, Bile Duct": [
+    "D002759",
+    "Adenoma, Bile Duct"
+  ],
+  "Aphasia, Progressive": [
+    "D001037",
+    "Aphasia"
+  ],
+  "Calcium Metabolism Disorders": [
+    "D002128",
+    "Calcium Metabolism Disorders"
+  ],
+  "Pilomatrixoma": [
+    "D018296",
+    "Pilomatrixoma"
+  ],
+  "Keratocysts": [
+    "D009807",
+    "Odontogenic Cysts"
+  ],
+  "Duodenal Diseases": [
+    "D004378",
+    "Duodenal Diseases"
+  ],
+  "Gastrinoma": [
+    "D015408",
+    "Gastrinoma"
+  ],
+  "Hunermann-Conradi Syndrome": [
+    "D002806",
+    "Chondrodysplasia Punctata"
+  ],
+  "Leiomyomatosis": [
+    "D018231",
+    "Leiomyomatosis"
+  ],
+  "Basal Cell Cancer": [
+    "D018295",
+    "Neoplasms, Basal Cell"
+  ],
+  "Amyloid Neuropathies": [
+    "D017772",
+    "Amyloid Neuropathies"
+  ],
+  "Urinary Incontinence, Stress": [
+    "D014550",
+    "Urinary Incontinence, Stress"
+  ],
+  "Chediak-Higashi Syndrome": [
+    "D002609",
+    "Chediak-Higashi Syndrome"
+  ],
+  "Rabies": [
+    "D011818",
+    "Rabies"
+  ],
+  "Galactose-1-Phosphate Uridyl-Transferase Deficiency Disease": [
+    "D005693",
+    "Galactosemias"
+  ],
+  "Gestational Trophoblastic Neoplasia": [
+    "D031901",
+    "Gestational Trophoblastic Disease"
+  ],
+  "Myoclonic Encephalopathy": [
+    "D004831",
+    "Epilepsies, Myoclonic"
+  ],
+  "Androgen-Insensitivity Syndrome": [
+    "D013734",
+    "Androgen-Insensitivity Syndrome"
+  ],
+  "Milroy Disease": [
+    "D008209",
+    "Lymphedema"
+  ],
+  "Polymicrogyria": [
+    "D065706",
+    "Polymicrogyria"
+  ],
+  "Hyperaldosteronism": [
+    "D006929",
+    "Hyperaldosteronism"
+  ],
+  "Polyhydramnios": [
+    "D006831",
+    "Polyhydramnios"
+  ],
+  "Porphyria, Acute Intermittent": [
+    "D017118",
+    "Porphyria, Acute Intermittent"
+  ],
+  "Depressive Syndrome": [
+    "D003866",
+    "Depressive Disorder"
+  ],
+  "Carotid Artery Thrombosis": [
+    "D002341",
+    "Carotid Artery Thrombosis"
+  ],
+  "Cogan Syndrome": [
+    "D055952",
+    "Cogan Syndrome"
+  ],
+  "Hyperphenylalaninaemia": [
+    "D010661",
+    "Phenylketonurias"
+  ],
+  "Schizencephaly": [
+    "D065707",
+    "Schizencephaly"
+  ],
+  "Seizures, Focal": [
+    "D012640",
+    "Seizures"
+  ],
+  "Intestinal Pseudo-Obstruction": [
+    "D007418",
+    "Intestinal Pseudo-Obstruction"
+  ],
+  "Liddle Syndrome": [
+    "D056929",
+    "Liddle Syndrome"
+  ],
+  "Pseudohypoaldosteronism, Type I": [
+    "D011546",
+    "Pseudohypoaldosteronism"
+  ],
+  "Periventricular Nodular Heterotopia": [
+    "D054091",
+    "Periventricular Nodular Heterotopia"
+  ],
+  "Polymyalgia Rheumatica": [
+    "D011111",
+    "Polymyalgia Rheumatica"
+  ],
+  "Anemia, Refractory": [
+    "D000753",
+    "Anemia, Refractory"
+  ],
+  "Porphyria, Erythropoietic": [
+    "D017092",
+    "Porphyria, Erythropoietic"
+  ],
+  "Systemic Vasculitis": [
+    "D056647",
+    "Systemic Vasculitis"
+  ],
+  "Pierre Robin Syndrome": [
+    "D010855",
+    "Pierre Robin Syndrome"
+  ],
+  "Aortic Stiffness": [
+    "D059289",
+    "Vascular Stiffness"
+  ],
+  "Hyper-IgM Immunodeficiency Syndrome, Type 1": [
+    "D053307",
+    "Hyper-IgM Immunodeficiency Syndrome, Type 1"
+  ],
+  "Hyperimmunoglobulinemia D": [
+    "D054078",
+    "Mevalonate Kinase Deficiency"
+  ],
+  "Lobar Pneumonia": [
+    "D011014",
+    "Pneumonia"
+  ],
+  "Self-Injurious Behavior": [
+    "D016728",
+    "Self-Injurious Behavior"
+  ],
+  "Right Bundle-Branch Block": [
+    "D002037",
+    "Bundle-Branch Block"
+  ],
+  "Manganese Poisoning": [
+    "D020149",
+    "Manganese Poisoning"
+  ],
+  "Mevalonic Aciduria": [
+    "D054078",
+    "Mevalonate Kinase Deficiency"
+  ],
+  "Overactive Detrusor": [
+    "D053201",
+    "Urinary Bladder, Overactive"
+  ],
+  "Aortic Coarctation": [
+    "D001017",
+    "Aortic Coarctation"
+  ],
+  "Mucopolysaccharidosis II": [
+    "D016532",
+    "Mucopolysaccharidosis II"
+  ],
+  "Bile Duct Neoplasms": [
+    "D001650",
+    "Bile Duct Neoplasms"
+  ],
+  "Multiple Carboxylase Deficiency": [
+    "D009100",
+    "Multiple Carboxylase Deficiency"
+  ],
+  "Neurothekeoma": [
+    "D018321",
+    "Neurothekeoma"
+  ],
+  "Colitis, Collagenous": [
+    "D046729",
+    "Colitis, Collagenous"
+  ],
+  "Diverticulitis": [
+    "D004238",
+    "Diverticulitis"
+  ],
+  "Alobar Holoprosencephaly": [
+    "D016142",
+    "Holoprosencephaly"
+  ],
+  "Methemoglobinemia": [
+    "D008708",
+    "Methemoglobinemia"
+  ],
+  "Glomerulonephritis, Minimal Change": [
+    "D009402",
+    "Nephrosis, Lipoid"
+  ],
+  "Chorea, Benign Hereditary": [
+    "D002819",
+    "Chorea"
+  ],
+  "Fibroadenoma": [
+    "D018226",
+    "Fibroadenoma"
+  ],
+  "Immune Complex Diseases": [
+    "D007105",
+    "Immune Complex Diseases"
+  ],
+  "Iridocyclitis": [
+    "D015863",
+    "Iridocyclitis"
+  ],
+  "Anti-Glomerular Basement Membrane Disease": [
+    "D019867",
+    "Anti-Glomerular Basement Membrane Disease"
+  ],
+  "Postprandial Hypoglycemia": [
+    "D007003",
+    "Hypoglycemia"
+  ],
+  "Thrombasthenia": [
+    "D013915",
+    "Thrombasthenia"
+  ],
+  "Breast Cyst": [
+    "D047688",
+    "Breast Cyst"
+  ],
+  "Latex Hypersensitivity": [
+    "D020315",
+    "Latex Hypersensitivity"
+  ],
+  "Alcoholic Neuropathy": [
+    "D020269",
+    "Alcoholic Neuropathy"
+  ],
+  "Gingival Overgrowth": [
+    "D019214",
+    "Gingival Overgrowth"
+  ],
+  "Penile Induration": [
+    "D010411",
+    "Penile Induration"
+  ],
+  "Multiple Sclerosis, Secondary Progressive": [
+    "D020528",
+    "Multiple Sclerosis, Chronic Progressive"
+  ],
+  "Harlequin Fetus": [
+    "D017490",
+    "Ichthyosis, Lamellar"
+  ],
+  "Periapical Granuloma": [
+    "D010484",
+    "Periapical Granuloma"
+  ],
+  "Congenital Thrombotic Thrombocytopenic Purpura": [
+    "D011697",
+    "Purpura, Thrombotic Thrombocytopenic"
+  ],
+  "Incontinentia Pigmenti": [
+    "D007184",
+    "Incontinentia Pigmenti"
+  ],
+  "Nephrogenic Fibrosing Dermopathy": [
+    "D054989",
+    "Nephrogenic Fibrosing Dermopathy"
+  ],
+  "Hemangioendothelioma": [
+    "D006390",
+    "Hemangioendothelioma"
+  ],
+  "Wolff-Parkinson-White Syndrome": [
+    "D014927",
+    "Wolff-Parkinson-White Syndrome"
+  ],
+  "Static Tremor": [
+    "D014202",
+    "Tremor"
+  ],
+  "Ichthyosis Bullosa of Siemens": [
+    "D053560",
+    "Ichthyosis Bullosa of Siemens"
+  ],
+  "Skin Diseases, Genetic": [
+    "D012873",
+    "Skin Diseases, Genetic"
+  ],
+  "Water-Electrolyte Imbalance": [
+    "D014883",
+    "Water-Electrolyte Imbalance"
+  ],
+  "Hearing Loss, Bilateral": [
+    "D006312",
+    "Hearing Loss, Bilateral"
+  ],
+  "Balo Concentric Sclerosis": [
+    "D002549",
+    "Diffuse Cerebral Sclerosis of Schilder"
+  ],
+  "Ureaplasma Infections": [
+    "D016869",
+    "Ureaplasma Infections"
+  ],
+  "Embryopathies": [
+    "D005315",
+    "Fetal Diseases"
+  ],
+  "Tyrosinemias": [
+    "D020176",
+    "Tyrosinemias"
+  ],
+  "Tyrosinemia, Type I": [
+    "D020176",
+    "Tyrosinemias"
+  ],
+  "Churg-Strauss Syndrome": [
+    "D015267",
+    "Churg-Strauss Syndrome"
+  ],
+  "Port-Wine Stain": [
+    "D019339",
+    "Port-Wine Stain"
+  ],
+  "Sturge-Weber Syndrome": [
+    "D013341",
+    "Sturge-Weber Syndrome"
+  ],
+  "Gynecomastia": [
+    "D006177",
+    "Gynecomastia"
+  ],
+  "Secretory Meningioma": [
+    "D008579",
+    "Meningioma"
+  ],
+  "Xerostomia": [
+    "D014987",
+    "Xerostomia"
+  ],
+  "Alopecia Areata": [
+    "D000506",
+    "Alopecia Areata"
+  ],
+  "Rupture, Spontaneous": [
+    "D012422",
+    "Rupture, Spontaneous"
+  ],
+  "Nystagmus, Pathologic": [
+    "D009759",
+    "Nystagmus, Pathologic"
+  ],
+  "Menorrhagia": [
+    "D008595",
+    "Menorrhagia"
+  ],
+  "Neurocutaneous Syndromes": [
+    "D020752",
+    "Neurocutaneous Syndromes"
+  ],
+  "Abruptio Placentae": [
+    "D000037",
+    "Abruptio Placentae"
+  ],
+  "Donohue Syndrome": [
+    "D056731",
+    "Donohue Syndrome"
+  ],
+  "Hypertension, Renovascular": [
+    "D006978",
+    "Hypertension, Renovascular"
+  ],
+  "Refsum Disease": [
+    "D012035",
+    "Refsum Disease"
+  ],
+  "Laron Syndrome": [
+    "D046150",
+    "Laron Syndrome"
+  ],
+  "Hypobetalipoproteinemias": [
+    "D006995",
+    "Hypobetalipoproteinemias"
+  ],
+  "Delirium": [
+    "D003693",
+    "Delirium"
+  ],
+  "Paget Disease, Extramammary": [
+    "D010145",
+    "Paget Disease, Extramammary"
+  ],
+  "Apert Syndrome": [
+    "D000168",
+    "Acrocephalosyndactylia"
+  ],
+  "Social Anhedonia": [
+    "D059445",
+    "Anhedonia"
+  ],
+  "Menstruation Disturbances": [
+    "D008599",
+    "Menstruation Disturbances"
+  ],
+  "Substance Withdrawal Syndrome": [
+    "D013375",
+    "Substance Withdrawal Syndrome"
+  ],
+  "Fasciitis, Necrotizing": [
+    "D019115",
+    "Fasciitis, Necrotizing"
+  ],
+  "ACTH Syndrome, Ectopic": [
+    "D000182",
+    "ACTH Syndrome, Ectopic"
+  ],
+  "Cholera Morbus": [
+    "D017688",
+    "Cholera Morbus"
+  ],
+  "Keratosis": [
+    "D007642",
+    "Keratosis"
+  ],
+  "Gangliosidoses, GM2": [
+    "D020143",
+    "Gangliosidoses, GM2"
+  ],
+  "Muscle-Eye-Brain Disease": [
+    "D058494",
+    "Walker-Warburg Syndrome"
+  ],
+  "Colitis, Granulomatous": [
+    "D003424",
+    "Crohn Disease"
+  ],
+  "Rubinstein-Taybi Syndrome": [
+    "D012415",
+    "Rubinstein-Taybi Syndrome"
+  ],
+  "Heterotaxy Syndrome": [
+    "D059446",
+    "Heterotaxy Syndrome"
+  ],
+  "von Willebrand Disease, Type 3": [
+    "D056729",
+    "von Willebrand Disease, Type 3"
+  ],
+  "Sleep Apnea Syndromes": [
+    "D012891",
+    "Sleep Apnea Syndromes"
+  ],
+  "Omenn Syndrome": [
+    "D016511",
+    "Severe Combined Immunodeficiency"
+  ],
+  "Craniopharyngioma": [
+    "D003397",
+    "Craniopharyngioma"
+  ],
+  "Circadian Rhythm Disorders": [
+    "D021081",
+    "Chronobiology Disorders"
+  ],
+  "Chloasma": [
+    "D008548",
+    "Melanosis"
+  ],
+  "Epilepsy, Lateral Temporal": [
+    "D004833",
+    "Epilepsy, Temporal Lobe"
+  ],
+  "MERRF Syndrome": [
+    "D017243",
+    "MERRF Syndrome"
+  ],
+  "Hypocapnia": [
+    "D016857",
+    "Hypocapnia"
+  ],
+  "Phenylketonuria I": [
+    "D010661",
+    "Phenylketonurias"
+  ],
+  "Marijuana Abuse": [
+    "D002189",
+    "Marijuana Abuse"
+  ],
+  "Panic Attacks": [
+    "D016584",
+    "Panic Disorder"
+  ],
+  "Cryoglobulinemia": [
+    "D003449",
+    "Cryoglobulinemia"
+  ],
+  "Renal Artery Stenosis": [
+    "D012078",
+    "Renal Artery Obstruction"
+  ],
+  "Syndactyly": [
+    "D013576",
+    "Syndactyly"
+  ],
+  "Frozen Shoulder": [
+    "D002062",
+    "Bursitis"
+  ],
+  "Ectodermal Dysplasia 1, Anhidrotic": [
+    "D053358",
+    "Ectodermal Dysplasia 1, Anhidrotic"
+  ],
+  "Central Serous Chorioretinopathy": [
+    "D056833",
+    "Central Serous Chorioretinopathy"
+  ],
+  "Burning Mouth Syndrome": [
+    "D002054",
+    "Burning Mouth Syndrome"
+  ],
+  "Urinary Bladder Neck Obstruction": [
+    "D001748",
+    "Urinary Bladder Neck Obstruction"
+  ],
+  "Familial Dementia": [
+    "D003704",
+    "Dementia"
+  ],
+  "Trophoblastic Cancer": [
+    "D014328",
+    "Trophoblastic Neoplasms"
+  ],
+  "Alcohol Withdrawal Seizures": [
+    "D020270",
+    "Alcohol Withdrawal Seizures"
+  ],
+  "Alcohol Withdrawal Delirium": [
+    "D000430",
+    "Alcohol Withdrawal Delirium"
+  ],
+  "Hidrotic Ectodermal Dysplasia": [
+    "D004476",
+    "Ectodermal Dysplasia"
+  ],
+  "Thyroid Hypoplasia": [
+    "D050033",
+    "Thyroid Dysgenesis"
+  ],
+  "Petit Mal Status": [
+    "D013226",
+    "Status Epilepticus"
+  ],
+  "Premenstrual Syndrome": [
+    "D011293",
+    "Premenstrual Syndrome"
+  ],
+  "Generalized Myotonia of Thomsen": [
+    "D009224",
+    "Myotonia Congenita"
+  ],
+  "Affective Disorders, Psychotic": [
+    "D000341",
+    "Affective Disorders, Psychotic"
+  ],
+  "Xanthomatosis, Cerebrotendinous": [
+    "D019294",
+    "Xanthomatosis, Cerebrotendinous"
+  ],
+  "Ophthalmoplegia": [
+    "D009886",
+    "Ophthalmoplegia"
+  ],
+  "Polychondritis, Relapsing": [
+    "D011081",
+    "Polychondritis, Relapsing"
+  ],
+  "Granular Dystrophy, Corneal": [
+    "D003317",
+    "Corneal Dystrophies, Hereditary"
+  ],
+  "Fetal Membranes, Premature Rupture": [
+    "D005322",
+    "Fetal Membranes, Premature Rupture"
+  ],
+  "Retinopathy of Prematurity": [
+    "D012178",
+    "Retinopathy of Prematurity"
+  ],
+  "Sjogren-Larsson Syndrome": [
+    "D016111",
+    "Sjogren-Larsson Syndrome"
+  ],
+  "Erdheim-Chester Disease": [
+    "D031249",
+    "Erdheim-Chester Disease"
+  ],
+  "Musculoskeletal Pain": [
+    "D059352",
+    "Musculoskeletal Pain"
+  ],
+  "Erythema Nodosum": [
+    "D004893",
+    "Erythema Nodosum"
+  ],
+  "Vesico-Ureteral Reflux": [
+    "D014718",
+    "Vesico-Ureteral Reflux"
+  ],
+  "Cancer of Pelvis": [
+    "D010386",
+    "Pelvic Neoplasms"
+  ],
+  "Charcot-Marie-Tooth Disease, Type Ib": [
+    "D002607",
+    "Charcot-Marie-Tooth Disease"
+  ],
+  "Astigmatism": [
+    "D001251",
+    "Astigmatism"
+  ],
+  "Reifenstein Syndrome": [
+    "D013734",
+    "Androgen-Insensitivity Syndrome"
+  ],
+  "Tyrosinemia, Type II": [
+    "D020176",
+    "Tyrosinemias"
+  ],
+  "Uterine Prolapse": [
+    "D014596",
+    "Uterine Prolapse"
+  ],
+  "Dendritic Cell Sarcoma, Follicular": [
+    "D054740",
+    "Dendritic Cell Sarcoma, Follicular"
+  ],
+  "Ovarian Diseases": [
+    "D010049",
+    "Ovarian Diseases"
+  ],
+  "Childhood Onset Dystonias": [
+    "D020821",
+    "Dystonic Disorders"
+  ],
+  "Low Cardiac Output Syndrome": [
+    "D002303",
+    "Cardiac Output, Low"
+  ],
+  "Angioma": [
+    "D006391",
+    "Hemangioma"
+  ],
+  "Idiopathic Hypoparathyroidism": [
+    "D007011",
+    "Hypoparathyroidism"
+  ],
+  "Resting Tremor": [
+    "D014202",
+    "Tremor"
+  ],
+  "Dysplastic Nevus Syndrome": [
+    "D004416",
+    "Dysplastic Nevus Syndrome"
+  ],
+  "HIV-Associated Lipodystrophy Syndrome": [
+    "D039682",
+    "HIV-Associated Lipodystrophy Syndrome"
+  ],
+  "Nocturnal Enuresis": [
+    "D053206",
+    "Nocturnal Enuresis"
+  ],
+  "MELAS Syndrome": [
+    "D017241",
+    "MELAS Syndrome"
+  ],
+  "Ring Chromosomes": [
+    "D012303",
+    "Ring Chromosomes"
+  ],
+  "Mobility Limitation": [
+    "D051346",
+    "Mobility Limitation"
+  ],
+  "Familial Cold Autoinflammatory Syndrome": [
+    "D056587",
+    "Cryopyrin-Associated Periodic Syndromes"
+  ],
+  "Glycogen Storage Disease Type VI": [
+    "D006013",
+    "Glycogen Storage Disease Type VI"
+  ],
+  "Thyroid Agenesis": [
+    "D050033",
+    "Thyroid Dysgenesis"
+  ],
+  "Myasthenia Gravis, Ocular": [
+    "D009157",
+    "Myasthenia Gravis"
+  ],
+  "Malignant Carcinoid Syndrome": [
+    "D008303",
+    "Malignant Carcinoid Syndrome"
+  ],
+  "Tension-Type Headache": [
+    "D018781",
+    "Tension-Type Headache"
+  ],
+  "Gigantism": [
+    "D005877",
+    "Gigantism"
+  ],
+  "Fructose Intolerance": [
+    "D005633",
+    "Fructose Intolerance"
+  ],
+  "Folliculitis": [
+    "D005499",
+    "Folliculitis"
+  ],
+  "Pyoderma Gangrenosum": [
+    "D017511",
+    "Pyoderma Gangrenosum"
+  ],
+  "Purpura Fulminans": [
+    "D055665",
+    "Purpura Fulminans"
+  ],
+  "Erythema Multiforme": [
+    "D004892",
+    "Erythema Multiforme"
+  ],
+  "Focal Dystonia": [
+    "D020821",
+    "Dystonic Disorders"
+  ],
+  "Leukemia, Myeloid, Chronic, Atypical, BCR-ABL Negative": [
+    "D054438",
+    "Leukemia, Myeloid, Chronic, Atypical, BCR-ABL Negative"
+  ],
+  "Stromal Dystrophies, Corneal": [
+    "D003317",
+    "Corneal Dystrophies, Hereditary"
+  ],
+  "Chorea": [
+    "D002819",
+    "Chorea"
+  ],
+  "Leukodystrophy, Metachromatic, Adult": [
+    "D007966",
+    "Leukodystrophy, Metachromatic"
+  ],
+  "Gardner Syndrome": [
+    "D005736",
+    "Gardner Syndrome"
+  ],
+  "alpha-Mannosidosis": [
+    "D008363",
+    "alpha-Mannosidosis"
+  ],
+  "Hyperoxaluria": [
+    "D006959",
+    "Hyperoxaluria"
+  ],
+  "Periodontal Pocket": [
+    "D010514",
+    "Periodontal Pocket"
+  ],
+  "Leukemia, Biphenotypic, Acute": [
+    "D015456",
+    "Leukemia, Biphenotypic, Acute"
+  ],
+  "Heart Failure, Diastolic": [
+    "D054144",
+    "Heart Failure, Diastolic"
+  ],
+  "Visceral Myopathy": [
+    "D007418",
+    "Intestinal Pseudo-Obstruction"
+  ],
+  "Isaacs Syndrome": [
+    "D020386",
+    "Isaacs Syndrome"
+  ],
+  "Retinoschisis": [
+    "D041441",
+    "Retinoschisis"
+  ],
+  "Branchio-Oculo-Facial Syndrome": [
+    "D019280",
+    "Branchio-Oto-Renal Syndrome"
+  ],
+  "Peroxisomal Disorders": [
+    "D018901",
+    "Peroxisomal Disorders"
+  ],
+  "Autosomal Dominant Parkinsonism": [
+    "D020734",
+    "Parkinsonian Disorders"
+  ],
+  "Coproporphyria, Hereditary": [
+    "D046349",
+    "Coproporphyria, Hereditary"
+  ],
+  "Hepatopulmonary Syndrome": [
+    "D020065",
+    "Hepatopulmonary Syndrome"
+  ],
+  "Depression, Bipolar": [
+    "D001714",
+    "Bipolar Disorder"
+  ],
+  "Mucopolysaccharidosis III": [
+    "D009084",
+    "Mucopolysaccharidosis III"
+  ],
+  "Cockayne-Touraine Disease": [
+    "D016108",
+    "Epidermolysis Bullosa Dystrophica"
+  ],
+  "Malformations of Cortical Development": [
+    "D054220",
+    "Malformations of Cortical Development"
+  ],
+  "Oral Ulcer": [
+    "D019226",
+    "Oral Ulcer"
+  ],
+  "Lymphoma, Diffuse": [
+    "D008228",
+    "Lymphoma, Non-Hodgkin"
+  ],
+  "Dyslipoproteinemias": [
+    "D050171",
+    "Dyslipidemias"
+  ],
+  "Cystadenocarcinoma, Mucinous": [
+    "D018282",
+    "Cystadenocarcinoma, Mucinous"
+  ],
+  "Bronchiolitis, Viral": [
+    "D001990",
+    "Bronchiolitis, Viral"
+  ],
+  "External Ophthalmoplegia": [
+    "D009886",
+    "Ophthalmoplegia"
+  ],
+  "Abnormal Karyotype": [
+    "D059786",
+    "Abnormal Karyotype"
+  ],
+  "Abdomen, Acute": [
+    "D000006",
+    "Abdomen, Acute"
+  ],
+  "Opisthorchiasis": [
+    "D009889",
+    "Opisthorchiasis"
+  ],
+  "Sinus Arrest, Cardiac": [
+    "D054138",
+    "Sinus Arrest, Cardiac"
+  ],
+  "Periapical Periodontitis": [
+    "D010485",
+    "Periapical Periodontitis"
+  ],
+  "Vitamin B 6 Deficiency": [
+    "D026681",
+    "Vitamin B 6 Deficiency"
+  ],
+  "Sialic Acid Storage Disease": [
+    "D029461",
+    "Sialic Acid Storage Disease"
+  ],
+  "Intracranial Hypertension": [
+    "D019586",
+    "Intracranial Hypertension"
+  ],
+  "Glomerulonephritis, Membranoproliferative": [
+    "D015432",
+    "Glomerulonephritis, Membranoproliferative"
+  ],
+  "Plasma Cell Granuloma, Pulmonary": [
+    "D016726",
+    "Plasma Cell Granuloma, Pulmonary"
+  ],
+  "Deficiency Diseases": [
+    "D003677",
+    "Deficiency Diseases"
+  ],
+  "Nicotine Use Disorder": [
+    "D014029",
+    "Tobacco Use Disorder"
+  ],
+  "Stridor": [
+    "D012135",
+    "Respiratory Sounds"
+  ],
+  "Multiple Endocrine Neoplasia Type 2b": [
+    "D018814",
+    "Multiple Endocrine Neoplasia Type 2b"
+  ],
+  "Genitourinary Cancer": [
+    "D014565",
+    "Urogenital Neoplasms"
+  ],
+  "Esophageal Diseases": [
+    "D004935",
+    "Esophageal Diseases"
+  ],
+  "Esophageal Achalasia": [
+    "D004931",
+    "Esophageal Achalasia"
+  ],
+  "Neuralgia, Amyotrophic": [
+    "D020968",
+    "Brachial Plexus Neuritis"
+  ],
+  "Hallucinations, Visual": [
+    "D006212",
+    "Hallucinations"
+  ],
+  "Hemorrhagic Fever, Crimean": [
+    "D006479",
+    "Hemorrhagic Fever, Crimean"
+  ],
+  "Acro-Osteolysis": [
+    "D030981",
+    "Acro-Osteolysis"
+  ],
+  "Sertoli Cell Tumor": [
+    "D012707",
+    "Sertoli Cell Tumor"
+  ],
+  "Adenoma, Follicular": [
+    "D000236",
+    "Adenoma"
+  ],
+  "Hypoalphalipoproteinemias": [
+    "D052456",
+    "Hypoalphalipoproteinemias"
+  ],
+  "Myopathy, Central Core": [
+    "D020512",
+    "Myopathy, Central Core"
+  ],
+  "Mixed Connective Tissue Disease": [
+    "D008947",
+    "Mixed Connective Tissue Disease"
+  ],
+  "Syncope": [
+    "D013575",
+    "Syncope"
+  ],
+  "Macrophage Activation Syndrome": [
+    "D055501",
+    "Macrophage Activation Syndrome"
+  ],
+  "Hemorrhagic Fever, Bolivian": [
+    "D006478",
+    "Hemorrhagic Fever, American"
+  ],
+  "Arteriosclerosis Obliterans": [
+    "D001162",
+    "Arteriosclerosis Obliterans"
+  ],
+  "Muscle Neoplasms": [
+    "D019042",
+    "Muscle Neoplasms"
+  ],
+  "Panuveitis": [
+    "D015864",
+    "Panuveitis"
+  ],
+  "Antley-Bixler Syndrome, Autosomal Dominant": [
+    "D054882",
+    "Antley-Bixler Syndrome Phenotype"
+  ],
+  "Single-Gene Defects": [
+    "D030342",
+    "Genetic Diseases, Inborn"
+  ],
+  "Lichen Planus": [
+    "D008010",
+    "Lichen Planus"
+  ],
+  "Colic": [
+    "D003085",
+    "Colic"
+  ],
+  "Inappropriate ADH Syndrome": [
+    "D007177",
+    "Inappropriate ADH Syndrome"
+  ],
+  "Klinefelter Syndrome": [
+    "D007713",
+    "Klinefelter Syndrome"
+  ],
+  "Mulibrey Nanism": [
+    "D050336",
+    "Mulibrey Nanism"
+  ],
+  "Hematoma": [
+    "D006406",
+    "Hematoma"
+  ],
+  "Congenital Hydrocephalus": [
+    "D006849",
+    "Hydrocephalus"
+  ],
+  "Hirsutism": [
+    "D006628",
+    "Hirsutism"
+  ],
+  "Facial Neoplasms": [
+    "D005153",
+    "Facial Neoplasms"
+  ],
+  "Abortion, Threatened": [
+    "D000033",
+    "Abortion, Threatened"
+  ],
+  "Sicca Syndrome": [
+    "D012859",
+    "Sjogren's Syndrome"
+  ],
+  "Infantile Neuroaxonal Dystrophy": [
+    "D019150",
+    "Neuroaxonal Dystrophies"
+  ],
+  "Prune Belly Syndrome": [
+    "D011535",
+    "Prune Belly Syndrome"
+  ],
+  "Juvenile Neuronal Ceroid Lipofuscinosis": [
+    "D009472",
+    "Neuronal Ceroid-Lipofuscinoses"
+  ],
+  "Ciguatera Poisoning": [
+    "D036841",
+    "Ciguatera Poisoning"
+  ],
+  "Hydrops Fetalis, Non-Immune": [
+    "D015160",
+    "Hydrops Fetalis"
+  ],
+  "Neuroleptic Malignant Syndrome": [
+    "D009459",
+    "Neuroleptic Malignant Syndrome"
+  ],
+  "Anemia, Hypoplastic": [
+    "D000741",
+    "Anemia, Aplastic"
+  ],
+  "Stomatitis, Aphthous": [
+    "D013281",
+    "Stomatitis, Aphthous"
+  ],
+  "Psychoses, Alcoholic": [
+    "D011604",
+    "Psychoses, Alcoholic"
+  ],
+  "Leukokeratosis, Hereditary Mucosal": [
+    "D053529",
+    "Leukokeratosis, Hereditary Mucosal"
+  ],
+  "Leprosy, Paucibacillary": [
+    "D056005",
+    "Leprosy, Paucibacillary"
+  ],
+  "Vitamin B 12 Deficiency": [
+    "D014806",
+    "Vitamin B 12 Deficiency"
+  ],
+  "Choroid Plexus Neoplasms": [
+    "D016545",
+    "Choroid Plexus Neoplasms"
+  ],
+  "Abdominal Neoplasms": [
+    "D000008",
+    "Abdominal Neoplasms"
+  ],
+  "Injuries, Surgical": [
+    "D007431",
+    "Intraoperative Complications"
+  ],
+  "Leukokeratosis": [
+    "D007971",
+    "Leukoplakia"
+  ],
+  "Drug Eruptions": [
+    "D003875",
+    "Drug Eruptions"
+  ],
+  "Glycogen Storage Disease Type III": [
+    "D006010",
+    "Glycogen Storage Disease Type III"
+  ],
+  "Colitis, Microscopic": [
+    "D046728",
+    "Colitis, Microscopic"
+  ],
+  "Myelopathic Muscular Atrophy": [
+    "D009134",
+    "Muscular Atrophy, Spinal"
+  ],
+  "Mitral Valve Stenosis": [
+    "D008946",
+    "Mitral Valve Stenosis"
+  ],
+  "Phenylketonuria II": [
+    "D010661",
+    "Phenylketonurias"
+  ],
+  "Sertoli Cell-Only Syndrome": [
+    "D054331",
+    "Sertoli Cell-Only Syndrome"
+  ],
+  "Zinsser-Cole-Engman Syndrome": [
+    "D019871",
+    "Dyskeratosis Congenita"
+  ],
+  "Abnormalities, Multiple": [
+    "D000015",
+    "Abnormalities, Multiple"
+  ],
+  "Microscopic Polyangiitis": [
+    "D055953",
+    "Microscopic Polyangiitis"
+  ],
+  "Thromboangiitis Obliterans": [
+    "D013919",
+    "Thromboangiitis Obliterans"
+  ],
+  "Appendicitis": [
+    "D001064",
+    "Appendicitis"
+  ],
+  "Anemia, Dyserythropoietic, Congenital": [
+    "D000742",
+    "Anemia, Dyserythropoietic, Congenital"
+  ],
+  "Adenosarcoma": [
+    "D018195",
+    "Adenosarcoma"
+  ],
+  "Asperger Syndrome": [
+    "D020817",
+    "Asperger Syndrome"
+  ],
+  "Trigonocephaly": [
+    "D003398",
+    "Craniosynostoses"
+  ],
+  "Chromosome Disorders": [
+    "D025063",
+    "Chromosome Disorders"
+  ],
+  "Cancer of Pharynx": [
+    "D010610",
+    "Pharyngeal Neoplasms"
+  ],
+  "Periapical Abscess": [
+    "D010482",
+    "Periapical Abscess"
+  ],
+  "Genital Neoplasms, Female": [
+    "D005833",
+    "Genital Neoplasms, Female"
+  ],
+  "Pre-Excitation Syndromes": [
+    "D011226",
+    "Pre-Excitation Syndromes"
+  ],
+  "Cerebellar Ataxia, Early Onset": [
+    "D013132",
+    "Spinocerebellar Degenerations"
+  ],
+  "Mucopolysaccharidosis Type IV B": [
+    "D009085",
+    "Mucopolysaccharidosis IV"
+  ],
+  "Neuropsychiatric Systemic Lupus Erythematosus": [
+    "D020945",
+    "Lupus Vasculitis, Central Nervous System"
+  ],
+  "Dyscoordination": [
+    "D001259",
+    "Ataxia"
+  ],
+  "Pulmonary Blastoma": [
+    "D018202",
+    "Pulmonary Blastoma"
+  ],
+  "Late-Onset Globoid Cell Leukodystrophy": [
+    "D007965",
+    "Leukodystrophy, Globoid Cell"
+  ],
+  "Platelet Storage Pool Deficiency": [
+    "D010981",
+    "Platelet Storage Pool Deficiency"
+  ],
+  "Type II Mucolipidosis": [
+    "D009081",
+    "Mucolipidoses"
+  ],
+  "Tibial Muscular Dystrophy": [
+    "D049310",
+    "Distal Myopathies"
+  ],
+  "Dentigerous Cyst": [
+    "D003803",
+    "Dentigerous Cyst"
+  ],
+  "Pneumonia, Viral": [
+    "D011024",
+    "Pneumonia, Viral"
+  ],
+  "Eunuchoidism": [
+    "D005058",
+    "Eunuchism"
+  ],
+  "Glycogen Storage Disease Type V": [
+    "D006012",
+    "Glycogen Storage Disease Type V"
+  ],
+  "Factor X Deficiency": [
+    "D005171",
+    "Factor X Deficiency"
+  ],
+  "Infections, Arenavirus": [
+    "D001117",
+    "Arenaviridae Infections"
+  ],
+  "Weber-Cockayne Syndrome": [
+    "D016110",
+    "Epidermolysis Bullosa Simplex"
+  ],
+  "Pouchitis": [
+    "D019449",
+    "Pouchitis"
+  ],
+  "Aneurysm, Dissecting": [
+    "D000784",
+    "Aneurysm, Dissecting"
+  ],
+  "Xanthogranuloma, Juvenile": [
+    "D014972",
+    "Xanthogranuloma, Juvenile"
+  ],
+  "Knee Dislocation": [
+    "D031221",
+    "Knee Dislocation"
+  ],
+  "Cryptogenic Organizing Pneumonia": [
+    "D018549",
+    "Cryptogenic Organizing Pneumonia"
+  ],
+  "Rodent Diseases": [
+    "D012376",
+    "Rodent Diseases"
+  ],
+  "Soft Tissue Neoplasms": [
+    "D012983",
+    "Soft Tissue Neoplasms"
+  ],
+  "Angina Pectoris, Variant": [
+    "D000788",
+    "Angina Pectoris, Variant"
+  ],
+  "Myoclonus, Action": [
+    "D009207",
+    "Myoclonus"
+  ],
+  "Citrullinemia": [
+    "D020159",
+    "Citrullinemia"
+  ],
+  "Bile Duct Diseases": [
+    "D001649",
+    "Bile Duct Diseases"
+  ],
+  "Nemaline Myopathy, Childhood Onset": [
+    "D017696",
+    "Myopathies, Nemaline"
+  ],
+  "Fructose-1,6-Diphosphatase Deficiency": [
+    "D015319",
+    "Fructose-1,6-Diphosphatase Deficiency"
+  ],
+  "Jervell-Lange Nielsen Syndrome": [
+    "D029593",
+    "Jervell-Lange Nielsen Syndrome"
+  ],
+  "Bladder Exstrophy": [
+    "D001746",
+    "Bladder Exstrophy"
+  ],
+  "Lissencephaly Syndrome, Miller-Dieker": [
+    "D054221",
+    "Classical Lissencephalies and Subcortical Band Heterotopias"
+  ],
+  "Tonsillitis": [
+    "D014069",
+    "Tonsillitis"
+  ],
+  "Retractile Mesenteritis": [
+    "D015436",
+    "Panniculitis, Peritoneal"
+  ],
+  "Lipoma, Pleomorphic": [
+    "D008067",
+    "Lipoma"
+  ],
+  "Rotor Syndrome": [
+    "D006933",
+    "Hyperbilirubinemia, Hereditary"
+  ],
+  "Trophoblastic Neoplasms": [
+    "D014328",
+    "Trophoblastic Neoplasms"
+  ],
+  "Spastic Quadriplegia": [
+    "D011782",
+    "Quadriplegia"
+  ],
+  "Coccidioidomycosis": [
+    "D003047",
+    "Coccidioidomycosis"
+  ],
+  "Mydriasis": [
+    "D015878",
+    "Mydriasis"
+  ],
+  "Encephalocele": [
+    "D004677",
+    "Encephalocele"
+  ],
+  "Pancreatitis, Acute Necrotizing": [
+    "D019283",
+    "Pancreatitis, Acute Necrotizing"
+  ],
+  "Prenatal Injuries": [
+    "D049188",
+    "Prenatal Injuries"
+  ],
+  "Nut Hypersensitivity": [
+    "D021184",
+    "Nut Hypersensitivity"
+  ],
+  "Hyper-IgM Immunodeficiency Syndrome, Type 3": [
+    "D053306",
+    "Hyper-IgM Immunodeficiency Syndrome"
+  ],
+  "Vulvar Vestibulitis": [
+    "D054515",
+    "Vulvar Vestibulitis"
+  ],
+  "Meningitis, Aseptic": [
+    "D008582",
+    "Meningitis, Aseptic"
+  ],
+  "Radiation Syndrome": [
+    "D011832",
+    "Radiation Injuries"
+  ],
+  "Acute Chest Syndrome": [
+    "D056586",
+    "Acute Chest Syndrome"
+  ],
+  "Jaundice, Chronic Idiopathic": [
+    "D007566",
+    "Jaundice, Chronic Idiopathic"
+  ],
+  "Nervous System Neoplasms": [
+    "D009423",
+    "Nervous System Neoplasms"
+  ],
+  "Anemia, Macrocytic": [
+    "D000748",
+    "Anemia, Macrocytic"
+  ],
+  "Psychophysiologic Disorders": [
+    "D011602",
+    "Psychophysiologic Disorders"
+  ],
+  "Dystonia Musculorum Deformans": [
+    "D004422",
+    "Dystonia Musculorum Deformans"
+  ],
+  "Alveolitis, Fibrosing": [
+    "D011658",
+    "Pulmonary Fibrosis"
+  ],
+  "Clubbed Fingers": [
+    "D010005",
+    "Osteoarthropathy, Secondary Hypertrophic"
+  ],
+  "Multiple Sclerosis, Primary Progressive": [
+    "D020528",
+    "Multiple Sclerosis, Chronic Progressive"
+  ],
+  "Hearing Loss, Mixed Conductive-Sensorineural": [
+    "D046089",
+    "Hearing Loss, Mixed Conductive-Sensorineural"
+  ],
+  "Tyrosinemia, Type III": [
+    "D020176",
+    "Tyrosinemias"
+  ],
+  "Carbamoyl-Phosphate Synthase I Deficiency Disease": [
+    "D020165",
+    "Carbamoyl-Phosphate Synthase I Deficiency Disease"
+  ],
+  "Lentigo": [
+    "D007911",
+    "Lentigo"
+  ],
+  "Budd-Chiari Syndrome": [
+    "D006502",
+    "Budd-Chiari Syndrome"
+  ],
+  "Paraneoplastic Syndromes, Nervous System": [
+    "D020361",
+    "Paraneoplastic Syndromes, Nervous System"
+  ],
+  "Hyperemesis Gravidarum": [
+    "D006939",
+    "Hyperemesis Gravidarum"
+  ],
+  "Pseudopseudohypoparathyroidism": [
+    "D011556",
+    "Pseudopseudohypoparathyroidism"
+  ],
+  "Glomus Jugulare Tumor": [
+    "D005925",
+    "Glomus Jugulare Tumor"
+  ],
+  "Anemia, Dyserythropoietic, Congenital, Type I": [
+    "D000742",
+    "Anemia, Dyserythropoietic, Congenital"
+  ],
+  "Syncope, Vasovagal": [
+    "D019462",
+    "Syncope, Vasovagal"
+  ],
+  "Lichen Simplex Chronicus": [
+    "D009450",
+    "Neurodermatitis"
+  ],
+  "Multiple Trauma": [
+    "D009104",
+    "Multiple Trauma"
+  ],
+  "Adolescent Gynecomastia": [
+    "D006177",
+    "Gynecomastia"
+  ],
+  "Argininosuccinic Acid Synthetase Deficiency, Complete": [
+    "D020159",
+    "Citrullinemia"
+  ],
+  "Urogenital Abnormalities": [
+    "D014564",
+    "Urogenital Abnormalities"
+  ],
+  "Cartilage Diseases": [
+    "D002357",
+    "Cartilage Diseases"
+  ],
+  "Colonic Diseases": [
+    "D003108",
+    "Colonic Diseases"
+  ],
+  "Learning Disorders": [
+    "D007859",
+    "Learning Disorders"
+  ],
+  "Vertigo, Paroxysmal": [
+    "D014717",
+    "Vertigo"
+  ],
+  "Myoglobinuria": [
+    "D009212",
+    "Myoglobinuria"
+  ],
+  "Paralysis, Hyperkalemic Periodic": [
+    "D020513",
+    "Paralysis, Hyperkalemic Periodic"
+  ],
+  "Extrapyramidal Disorders": [
+    "D001480",
+    "Basal Ganglia Diseases"
+  ],
+  "Juvenile Huntington Disease": [
+    "D006816",
+    "Huntington Disease"
+  ],
+  "Megacolon": [
+    "D008531",
+    "Megacolon"
+  ],
+  "Craniofacial Dysostosis": [
+    "D003394",
+    "Craniofacial Dysostosis"
+  ],
+  "Iron Metabolism Disorders": [
+    "D019189",
+    "Iron Metabolism Disorders"
+  ],
+  "Pelvic Floor Disorders": [
+    "D059952",
+    "Pelvic Floor Disorders"
+  ],
+  "Hypertelorism": [
+    "D006972",
+    "Hypertelorism"
+  ],
+  "Hartnup Disease": [
+    "D006250",
+    "Hartnup Disease"
+  ],
+  "Carbon Monoxide Poisoning": [
+    "D002249",
+    "Carbon Monoxide Poisoning"
+  ],
+  "Lung Diseases, Fungal": [
+    "D008172",
+    "Lung Diseases, Fungal"
+  ],
+  "Retinal Edema": [
+    "D010211",
+    "Papilledema"
+  ],
+  "FRAXA Syndrome": [
+    "D005600",
+    "Fragile X Syndrome"
+  ],
+  "Factor XI Deficiency": [
+    "D005173",
+    "Factor XI Deficiency"
+  ],
+  "Dizziness": [
+    "D004244",
+    "Dizziness"
+  ],
+  "Keratoconjunctivitis, Infectious": [
+    "D007639",
+    "Keratoconjunctivitis, Infectious"
+  ],
+  "Congenital Generalized Lipodystrophy Type 1": [
+    "D052497",
+    "Lipodystrophy, Congenital Generalized"
+  ],
+  "Cytopathogenic Effect, Viral": [
+    "D003588",
+    "Cytopathogenic Effect, Viral"
+  ],
+  "Lipoid Proteinosis of Urbach and Wiethe": [
+    "D008065",
+    "Lipoid Proteinosis of Urbach and Wiethe"
+  ],
+  "Menopause, Premature": [
+    "D008594",
+    "Menopause, Premature"
+  ],
+  "Deglutition Disorders": [
+    "D003680",
+    "Deglutition Disorders"
+  ],
+  "gamma-Chain Disease": [
+    "D006362",
+    "Heavy Chain Disease"
+  ],
+  "Lyme Neuroborreliosis": [
+    "D020852",
+    "Lyme Neuroborreliosis"
+  ],
+  "Renal Aminoacidurias": [
+    "D000608",
+    "Renal Aminoacidurias"
+  ],
+  "Multiple Acyl Coenzyme A Dehydrogenase Deficiency": [
+    "D054069",
+    "Multiple Acyl Coenzyme A Dehydrogenase Deficiency"
+  ],
+  "Diabetes Mellitus, Lipoatrophic": [
+    "D003923",
+    "Diabetes Mellitus, Lipoatrophic"
+  ],
+  "Bluetongue": [
+    "D001819",
+    "Bluetongue"
+  ],
+  "Apraxia, Motor": [
+    "D001072",
+    "Apraxias"
+  ],
+  "Gallbladder Diseases": [
+    "D005705",
+    "Gallbladder Diseases"
+  ],
+  "X-Linked Lissencephaly": [
+    "D054221",
+    "Classical Lissencephalies and Subcortical Band Heterotopias"
+  ],
+  "Sexual Dysfunction, Physiological": [
+    "D012735",
+    "Sexual Dysfunction, Physiological"
+  ],
+  "Appendiceal Neoplasms": [
+    "D001063",
+    "Appendiceal Neoplasms"
+  ],
+  "Erysipelas": [
+    "D004886",
+    "Erysipelas"
+  ],
+  "No-Reflow Phenomenon": [
+    "D054318",
+    "No-Reflow Phenomenon"
+  ],
+  "Sex Cord-Gonadal Stromal Tumors": [
+    "D018312",
+    "Sex Cord-Gonadal Stromal Tumors"
+  ],
+  "Thecoma": [
+    "D013798",
+    "Thecoma"
+  ],
+  "Vasculitis, Central Nervous System": [
+    "D020293",
+    "Vasculitis, Central Nervous System"
+  ],
+  "Adenoma, Villous": [
+    "D018253",
+    "Adenoma, Villous"
+  ],
+  "Post-Traumatic Headache": [
+    "D051298",
+    "Post-Traumatic Headache"
+  ],
+  "Adrenal Cortex Diseases": [
+    "D000303",
+    "Adrenal Cortex Diseases"
+  ],
+  "Histiocytoma, Benign Fibrous": [
+    "D018219",
+    "Histiocytoma, Benign Fibrous"
+  ],
+  "Nevi and Melanomas": [
+    "D018326",
+    "Nevi and Melanomas"
+  ],
+  "Hemangioblastoma": [
+    "D018325",
+    "Hemangioblastoma"
+  ],
+  "Melanoma, Amelanotic": [
+    "D018328",
+    "Melanoma, Amelanotic"
+  ],
+  "Macular Holes": [
+    "D012167",
+    "Retinal Perforations"
+  ],
+  "Klippel-Trenaunay-Weber Syndrome": [
+    "D007715",
+    "Klippel-Trenaunay-Weber Syndrome"
+  ],
+  "Nails, Abnormal": [
+    "D009264",
+    "Nails, Malformed"
+  ],
+  "MPS III A": [
+    "D009084",
+    "Mucopolysaccharidosis III"
+  ],
+  "Hyperargininemia": [
+    "D020162",
+    "Hyperargininemia"
+  ],
+  "Wasting Disease, Chronic": [
+    "D034081",
+    "Wasting Disease, Chronic"
+  ],
+  "Asbestosis": [
+    "D001195",
+    "Asbestosis"
+  ],
+  "Osteoarthritis, Spine": [
+    "D055013",
+    "Osteoarthritis, Spine"
+  ],
+  "Spinal Cord Diseases": [
+    "D013118",
+    "Spinal Cord Diseases"
+  ],
+  "Swyer Syndrome": [
+    "D006061",
+    "Gonadal Dysgenesis, 46,XY"
+  ],
+  "Disruptive Behavior Disorder": [
+    "D019958",
+    "Attention Deficit and Disruptive Behavior Disorders"
+  ],
+  "Nephritis, Tubulointerstitial": [
+    "D009395",
+    "Nephritis, Interstitial"
+  ],
+  "Leukemia, T-Cell Large Granular Lymphocytic": [
+    "D054066",
+    "Leukemia, Large Granular Lymphocytic"
+  ],
+  "Neonatal Hypotonia": [
+    "D009123",
+    "Muscle Hypotonia"
+  ],
+  "Uterine Hemorrhage": [
+    "D014592",
+    "Uterine Hemorrhage"
+  ],
+  "Myelodysplastic-Myeloproliferative Diseases": [
+    "D054437",
+    "Myelodysplastic-Myeloproliferative Diseases"
+  ],
+  "Primary Graft Dysfunction": [
+    "D055031",
+    "Primary Graft Dysfunction"
+  ],
+  "Conjunctivitis": [
+    "D003231",
+    "Conjunctivitis"
+  ],
+  "Sick Sinus Syndrome": [
+    "D012804",
+    "Sick Sinus Syndrome"
+  ],
+  "Sinus Node Dysfunction": [
+    "D012804",
+    "Sick Sinus Syndrome"
+  ],
+  "Metrorrhagia": [
+    "D008796",
+    "Metrorrhagia"
+  ],
+  "Condylomata Acuminata": [
+    "D003218",
+    "Condylomata Acuminata"
+  ],
+  "Meningiomas, Multiple": [
+    "D008579",
+    "Meningioma"
+  ],
+  "Stiff-Person Syndrome": [
+    "D016750",
+    "Stiff-Person Syndrome"
+  ],
+  "Fallopian Tube Cancer": [
+    "D005185",
+    "Fallopian Tube Neoplasms"
+  ],
+  "Siderosis": [
+    "D012806",
+    "Siderosis"
+  ],
+  "Germinoma": [
+    "D018237",
+    "Germinoma"
+  ],
+  "Pseudohermaphroditism": [
+    "D012734",
+    "Disorders of Sex Development"
+  ],
+  "Membranoproliferative Glomerulonephritis, Type II": [
+    "D015432",
+    "Glomerulonephritis, Membranoproliferative"
+  ],
+  "Congenital Afibrinogenemia": [
+    "D000347",
+    "Afibrinogenemia"
+  ],
+  "Thymus Hyperplasia": [
+    "D013952",
+    "Thymus Hyperplasia"
+  ],
+  "Duodenal Cancer": [
+    "D004379",
+    "Duodenal Neoplasms"
+  ],
+  "Ectodermal Dysplasia, Hypohidrotic, Autosomal Recessive": [
+    "D053360",
+    "Ectodermal Dysplasia, Hypohidrotic, Autosomal Recessive"
+  ],
+  "Action Myoclonus-Renal Failure Syndrome": [
+    "D020191",
+    "Myoclonic Epilepsies, Progressive"
+  ],
+  "Unverricht-Lundborg Syndrome": [
+    "D020194",
+    "Unverricht-Lundborg Syndrome"
+  ],
+  "Glycosuria, Renal": [
+    "D006030",
+    "Glycosuria, Renal"
+  ],
+  "Delayed Sleep Phase Syndrome": [
+    "D020178",
+    "Sleep Disorders, Circadian Rhythm"
+  ],
+  "Normokalemic Periodic Paralysis": [
+    "D010245",
+    "Paralyses, Familial Periodic"
+  ],
+  "Paralyses, Familial Periodic": [
+    "D010245",
+    "Paralyses, Familial Periodic"
+  ],
+  "CREST Syndrome": [
+    "D017675",
+    "CREST Syndrome"
+  ],
+  "Painful Bladder Syndrome": [
+    "D018856",
+    "Cystitis, Interstitial"
+  ],
+  "Endolymphatic Hydrops": [
+    "D018159",
+    "Endolymphatic Hydrops"
+  ],
+  "Chilblains": [
+    "D002647",
+    "Chilblains"
+  ],
+  "Monilethrix": [
+    "D056734",
+    "Monilethrix"
+  ],
+  "Refractive Errors": [
+    "D012030",
+    "Refractive Errors"
+  ],
+  "Romano-Ward Syndrome": [
+    "D029597",
+    "Romano-Ward Syndrome"
+  ],
+  "Aplasia Cutis Congenita": [
+    "D004476",
+    "Ectodermal Dysplasia"
+  ],
+  "Cardiac Death": [
+    "D003643",
+    "Death"
+  ],
+  "Maxillofacial Abnormalities": [
+    "D019767",
+    "Maxillofacial Abnormalities"
+  ],
+  "Lupus Erythematosus, Cutaneous": [
+    "D008178",
+    "Lupus Erythematosus, Cutaneous"
+  ],
+  "Mycobacterium avium-intracellulare Infection": [
+    "D015270",
+    "Mycobacterium avium-intracellulare Infection"
+  ],
+  "Dermatitis, Photoallergic": [
+    "D017454",
+    "Dermatitis, Photoallergic"
+  ],
+  "Paris-Trousseau Thrombocytopenia": [
+    "D054868",
+    "Jacobsen Distal 11q Deletion Syndrome"
+  ],
+  "Urologic Diseases": [
+    "D014570",
+    "Urologic Diseases"
+  ],
+  "Dextrocardia": [
+    "D003914",
+    "Dextrocardia"
+  ],
+  "Fukuyama Type Congenital Muscular Dystrophy": [
+    "D058494",
+    "Walker-Warburg Syndrome"
+  ],
+  "Hair Diseases": [
+    "D006201",
+    "Hair Diseases"
+  ],
+  "Anterior Ischemic Optic Neuropathy": [
+    "D018917",
+    "Optic Neuropathy, Ischemic"
+  ],
+  "Tuberculosis, Osteoarticular": [
+    "D014394",
+    "Tuberculosis, Osteoarticular"
+  ],
+  "Pityriasis Lichenoides et Varioliformis Acuta": [
+    "D017514",
+    "Pityriasis Lichenoides"
+  ],
+  "Cerebral Hemorrhage, Hypertensive": [
+    "D020299",
+    "Intracranial Hemorrhage, Hypertensive"
+  ],
+  "Transposition of Great Vessels": [
+    "D014188",
+    "Transposition of Great Vessels"
+  ],
+  "Acrokeratosis Verruciformis of Hopf": [
+    "D007644",
+    "Darier Disease"
+  ],
+  "Muscular Dystrophy, Emery-Dreifuss": [
+    "D020389",
+    "Muscular Dystrophy, Emery-Dreifuss"
+  ],
+  "Urticaria Pigmentosa": [
+    "D014582",
+    "Urticaria Pigmentosa"
+  ],
+  "Scheie Syndrome": [
+    "D008059",
+    "Mucopolysaccharidosis I"
+  ],
+  "Endometrial Diseases": [
+    "D014591",
+    "Uterine Diseases"
+  ],
+  "Vasculitis, Leukocytoclastic, Cutaneous": [
+    "D018366",
+    "Vasculitis, Leukocytoclastic, Cutaneous"
+  ],
+  "Choledochal Cyst": [
+    "D015529",
+    "Choledochal Cyst"
+  ],
+  "Hyperostosis, Cortical, Congenital": [
+    "D006958",
+    "Hyperostosis, Cortical, Congenital"
+  ],
+  "Otitis Media, Suppurative": [
+    "D010035",
+    "Otitis Media, Suppurative"
+  ],
+  "Organoid Nevus Phakomatosis": [
+    "D054000",
+    "Nevus, Sebaceous of Jadassohn"
+  ],
+  "Riboflavin Deficiency": [
+    "D012257",
+    "Riboflavin Deficiency"
+  ],
+  "Gangliosidosis, Generalized GM1, Type 1": [
+    "D016537",
+    "Gangliosidosis, GM1"
+  ],
+  "Septo-Optic Dysplasia": [
+    "D025962",
+    "Septo-Optic Dysplasia"
+  ],
+  "Hearing Loss, Conductive": [
+    "D006314",
+    "Hearing Loss, Conductive"
+  ],
+  "Congenital Myasthenic Syndromes, Postsynaptic": [
+    "D020294",
+    "Myasthenic Syndromes, Congenital"
+  ],
+  "Sebaceous Gland Neoplasms": [
+    "D012626",
+    "Sebaceous Gland Neoplasms"
+  ],
+  "Glycogen Storage Disease Type VII": [
+    "D006014",
+    "Glycogen Storage Disease Type VII"
+  ],
+  "Peripheral Nerve Sheath Tumors": [
+    "D018317",
+    "Nerve Sheath Neoplasms"
+  ],
+  "Adenoma, Basal Cell": [
+    "D000236",
+    "Adenoma"
+  ],
+  "Syphilis": [
+    "D013587",
+    "Syphilis"
+  ],
+  "Alphavirus Infections": [
+    "D018354",
+    "Alphavirus Infections"
+  ],
+  "Pulmonary Sclerosing Hemangioma": [
+    "D047868",
+    "Pulmonary Sclerosing Hemangioma"
+  ],
+  "Kearns-Sayre Syndrome": [
+    "D007625",
+    "Kearns-Sayre Syndrome"
+  ],
+  "Pemphigoid, Benign Mucous Membrane": [
+    "D010390",
+    "Pemphigoid, Benign Mucous Membrane"
+  ],
+  "Neurosyphilis, Asymptomatic": [
+    "D009494",
+    "Neurosyphilis"
+  ],
+  "Warm Ischemia": [
+    "D052096",
+    "Warm Ischemia"
+  ],
+  "Langerhans Cell Sarcoma": [
+    "D054752",
+    "Langerhans Cell Sarcoma"
+  ],
+  "Exencephaly": [
+    "D009436",
+    "Neural Tube Defects"
+  ],
+  "Arthus Reaction": [
+    "D001183",
+    "Arthus Reaction"
+  ],
+  "Knee Injuries": [
+    "D007718",
+    "Knee Injuries"
+  ],
+  "Retroperitoneal Fibrosis": [
+    "D012185",
+    "Retroperitoneal Fibrosis"
+  ],
+  "Hemangioma, Intramuscular": [
+    "D006391",
+    "Hemangioma"
+  ],
+  "Cluster Headache": [
+    "D003027",
+    "Cluster Headache"
+  ],
+  "Goiter, Endemic": [
+    "D006043",
+    "Goiter, Endemic"
+  ],
+  "Paresthesia, Distal": [
+    "D010292",
+    "Paresthesia"
+  ],
+  "Benign Paroxysmal Positional Vertigo": [
+    "D065635",
+    "Benign Paroxysmal Positional Vertigo"
+  ],
+  "Gonadal Dysgenesis, 46,XX": [
+    "D023961",
+    "Gonadal Dysgenesis, 46,XX"
+  ],
+  "Adenolymphoma": [
+    "D000235",
+    "Adenolymphoma"
+  ],
+  "Myoclonic Astatic Epilepsy": [
+    "D004831",
+    "Epilepsies, Myoclonic"
+  ],
+  "Porphyrias, Hepatic": [
+    "D017094",
+    "Porphyrias, Hepatic"
+  ],
+  "Testicular Feminization": [
+    "D013734",
+    "Androgen-Insensitivity Syndrome"
+  ],
+  "Prodromal Symptoms": [
+    "D062706",
+    "Prodromal Symptoms"
+  ],
+  "Lens Subluxation": [
+    "D007906",
+    "Lens Subluxation"
+  ],
+  "Pulmonary Valve Stenosis": [
+    "D011666",
+    "Pulmonary Valve Stenosis"
+  ],
+  "Chorioretinitis": [
+    "D002825",
+    "Chorioretinitis"
+  ],
+  "Central Nervous System Infections": [
+    "D002494",
+    "Central Nervous System Infections"
+  ],
+  "Asphyxia": [
+    "D001237",
+    "Asphyxia"
+  ],
+  "Eosinophilia-Myalgia Syndrome": [
+    "D016603",
+    "Eosinophilia-Myalgia Syndrome"
+  ],
+  "Multicystic Dysplastic Kidney": [
+    "D021782",
+    "Multicystic Dysplastic Kidney"
+  ],
+  "Coxsackievirus Infections": [
+    "D003384",
+    "Coxsackievirus Infections"
+  ],
+  "Encephalopathy, Toxic": [
+    "D020258",
+    "Neurotoxicity Syndromes"
+  ],
+  "Hypopharyngeal Neoplasms": [
+    "D007012",
+    "Hypopharyngeal Neoplasms"
+  ],
+  "Myasthenia Gravis, Autoimmune, Experimental": [
+    "D020720",
+    "Myasthenia Gravis, Autoimmune, Experimental"
+  ],
+  "Subarachnoid Hemorrhage, Spontaneous": [
+    "D013345",
+    "Subarachnoid Hemorrhage"
+  ],
+  "Weill-Marchesani Syndrome, Autosomal Dominant": [
+    "D056846",
+    "Weill-Marchesani Syndrome"
+  ],
+  "Neurogenic Muscular Atrophy": [
+    "D009133",
+    "Muscular Atrophy"
+  ],
+  "Adrenal Gland Diseases": [
+    "D000307",
+    "Adrenal Gland Diseases"
+  ],
+  "Meningitis, Cryptococcal": [
+    "D016919",
+    "Meningitis, Cryptococcal"
+  ],
+  "Factor V Deficiency": [
+    "D005166",
+    "Factor V Deficiency"
+  ],
+  "Watson Syndrome": [
+    "D009456",
+    "Neurofibromatosis 1"
+  ],
+  "Xanthoma": [
+    "D014973",
+    "Xanthomatosis"
+  ],
+  "Idiocy": [
+    "D008607",
+    "Intellectual Disability"
+  ],
+  "Chronically Ill": [
+    "D002908",
+    "Chronic Disease"
+  ],
+  "Necrotic Arachnidism": [
+    "D001098",
+    "Spider Bites"
+  ],
+  "Hypolipoproteinemias": [
+    "D007009",
+    "Hypolipoproteinemias"
+  ],
+  "Myoma": [
+    "D009214",
+    "Myoma"
+  ],
+  "Pigmentation Disorders": [
+    "D010859",
+    "Pigmentation Disorders"
+  ],
+  "Placenta Accreta": [
+    "D010921",
+    "Placenta Accreta"
+  ],
+  "Gastroschisis": [
+    "D020139",
+    "Gastroschisis"
+  ],
+  "Hallucinations, Olfactory": [
+    "D006212",
+    "Hallucinations"
+  ],
+  "Blood Coagulation Disorders, Inherited": [
+    "D025861",
+    "Blood Coagulation Disorders, Inherited"
+  ],
+  "Basilar-Type Migraine": [
+    "D020325",
+    "Migraine with Aura"
+  ],
+  "Biliary Tract Diseases": [
+    "D001660",
+    "Biliary Tract Diseases"
+  ],
+  "Kimura Disease": [
+    "D000796",
+    "Angiolymphoid Hyperplasia with Eosinophilia"
+  ],
+  "Sleep Bruxism": [
+    "D020186",
+    "Sleep Bruxism"
+  ],
+  "Fourth Cranial Nerve Palsy": [
+    "D020432",
+    "Trochlear Nerve Diseases"
+  ],
+  "Pericardial Effusion": [
+    "D010490",
+    "Pericardial Effusion"
+  ],
+  "Thymus Neoplasms": [
+    "D013953",
+    "Thymus Neoplasms"
+  ],
+  "Cancer of Penis": [
+    "D010412",
+    "Penile Neoplasms"
+  ],
+  "Phlebitis": [
+    "D010689",
+    "Phlebitis"
+  ],
+  "Esophageal Atresia": [
+    "D004933",
+    "Esophageal Atresia"
+  ],
+  "Epilepsy, Reflex": [
+    "D020195",
+    "Epilepsy, Reflex"
+  ],
+  "Wernicke Encephalopathy": [
+    "D014899",
+    "Wernicke Encephalopathy"
+  ],
+  "Oral Manifestations": [
+    "D009912",
+    "Oral Manifestations"
+  ],
+  "Spondylitis": [
+    "D013166",
+    "Spondylitis"
+  ],
+  "Temporal Arteritis": [
+    "D013700",
+    "Giant Cell Arteritis"
+  ],
+  "Prognathism": [
+    "D011378",
+    "Prognathism"
+  ],
+  "Serositis": [
+    "D012700",
+    "Serositis"
+  ],
+  "Leishmaniasis, Diffuse Cutaneous": [
+    "D016774",
+    "Leishmaniasis, Diffuse Cutaneous"
+  ],
+  "Hoarseness": [
+    "D006685",
+    "Hoarseness"
+  ],
+  "Myofibroma": [
+    "D047708",
+    "Myofibroma"
+  ],
+  "Postpartum Thyroiditis": [
+    "D050032",
+    "Postpartum Thyroiditis"
+  ],
+  "Facial Nerve Avulsion": [
+    "D020220",
+    "Facial Nerve Injuries"
+  ],
+  "Dysarthria": [
+    "D004401",
+    "Dysarthria"
+  ],
+  "Rathke Cleft Cysts": [
+    "D020863",
+    "Central Nervous System Cysts"
+  ],
+  "Thyroiditis": [
+    "D013966",
+    "Thyroiditis"
+  ],
+  "Uterine Cervical Incompetence": [
+    "D002581",
+    "Uterine Cervical Incompetence"
+  ],
+  "Meningoencephalitis": [
+    "D008590",
+    "Meningoencephalitis"
+  ],
+  "Diabetic Neuralgia": [
+    "D003929",
+    "Diabetic Neuropathies"
+  ],
+  "Apolipoprotein C-II Deficiency": [
+    "D008072",
+    "Hyperlipoproteinemia Type I"
+  ],
+  "Ebstein Anomaly": [
+    "D004437",
+    "Ebstein Anomaly"
+  ],
+  "Vascular Malformations, Brain": [
+    "D020785",
+    "Central Nervous System Vascular Malformations"
+  ],
+  "Familial Partial Lipodystrophy, Type 3": [
+    "D052496",
+    "Lipodystrophy, Familial Partial"
+  ],
+  "Mucocele": [
+    "D009078",
+    "Mucocele"
+  ],
+  "Lichen Sclerosus et Atrophicus": [
+    "D018459",
+    "Lichen Sclerosus et Atrophicus"
+  ],
+  "UDPglucose 4-Epimerase Deficiency Disease": [
+    "D005693",
+    "Galactosemias"
+  ],
+  "Mastocytosis, Cutaneous": [
+    "D034701",
+    "Mastocytosis, Cutaneous"
+  ],
+  "Ocular Cicatricial Pemphigoid": [
+    "D010390",
+    "Pemphigoid, Benign Mucous Membrane"
+  ],
+  "Ophthalmoplegia, Chronic Progressive External": [
+    "D017246",
+    "Ophthalmoplegia, Chronic Progressive External"
+  ],
+  "Angiodysplasia": [
+    "D016888",
+    "Angiodysplasia"
+  ],
+  "Teratoma, Malignant": [
+    "D013724",
+    "Teratoma"
+  ],
+  "Transsexualism": [
+    "D014189",
+    "Transsexualism"
+  ],
+  "Trachoma": [
+    "D014141",
+    "Trachoma"
+  ],
+  "Aspartylglucosaminuria": [
+    "D054880",
+    "Aspartylglucosaminuria"
+  ],
+  "Neoplasms, Connective and Soft Tissue": [
+    "D018204",
+    "Neoplasms, Connective and Soft Tissue"
+  ],
+  "Hypersomnia": [
+    "D006970",
+    "Disorders of Excessive Somnolence"
+  ],
+  "Rheumatoid Nodule": [
+    "D012218",
+    "Rheumatoid Nodule"
+  ],
+  "Pilonidal Sinus": [
+    "D010864",
+    "Pilonidal Sinus"
+  ],
+  "Hypoaldosteronism, Hyporeninemic": [
+    "D006994",
+    "Hypoaldosteronism"
+  ],
+  "Spirochaetales Infections": [
+    "D013145",
+    "Spirochaetales Infections"
+  ],
+  "Paraplegia": [
+    "D010264",
+    "Paraplegia"
+  ],
+  "Alcohol Amnestic Disorder": [
+    "D000425",
+    "Alcohol Amnestic Disorder"
+  ],
+  "Brain Damage, Chronic": [
+    "D001925",
+    "Brain Damage, Chronic"
+  ],
+  "Neuralgia": [
+    "D009437",
+    "Neuralgia"
+  ],
+  "Adrenal Rest Tumor": [
+    "D000314",
+    "Adrenal Rest Tumor"
+  ],
+  "Whipple Disease": [
+    "D008061",
+    "Whipple Disease"
+  ],
+  "Melanoma, Experimental": [
+    "D008546",
+    "Melanoma, Experimental"
+  ],
+  "Host vs Graft Reaction": [
+    "D006789",
+    "Host vs Graft Reaction"
+  ],
+  "Intracranial Atherosclerosis": [
+    "D002537",
+    "Intracranial Arteriosclerosis"
+  ],
+  "Paresis": [
+    "D010291",
+    "Paresis"
+  ],
+  "Hyperlysinemias": [
+    "D020167",
+    "Hyperlysinemias"
+  ],
+  "Asphyxia Neonatorum": [
+    "D001238",
+    "Asphyxia Neonatorum"
+  ],
+  "Hypomenorrhea": [
+    "D008599",
+    "Menstruation Disturbances"
+  ],
+  "Pseudotumor Cerebri": [
+    "D011559",
+    "Pseudotumor Cerebri"
+  ],
+  "Blepharospasm": [
+    "D001764",
+    "Blepharospasm"
+  ],
+  "Crisscross Heart": [
+    "D003420",
+    "Crisscross Heart"
+  ],
+  "Glycogen Storage Disease Type VIII": [
+    "D006015",
+    "Glycogen Storage Disease Type VIII"
+  ],
+  "Funnel Chest": [
+    "D005660",
+    "Funnel Chest"
+  ],
+  "Cancer of Thymus": [
+    "D013953",
+    "Thymus Neoplasms"
+  ],
+  "Disorders of Excessive Somnolence": [
+    "D006970",
+    "Disorders of Excessive Somnolence"
+  ],
+  "Granuloma, Pyogenic": [
+    "D017789",
+    "Granuloma, Pyogenic"
+  ],
+  "Carcinoma, Anaplastic": [
+    "D002277",
+    "Carcinoma"
+  ],
+  "Vestibular Diseases": [
+    "D015837",
+    "Vestibular Diseases"
+  ],
+  "Leprosy, Borderline": [
+    "D015439",
+    "Leprosy, Borderline"
+  ],
+  "Tympanosclerosis": [
+    "D063371",
+    "Myringosclerosis"
+  ],
+  "Immunoproliferative Disorders": [
+    "D007160",
+    "Immunoproliferative Disorders"
+  ],
+  "Liver Cirrhosis, Biliary": [
+    "D008105",
+    "Liver Cirrhosis, Biliary"
+  ],
+  "Anxiety, Separation": [
+    "D001010",
+    "Anxiety, Separation"
+  ],
+  "Nevus, Epithelioid and Spindle Cell": [
+    "D018332",
+    "Nevus, Epithelioid and Spindle Cell"
+  ],
+  "Hypertension, Malignant": [
+    "D006974",
+    "Hypertension, Malignant"
+  ],
+  "Sore Throat": [
+    "D010612",
+    "Pharyngitis"
+  ],
+  "Aortic Rupture": [
+    "D001019",
+    "Aortic Rupture"
+  ],
+  "Ferrochelatase Deficiency": [
+    "D046351",
+    "Protoporphyria, Erythropoietic"
+  ],
+  "Chorea, Rheumatic": [
+    "D002819",
+    "Chorea"
+  ],
+  "Orthostatic Intolerance": [
+    "D054971",
+    "Orthostatic Intolerance"
+  ],
+  "Cancer of Parotid": [
+    "D010307",
+    "Parotid Neoplasms"
+  ],
+  "Fractures, Ununited": [
+    "D005599",
+    "Fractures, Ununited"
+  ],
+  "Hypergonadotropic Hypogonadism": [
+    "D007006",
+    "Hypogonadism"
+  ],
+  "Fanconi Syndrome": [
+    "D005198",
+    "Fanconi Syndrome"
+  ],
+  "Photosensitive Trichothiodystrophy": [
+    "D054463",
+    "Trichothiodystrophy Syndromes"
+  ],
+  "Mutism": [
+    "D009155",
+    "Mutism"
+  ],
+  "Subcortical Infarction": [
+    "D002544",
+    "Cerebral Infarction"
+  ],
+  "Dengue Shock Syndrome": [
+    "D019595",
+    "Severe Dengue"
+  ],
+  "Phobic Disorders": [
+    "D010698",
+    "Phobic Disorders"
+  ],
+  "Gynandroblastoma": [
+    "D018312",
+    "Sex Cord-Gonadal Stromal Tumors"
+  ],
+  "Optic Neuropathy, Ischemic": [
+    "D018917",
+    "Optic Neuropathy, Ischemic"
+  ],
+  "Hyper-IgM Immunodeficiency Syndrome, Type 2": [
+    "D053306",
+    "Hyper-IgM Immunodeficiency Syndrome"
+  ],
+  "Progressive Muscular Atrophy": [
+    "D009134",
+    "Muscular Atrophy, Spinal"
+  ],
+  "Frasier Syndrome": [
+    "D052159",
+    "Frasier Syndrome"
+  ],
+  "Hemorrhagic Disorders": [
+    "D006474",
+    "Hemorrhagic Disorders"
+  ],
+  "Hallucinations, Auditory": [
+    "D006212",
+    "Hallucinations"
+  ],
+  "Amino Acid Metabolism, Inborn Errors": [
+    "D000592",
+    "Amino Acid Metabolism, Inborn Errors"
+  ],
+  "Hemosiderosis": [
+    "D006486",
+    "Hemosiderosis"
+  ],
+  "Epidermolysis Bullosa Acquisita": [
+    "D016107",
+    "Epidermolysis Bullosa Acquisita"
+  ],
+  "Preleukemia": [
+    "D011289",
+    "Preleukemia"
+  ],
+  "Amnesia": [
+    "D000647",
+    "Amnesia"
+  ],
+  "Atrial Flutter": [
+    "D001282",
+    "Atrial Flutter"
+  ],
+  "Nemaline Myopathy, Autosomal Recessive": [
+    "D017696",
+    "Myopathies, Nemaline"
+  ],
+  "Funisitis": [
+    "D002821",
+    "Chorioamnionitis"
+  ],
+  "Cri-du-Chat Syndrome": [
+    "D003410",
+    "Cri-du-Chat Syndrome"
+  ],
+  "Causalgia": [
+    "D002422",
+    "Causalgia"
+  ],
+  "Agraphia": [
+    "D000381",
+    "Agraphia"
+  ],
+  "Sinusitis": [
+    "D012852",
+    "Sinusitis"
+  ],
+  "Motor Neuron Disease, Upper": [
+    "D016472",
+    "Motor Neuron Disease"
+  ],
+  "Exanthema Subitum": [
+    "D005077",
+    "Exanthema Subitum"
+  ],
+  "Hernia, Diaphragmatic": [
+    "D006548",
+    "Hernia, Diaphragmatic"
+  ],
+  "Kallmann Syndrome 1": [
+    "D017436",
+    "Kallmann Syndrome"
+  ],
+  "Choroid Neoplasms": [
+    "D002830",
+    "Choroid Neoplasms"
+  ],
+  "Injuries, Acute Brain": [
+    "D001930",
+    "Brain Injuries"
+  ],
+  "Ductus Arteriosus, Patent": [
+    "D004374",
+    "Ductus Arteriosus, Patent"
+  ],
+  "Exotropia": [
+    "D005099",
+    "Exotropia"
+  ],
+  "Congenital, Hereditary, and Neonatal Diseases and Abnormalities": [
+    "D009358",
+    "Congenital, Hereditary, and Neonatal Diseases and Abnormalities"
+  ],
+  "Calcium Pyrophosphate Dihydrate Deposition": [
+    "D002805",
+    "Chondrocalcinosis"
+  ],
+  "Acute Generalized Exanthematous Pustulosis": [
+    "D056150",
+    "Acute Generalized Exanthematous Pustulosis"
+  ],
+  "Leukemia, Prolymphocytic, B-Cell": [
+    "D054403",
+    "Leukemia, Prolymphocytic, B-Cell"
+  ],
+  "Retrocochlear Hearing Loss": [
+    "D012181",
+    "Retrocochlear Diseases"
+  ],
+  "Toxoplasmosis, Cerebral": [
+    "D016781",
+    "Toxoplasmosis, Cerebral"
+  ],
+  "Pregnancy Complications, Infectious": [
+    "D011251",
+    "Pregnancy Complications, Infectious"
+  ],
+  "Drowning": [
+    "D004332",
+    "Drowning"
+  ],
+  "Anaplastic Ependymoma": [
+    "D004806",
+    "Ependymoma"
+  ],
+  "Lhermitte-Duclos Disease": [
+    "D006223",
+    "Hamartoma Syndrome, Multiple"
+  ],
+  "Ovarian Cysts": [
+    "D010048",
+    "Ovarian Cysts"
+  ],
+  "Spondylolysis": [
+    "D013169",
+    "Spondylolysis"
+  ],
+  "Phenylketonuria, Maternal": [
+    "D017042",
+    "Phenylketonuria, Maternal"
+  ],
+  "Necrosis, Aseptic, of Bone": [
+    "D010020",
+    "Osteonecrosis"
+  ],
+  "Polyomavirus Infections": [
+    "D027601",
+    "Polyomavirus Infections"
+  ],
+  "Enchondromatosis": [
+    "D004687",
+    "Enchondromatosis"
+  ],
+  "Hemiplegia": [
+    "D006429",
+    "Hemiplegia"
+  ],
+  "Fibroma, Ossifying": [
+    "D018214",
+    "Fibroma, Ossifying"
+  ],
+  "Factor XII Deficiency": [
+    "D005175",
+    "Factor XII Deficiency"
+  ],
+  "Jaundice, Obstructive": [
+    "D041781",
+    "Jaundice, Obstructive"
+  ],
+  "Alpha-Sarcoglycanopathies": [
+    "D058088",
+    "Sarcoglycanopathies"
+  ],
+  "Epilepsy, Frontal Lobe": [
+    "D017034",
+    "Epilepsy, Frontal Lobe"
+  ],
+  "Bulbo-Spinal Atrophy, X-Linked": [
+    "D055534",
+    "Bulbo-Spinal Atrophy, X-Linked"
+  ],
+  "Lissencephalies, Classical": [
+    "D054221",
+    "Classical Lissencephalies and Subcortical Band Heterotopias"
+  ],
+  "Speech Delay": [
+    "D007805",
+    "Language Development Disorders"
+  ],
+  "Hypokinesia": [
+    "D018476",
+    "Hypokinesia"
+  ],
+  "Fibromuscular Dysplasia": [
+    "D005352",
+    "Fibromuscular Dysplasia"
+  ],
+  "Neoplasms, Fibroepithelial": [
+    "D018225",
+    "Neoplasms, Fibroepithelial"
+  ],
+  "Heavy Metal Poisoning, Nervous System": [
+    "D020260",
+    "Heavy Metal Poisoning, Nervous System"
+  ],
+  "Somatostatinoma": [
+    "D013005",
+    "Somatostatinoma"
+  ],
+  "Chondroblastoma": [
+    "D002804",
+    "Chondroblastoma"
+  ],
+  "Drug Hypersensitivity": [
+    "D004342",
+    "Drug Hypersensitivity"
+  ],
+  "Ophthalmia, Sympathetic": [
+    "D009879",
+    "Ophthalmia, Sympathetic"
+  ],
+  "Schizotypal Personality Disorder": [
+    "D012569",
+    "Schizotypal Personality Disorder"
+  ],
+  "Cranial Arteritis": [
+    "D013700",
+    "Giant Cell Arteritis"
+  ],
+  "Pachygyria": [
+    "D054082",
+    "Lissencephaly"
+  ],
+  "Testicular Hydrocele": [
+    "D006848",
+    "Testicular Hydrocele"
+  ],
+  "Lupus Erythematosus, Subacute Cutaneous": [
+    "D008178",
+    "Lupus Erythematosus, Cutaneous"
+  ],
+  "Cystadenoma, Serous": [
+    "D018293",
+    "Cystadenoma, Serous"
+  ],
+  "Toothache": [
+    "D014098",
+    "Toothache"
+  ],
+  "Enterobacteriaceae Infections": [
+    "D004756",
+    "Enterobacteriaceae Infections"
+  ],
+  "Periventricular Heterotopia, X-Linked": [
+    "D054091",
+    "Periventricular Nodular Heterotopia"
+  ],
+  "Nevus, Blue": [
+    "D018329",
+    "Nevus, Blue"
+  ],
+  "Ache": [
+    "D010146",
+    "Pain"
+  ],
+  "Sweating Sickness": [
+    "D018614",
+    "Sweating Sickness"
+  ],
+  "Myotonic Disorders": [
+    "D020967",
+    "Myotonic Disorders"
+  ],
+  "Placenta Previa": [
+    "D010923",
+    "Placenta Previa"
+  ],
+  "Cerebral Atherosclerosis": [
+    "D002537",
+    "Intracranial Arteriosclerosis"
+  ],
+  "Herpes Labialis": [
+    "D006560",
+    "Herpes Labialis"
+  ],
+  "Niemann-Pick Disease, Type D": [
+    "D052556",
+    "Niemann-Pick Disease, Type C"
+  ],
+  "Choledocholithiasis": [
+    "D042883",
+    "Choledocholithiasis"
+  ],
+  "Lassa Fever": [
+    "D007835",
+    "Lassa Fever"
+  ],
+  "Brain Injury, Chronic": [
+    "D020208",
+    "Brain Injury, Chronic"
+  ],
+  "Venous Insufficiency": [
+    "D014689",
+    "Venous Insufficiency"
+  ],
+  "Fasciitis": [
+    "D005208",
+    "Fasciitis"
+  ],
+  "Eisenmenger Complex": [
+    "D004541",
+    "Eisenmenger Complex"
+  ],
+  "Urinary Bladder Diseases": [
+    "D001745",
+    "Urinary Bladder Diseases"
+  ],
+  "Hemifacial Spasm": [
+    "D019569",
+    "Hemifacial Spasm"
+  ],
+  "Parathyroid Diseases": [
+    "D010279",
+    "Parathyroid Diseases"
+  ],
+  "Cerebellar Ataxia, Late Onset": [
+    "D013132",
+    "Spinocerebellar Degenerations"
+  ],
+  "Hernia, Inguinal": [
+    "D006552",
+    "Hernia, Inguinal"
+  ],
+  "Hypoprothrombinemias": [
+    "D007020",
+    "Hypoprothrombinemias"
+  ],
+  "Adult Sandhoff Disease": [
+    "D012497",
+    "Sandhoff Disease"
+  ],
+  "Uterine Cervical Diseases": [
+    "D002577",
+    "Uterine Cervical Diseases"
+  ],
+  "Carotid Body Tumor": [
+    "D002345",
+    "Carotid Body Tumor"
+  ],
+  "Rabson-Mendenhall Syndrome": [
+    "D056731",
+    "Donohue Syndrome"
+  ],
+  "Arrhythmia, Sinus": [
+    "D001146",
+    "Arrhythmia, Sinus"
+  ],
+  "Bland White Garland Syndrome": [
+    "D063748",
+    "Bland White Garland Syndrome"
+  ],
+  "Sensory Disorders": [
+    "D012678",
+    "Sensation Disorders"
+  ],
+  "Cardiomyopathies, Primary": [
+    "D009202",
+    "Cardiomyopathies"
+  ],
+  "Presyncope": [
+    "D013575",
+    "Syncope"
+  ],
+  "Dental Anxiety": [
+    "D016854",
+    "Dental Anxiety"
+  ],
+  "Orofacial Pain": [
+    "D005157",
+    "Facial Pain"
+  ],
+  "Reflex Sympathetic Dystrophy": [
+    "D012019",
+    "Reflex Sympathetic Dystrophy"
+  ],
+  "Yawning": [
+    "D015000",
+    "Yawning"
+  ],
+  "familial hypophosphatemic rickets": [
+    "D053098",
+    "Familial Hypophosphatemic Rickets"
+  ],
+  "Neoplasms, Complex and Mixed": [
+    "D018193",
+    "Neoplasms, Complex and Mixed"
+  ],
+  "Adenomatoid Tumor": [
+    "D018254",
+    "Adenomatoid Tumor"
+  ],
+  "Apraxia, Verbal": [
+    "D001072",
+    "Apraxias"
+  ],
+  "MPS III D": [
+    "D009084",
+    "Mucopolysaccharidosis III"
+  ],
+  "Dyskinesia, Drug-Induced": [
+    "D004409",
+    "Dyskinesia, Drug-Induced"
+  ],
+  "Keratoderma, Palmoplantar, Diffuse": [
+    "D015776",
+    "Keratoderma, Palmoplantar, Diffuse"
+  ],
+  "Osteosarcoma, Juxtacortical": [
+    "D018217",
+    "Osteosarcoma, Juxtacortical"
+  ],
+  "Alkalosis": [
+    "D000471",
+    "Alkalosis"
+  ],
+  "Myotonia Fluctuans": [
+    "D020967",
+    "Myotonic Disorders"
+  ],
+  "Diffuse Axonal Injury": [
+    "D020833",
+    "Diffuse Axonal Injury"
+  ],
+  "Internal Carotid Artery Stenosis": [
+    "D016893",
+    "Carotid Stenosis"
+  ],
+  "Morphea": [
+    "D012594",
+    "Scleroderma, Localized"
+  ],
+  "Epilepsy, Atonic": [
+    "D004829",
+    "Epilepsy, Generalized"
+  ],
+  "Lymphoma, Low-Grade": [
+    "D008228",
+    "Lymphoma, Non-Hodgkin"
+  ],
+  "Lipomatosis, Multiple Symmetrical": [
+    "D008069",
+    "Lipomatosis, Multiple Symmetrical"
+  ],
+  "Gray Platelet Syndrome": [
+    "D055652",
+    "Gray Platelet Syndrome"
+  ],
+  "Cholestasis, Extrahepatic": [
+    "D001651",
+    "Cholestasis, Extrahepatic"
+  ],
+  "Gliomatosis Cerebri": [
+    "D018302",
+    "Neoplasms, Neuroepithelial"
+  ],
+  "Anhidrotic Ectodermal Dysplasia": [
+    "D004476",
+    "Ectodermal Dysplasia"
+  ],
+  "Advanced Sleep Phase Syndrome": [
+    "D020178",
+    "Sleep Disorders, Circadian Rhythm"
+  ],
+  "Macrostomia": [
+    "D008265",
+    "Macrostomia"
+  ],
+  "von Willebrand Disease, Type 2A": [
+    "D056728",
+    "von Willebrand Disease, Type 2"
+  ],
+  "Ureteral Neoplasms": [
+    "D014516",
+    "Ureteral Neoplasms"
+  ],
+  "Papilloma, Intraductal": [
+    "D018300",
+    "Papilloma, Intraductal"
+  ],
+  "Erythroblastosis, Fetal": [
+    "D004899",
+    "Erythroblastosis, Fetal"
+  ],
+  "Schizoid Personality Disorder": [
+    "D012557",
+    "Schizoid Personality Disorder"
+  ],
+  "Uterine Cervicitis": [
+    "D002575",
+    "Uterine Cervicitis"
+  ],
+  "Papillon-Leage and Psaume Syndrome": [
+    "D009958",
+    "Orofaciodigital Syndromes"
+  ],
+  "Nemaline Myopathy, Autosomal Dominant": [
+    "D017696",
+    "Myopathies, Nemaline"
+  ],
+  "Congenital Myasthenic Syndromes, Presynaptic": [
+    "D020294",
+    "Myasthenic Syndromes, Congenital"
+  ],
+  "Septicemia": [
+    "D018805",
+    "Sepsis"
+  ],
+  "Sarcoma, Clear Cell": [
+    "D018227",
+    "Sarcoma, Clear Cell"
+  ],
+  "Primary Dysautonomias": [
+    "D054969",
+    "Primary Dysautonomias"
+  ],
+  "Brain Abscess": [
+    "D001922",
+    "Brain Abscess"
+  ],
+  "Anemia, Pernicious": [
+    "D000752",
+    "Anemia, Pernicious"
+  ],
+  "Perineurioma": [
+    "D018317",
+    "Nerve Sheath Neoplasms"
+  ],
+  "Varicose Ulcer": [
+    "D014647",
+    "Varicose Ulcer"
+  ],
+  "Tricuspid Valve Insufficiency": [
+    "D014262",
+    "Tricuspid Valve Insufficiency"
+  ],
+  "Mitral Valve Insufficiency": [
+    "D008944",
+    "Mitral Valve Insufficiency"
+  ],
+  "Laryngismus": [
+    "D007826",
+    "Laryngismus"
+  ],
+  "Abortion, Induced": [
+    "D000028",
+    "Abortion, Induced"
+  ],
+  "Lens Diseases": [
+    "D007905",
+    "Lens Diseases"
+  ],
+  "Cervical Spondylosis": [
+    "D055009",
+    "Spondylosis"
+  ],
+  "Enterocutaneous Fistula": [
+    "D007412",
+    "Intestinal Fistula"
+  ],
+  "Acute Anterior Wall Myocardial Infarction": [
+    "D056988",
+    "Anterior Wall Myocardial Infarction"
+  ],
+  "Echinococcosis": [
+    "D004443",
+    "Echinococcosis"
+  ],
+  "Strabismus, Comitant": [
+    "D013285",
+    "Strabismus"
+  ],
+  "Gonadal Dysgenesis, Mixed": [
+    "D006060",
+    "Gonadal Dysgenesis, Mixed"
+  ],
+  "Fibromatosis": [
+    "D005350",
+    "Fibroma"
+  ],
+  "Embolism, Fat": [
+    "D004620",
+    "Embolism, Fat"
+  ],
+  "Fibromatosis, Gingival": [
+    "D005351",
+    "Fibromatosis, Gingival"
+  ],
+  "delta-Thalassemia": [
+    "D055538",
+    "delta-Thalassemia"
+  ],
+  "Eye Diseases, Hereditary": [
+    "D015785",
+    "Eye Diseases, Hereditary"
+  ],
+  "Agoraphobia": [
+    "D000379",
+    "Agoraphobia"
+  ],
+  "Hyperhidrosis": [
+    "D006945",
+    "Hyperhidrosis"
+  ],
+  "Choline Deficiency": [
+    "D002796",
+    "Choline Deficiency"
+  ],
+  "Hemangiopericytoma": [
+    "D006393",
+    "Hemangiopericytoma"
+  ],
+  "Psychoses, Drug": [
+    "D011605",
+    "Psychoses, Substance-Induced"
+  ],
+  "Blastomycosis": [
+    "D001759",
+    "Blastomycosis"
+  ],
+  "Arachnoid Cysts": [
+    "D016080",
+    "Arachnoid Cysts"
+  ],
+  "Papilloma, Choroid Plexus": [
+    "D020288",
+    "Papilloma, Choroid Plexus"
+  ],
+  "Tachycardia, Supraventricular": [
+    "D013617",
+    "Tachycardia, Supraventricular"
+  ],
+  "Salla Disease": [
+    "D029461",
+    "Sialic Acid Storage Disease"
+  ],
+  "Infantile Sialic Acid Storage Disease": [
+    "D029461",
+    "Sialic Acid Storage Disease"
+  ],
+  "Adenocarcinoma, Tubular": [
+    "D000230",
+    "Adenocarcinoma"
+  ],
+  "Neurocytoma, Central": [
+    "D018306",
+    "Neurocytoma"
+  ],
+  "Acatalasia": [
+    "D020642",
+    "Acatalasia"
+  ],
+  "Desmoplastic Small Round Cell Tumor": [
+    "D058405",
+    "Desmoplastic Small Round Cell Tumor"
+  ],
+  "Dystonic Disorders": [
+    "D020821",
+    "Dystonic Disorders"
+  ],
+  "Keratoconjunctivitis": [
+    "D007637",
+    "Keratoconjunctivitis"
+  ],
+  "Uveal Neoplasms": [
+    "D014604",
+    "Uveal Neoplasms"
+  ],
+  "Subacute Combined Degeneration": [
+    "D052879",
+    "Subacute Combined Degeneration"
+  ],
+  "Spondylolisthesis": [
+    "D013168",
+    "Spondylolisthesis"
+  ],
+  "Bundle-Branch Block": [
+    "D002037",
+    "Bundle-Branch Block"
+  ],
+  "FRAXE Syndrome": [
+    "D005600",
+    "Fragile X Syndrome"
+  ],
+  "Diabetic Polyneuropathy": [
+    "D003929",
+    "Diabetic Neuropathies"
+  ],
+  "Nervous System Diseases, Parasympathetic": [
+    "D001342",
+    "Autonomic Nervous System Diseases"
+  ],
+  "Eye Hemorrhage": [
+    "D005130",
+    "Eye Hemorrhage"
+  ],
+  "Teratoma, Benign": [
+    "D013724",
+    "Teratoma"
+  ],
+  "Hemophilia B": [
+    "D002836",
+    "Hemophilia B"
+  ],
+  "Cellular Blue Nevus": [
+    "D018329",
+    "Nevus, Blue"
+  ],
+  "Dysgammaglobulinemia": [
+    "D004406",
+    "Dysgammaglobulinemia"
+  ],
+  "Eumycetoma": [
+    "D008271",
+    "Mycetoma"
+  ],
+  "Asplenia Syndrome": [
+    "D059446",
+    "Heterotaxy Syndrome"
+  ],
+  "von Willebrand Disease, Type 2N": [
+    "D056728",
+    "von Willebrand Disease, Type 2"
+  ],
+  "Neuromuscular Junction Diseases": [
+    "D020511",
+    "Neuromuscular Junction Diseases"
+  ],
+  "Angioma, Cavernous": [
+    "D006392",
+    "Hemangioma, Cavernous"
+  ],
+  "Hydranencephaly": [
+    "D006832",
+    "Hydranencephaly"
+  ],
+  "Granular Cell Tumor": [
+    "D016586",
+    "Granular Cell Tumor"
+  ],
+  "Heartburn": [
+    "D006356",
+    "Heartburn"
+  ],
+  "Hodgkin Lymphoma, Adult": [
+    "D006689",
+    "Hodgkin Disease"
+  ],
+  "Lymphomatoid Papulosis": [
+    "D017731",
+    "Lymphomatoid Papulosis"
+  ],
+  "Cholangitis, Sclerosing": [
+    "D015209",
+    "Cholangitis, Sclerosing"
+  ],
+  "Condition, Preneoplastic": [
+    "D011230",
+    "Precancerous Conditions"
+  ],
+  "Osteopoikilosis": [
+    "D010023",
+    "Osteopoikilosis"
+  ],
+  "Myopia, Degenerative": [
+    "D047728",
+    "Myopia, Degenerative"
+  ],
+  "Sarcoma, Spindle Cell": [
+    "D012509",
+    "Sarcoma"
+  ],
+  "Herpes Zoster Oticus": [
+    "D016697",
+    "Herpes Zoster Oticus"
+  ],
+  "Tachycardia, Atrioventricular Nodal Reentry": [
+    "D013611",
+    "Tachycardia, Atrioventricular Nodal Reentry"
+  ],
+  "Enteropathy-Associated T-Cell Lymphoma": [
+    "D058527",
+    "Enteropathy-Associated T-Cell Lymphoma"
+  ],
+  "Reticulocytosis": [
+    "D045262",
+    "Reticulocytosis"
+  ],
+  "Encephalomyelitis, Acute Disseminated": [
+    "D004673",
+    "Encephalomyelitis, Acute Disseminated"
+  ],
+  "Tuberculosis, Drug-Resistant": [
+    "D018088",
+    "Tuberculosis, Multidrug-Resistant"
+  ],
+  "Pyelonephritis, Xanthogranulomatous": [
+    "D011705",
+    "Pyelonephritis, Xanthogranulomatous"
+  ],
+  "Odontoma": [
+    "D009810",
+    "Odontoma"
+  ],
+  "Nocturnal Myoclonus Syndrome": [
+    "D020189",
+    "Nocturnal Myoclonus Syndrome"
+  ],
+  "Adrenoleukodystrophy, Neonatal": [
+    "D018901",
+    "Peroxisomal Disorders"
+  ],
+  "Vision, Low": [
+    "D015354",
+    "Vision, Low"
+  ],
+  "Gonadoblastoma": [
+    "D018238",
+    "Gonadoblastoma"
+  ],
+  "Bell Palsy": [
+    "D020330",
+    "Bell Palsy"
+  ],
+  "von Willebrand Disease, Type 1": [
+    "D056725",
+    "von Willebrand Disease, Type 1"
+  ],
+  "Feline Infectious Peritonitis": [
+    "D016766",
+    "Feline Infectious Peritonitis"
+  ],
+  "Allergic Bronchopulmonary Mycosis": [
+    "D055744",
+    "Invasive Pulmonary Aspergillosis"
+  ],
+  "Vulvar Lichen Sclerosus": [
+    "D007724",
+    "Vulvar Lichen Sclerosus"
+  ],
+  "Dihydropyrimidinuria": [
+    "D054067",
+    "Dihydropyrimidine Dehydrogenase Deficiency"
+  ],
+  "Rickettsia Infections": [
+    "D012282",
+    "Rickettsia Infections"
+  ],
+  "Ocular Motility Disorders": [
+    "D015835",
+    "Ocular Motility Disorders"
+  ],
+  "Quadriplegia": [
+    "D011782",
+    "Quadriplegia"
+  ],
+  "Malignant Cystosarcoma Phyllodes": [
+    "D003557",
+    "Phyllodes Tumor"
+  ],
+  "Epidermolysis Bullosa Letalis": [
+    "D016109",
+    "Epidermolysis Bullosa, Junctional"
+  ],
+  "Peritonitis, Tuberculous": [
+    "D014395",
+    "Peritonitis, Tuberculous"
+  ],
+  "Psychomotor Impairment": [
+    "D011596",
+    "Psychomotor Disorders"
+  ],
+  "Arachnodactyly": [
+    "D054119",
+    "Arachnodactyly"
+  ],
+  "Adenocarcinoma, Scirrhous": [
+    "D002293",
+    "Adenocarcinoma, Scirrhous"
+  ],
+  "Postoperative Nausea": [
+    "D020250",
+    "Postoperative Nausea and Vomiting"
+  ],
+  "Gingival Hemorrhage": [
+    "D005884",
+    "Gingival Hemorrhage"
+  ],
+  "Landau-Kleffner Syndrome": [
+    "D018887",
+    "Landau-Kleffner Syndrome"
+  ],
+  "Brain Stem Infarctions": [
+    "D020526",
+    "Brain Stem Infarctions"
+  ],
+  "Majewski Syndrome": [
+    "D012779",
+    "Short Rib-Polydactyly Syndrome"
+  ],
+  "Retinal Cancer": [
+    "D019572",
+    "Retinal Neoplasms"
+  ],
+  "Cancer of the Jejunum": [
+    "D007580",
+    "Jejunal Neoplasms"
+  ],
+  "Embolism, Paradoxical": [
+    "D019320",
+    "Embolism, Paradoxical"
+  ],
+  "Deafness, Sudden": [
+    "D003639",
+    "Hearing Loss, Sudden"
+  ],
+  "Pachyonychia Congenita, Type 1": [
+    "D053549",
+    "Pachyonychia Congenita"
+  ],
+  "Molluscum Contagiosum": [
+    "D008976",
+    "Molluscum Contagiosum"
+  ],
+  "T-Lymphocytopenia, Idiopathic CD4-Positive": [
+    "D018344",
+    "T-Lymphocytopenia, Idiopathic CD4-Positive"
+  ],
+  "Paraneoplastic Cerebellar Degeneration, Anti-Yo-Associated": [
+    "D020362",
+    "Paraneoplastic Cerebellar Degeneration"
+  ],
+  "Gastroenteritis": [
+    "D005759",
+    "Gastroenteritis"
+  ],
+  "Anterior Wall Myocardial Infarction": [
+    "D056988",
+    "Anterior Wall Myocardial Infarction"
+  ],
+  "Herpes Genitalis": [
+    "D006558",
+    "Herpes Genitalis"
+  ],
+  "Klebsiella Infections": [
+    "D007710",
+    "Klebsiella Infections"
+  ],
+  "Angiomyoma": [
+    "D018229",
+    "Angiomyoma"
+  ],
+  "Nelson Syndrome": [
+    "D009347",
+    "Nelson Syndrome"
+  ],
+  "Hemiplegia, Crossed": [
+    "D006429",
+    "Hemiplegia"
+  ],
+  "Intracranial Meningioma": [
+    "D008579",
+    "Meningioma"
+  ],
+  "Hemiplegia, Infantile": [
+    "D006429",
+    "Hemiplegia"
+  ],
+  "Borna Disease": [
+    "D001890",
+    "Borna Disease"
+  ],
+  "Hearing Disorders": [
+    "D006311",
+    "Hearing Disorders"
+  ],
+  "Leukemia, Eosinophilic": [
+    "D017681",
+    "Hypereosinophilic Syndrome"
+  ],
+  "Curling Ulcer": [
+    "D004381",
+    "Duodenal Ulcer"
+  ],
+  "Torticollis": [
+    "D014103",
+    "Torticollis"
+  ],
+  "Cerebellar Neoplasms": [
+    "D002528",
+    "Cerebellar Neoplasms"
+  ],
+  "Transient Tachypnea of the Newborn": [
+    "D059245",
+    "Transient Tachypnea of the Newborn"
+  ],
+  "Acrocephalosyndactylia": [
+    "D000168",
+    "Acrocephalosyndactylia"
+  ],
+  "Myelitis, Transverse": [
+    "D009188",
+    "Myelitis, Transverse"
+  ],
+  "Postpartum Hemorrhage": [
+    "D006473",
+    "Postpartum Hemorrhage"
+  ],
+  "Hypoactive Sexual Desire Disorder": [
+    "D020018",
+    "Sexual Dysfunctions, Psychological"
+  ],
+  "Paraneoplastic Encephalomyelitis": [
+    "D020361",
+    "Paraneoplastic Syndromes, Nervous System"
+  ],
+  "Hurler-Scheie Syndrome": [
+    "D008059",
+    "Mucopolysaccharidosis I"
+  ],
+  "Linear IgA Bullous Dermatosis": [
+    "D062027",
+    "Linear IgA Bullous Dermatosis"
+  ],
+  "Lumbar Osteoarthritis": [
+    "D055013",
+    "Osteoarthritis, Spine"
+  ],
+  "Kwashiorkor": [
+    "D007732",
+    "Kwashiorkor"
+  ],
+  "Astrocytoma, Subependymal Giant Cell": [
+    "D001254",
+    "Astrocytoma"
+  ],
+  "Ageusia": [
+    "D000370",
+    "Ageusia"
+  ],
+  "Immune Reconstitution Inflammatory Syndrome": [
+    "D054019",
+    "Immune Reconstitution Inflammatory Syndrome"
+  ],
+  "Mixed Tumor, Mesodermal": [
+    "D018199",
+    "Mixed Tumor, Mesodermal"
+  ],
+  "Reye-Like Syndrome": [
+    "D012202",
+    "Reye Syndrome"
+  ],
+  "Urination Disorders": [
+    "D014555",
+    "Urination Disorders"
+  ],
+  "Paramyxoviridae Infections": [
+    "D018184",
+    "Paramyxoviridae Infections"
+  ],
+  "Sleep Fragmentation": [
+    "D012892",
+    "Sleep Deprivation"
+  ],
+  "Pyloric Stenosis, Hypertrophic": [
+    "D046248",
+    "Pyloric Stenosis, Hypertrophic"
+  ],
+  "Dural Arteriovenous Fistula": [
+    "D020785",
+    "Central Nervous System Vascular Malformations"
+  ],
+  "Colitis, Lymphocytic": [
+    "D046730",
+    "Colitis, Lymphocytic"
+  ],
+  "Mucopolysaccharidosis VII": [
+    "D016538",
+    "Mucopolysaccharidosis VII"
+  ],
+  "Olivopontocerebellar Atrophies": [
+    "D009849",
+    "Olivopontocerebellar Atrophies"
+  ],
+  "Dog Diseases": [
+    "D004283",
+    "Dog Diseases"
+  ],
+  "Hepatitis, Chronic Persistent": [
+    "D006521",
+    "Hepatitis, Chronic"
+  ],
+  "Hyperventilation": [
+    "D006985",
+    "Hyperventilation"
+  ],
+  "Schnitzler Syndrome": [
+    "D019873",
+    "Schnitzler Syndrome"
+  ],
+  "Persistent Vegetative State": [
+    "D018458",
+    "Persistent Vegetative State"
+  ],
+  "Adamantinoma": [
+    "D050398",
+    "Adamantinoma"
+  ],
+  "Subarachnoid Hemorrhage, Traumatic": [
+    "D020206",
+    "Subarachnoid Hemorrhage, Traumatic"
+  ],
+  "Wounds, Nonpenetrating": [
+    "D014949",
+    "Wounds, Nonpenetrating"
+  ],
+  "Amyotrophic Lateral Sclerosis With Dementia": [
+    "D000690",
+    "Amyotrophic Lateral Sclerosis"
+  ],
+  "Classical Swine Fever": [
+    "D006691",
+    "Classical Swine Fever"
+  ],
+  "Pruritus Vulvae": [
+    "D011539",
+    "Pruritus Vulvae"
+  ],
+  "Mast-Cell Sarcoma": [
+    "D012515",
+    "Mast-Cell Sarcoma"
+  ],
+  "Sexual Arousal Disorder": [
+    "D020018",
+    "Sexual Dysfunctions, Psychological"
+  ],
+  "Elephantiasis, Filarial": [
+    "D004605",
+    "Elephantiasis, Filarial"
+  ],
+  "Arnold-Chiari Malformation, Type I": [
+    "D001139",
+    "Arnold-Chiari Malformation"
+  ],
+  "Articulation Disorders": [
+    "D001184",
+    "Articulation Disorders"
+  ],
+  "Syringomyelia": [
+    "D013595",
+    "Syringomyelia"
+  ],
+  "Lacrimal Apparatus Diseases": [
+    "D007766",
+    "Lacrimal Apparatus Diseases"
+  ],
+  "Salivary Gland Diseases": [
+    "D012466",
+    "Salivary Gland Diseases"
+  ],
+  "Acrospiroma, Eccrine": [
+    "D018250",
+    "Acrospiroma"
+  ],
+  "Prosopagnosia, Developmental": [
+    "D020238",
+    "Prosopagnosia"
+  ],
+  "Yin Deficiency": [
+    "D016710",
+    "Yin Deficiency"
+  ],
+  "Brain Diseases, Metabolic": [
+    "D001928",
+    "Brain Diseases, Metabolic"
+  ],
+  "Ischemic Contracture": [
+    "D054061",
+    "Ischemic Contracture"
+  ],
+  "Paraganglioma, Extra-Adrenal": [
+    "D010236",
+    "Paraganglioma, Extra-Adrenal"
+  ],
+  "Hypohidrosis": [
+    "D007007",
+    "Hypohidrosis"
+  ],
+  "Angioid Streaks": [
+    "D000793",
+    "Angioid Streaks"
+  ],
+  "Motion Sickness": [
+    "D009041",
+    "Motion Sickness"
+  ],
+  "Syphilis, Congenital": [
+    "D013590",
+    "Syphilis, Congenital"
+  ],
+  "Roussy-Levy Syndrome": [
+    "D002607",
+    "Charcot-Marie-Tooth Disease"
+  ],
+  "Spinal Neoplasms": [
+    "D013125",
+    "Spinal Neoplasms"
+  ],
+  "Heart Murmurs": [
+    "D006337",
+    "Heart Murmurs"
+  ],
+  "Leukocyte Disorders": [
+    "D007960",
+    "Leukocyte Disorders"
+  ],
+  "Candidiasis, Cutaneous": [
+    "D002179",
+    "Candidiasis, Cutaneous"
+  ],
+  "Arthritis, Infectious": [
+    "D001170",
+    "Arthritis, Infectious"
+  ],
+  "Lordosis": [
+    "D008141",
+    "Lordosis"
+  ],
+  "Sporadic Retinoblastoma": [
+    "D012175",
+    "Retinoblastoma"
+  ],
+  "Brachial Plexus Neuropathies": [
+    "D020516",
+    "Brachial Plexus Neuropathies"
+  ],
+  "Intestinal Atresia": [
+    "D007409",
+    "Intestinal Atresia"
+  ],
+  "Cancer of Head": [
+    "D006258",
+    "Head and Neck Neoplasms"
+  ],
+  "Sunburn": [
+    "D013471",
+    "Sunburn"
+  ],
+  "Hypophosphatemia, Familial": [
+    "D007015",
+    "Hypophosphatemia, Familial"
+  ],
+  "Foot Ulcer": [
+    "D016523",
+    "Foot Ulcer"
+  ],
+  "Hand Deformities": [
+    "D006226",
+    "Hand Deformities"
+  ],
+  "Lower Extremity Deformities, Congenital": [
+    "D038061",
+    "Lower Extremity Deformities, Congenital"
+  ],
+  "Liver Cirrhosis, Experimental": [
+    "D008106",
+    "Liver Cirrhosis, Experimental"
+  ],
+  "Depression, Endogenous": [
+    "D003866",
+    "Depressive Disorder"
+  ],
+  "Acrania": [
+    "D009436",
+    "Neural Tube Defects"
+  ],
+  "Headache Disorders": [
+    "D020773",
+    "Headache Disorders"
+  ],
+  "Ectromelia": [
+    "D004480",
+    "Ectromelia"
+  ],
+  "Sialadenitis": [
+    "D012793",
+    "Sialadenitis"
+  ],
+  "Compulsive Personality Disorder": [
+    "D003193",
+    "Compulsive Personality Disorder"
+  ],
+  "Spinal Cord Ischemia": [
+    "D020760",
+    "Spinal Cord Ischemia"
+  ],
+  "Retinal Telangiectasis": [
+    "D058456",
+    "Retinal Telangiectasis"
+  ],
+  "Sneddon Syndrome": [
+    "D018860",
+    "Sneddon Syndrome"
+  ],
+  "Nerve Sheath Neoplasms": [
+    "D018317",
+    "Nerve Sheath Neoplasms"
+  ],
+  "Cardiac Carcinoma": [
+    "D006338",
+    "Heart Neoplasms"
+  ],
+  "Maffucci Syndrome": [
+    "D004687",
+    "Enchondromatosis"
+  ],
+  "Hypoxic Brain Damage": [
+    "D002534",
+    "Hypoxia, Brain"
+  ],
+  "Diverticulosis": [
+    "D004240",
+    "Diverticulum"
+  ],
+  "Gingival Diseases": [
+    "D005882",
+    "Gingival Diseases"
+  ],
+  "Cranial Nerve Diseases": [
+    "D003389",
+    "Cranial Nerve Diseases"
+  ],
+  "Pars Planitis": [
+    "D015868",
+    "Pars Planitis"
+  ],
+  "Ileus": [
+    "D045823",
+    "Ileus"
+  ],
+  "Avoidant Personality Disorder": [
+    "D010554",
+    "Personality Disorders"
+  ],
+  "Radicular Cyst": [
+    "D011842",
+    "Radicular Cyst"
+  ],
+  "Alagille Syndrome 1": [
+    "D016738",
+    "Alagille Syndrome"
+  ],
+  "Pneumonia, Eosinophilic": [
+    "D011657",
+    "Pulmonary Eosinophilia"
+  ],
+  "Hypermobility, Joint": [
+    "D007593",
+    "Joint Instability"
+  ],
+  "Intraoperative Complications": [
+    "D007431",
+    "Intraoperative Complications"
+  ],
+  "Favism": [
+    "D005236",
+    "Favism"
+  ],
+  "Odontogenic Cyst, Calcifying": [
+    "D018333",
+    "Odontogenic Cyst, Calcifying"
+  ],
+  "Legionellosis": [
+    "D007876",
+    "Legionellosis"
+  ],
+  "xxy trisomy": [
+    "D007713",
+    "Klinefelter Syndrome"
+  ],
+  "Hypogalactia": [
+    "D007775",
+    "Lactation Disorders"
+  ],
+  "Duodenal Neoplasms": [
+    "D004379",
+    "Duodenal Neoplasms"
+  ],
+  "Reversible Posterior Leukoencephalopathy Syndrome": [
+    "D054038",
+    "Posterior Leukoencephalopathy Syndrome"
+  ],
+  "Hearing Loss, Sudden": [
+    "D003639",
+    "Hearing Loss, Sudden"
+  ],
+  "Congenital Generalized Lipodystrophy Type 2": [
+    "D052497",
+    "Lipodystrophy, Congenital Generalized"
+  ],
+  "Scrub Typhus": [
+    "D012612",
+    "Scrub Typhus"
+  ],
+  "Epilepsy, Partial, Motor": [
+    "D020938",
+    "Epilepsy, Partial, Motor"
+  ],
+  "Dwarfism, Pituitary": [
+    "D004393",
+    "Dwarfism, Pituitary"
+  ],
+  "Scaphocephaly": [
+    "D003398",
+    "Craniosynostoses"
+  ],
+  "Femur Head Necrosis": [
+    "D005271",
+    "Femur Head Necrosis"
+  ],
+  "Peptic Ulcer Hemorrhage": [
+    "D010438",
+    "Peptic Ulcer Hemorrhage"
+  ],
+  "Tooth Diseases": [
+    "D014076",
+    "Tooth Diseases"
+  ],
+  "Lymphadenitis": [
+    "D008199",
+    "Lymphadenitis"
+  ],
+  "Pseudorabies": [
+    "D011557",
+    "Pseudorabies"
+  ],
+  "Spastic Dysphonia": [
+    "D055154",
+    "Dysphonia"
+  ],
+  "Vitreous Hemorrhage": [
+    "D014823",
+    "Vitreous Hemorrhage"
+  ],
+  "Hereditary Angioedema Type III": [
+    "D056828",
+    "Hereditary Angioedema Type III"
+  ],
+  "Familial Motor Neuron Disease": [
+    "D016472",
+    "Motor Neuron Disease"
+  ],
+  "Involuntary Quiver": [
+    "D014202",
+    "Tremor"
+  ],
+  "Tonsillar Neoplasms": [
+    "D014067",
+    "Tonsillar Neoplasms"
+  ],
+  "Cerebral Amyloid Angiopathy, Hereditary": [
+    "D028243",
+    "Cerebral Amyloid Angiopathy, Familial"
+  ],
+  "Granuloma, Giant Cell": [
+    "D006101",
+    "Granuloma, Giant Cell"
+  ],
+  "Embryo Loss": [
+    "D020964",
+    "Embryo Loss"
+  ],
+  "Amphetamine Addiction": [
+    "D019969",
+    "Amphetamine-Related Disorders"
+  ],
+  "Akathisia, Drug-Induced": [
+    "D017109",
+    "Akathisia, Drug-Induced"
+  ],
+  "Intraabdominal Infections": [
+    "D059413",
+    "Intraabdominal Infections"
+  ],
+  "Erythema Infectiosum": [
+    "D016731",
+    "Erythema Infectiosum"
+  ],
+  "Pulpitis": [
+    "D011671",
+    "Pulpitis"
+  ],
+  "Syncope, Cardiogenic": [
+    "D013575",
+    "Syncope"
+  ],
+  "Arteriovenous Malformations, Cerebral": [
+    "D002538",
+    "Intracranial Arteriovenous Malformations"
+  ],
+  "Arsenic Poisoning": [
+    "D020261",
+    "Arsenic Poisoning"
+  ],
+  "Optic Disk Drusen": [
+    "D015594",
+    "Optic Disk Drusen"
+  ],
+  "Mastocytoma, Skin": [
+    "D054705",
+    "Mastocytoma, Skin"
+  ],
+  "Pain, Burning": [
+    "D010146",
+    "Pain"
+  ],
+  "Unconsciousness": [
+    "D014474",
+    "Unconsciousness"
+  ],
+  "Anemia, Dyserythropoietic, Congenital, Type III": [
+    "D000742",
+    "Anemia, Dyserythropoietic, Congenital"
+  ],
+  "Binge Drinking": [
+    "D063425",
+    "Binge Drinking"
+  ],
+  "Giardiasis": [
+    "D005873",
+    "Giardiasis"
+  ],
+  "Jaundice, Hemolytic": [
+    "D007565",
+    "Jaundice"
+  ],
+  "Arthritis, Bacterial": [
+    "D001170",
+    "Arthritis, Infectious"
+  ],
+  "Right Atrial Isomerism": [
+    "D059446",
+    "Heterotaxy Syndrome"
+  ],
+  "Spina Bifida Occulta": [
+    "D016136",
+    "Spina Bifida Occulta"
+  ],
+  "Brain Aneurysm": [
+    "D002532",
+    "Intracranial Aneurysm"
+  ],
+  "Lethargy": [
+    "D053609",
+    "Lethargy"
+  ],
+  "Laryngopharyngeal Reflux": [
+    "D057045",
+    "Laryngopharyngeal Reflux"
+  ],
+  "Muscle Hypertonia": [
+    "D009122",
+    "Muscle Hypertonia"
+  ],
+  "Thyroiditis, Subacute": [
+    "D013968",
+    "Thyroiditis, Subacute"
+  ],
+  "Leukemoid Reaction": [
+    "D007955",
+    "Leukemoid Reaction"
+  ],
+  "Pain, Intractable": [
+    "D010148",
+    "Pain, Intractable"
+  ],
+  "Albinism, Yellow-Mutant": [
+    "D016115",
+    "Albinism, Oculocutaneous"
+  ],
+  "Facial Paresis": [
+    "D005158",
+    "Facial Paralysis"
+  ],
+  "Neoplasms, Adipose Tissue": [
+    "D018205",
+    "Neoplasms, Adipose Tissue"
+  ],
+  "Retinal Dysplasia": [
+    "D015792",
+    "Retinal Dysplasia"
+  ],
+  "Vasogenic Brain Edema": [
+    "D001929",
+    "Brain Edema"
+  ],
+  "Epispadias": [
+    "D004842",
+    "Epispadias"
+  ],
+  "von Willebrand Disease, Type 2M": [
+    "D056728",
+    "von Willebrand Disease, Type 2"
+  ],
+  "Endometritis": [
+    "D004716",
+    "Endometritis"
+  ],
+  "Subcortical Vascular Dementia": [
+    "D015140",
+    "Dementia, Vascular"
+  ],
+  "Sporadic Cerebral Amyloid Angiopathy": [
+    "D016657",
+    "Cerebral Amyloid Angiopathy"
+  ],
+  "Pneumonia, Staphylococcal": [
+    "D011023",
+    "Pneumonia, Staphylococcal"
+  ],
+  "Anencephaly": [
+    "D000757",
+    "Anencephaly"
+  ],
+  "Cecal Neoplasms": [
+    "D002430",
+    "Cecal Neoplasms"
+  ],
+  "Hypertropia": [
+    "D013285",
+    "Strabismus"
+  ],
+  "Skin Diseases, Bullous": [
+    "D012872",
+    "Skin Diseases, Vesiculobullous"
+  ],
+  "Early-Onset Globoid Cell Leukodystrophy": [
+    "D007965",
+    "Leukodystrophy, Globoid Cell"
+  ],
+  "Macular Edema, Cystoid": [
+    "D008269",
+    "Macular Edema"
+  ],
+  "Synovitis, Pigmented Villonodular": [
+    "D013586",
+    "Synovitis, Pigmented Villonodular"
+  ],
+  "Hemiparesis": [
+    "D010291",
+    "Paresis"
+  ],
+  "Squamous Intraepithelial Lesions of the Cervix": [
+    "D065310",
+    "Squamous Intraepithelial Lesions of the Cervix"
+  ],
+  "Leukoplakia, Hairy": [
+    "D017733",
+    "Leukoplakia, Hairy"
+  ],
+  "Maple Syrup Urine Disease, Thiamine Responsive": [
+    "D008375",
+    "Maple Syrup Urine Disease"
+  ],
+  "Sebaceous Gland Diseases": [
+    "D012625",
+    "Sebaceous Gland Diseases"
+  ],
+  "Equinus Deformity": [
+    "D004863",
+    "Equinus Deformity"
+  ],
+  "Pneumoperitoneum": [
+    "D011027",
+    "Pneumoperitoneum"
+  ],
+  "Massive Hepatic Necrosis": [
+    "D047508",
+    "Massive Hepatic Necrosis"
+  ],
+  "Cystadenocarcinoma": [
+    "D003536",
+    "Cystadenocarcinoma"
+  ],
+  "Sarcoma, Engelbreth-Holm-Swarm": [
+    "D012513",
+    "Sarcoma, Experimental"
+  ],
+  "Pituitary Diseases": [
+    "D010900",
+    "Pituitary Diseases"
+  ],
+  "Feeding and Eating Disorders of Childhood": [
+    "D019959",
+    "Feeding and Eating Disorders of Childhood"
+  ],
+  "Cerebral Palsy, Athetoid": [
+    "D002547",
+    "Cerebral Palsy"
+  ],
+  "Insulin Shock": [
+    "D007331",
+    "Insulin Coma"
+  ],
+  "Colonic Inertia": [
+    "D003248",
+    "Constipation"
+  ],
+  "Fetomaternal Transfusion": [
+    "D005331",
+    "Fetomaternal Transfusion"
+  ],
+  "Phagocyte Bactericidal Dysfunction": [
+    "D010585",
+    "Phagocyte Bactericidal Dysfunction"
+  ],
+  "Isochromosomes": [
+    "D018404",
+    "Isochromosomes"
+  ],
+  "Pulmonary Atresia": [
+    "D018633",
+    "Pulmonary Atresia"
+  ],
+  "Bone Marrow Diseases": [
+    "D001855",
+    "Bone Marrow Diseases"
+  ],
+  "Deaf-Blind Syndromes": [
+    "D054062",
+    "Deaf-Blind Disorders"
+  ],
+  "HTLV Infections": [
+    "D006800",
+    "Deltaretrovirus Infections"
+  ],
+  "Facial Nerve Injuries": [
+    "D020220",
+    "Facial Nerve Injuries"
+  ],
+  "Eccrine Porocarcinoma": [
+    "D057090",
+    "Eccrine Porocarcinoma"
+  ],
+  "Eccrine Poroma": [
+    "D057091",
+    "Poroma"
+  ],
+  "Sick Building Syndrome": [
+    "D018877",
+    "Sick Building Syndrome"
+  ],
+  "Pseudopyogenic Granuloma": [
+    "D000796",
+    "Angiolymphoid Hyperplasia with Eosinophilia"
+  ],
+  "Morvan Disease": [
+    "D013595",
+    "Syringomyelia"
+  ],
+  "Ileitis, Terminal": [
+    "D003424",
+    "Crohn Disease"
+  ],
+  "Zollinger-Ellison Syndrome": [
+    "D015043",
+    "Zollinger-Ellison Syndrome"
+  ],
+  "Corpus Luteum Cyst": [
+    "D010048",
+    "Ovarian Cysts"
+  ],
+  "Adenomyoma": [
+    "D018194",
+    "Adenomyoma"
+  ],
+  "Cholecystitis": [
+    "D002764",
+    "Cholecystitis"
+  ],
+  "Goldenhar Syndrome": [
+    "D006053",
+    "Goldenhar Syndrome"
+  ],
+  "Hyperlipoproteinemia Type III": [
+    "D006952",
+    "Hyperlipoproteinemia Type III"
+  ],
+  "Bites": [
+    "D001733",
+    "Bites and Stings"
+  ],
+  "Megaesophagus": [
+    "D004931",
+    "Esophageal Achalasia"
+  ],
+  "Arthritis, Viral": [
+    "D001170",
+    "Arthritis, Infectious"
+  ],
+  "Pemphigoid Gestationis": [
+    "D006559",
+    "Pemphigoid Gestationis"
+  ],
+  "Cystadenofibroma": [
+    "D062625",
+    "Cystadenofibroma"
+  ],
+  "Action Tremor": [
+    "D014202",
+    "Tremor"
+  ],
+  "Back Pain": [
+    "D001416",
+    "Back Pain"
+  ],
+  "Adenovirus Infections, Human": [
+    "D000258",
+    "Adenovirus Infections, Human"
+  ],
+  "Central Nervous System Viral Diseases": [
+    "D020805",
+    "Central Nervous System Viral Diseases"
+  ],
+  "Laryngeal Edema": [
+    "D007819",
+    "Laryngeal Edema"
+  ],
+  "Narcotic Dependence": [
+    "D009293",
+    "Opioid-Related Disorders"
+  ],
+  "Familial Dystonia": [
+    "D020821",
+    "Dystonic Disorders"
+  ],
+  "Drop Attack": [
+    "D013575",
+    "Syncope"
+  ],
+  "Burns, Electric": [
+    "D002058",
+    "Burns, Electric"
+  ],
+  "Abdominal Injuries": [
+    "D000007",
+    "Abdominal Injuries"
+  ],
+  "Occupational Diseases": [
+    "D009784",
+    "Occupational Diseases"
+  ],
+  "Conjunctival Neoplasms": [
+    "D003230",
+    "Conjunctival Neoplasms"
+  ],
+  "Astroviridae Infections": [
+    "D019350",
+    "Astroviridae Infections"
+  ],
+  "Fetofetal Transfusion": [
+    "D005330",
+    "Fetofetal Transfusion"
+  ],
+  "Hibernoma": [
+    "D008067",
+    "Lipoma"
+  ],
+  "Vein of Galen Malformations": [
+    "D054080",
+    "Vein of Galen Malformations"
+  ],
+  "Retinal Pigment Epithelial Detachment": [
+    "D012163",
+    "Retinal Detachment"
+  ],
+  "Ochronosis": [
+    "D009794",
+    "Ochronosis"
+  ],
+  "Hepatic Coma": [
+    "D006501",
+    "Hepatic Encephalopathy"
+  ],
+  "Dysphasia": [
+    "D001037",
+    "Aphasia"
+  ],
+  "Open Bite": [
+    "D024343",
+    "Open Bite"
+  ],
+  "Chronic Lung Injury": [
+    "D055370",
+    "Lung Injury"
+  ],
+  "Epilepsy, Cryptogenic": [
+    "D004827",
+    "Epilepsy"
+  ],
+  "Dental Diseases": [
+    "D009057",
+    "Stomatognathic Diseases"
+  ],
+  "Retrognathism": [
+    "D063173",
+    "Retrognathia"
+  ],
+  "Bronchopneumonia": [
+    "D001996",
+    "Bronchopneumonia"
+  ],
+  "Irvine-Gass Syndrome": [
+    "D008269",
+    "Macular Edema"
+  ],
+  "Reflex Epilepsy, Photosensitive": [
+    "D020195",
+    "Epilepsy, Reflex"
+  ],
+  "Buruli Ulcer": [
+    "D054312",
+    "Buruli Ulcer"
+  ],
+  "Ascorbic Acid Deficiency": [
+    "D001206",
+    "Ascorbic Acid Deficiency"
+  ],
+  "HIV Enteropathy": [
+    "D019053",
+    "HIV Enteropathy"
+  ],
+  "Mastocytosis, Diffuse Cutaneous": [
+    "D034701",
+    "Mastocytosis, Cutaneous"
+  ],
+  "Intersexuality": [
+    "D012734",
+    "Disorders of Sex Development"
+  ],
+  "Paronychia": [
+    "D010304",
+    "Paronychia"
+  ],
+  "Spinal Meningioma": [
+    "D008579",
+    "Meningioma"
+  ],
+  "Urinary Bladder, Neurogenic": [
+    "D001750",
+    "Urinary Bladder, Neurogenic"
+  ],
+  "Presbyopia": [
+    "D011305",
+    "Presbyopia"
+  ],
+  "Enuresis": [
+    "D004775",
+    "Enuresis"
+  ],
+  "Hypoxia, Brain": [
+    "D002534",
+    "Hypoxia, Brain"
+  ],
+  "Granulomatous Mastitis": [
+    "D058890",
+    "Granulomatous Mastitis"
+  ],
+  "Familial Atypical Multiple Mole-Melanoma": [
+    "D004416",
+    "Dysplastic Nevus Syndrome"
+  ],
+  "Asthenia": [
+    "D001247",
+    "Asthenia"
+  ],
+  "Head Injuries, Penetrating": [
+    "D020197",
+    "Head Injuries, Penetrating"
+  ],
+  "Hypoproteinemia": [
+    "D007019",
+    "Hypoproteinemia"
+  ],
+  "Holocarboxylase Synthetase Deficiency": [
+    "D028922",
+    "Holocarboxylase Synthetase Deficiency"
+  ],
+  "Scurvy": [
+    "D012614",
+    "Scurvy"
+  ],
+  "Urethral Stricture": [
+    "D014525",
+    "Urethral Stricture"
+  ],
+  "Endocardial Fibroelastosis": [
+    "D004695",
+    "Endocardial Fibroelastosis"
+  ],
+  "Nerve Pain": [
+    "D009437",
+    "Neuralgia"
+  ],
+  "Short Bowel Syndrome": [
+    "D012778",
+    "Short Bowel Syndrome"
+  ],
+  "Lens Dislocation": [
+    "D007906",
+    "Lens Subluxation"
+  ],
+  "Vomiting, Postoperative": [
+    "D020250",
+    "Postoperative Nausea and Vomiting"
+  ],
+  "Splenic Infarction": [
+    "D013159",
+    "Splenic Infarction"
+  ],
+  "Early Awakening": [
+    "D007319",
+    "Sleep Initiation and Maintenance Disorders"
+  ],
+  "Cholecystitis, Acute": [
+    "D041881",
+    "Cholecystitis, Acute"
+  ],
+  "Arachnoidal Cerebellar Sarcoma, Circumscribed": [
+    "D008527",
+    "Medulloblastoma"
+  ],
+  "Bronchopulmonary Sequestration": [
+    "D001998",
+    "Bronchopulmonary Sequestration"
+  ],
+  "Cranial Nerve Palsies": [
+    "D003389",
+    "Cranial Nerve Diseases"
+  ],
+  "Congenital Intestinal Aganglionosis": [
+    "D006627",
+    "Hirschsprung Disease"
+  ],
+  "Simple Pulmonary Eosinophilia": [
+    "D011657",
+    "Pulmonary Eosinophilia"
+  ],
+  "Papillomatosis": [
+    "D010212",
+    "Papilloma"
+  ],
+  "Ciliary Motility Disorders": [
+    "D002925",
+    "Ciliary Motility Disorders"
+  ],
+  "Infantile Sandhoff Disease": [
+    "D012497",
+    "Sandhoff Disease"
+  ],
+  "Tennis Elbow": [
+    "D013716",
+    "Tennis Elbow"
+  ],
+  "Rheumatoid Vasculitis": [
+    "D056653",
+    "Rheumatoid Vasculitis"
+  ],
+  "Rhinitis, Vasomotor": [
+    "D012223",
+    "Rhinitis, Vasomotor"
+  ],
+  "Adenoma, Papillary": [
+    "D000236",
+    "Adenoma"
+  ],
+  "Malocclusion, Angle Class III": [
+    "D008313",
+    "Malocclusion, Angle Class III"
+  ],
+  "Fetal Distress": [
+    "D005316",
+    "Fetal Distress"
+  ],
+  "Post-Traumatic Vegetative State": [
+    "D018458",
+    "Persistent Vegetative State"
+  ],
+  "Vegetative State": [
+    "D018458",
+    "Persistent Vegetative State"
+  ],
+  "Fecal Incontinence": [
+    "D005242",
+    "Fecal Incontinence"
+  ],
+  "Azotemia": [
+    "D053099",
+    "Azotemia"
+  ],
+  "Sarcoma 180": [
+    "D012510",
+    "Sarcoma 180"
+  ],
+  "Anus Neoplasms": [
+    "D001005",
+    "Anus Neoplasms"
+  ],
+  "Hemoptysis": [
+    "D006469",
+    "Hemoptysis"
+  ],
+  "Chemically-Induced Disorders": [
+    "D064419",
+    "Chemically-Induced Disorders"
+  ],
+  "Oligohydramnios": [
+    "D016104",
+    "Oligohydramnios"
+  ],
+  "Cancer of Tonsil": [
+    "D014067",
+    "Tonsillar Neoplasms"
+  ],
+  "Angiokeratoma": [
+    "D000794",
+    "Angiokeratoma"
+  ],
+  "Epiglottitis": [
+    "D004826",
+    "Epiglottitis"
+  ],
+  "Melnick-Needles Syndrome": [
+    "D010009",
+    "Osteochondrodysplasias"
+  ],
+  "Egg Hypersensitivity": [
+    "D021181",
+    "Egg Hypersensitivity"
+  ],
+  "Jaw Neoplasms": [
+    "D007573",
+    "Jaw Neoplasms"
+  ],
+  "Polyneuropathy, Motor": [
+    "D011115",
+    "Polyneuropathies"
+  ],
+  "Serotonin Syndrome": [
+    "D020230",
+    "Serotonin Syndrome"
+  ],
+  "Acquired Hyperostosis Syndrome": [
+    "D020083",
+    "Acquired Hyperostosis Syndrome"
+  ],
+  "Postthrombotic Syndrome": [
+    "D054070",
+    "Postthrombotic Syndrome"
+  ],
+  "Tachycardia, Ectopic Junctional": [
+    "D013613",
+    "Tachycardia, Ectopic Junctional"
+  ],
+  "Reflex Epilepsy, Audiogenic": [
+    "D020195",
+    "Epilepsy, Reflex"
+  ],
+  "Dacryoadenitis": [
+    "D003607",
+    "Dacryocystitis"
+  ],
+  "Encephalitis, St. Louis": [
+    "D004674",
+    "Encephalitis, St. Louis"
+  ],
+  "Filoviridae Infections": [
+    "D018702",
+    "Filoviridae Infections"
+  ],
+  "Embolus": [
+    "D004617",
+    "Embolism"
+  ],
+  "Adult-Onset Dystonias": [
+    "D020821",
+    "Dystonic Disorders"
+  ],
+  "Graft vs Host Reaction": [
+    "D006087",
+    "Graft vs Host Reaction"
+  ],
+  "Leukemia, Radiation-Induced": [
+    "D007953",
+    "Leukemia, Radiation-Induced"
+  ],
+  "Micrognathism": [
+    "D008844",
+    "Micrognathism"
+  ],
+  "Orbital Neoplasms": [
+    "D009918",
+    "Orbital Neoplasms"
+  ],
+  "Paresthesia": [
+    "D010292",
+    "Paresthesia"
+  ],
+  "Myasthenia Gravis, Neonatal": [
+    "D020941",
+    "Myasthenia Gravis, Neonatal"
+  ],
+  "Hernia, Umbilical": [
+    "D006554",
+    "Hernia, Umbilical"
+  ],
+  "Porokeratosis, Disseminated Superficial Actinic": [
+    "D017499",
+    "Porokeratosis"
+  ],
+  "Sex Chromosome Aberrations": [
+    "D012729",
+    "Sex Chromosome Aberrations"
+  ],
+  "Scleritis": [
+    "D015423",
+    "Scleritis"
+  ],
+  "Hantavirus Pulmonary Syndrome": [
+    "D018804",
+    "Hantavirus Pulmonary Syndrome"
+  ],
+  "Migraine with Typical Aura": [
+    "D020325",
+    "Migraine with Aura"
+  ],
+  "Blepharitis": [
+    "D001762",
+    "Blepharitis"
+  ],
+  "IgG Deficiency": [
+    "D017099",
+    "IgG Deficiency"
+  ],
+  "Antithrombin III Deficiency": [
+    "D020152",
+    "Antithrombin III Deficiency"
+  ],
+  "Ocular Hypotension": [
+    "D015814",
+    "Ocular Hypotension"
+  ],
+  "Scimitar Syndrome": [
+    "D012587",
+    "Scimitar Syndrome"
+  ],
+  "Endemic Diseases": [
+    "D019353",
+    "Endemic Diseases"
+  ],
+  "Endophthalmitis": [
+    "D009877",
+    "Endophthalmitis"
+  ],
+  "Fibrosis, Radiation": [
+    "D017564",
+    "Radiation Pneumonitis"
+  ],
+  "Benign Neoplasms, Brain": [
+    "D001932",
+    "Brain Neoplasms"
+  ],
+  "Hyperostosis, Diffuse Idiopathic Skeletal": [
+    "D004057",
+    "Hyperostosis, Diffuse Idiopathic Skeletal"
+  ],
+  "Pityriasis Lichenoides": [
+    "D017514",
+    "Pityriasis Lichenoides"
+  ],
+  "Paraneoplastic Opsoclonus-Myoclonus Ataxia": [
+    "D053578",
+    "Opsoclonus-Myoclonus Syndrome"
+  ],
+  "Potassium Deficiency": [
+    "D011191",
+    "Potassium Deficiency"
+  ],
+  "Mesonephroma": [
+    "D008649",
+    "Mesonephroma"
+  ],
+  "White Coat Hypertension": [
+    "D059466",
+    "White Coat Hypertension"
+  ],
+  "Haim-Monk Syndrome": [
+    "D010214",
+    "Papillon-Lefevre Disease"
+  ],
+  "Staphylococcal Scalded Skin Syndrome": [
+    "D013206",
+    "Staphylococcal Scalded Skin Syndrome"
+  ],
+  "Lateral Sinus Thrombosis": [
+    "D020227",
+    "Lateral Sinus Thrombosis"
+  ],
+  "Bilateral Cryptorchidism": [
+    "D003456",
+    "Cryptorchidism"
+  ],
+  "Mandibular Neoplasms": [
+    "D008339",
+    "Mandibular Neoplasms"
+  ],
+  "Macroglossia": [
+    "D008260",
+    "Macroglossia"
+  ],
+  "Fibromatosis, Abdominal": [
+    "D018221",
+    "Fibromatosis, Abdominal"
+  ],
+  "Hemarthrosis": [
+    "D006395",
+    "Hemarthrosis"
+  ],
+  "Angiofibroma": [
+    "D018322",
+    "Angiofibroma"
+  ],
+  "Toxemia": [
+    "D014115",
+    "Toxemia"
+  ],
+  "Duodenitis": [
+    "D004382",
+    "Duodenitis"
+  ]
+}

--- a/indra/tests/test_mesh.py
+++ b/indra/tests/test_mesh.py
@@ -38,7 +38,7 @@ def test_mesh_term_lookup_local():
 
 
 def test_mesh_term_local_missing():
-    mesh_term = 'Prostate Cancer'
+    mesh_term = 'Rectal Tumors'
     mesh_id, mesh_name = mesh_client.get_mesh_id_name(mesh_term, offline=True)
     assert mesh_id is None
     assert mesh_name is None


### PR DESCRIPTION
While running medscan, sparql queries were run looking up mappings from mesh terms to valid names and ids, and their results cached. This PR commits that cache to resources and integrates it into the mesh client.