### PR TITLE
Modelchecker fix

### DIFF
--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -151,6 +151,23 @@ def get_uncond_agent(agent):
 
 def grounded_monomer_patterns(model, agent, ignore_activities=False):
     """Get monomer patterns for the agent accounting for grounding information.
+
+    Parameters
+    ----------
+    model : pysb.core.Model
+        The model to search for MonomerPatterns matching the given Agent.
+    agent : indra.statements.Agent
+        The Agent to find matching MonomerPatterns for.
+    ignore_activites : bool
+        Whether to ignore any ActivityConditions on the agent when determining
+        the required site conditions for the MonomerPattern. For example, if
+        set to True, will find a match for the agent `MAPK1(activity=kinase)`
+        even if the corresponding MAPK1 Monomer in the model has no site
+        named `kinase`. Default is False (more stringent matching).
+
+    Returns
+    -------
+    generator of MonomerPatterns
     """
     # If it's not a molecular agent
     if not isinstance(agent, ist.Agent):

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -149,7 +149,7 @@ def get_uncond_agent(agent):
     return agent_uncond
 
 
-def grounded_monomer_patterns(model, agent):
+def grounded_monomer_patterns(model, agent, ignore_activities=False):
     """Get monomer patterns for the agent accounting for grounding information.
     """
     # If it's not a molecular agent
@@ -240,7 +240,7 @@ def grounded_monomer_patterns(model, agent):
             pattern_list.append({site_name: (mod_sites[site_name], WILD)})
         sc_list.append(pattern_list)
     # Now check for monomer patterns satisfying the agent's activity condition
-    if agent.activity:
+    if agent.activity and not ignore_activities:
         # Iterate through annotations with this monomer as the subject
         # and a has_active_pattern or has_inactive_pattern relationship
         # FIXME: Currently activity type is not annotated/checked

--- a/indra/explanation/model_checker.py
+++ b/indra/explanation/model_checker.py
@@ -390,7 +390,8 @@ class ModelChecker(object):
         # enzyme in a rule of the appropriate activity (e.g., a phosphorylation
         # rule) FIXME
         if subj is not None:
-            subj_mps = list(pa.grounded_monomer_patterns(self.model, subj))
+            subj_mps = list(pa.grounded_monomer_patterns(self.model, subj,
+                                                    ignore_activities=True))
             if not subj_mps:
                 logger.debug('No monomers found corresponding to agent %s' %
                              subj)
@@ -418,7 +419,6 @@ class ModelChecker(object):
         # If we got here, then there was no path for any observable
         return PathResult(False, 'NO_PATHS_FOUND',
                           max_paths, max_path_length)
-
 
     def _get_input_rules(self, subj_mp):
         if subj_mp is None:

--- a/indra/explanation/model_checker.py
+++ b/indra/explanation/model_checker.py
@@ -67,11 +67,13 @@ class PathResult(object):
     path_found : bool
         True if a path was found, False otherwise.
     result_code : string
-        - *STATEMENT_TYPE_NOT_HANDLED* - The provided statement type is not handled
+        - *STATEMENT_TYPE_NOT_HANDLED* - The provided statement type is not
+          handled
         - *SUBJECT_MONOMERS_NOT_FOUND* - Statement subject not found in model
         - *OBSERVABLES_NOT_FOUND* - Statement has no associated observable
         - *NO_PATHS_FOUND* - Statement has no path for any observable
-        - *MAX_PATH_LENGTH_EXCEEDED* - Statement has no path len <= MAX_PATH_LENGTH
+        - *MAX_PATH_LENGTH_EXCEEDED* - Statement has no path len <=
+          MAX_PATH_LENGTH
         - *PATHS_FOUND* - Statement has path len <= MAX_PATH_LENGTH
         - *INPUT_RULES_NOT_FOUND* - No rules with Statement subject found
         - *MAX_PATHS_ZERO* - Path found but MAX_PATHS is set to zero
