### PR TITLE
Update lit clients

### DIFF
--- a/indra/literature/deft_tools.py
+++ b/indra/literature/deft_tools.py
@@ -130,15 +130,20 @@ def universal_extract_text(xml, contains=None):
     try:
         paragraphs = elsevier_client.extract_paragraphs(xml)
     except Exception:
+        print(1)
         paragraphs = None
     if paragraphs is None:
         try:
             paragraphs = pmc_client.extract_paragraphs(xml)
         except Exception:
+            print(2)
             paragraphs = [xml]
-    if isinstance(contains, str):
-        contains = [contains]
-    pattern = ''.join('(%s)' % shortform for shortform in contains)
-    pattern = '[%s]' % pattern
-    paragraphs = [p for p in paragraphs if re.match(pattern, p)]
+    if contains is None:
+        pattern = ''
+    else:
+        if isinstance(contains, str):
+            contains = [contains]
+        pattern = '|'.join(r'[^\w]%s[^\w]' % shortform
+                           for shortform in contains)
+    paragraphs = [p for p in paragraphs if re.search(pattern, p)]
     return '\n'.join(paragraphs) + '\n'

--- a/indra/literature/deft_tools.py
+++ b/indra/literature/deft_tools.py
@@ -103,9 +103,8 @@ def get_plaintexts(text_content, contains=None):
     return [universal_extract_text(article, contains)
             for article in text_content]
 
-
-def universal_extract_text(xml, contains=None):
-    """Extract plaintext from xml
+def universal_extract_paragraphs(xml):
+    """Extract paragraphs from xml that could be from  different sources
 
     First try to parse the xml as if it came from elsevier. if we do not
     have valid elsevier xml this will throw an exception. the text extraction
@@ -117,15 +116,10 @@ def universal_extract_text(xml, contains=None):
     xml : str
        Either an NLM xml, Elsevier xml or plaintext
 
-    contains : Optional[list of str]
-        Extract paragraphs containing at least one string from this
-        list.
-
     Returns
     -------
