### PR TITLE
Fixes to process RLIMS-P bulk files

### DIFF
--- a/indra/sources/rlimsp/api.py
+++ b/indra/sources/rlimsp/api.py
@@ -1,5 +1,6 @@
-__all__ = ['process_from_webservice']
+__all__ = ['process_from_webservice', 'process_from_json_file']
 
+import json
 import logging
 import requests
 
@@ -9,7 +10,8 @@ from .processor import RlimspProcessor
 logger = logging.getLogger(__name__)
 
 
-RLIMSP_URL = 'https://research.bioinformatics.udel.edu/itextmine/api/data/rlims/'
+RLIMSP_URL = ('https://research.bioinformatics.udel.edu/itextmine/api/data/'
+             'rlims/')
 
 
 class RLIMSP_Error(Exception):
@@ -54,4 +56,27 @@ def process_from_webservice(id_val, id_type='pmcid', source='pmc',
 
     rp = RlimspProcessor(resp.json())
 
+    return rp
+
+
+def process_from_json_file(filename):
+    """Process RLIMSP extractions from a bulk-download JSON file.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the JSON file.
+
+    Returns
+    -------
+    :py:class:`indra.sources.rlimsp.processor.RlimspProcessor`
+        An RlimspProcessor which contains a list of extracted INDRA Statements
+        in its statements attribute.
+    """
+    with open(filename, 'rt') as f:
+        lines = f.readlines()
+        json_list = []
+        for line in lines:
+            json_list.append(json.loads(line))
+        rp = RlimspProcessor(json_list)
     return rp

--- a/indra/sources/rlimsp/api.py
+++ b/indra/sources/rlimsp/api.py
@@ -59,13 +59,18 @@ def process_from_webservice(id_val, id_type='pmcid', source='pmc',
     return rp
 
 
-def process_from_json_file(filename):
+def process_from_json_file(filename, doc_id_type=None):
     """Process RLIMSP extractions from a bulk-download JSON file.
 
     Parameters
     ----------
     filename : str
         Path to the JSON file.
+    doc_id_type : Optional[str]
+        In some cases the RLIMS-P paragraph info doesn't contain 'pmid' or
+        'pmcid' explicitly, instead if contains a 'docId' key. This parameter
+        allows defining what ID type 'docId' sould be interpreted as. Its
+        values should be 'pmid' or 'pmcid' or None if not used.
 
     Returns
     -------
@@ -78,5 +83,6 @@ def process_from_json_file(filename):
         json_list = []
         for line in lines:
             json_list.append(json.loads(line))
-        rp = RlimspProcessor(json_list)
+        rp = RlimspProcessor(json_list, doc_id_type=doc_id_type)
+        rp.extract_statements()
     return rp

--- a/indra/sources/rlimsp/api.py
+++ b/indra/sources/rlimsp/api.py
@@ -55,7 +55,7 @@ def process_from_webservice(id_val, id_type='pmcid', source='pmc',
                            % (resp.status_code, resp.reason))
 
     rp = RlimspProcessor(resp.json())
-
+    rp.extract_statements()
     return rp
 
 

--- a/indra/sources/rlimsp/processor.py
+++ b/indra/sources/rlimsp/processor.py
@@ -114,20 +114,26 @@ class RlimspParagraph(object):
 
         # Get the sentence index from the trigger word.
         s_idx_set = {self._entity_dict[eid]['sentenceIndex']
-                     for eid in args.values()}
-        i_min = min(s_idx_set)
-        i_max = max(s_idx_set)
+                     for eid in args.values()
+                     if 'sentenceIndex' in self._entity_dict[eid]}
+        if s_idx_set:
+            i_min = min(s_idx_set)
+            i_max = max(s_idx_set)
 
-        text = '. '.join(self._sentences[i_min:(i_max+1)]) + '.'
+            text = '. '.join(self._sentences[i_min:(i_max+1)]) + '.'
 
-        s_start = self._sentence_starts[i_min]
-        annotations = {
-            'agents': {'coords': [_fix_coords(coords, s_start)
-                                  for coords in agent_coords]},
-            'trigger': {'coords': _fix_coords([trigger_info['charStart'],
-                                               trigger_info['charEnd']],
-                                              s_start)}
-            }
+            s_start = self._sentence_starts[i_min]
+            annotations = {
+                'agents': {'coords': [_fix_coords(coords, s_start)
+                                      for coords in agent_coords]},
+                'trigger': {'coords': _fix_coords([trigger_info['charStart'],
+                                                   trigger_info['charEnd']],
+                                                  s_start)}
+                }
+        else:
+            logger.info('Unable to get sentence index')
+            annotations = {}
+            text = None
         if site_coords:
             annotations['site'] = {'coords': _fix_coords(site_coords, s_start)}
 

--- a/indra/sources/rlimsp/processor.py
+++ b/indra/sources/rlimsp/processor.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 class RlimspProcessor(object):
     """Convert RLIMS-P JSON into INDRA Statements."""
 
-    def __init__(self, rlimsp_json, doc_id_type):
+    def __init__(self, rlimsp_json, doc_id_type=None):
         self._json = rlimsp_json
         self.statements = []
         self.doc_id_type = doc_id_type

--- a/indra/sources/rlimsp/processor.py
+++ b/indra/sources/rlimsp/processor.py
@@ -67,8 +67,8 @@ class RlimspParagraph(object):
                     if 'HGNC' in refs.keys():
                         if refs['HGNC'] != hgnc_id:
                             logger.info("HGNC id for Entrez id {EGID} did not "
-                                        "match id inferred from UniProt id "
-                                        "{UP}.".format(**refs))
+                                        "match HGNC id provided "
+                                        "{HGNC}.".format(**refs))
                     else:
                         refs['HGNC'] = hgnc_id
             elif id_dict['source'] == 'UniProt':


### PR DESCRIPTION
This PR handles some corner cases that occur when processing bulk JSON files from RLIMS-P. These have to do with (1) inconsistent HGNC/EGID entries, (2) docId instead of pmid/pmcid entries, and (3) missing sentence and coordinate information.