@@ -366,118 +368,57 @@ class ModelChecker(object):
         """
         # Make sure the influence map is initialized
         self.get_im()
-        if isinstance(stmt, Modification):
-            return self._check_modification(stmt, max_paths, max_path_length)
-        elif isinstance(stmt, RegulateActivity):
-            return self._check_regulate_activity(stmt, max_paths,
-                                                 max_path_length)
-        elif isinstance(stmt, RegulateAmount):
-            return self._check_regulate_amount(stmt, max_paths,
-                                               max_path_length)
-        else:
+        # Check if this is one of the statement types that we can check
+        if not (isinstance(stmt, Modification) or
+                isinstance(stmt, RegulateAmount) or
+                isinstance(stmt, RegulateActivity)):
             return PathResult(False, 'STATEMENT_TYPE_NOT_HANDLED',
                               max_paths, max_path_length)
-
-
-    def _check_regulate_activity(self, stmt, max_paths, max_path_length):
-        """Check a RegulateActivity statement."""
-        logger.info('Checking stmt: %s' % stmt)
-        # FIXME Currently this will match rules with the corresponding monomer
-        # pattern from the Activation/Inhibition statement, which will nearly
-        # always have no state conditions on it. In future, this statement foo
-        # should also match rules in which 1) the agent is in its active form,
-        # or 2) the agent is tagged as the enzyme in a rule of the appropriate
-        # activity (e.g., a phosphorylation rule) FIXME
-        if stmt.subj is not None:
-            subj_mps = list(pa.grounded_monomer_patterns(self.model, stmt.subj))
+        # Get the polarity for the statement
+        if isinstance(stmt, Modification):
+            target_polarity = -1 if isinstance(stmt, RemoveModification) else 1
+        elif isinstance(stmt, RegulateActivity):
+            target_polarity = 1 if stmt.is_activation else -1
+        elif isinstance(stmt, RegulateAmount):
+            target_polarity = -1 if isinstance(stmt, DecreaseAmount) else 1
+        # Get the subject and object (works also for Modifications)
+        subj, obj = stmt.agent_list()
+        # Get a list of monomer patterns matching the subject FIXME Currently
+        # this will match rules with the corresponding monomer pattern on it.
+        # In future, this statement should (possibly) also match rules in which
+        # 1) the agent is in its active form, or 2) the agent is tagged as the
+        # enzyme in a rule of the appropriate activity (e.g., a phosphorylation
+        # rule) FIXME
+        if subj is not None:
+            subj_mps = list(pa.grounded_monomer_patterns(self.model, subj))
             if not subj_mps:
                 logger.debug('No monomers found corresponding to agent %s' %
-                             stmt.subj)
+                             subj)
                 return PathResult(False, 'SUBJECT_MONOMERS_NOT_FOUND',
                                   max_paths, max_path_length)
         else:
             subj_mps = [None]
-        target_polarity = 1 if stmt.is_activation else -1
-        # This may fail, since there may be no rule in the model activating the
-        # object, and the object may not have an "active" site of the
-        # appropriate type
+        # Observables may not be found for an activation since there may be no
+        # rule in the model activating the object, and the object may not have
+        # an "active" site of the appropriate type
         obs_names = self.stmt_to_obs[stmt]
         if not obs_names:
             logger.debug("No observables for stmt %s, returning False" % stmt)
             return PathResult(False, 'OBSERVABLES_NOT_FOUND',
                               max_paths, max_path_length)
         for subj_mp, obs_name in itertools.product(subj_mps, obs_names):
-            # FIXME Returns on the path found for the first enz_mp/obs combo
+            # NOTE: Returns on the path found for the first enz_mp/obs combo
             result = self._find_im_paths(subj_mp, obs_name, target_polarity,
                                          max_paths, max_path_length)
-            # If result for this observable is not False, then we return it;
-            # otherwise, that means there was no path for this observable, so
-            # we have to try the next one
+            # If a path was found, then we return it; otherwise, that means
+            # there was no path for this observable, so we have to try the next
+            # one
             if result.path_found:
                 return result
         # If we got here, then there was no path for any observable
         return PathResult(False, 'NO_PATHS_FOUND',
                           max_paths, max_path_length)
 
-
-    def _check_regulate_amount(self, stmt, max_paths, max_path_length):
-        """Check a RegulateAmount statement."""
-        return self._check_regulate_activity(stmt, max_paths, max_path_length)
-        """
-        logger.info('Checking stmt: %s' % stmt)
-        subj_mp = pa.get_monomer_pattern(self.model, stmt.subj)
-        if isinstance(stmt, Influence):
-            target_polarity = stmt.overall_polarity()
-            if target_polarity is None:
-                target_polarity = 1
-        else:
-            target_polarity = 1 if isinstance(stmt, IncreaseAmount) else -1
-        obs_names = self.stmt_to_obs[stmt]
-        if not obs_names:
-            logger.debug("No observables for stmt %s, returning False" % stmt)
-            return PathResult(False, 'OBSERVABLES_NOT_FOUND',
-                              max_paths, max_path_length)
-        for obs_name in obs_names:
-            return self._find_im_paths(subj_mp, obs_name, target_polarity,
-                                       max_paths, max_path_length)
-        """
-
-    def _check_modification(self, stmt, max_paths, max_path_length):
-        """Check a Modification statement."""
-        # Identify the observable we're looking for in the model, which
-        # may not exist!
-        # The observable is the modified form of the substrate
-        logger.info('Checking stmt: %s' % stmt)
-        # Look for an agent with the appropriate grounding in the model
-        if stmt.enz is not None:
-            enz_mps = list(pa.grounded_monomer_patterns(self.model, stmt.enz))
-            if not enz_mps:
-                logger.debug('No monomers found corresponding to agent %s' %
-                             stmt.enz)
-                return PathResult(False, 'SUBJECT_MONOMERS_NOT_FOUND',
-                                  max_paths, max_path_length)
-        else:
-            enz_mps = [None]
-        # Get target polarity
-        target_polarity = -1 if isinstance(stmt, RemoveModification) else 1
-        obs_names = self.stmt_to_obs[stmt]
-        if not obs_names:
-            logger.debug("No observables for stmt %s, returning False" % stmt)
-            return PathResult(False, 'OBSERVABLES_NOT_FOUND',
-                              max_paths, max_path_length)
-
-        for enz_mp, obs_name in itertools.product(enz_mps, obs_names):
-            # FIXME Returns on the path found for the first enz_mp/obs combo
-            result = self._find_im_paths(enz_mp, obs_name, target_polarity,
-                                         max_paths, max_path_length)
-            # If result for this observable is not False, then we return it;
-            # otherwise, that means there was no path for this observable, so
-            # we have to try the next one
-            if result.path_found:
-                return result
-        # If we got here, then there was no path for any observable
-        return PathResult(False, 'NO_PATHS_FOUND',
-                          max_paths, max_path_length)
 
     def _get_input_rules(self, subj_mp):
         if subj_mp is None:
@@ -626,10 +567,9 @@ class ModelChecker(object):
 
         Returns
         -------
-        boolean or list of str
-            Whether there is a path from a rule matching the subject
-            MonomerPattern to the object Observable with the appropriate
-            polarity.
+        PathResult
+            PathResult object indicating the results of the attempt to find
+            a path.
         """
         logger.info(('Running path finding with max_paths=%d,'
                      ' max_path_length=%d') % (max_paths, max_path_length))
