### PR TITLE
Add new method to get Agents from TRIPS with TERM IDs

### DIFF
--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -1069,14 +1069,32 @@ class TripsProcessor(object):
         agents : list[indra.statements.Agent]
             List of INDRA Agents extracted from EKB.
         """
+        agents_dict = self.get_term_agents()
+        agents = [a for a in agents_dict.values() if a is not None]
+        return agents
+
+    def get_term_agents(self):
+        """Return dict of INDRA Agents keyed by corresponding TERMs in the EKB.
+
+        This is meant to be used when entities e.g. "phosphorylated ERK",
+        rather than events need to be extracted from processed natural
+        language. These entities with their respective states are represented
+        as INDRA Agents. Further, each key of the dictionary corresponds to
+        the ID assigned by TRIPS to the given TERM that the Agent was
+        extracted from.
+
+        Returns
+        -------
+        agents : dict[str, indra.statements.Agent]
+            Dict of INDRA Agents extracted from EKB.
+        """
         terms = self.tree.findall('TERM')
-        agents = []
+        agents = {}
         for term in terms:
             term_id = term.attrib.get('id')
             if term_id:
                 agent = self._get_agent_by_id(term_id, None)
-                if agent:
-                    agents.append(agent)
+                agents[term_id] = agent
         return agents
 
     def _get_cell_loc_by_id(self, term_id):

--- a/indra/tests/test_trips_ekbs.py
+++ b/indra/tests/test_trips_ekbs.py
@@ -731,8 +731,8 @@ def test_57():
     assert sel.db_refs.get('PUBCHEM') == '10127622'
 
     agents = tp.get_agents()
-    assert agents[0].name == 'MEK', agents[0]
-    assert agents[2].db_refs.get('PUBCHEM') == '10127622', agents[1]
+    names = {a.name for a in agents}
+    assert names == {'MEK', 'SELUMETINIB', 'ERK'}
 
     agents_dict = tp.get_term_agents()
     assert 'V16439992' in agents_dict, agents_dict

--- a/indra/tests/test_trips_ekbs.py
+++ b/indra/tests/test_trips_ekbs.py
@@ -728,7 +728,15 @@ def test_57():
     sel = st.enz.bound_conditions[0].agent
     # Make sure we mapped PC to PUBCHEM correctly
     assert 'PC' not in sel.db_refs
-    assert sel.db_refs['PUBCHEM'] == '10127622'
+    assert sel.db_refs.get('PUBCHEM') == '10127622'
+
+    agents = tp.get_agents()
+    assert agents[0].name == 'MEK', agents[0]
+    assert agents[2].db_refs.get('PUBCHEM') == '10127622', agents[1]
+
+    agents_dict = tp.get_term_agents()
+    assert 'V16439992' in agents_dict, agents_dict
+    assert agents_dict['V16439916'].name == 'MEK', agents_dict
 
 
 def test_58():


### PR DESCRIPTION
This PR adds a new method to the  TripsProcessor which allows extracting Agents from an EKB keyed by the corresponding TERM ID, e.g., 
```
{'V16439916': MEK(bound: [SELUMETINIB, False]), 'V16440012': ERK(), 'V16439992': SELUMETINIB()}
```