### PR TITLE
Pubmed annotations

### DIFF
--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -238,7 +238,7 @@ def get_abstract(pubmed_id, prepend_title=True):
 
 
 # A function to get the text for the element, or None if not found
-def find_elem_text(root, xpath_string):
+def _find_elem_text(root, xpath_string):
     elem = root.find(xpath_string)
     return None if elem is None else elem.text
 
@@ -246,24 +246,24 @@ def find_elem_text(root, xpath_string):
 def _get_journal_info(medline_citation, get_issns_from_nlm):
     # Journal info
     journal = medline_citation.find('Article/Journal')
-    journal_title = find_elem_text(journal, 'Title')
-    journal_abbrev = find_elem_text(journal, 'ISOAbbreviation')
+    journal_title = _find_elem_text(journal, 'Title')
+    journal_abbrev = _find_elem_text(journal, 'ISOAbbreviation')
 
     # Add the ISSN from the article record
     issn_list = []
-    issn = find_elem_text(journal, 'ISSN')
+    issn = _find_elem_text(journal, 'ISSN')
     if issn:
         issn_list.append(issn)
 
     # Add the Linking ISSN from the article record
-    issn_linking = find_elem_text(medline_citation,
-                                  'MedlineJournalInfo/ISSNLinking')
+    issn_linking = _find_elem_text(medline_citation,
+                                   'MedlineJournalInfo/ISSNLinking')
     if issn_linking:
         issn_list.append(issn_linking)
 
     # Now get the list of ISSNs from the NLM Catalog
-    nlm_id = find_elem_text(medline_citation,
-                            'MedlineJournalInfo/NlmUniqueID')
+    nlm_id = _find_elem_text(medline_citation,
+                             'MedlineJournalInfo/NlmUniqueID')
     if nlm_id and get_issns_from_nlm:
         nlm_issn_list = get_issns_for_journal(nlm_id)
         if nlm_issn_list:
@@ -278,20 +278,20 @@ def _get_journal_info(medline_citation, get_issns_from_nlm):
 
 def _get_article_info(medline_citation, pubmed_data):
     article = medline_citation.find('Article')
-    pmid = find_elem_text(medline_citation, './PMID')
-    pii = find_elem_text(article,
-                         './ELocationID[@EIdType="pii"][@ValidYN="Y"]')
+    pmid = _find_elem_text(medline_citation, './PMID')
+    pii = _find_elem_text(article,
+                          './ELocationID[@EIdType="pii"][@ValidYN="Y"]')
 
     # Look for the DOI in the ELocationID field...
-    doi = find_elem_text(article,
-                         './ELocationID[@EIdType="doi"][@ValidYN="Y"]')
+    doi = _find_elem_text(article,
+                          './ELocationID[@EIdType="doi"][@ValidYN="Y"]')
 
     # ...and if that doesn't work, look in the ArticleIdList
     if doi is None:
-        doi = find_elem_text(pubmed_data, './/ArticleId[@IdType="doi"]')
+        doi = _find_elem_text(pubmed_data, './/ArticleId[@IdType="doi"]')
 
     # Try to get the PMCID
-    pmcid = find_elem_text(pubmed_data, './/ArticleId[@IdType="pmc"]')
+    pmcid = _find_elem_text(pubmed_data, './/ArticleId[@IdType="pmc"]')
 
     # Title
     title = _get_title_from_article_element(article)
@@ -302,7 +302,7 @@ def _get_article_info(medline_citation, pubmed_data):
         else [au.text for au in author_elems]
 
     # Get the page number entry
-    page = find_elem_text(article, 'Pagination/MedlinePgn')
+    page = _find_elem_text(article, 'Pagination/MedlinePgn')
 
     return {'pmid': pmid, 'pii': pii, 'doi': doi, 'pmcid': pmcid,
             'title': title, 'authors': author_names, 'page': page}

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -150,7 +150,7 @@ def test_pmid_27821631():
 
 @attr('webservice')
 def test_get_annotations():
-    pmid =  '30971'
+    pmid = '30971'
     tree = pubmed_client.send_request(pubmed_client.pubmed_fetch,
                                       dict(db='pubmed', retmode='xml',
                                            id=pmid))
@@ -159,7 +159,6 @@ def test_get_annotations():
     assert len(results) == 1, len(results)
     assert 'mesh_annotations' in results[pmid].keys(), results[pmid].keys()
     me_ans = results[pmid]['mesh_annotations']
-    assert len(me_ans) == 12, len(me_ans)
-    assert 'Q000188' in me_ans.keys()
-    assert me_ans['Q000188']['major_topic']
-    assert not me_ans['D000070']['major_topic']
+    assert len(me_ans) == 9, len(me_ans)
+    assert all(d['mesh'].startswith('D') for d in me_ans)
+    assert any(d['major_topic'] for d in me_ans)

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -146,3 +146,20 @@ def test_pmid_27821631():
     res = pubmed_client.get_metadata_for_ids([pmid], get_abstracts=True)
     assert res[pmid]['title'] is not None
     assert len(res[pmid]['abstract']) > 50
+
+
+@attr('webservice')
+def test_get_annotations():
+    pmid =  '30971'
+    tree = pubmed_client.send_request(pubmed_client.pubmed_fetch,
+                                      dict(db='pubmed', retmode='xml',
+                                           id=pmid))
+    results = pubmed_client.get_metadata_from_xml_tree(tree,
+                                                       mesh_annotations=True)
+    assert len(results) == 1, len(results)
+    assert 'mesh_annotations' in results[pmid].keys(), results[pmid].keys()
+    me_ans = results[pmid]['mesh_annotations']
+    assert len(me_ans) == 12, len(me_ans)
+    assert 'Q000188' in me_ans.keys()
+    assert me_ans['Q000188']['major_topic']
+    assert not me_ans['D000070']['major_topic']


### PR DESCRIPTION
This PR introduces the ability for the pubmed client to extract mesh annotations from the pubmed XML. The function `get_metadata_from_xml_tree` was also refactored as a function calling several smaller functions. Python 2-3 compatibility boilerplate was also removed.