@@ -647,7 +587,8 @@ class ModelChecker(object):
         # -- Route to the path sampling function --
         if self.do_sampling:
             if not has_pg:
-                raise Exception('The paths_graph package could not be imported.')
+                raise Exception('The paths_graph package could not be '
+                                'imported.')
             return self._sample_paths(input_rule_set, obs_name, target_polarity,
                                max_paths, max_path_length)
 

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -521,6 +521,26 @@ def test_check_increase_grounded():
     assert path_result.path_found is False
     assert path_result.result_code == 'SUBJECT_MONOMERS_NOT_FOUND'
 
+
+def test_check_increase_grounded_with_state():
+    mmp9_act = Agent('MMP9', activity=ActivityCondition('catalytic', True),
+                 db_refs={'HGNC': '7176', 'UP': 'P14780'})
+    mmp9 = Agent('MMP9', db_refs={'HGNC': '7176', 'UP': 'P14780'})
+    tgfb1 = Agent('TGFB1', db_refs={'HGNC': '11766', 'UP': 'P01137'})
+    stmt1 = IncreaseAmount(mmp9_act, tgfb1)
+    stmt2 = IncreaseAmount(mmp9, tgfb1)
+    # Make the model out of statement 2 (no activity), but test with stmt 1
+    # (has activity)
+    pa = PysbAssembler()
+    pa.add_statements([stmt2])
+    pa.make_model(policies='one_step')
+    mc = ModelChecker(pa.model, [stmt1])
+    results = mc.check_model()
+    assert len(results) == 1
+    path_result = results[0][1]
+    assert path_result.path_found is True
+
+
 def test_check_activation_grounded():
     mmp9 = Agent('MMP9', activity=ActivityCondition('catalytic', True),
                  db_refs={'HGNC': '7176', 'UP': 'P14780'})
@@ -538,7 +558,6 @@ def test_check_activation_grounded():
     path_result = results[0][1]
     assert path_result.path_found is False
     assert path_result.result_code == 'SUBJECT_MONOMERS_NOT_FOUND'