-    plaintext : str
-        for NLM or Elsevier xml as input, this is the extracted plaintext
-        otherwise the input is returned unchanged
+    paragraphs : str
+        Extracted plaintext paragraphs from NLM or Elsevier XML
     """
     try:
         paragraphs = elsevier_client.extract_paragraphs(xml)
@@ -136,6 +130,28 @@ def universal_extract_text(xml, contains=None):
             paragraphs = pmc_client.extract_paragraphs(xml)
         except Exception:
             paragraphs = [xml]
+    return paragraphs
+
+
+def filter_paragraphs(paragraphs, contains=None):
+    """Filter paragraphs to only those containing one of a list of strings
+
+    Parameters
+    ----------
+    paragraphs : list of str
+        List of plaintext paragraphs from an article
+
+    contains : list of str
+        Output consists only of paragraphs containing at least one string
+        in this list as a token (surrounded by nonalphanumeric characters
+        on each side.)
+
+    Returns
+    -------
+    str
+        Plaintext consisting of all input paragraphs containing at least
+        one of the supplied tokens.
+    """
     if contains is None:
         pattern = ''
     else:

--- a/indra/literature/deft_tools.py
+++ b/indra/literature/deft_tools.py
@@ -137,7 +137,7 @@ def universal_extract_text(xml, contains=None):
         except Exception:
             paragraphs = [xml]
     if isinstance(contains, str):
-        contains = []
+        contains = [contains]
     pattern = ''.join('(%s)' % shortform for shortform in contains)
     pattern = '[%s]' % pattern
     paragraphs = [p for p in paragraphs if re.match(pattern, p)]

--- a/indra/literature/deft_tools.py
+++ b/indra/literature/deft_tools.py
@@ -122,10 +122,9 @@ def filter_paragraphs(paragraphs, contains=None):
     paragraphs : list of str
         List of plaintext paragraphs from an article
 
-    contains : list of str
-        Output consists only of paragraphs containing at least one string
-        in this list as a token (surrounded by nonalphanumeric characters
-        on each side.)
+    contains : str or list of str
+        Exclude paragraphs not containing this string as a token, or
+        at least one of the strings in contains if it is a list
 
     Returns
     -------
@@ -142,3 +141,26 @@ def filter_paragraphs(paragraphs, contains=None):
                            for shortform in contains)
     paragraphs = [p for p in paragraphs if re.search(pattern, p)]
     return '\n'.join(paragraphs) + '\n'
+
+
+def universal_extract_text(xml, contains=None):
+    """Extract plaintext from xml that could be from different sources
+
+    Parameters
+    ----------
+    xml : str
+        Either an NLM xml, Elsevier xml, or plaintext
+
+    contains : str or list of str
+         Exclude paragraphs not containing this string, or at least one
+         of the strings in contains if it is a list
+
+    Returns
+    -------
+    str
+        The concatentation of all paragraphs in the input xml, excluding
+        paragraphs not containing one of the tokens in the list contains.
+        Paragraphs are separated by new lines.
+    """
+    paragraphs = universal_extract_paragraphs(xml)
+    return filter_paragraphs(paragraphs, contains)

--- a/indra/literature/deft_tools.py
+++ b/indra/literature/deft_tools.py
@@ -130,13 +130,11 @@ def universal_extract_text(xml, contains=None):
     try:
         paragraphs = elsevier_client.extract_paragraphs(xml)
     except Exception:
-        print(1)
         paragraphs = None
     if paragraphs is None:
         try:
             paragraphs = pmc_client.extract_paragraphs(xml)
         except Exception:
-            print(2)
             paragraphs = [xml]
     if contains is None:
         pattern = ''

--- a/indra/literature/deft_tools.py
+++ b/indra/literature/deft_tools.py
@@ -84,25 +84,6 @@ def get_text_content_for_pmids(pmids):
             for text_content in source if text_content is not None]
 
 
-def get_plaintexts(text_content, contains=None):
-    """Returns a corpus of plaintexts given text content from different sources
-
-    Converts xml files into plaintext, leaves abstracts as they are.
-
-    Parameters
-    ----------
-    sources : list of str
-        lists of text content. each item should either be a plaintext, an
-        an NLM xml or an Elsevier xml
-
-    Returns
-    -------
-    plaintexts : list of str
-        list of plaintexts for input list of xml strings
-    """
-    return [universal_extract_text(article, contains)
-            for article in text_content]
-
 def universal_extract_paragraphs(xml):
     """Extract paragraphs from xml that could be from  different sources
 

--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -237,7 +237,7 @@ def extract_text(xml_string):
     """Get text from the body of the given Elsevier xml."""
     paragraphs = extract_paragraphs(xml_string)
     if paragraphs:
-        return '/n'.join(paragraphs) + '/n'
+        return '\n'.join(paragraphs) + '\n'
     else:
         return None
 

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -109,7 +109,7 @@ def get_xml(pmc_id):
         return xml_bytes.decode('utf-8')
 
 
-def extract_text(xml_string, contains=None):
+def extract_text(xml_string):
     """Get text from the body of the given NLM XML string.
 
     Parameters
@@ -122,6 +122,26 @@ def extract_text(xml_string, contains=None):
     str
         Extracted plaintext.
     """
+    paragraphs = extract_paragraphs(xml_string)
+    if paragraphs:
+        return '/n'.join(paragraphs) + '/n'
+    else:
+        return None
+
+
+def extract_paragraphs(xml_string):
+    """Returns list of paragraphs in an NLM XML.
+
+    Parameters
+    ----------
+    xml_string : str
+        String containing valid NLM XML.
+
+    Returns
+    -------
+    list of str
+        List of extracted paragraphs in an NLM XML
+    """
     tree = etree.fromstring(xml_string.encode('utf-8'))
 
     paragraphs = []
