### PR TITLE
TRIPS processor agent construction fixes

### DIFF
--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import os
-import re
 import logging
 import operator
 import itertools
@@ -1920,6 +1919,10 @@ def _get_grounding_terms(term):
                 continue
             if db_ns == 'BE':
                 db_ns = 'FPLX'
+            # Skip UP/etc grounding here
+            elif db_ns == 'UP' and db_id == 'etc':
+                continue
+            # Otherwise set the grounding as a ref
             refs[db_ns] = db_id
 
         comment = None

--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -1233,8 +1233,9 @@ class TripsProcessor(object):
             # to the FamPlex entry name
             elif be_id:
                 agent_name = be_id
-            # Otherwise, take the name of the term as agent name
-            else:
+            # If agent_name is still None take the name of the term as
+            # agent name
+            if agent_name is None:
                 name = term.find("name")
                 if name is not None:
                     agent_name = name.text

--- a/indra/tests/test_trips_ekbs.py
+++ b/indra/tests/test_trips_ekbs.py
@@ -739,14 +739,14 @@ def test_58():
     assert isinstance(tp.statements[1], Phosphorylation)
     enzs = {st.enz.name for st in tp.statements} == {'EGF', 'NGF'}
 
-def test_58():
+
+def test_59():
     sentence = 'HRAS and KRAS convert GTP into GDP.'
     tp = process_sentence_xml(sentence)
     assert len(tp.statements) == 2
     assert isinstance(tp.statements[0], Conversion)
     assert isinstance(tp.statements[1], Conversion)
     enzs = {st.subj.name for st in tp.statements} == {'HRAS', 'KRAS'}
-
 
 def test_assoc_with():
     fname = os.path.join(path_this, 'trips_ekbs', 'ekb_assoc.ekb')
@@ -764,3 +764,12 @@ def test_increase_amount_of():
     assert isinstance(tp.statements[0], IncreaseAmount)
     assert tp.statements[0].subj.name == 'TGFBR1'
     assert tp.statements[0].obj.name == 'SMURF2'
+
+
+def test_fakeprotein():
+    fname = os.path.join(path_this, 'trips_ekbs', 'FAKEPROTEIN.ekb')
+    tp = trips.process_xml(open(fname, 'r').read())
+    agent = tp._get_agent_by_id('V38735', None)
+    assert agent is not None
+    assert agent.db_refs['UP'] == 'P04324', agent.db_refs
+    assert agent.name == 'nef', agent.name

--- a/indra/tests/trips_ekbs/FAKEPROTEIN.ekb
+++ b/indra/tests/trips_ekbs/FAKEPROTEIN.ekb
@@ -1,0 +1,16 @@
+<?xml version="1.0"?><ekb>
+  <TERM id="V38735">
+    <type>ONT::GENE-PROTEIN</type>
+    <name>FAKEPROTEIN</name>
+    <drum-terms>
+      <drum-term dbid="XFAM:PF00469" name="F-protein" match-score="0.63779" matched-name="F-protein">
+        <xrefs>
+          <xref dbid="UP:P04324"/>
+          <xref dbid="UP:etc"/>
+        </xrefs>
+      </drum-term>
+      <drum-term dbid="UP:P12480" name="F-protein" match-score="0.49322" matched-name="F-protein"/>
+      <drum-term dbid="UP:etc" name="F-protein" match-score="0.05948" matched-name="F-protein"/>
+    </drum-terms>
+  </TERM>
+</ekb>


### PR DESCRIPTION
This PR fixes two pretty basic bugs in the TRIPS processor related to Agent extraction and naming.