-
 
 
 @with_model

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -503,7 +503,7 @@ def test_check_activation():
                                     ('C_kinase_active_obs', -1))]
 
 
-def test_check_activation_grounded():
+def test_check_increase_grounded():
     mmp9 = Agent('MMP9', activity=ActivityCondition('catalytic', True),
                  db_refs={'HGNC': '7176', 'UP': 'P14780'})
     tgfb1 = Agent('TGFB1', db_refs={'HGNC': '11766', 'UP': 'P01137'})
@@ -517,10 +517,28 @@ def test_check_activation_grounded():
     mc = ModelChecker(pa.model, [stmt1])
     results = mc.check_model()
     assert len(results) == 1
+    path_result = results[0][1]
+    assert path_result.path_found is False
+    assert path_result.result_code == 'SUBJECT_MONOMERS_NOT_FOUND'
 
+def test_check_activation_grounded():
+    mmp9 = Agent('MMP9', activity=ActivityCondition('catalytic', True),
+                 db_refs={'HGNC': '7176', 'UP': 'P14780'})
+    tgfb1 = Agent('TGFB1', db_refs={'HGNC': '11766', 'UP': 'P01137'})
+    mapk1 = Agent('MAPK1', db_refs={'HGNC': '6871', 'UP': 'P28482'})
+    stmt1 = Activation(mmp9, tgfb1)
+    stmt2 = Activation(mapk1, tgfb1)
+    # Make the model out of statement 2 (mapk1), but test with stmt 1 (mmp9)
+    pa = PysbAssembler()
+    pa.add_statements([stmt2])
+    pa.make_model(policies='one_step')
+    mc = ModelChecker(pa.model, [stmt1])
+    results = mc.check_model()
+    assert len(results) == 1
+    path_result = results[0][1]
+    assert path_result.path_found is False
+    assert path_result.result_code == 'SUBJECT_MONOMERS_NOT_FOUND'
 
-def test_check_increase_grounded():
-    pass
 
 
 @with_model

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -503,6 +503,26 @@ def test_check_activation():
                                     ('C_kinase_active_obs', -1))]
 
 
+def test_check_activation_grounded():
+    mmp9 = Agent('MMP9', activity=ActivityCondition('catalytic', True),
+                 db_refs={'HGNC': '7176', 'UP': 'P14780'})
+    tgfb1 = Agent('TGFB1', db_refs={'HGNC': '11766', 'UP': 'P01137'})
+    mapk1 = Agent('MAPK1', db_refs={'HGNC': '6871', 'UP': 'P28482'})
+    stmt1 = IncreaseAmount(mmp9, tgfb1)
+    stmt2 = IncreaseAmount(mapk1, tgfb1)
+    # Make the model out of statement 2 (mapk1), but test with stmt 1 (mmp9)
+    pa = PysbAssembler()
+    pa.add_statements([stmt2])
+    pa.make_model(policies='one_step')
+    mc = ModelChecker(pa.model, [stmt1])
+    results = mc.check_model()
+    assert len(results) == 1
+
+
+def test_check_increase_grounded():
+    pass
+
+
 @with_model
 def test_none_phosphorylation_stmt():
     # Create the statement
@@ -629,6 +649,7 @@ def test_activation_annotations():
     assert results[2][0] == st3
     assert results[1][1].paths == [(('A_phos_B', 1),
                                     ('B_monomer_Thr185_phos_obs', 1))]
+
 
 
 def test_multitype_path():


### PR DESCRIPTION
This PR makes a series of changes intended to fix some bugs in model checking identified in EMMAA:

* RegulateAmount, RegulateActivity, and Modification statements are now checked by a single shared function, `check_statement`, eliminating much unnecessary code.
* In particular, RegulateAmount and RegulateActivity statements are now checked by using the `grounded_monomer_patterns` function to identify MonomerPatterns corresponding to subject Agents. This eliminates the bug whereby the failure to identify matching patterns led to an assumed `None` for the statement subject, and a subsequent false positive passing test.
* The `grounded_monomer_patterns` function (in the PysbAssembler) now has an additional option, `ignore_activities`, which ignores any specified activity states on the given agent when identifying required site conditions for a matching MonomerPattern. `ModelChecker.check_statement` uses this flag to now (by default) ignore subject activities when checking models. Note that (at least for now) object activities are not ignored.
* New tests corresponding to the above changes.