@@ -132,13 +152,8 @@ def extract_text(xml_string, contains=None):
         if isinstance(element.tag, basestring) and \
            re.search('(^|})[p|title]$', element.tag) and element.text:
             paragraph = ' '.join(element.itertext())
-            if contains is None or re.search(r'[^\w]%s[^\w]' % contains,
-                                             paragraph):
-                paragraphs.append(paragraph)
-    if paragraphs:
-        return ' '.join(paragraphs).strip()
-    else:
-        return None
+            paragraphs.append(paragraph)
+    return paragraphs
 
 
 def filter_pmids(pmid_list, source_type):

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -124,7 +124,7 @@ def extract_text(xml_string):
     """
     paragraphs = extract_paragraphs(xml_string)
     if paragraphs:
-        return '/n'.join(paragraphs) + '/n'
+        return '\n'.join(paragraphs) + '\n'
     else:
         return None
 

--- a/indra/tests/test_deft_tools.py
+++ b/indra/tests/test_deft_tools.py
@@ -1,0 +1,57 @@
+from nose.plugins.attrib import attr
+
+from indra.literature.deft_tools import universal_extract_text
+from indra.literature import pmc_client, elsevier_client, pubmed_client
+
+
+@attr('nonpublic', 'webservice')
+def test_universal_extract_text_elsevier():
+    doi = '10.1016/B978-0-12-416673-8.00004-6'
+    xml_str = elsevier_client.download_article(doi)
+    text = universal_extract_text(xml_str)
+    assert text is not None
+    assert ' ER ' in text
+
+
+@attr('webservice')
+def test_universal_extract_text_pmc():
+    pmc_id = 'PMC3262597'
+    xml_str = pmc_client.get_xml(pmc_id)
+    text = universal_extract_text(xml_str)
+    assert text is not None
+    assert ' ER ' in text
+
+
+@attr('webservice')
+def test_universal_extract_text_abstract():
+    pmid = '16511588'
+    abstract = pubmed_client.get_abstract(pmid)
+    result = universal_extract_text(abstract)
+    assert result == abstract + '\n'
+
+
+@attr('webservice')
+def test_universal_extract_text_contains():
+    pmc_id = 'PMC3262597'
+    xml_str = pmc_client.get_xml(pmc_id)
+    text1 = universal_extract_text(xml_str)
+    text2 = universal_extract_text(xml_str, contains='ER')
+    assert text1 is not None
+    assert text2 is not None
+    assert ' ER ' in text1 and ' ER ' in text2
+    assert len(text2) < len(text1)
+
+
+@attr('webservice')
+def test_universal_extract_text_contains_union():
+    pmc_id = 'PMC4954987'
+    xml_str = pmc_client.get_xml(pmc_id)
+    text1 = universal_extract_text(xml_str)
+    text2 = universal_extract_text(xml_str, contains='NP')
+    text3 = universal_extract_text(xml_str, contains='NPs')
+    text4 = universal_extract_text(xml_str, contains=['NP', 'NPs'])
+    assert text1 is not None
+    assert text2 is not None
+    assert text3 is not None
+    assert text4 is not None
+    assert len(text2) < len(text3) < len(text4) < len(text1)

--- a/indra/tests/test_deft_tools.py
+++ b/indra/tests/test_deft_tools.py
@@ -1,57 +1,54 @@
+import re
 from nose.plugins.attrib import attr
 
-from indra.literature.deft_tools import universal_extract_text
+from indra.literature.deft_tools import universal_extract_paragraphs, \
+    filter_paragraphs
 from indra.literature import pmc_client, elsevier_client, pubmed_client
 
 
 @attr('nonpublic', 'webservice')
-def test_universal_extract_text_elsevier():
+def test_universal_extract_paragraphs_elsevier():
     doi = '10.1016/B978-0-12-416673-8.00004-6'
     xml_str = elsevier_client.download_article(doi)
-    text = universal_extract_text(xml_str)
-    assert text is not None
-    assert ' ER ' in text
+    paragraphs = universal_extract_paragraphs(xml_str)
+    assert len(paragraphs) > 1
 
 
 @attr('webservice')
-def test_universal_extract_text_pmc():
+def test_universal_extract_paragraphs_pmc():
     pmc_id = 'PMC3262597'
     xml_str = pmc_client.get_xml(pmc_id)
-    text = universal_extract_text(xml_str)
-    assert text is not None
-    assert ' ER ' in text
+    paragraphs = universal_extract_paragraphs(xml_str)
+    assert len(paragraphs) > 1
 
 
 @attr('webservice')
-def test_universal_extract_text_abstract():
+def test_universal_extract_paragraphs_abstract():
     pmid = '16511588'
     abstract = pubmed_client.get_abstract(pmid)
-    result = universal_extract_text(abstract)
-    assert result == abstract + '\n'
+    result = universal_extract_paragraphs(abstract)
+    assert result[0] == abstract
 
 
-@attr('webservice')
-def test_universal_extract_text_contains():
-    pmc_id = 'PMC3262597'
-    xml_str = pmc_client.get_xml(pmc_id)
-    text1 = universal_extract_text(xml_str)
-    text2 = universal_extract_text(xml_str, contains='ER')
-    assert text1 is not None
-    assert text2 is not None
-    assert ' ER ' in text1 and ' ER ' in text2
-    assert len(text2) < len(text1)
+def test_universal_extract_texts_contains():
+    example = ['eeeeeeeeeeeeeEReeeeeeeeee',
+               'eeeeeee-ER-eeeeeeeeeeeeee',
+               'eeeeeee ER eeeeeeeeeeeeee',
+               'eeeeeeeER eeeeeeeeeeeeeee']
+    result = ('eeeeeee-ER-eeeeeeeeeeeeee\n'
+              'eeeeeee ER eeeeeeeeeeeeee\n')
+    text = filter_paragraphs(example, contains='ER')
+    assert text == result
 
 
-@attr('webservice')
-def test_universal_extract_text_contains_union():
-    pmc_id = 'PMC4954987'
-    xml_str = pmc_client.get_xml(pmc_id)
-    text1 = universal_extract_text(xml_str)
-    text2 = universal_extract_text(xml_str, contains='NP')
-    text3 = universal_extract_text(xml_str, contains='NPs')
-    text4 = universal_extract_text(xml_str, contains=['NP', 'NPs'])
-    assert text1 is not None
-    assert text2 is not None
-    assert text3 is not None
-    assert text4 is not None
-    assert len(text2) < len(text3) < len(text4) < len(text1)
+def test_universal_extract_texts_contains_union():
+    example = ['eeeeeeeeeeNPeeeeeeeeeeeeee',
+               'eeeeeee-NPs-eeeeeeeeeeeeee',
+               'eeeeeee NP eeeeeeeeeeeeeee',
+               'eeeeeeeNPseeeee NP-eeeeeee',
+               'eeeeeeeeeeeeeeeeeeeeeeeeee']
+    result = ('eeeeeee-NPs-eeeeeeeeeeeeee\n'
+              'eeeeeee NP eeeeeeeeeeeeeee\n'
+              'eeeeeeeNPseeeee NP-eeeeeee\n')
+    text = filter_paragraphs(example, contains=['NP', 'NPs'])
+    assert text == result


### PR DESCRIPTION
This PR removes filtering of paragraphs from core extract_text functions within the literature clients as suggested by bgyori. This filtering is deft specific and should be handled within deft_tools instead. To facilitate this, the extract_text endpoints continue having the same behavior, but each calls a function that extracts paragraphs and then joins these paragraphs. Text processing functions for deft can now call this extract paragraphs function and then do their own filtering. Filtering is deft specific and may need to change in unforeseen ways. It is bad to have to touch the core extract_text functions for deft specific filtering. These functions are used widely throughout Indra.