### PR TITLE
Ensure cython is installed before pyjnius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ install:
   - tar xzf bionetgen.tar.gz
   - export BNGPATH=`pwd`/BioNetGen-2.2.6-stable
   - pip install git+https://github.com/pysb/pysb.git
+  # Temporary fix. Ensure cython is installed before pyjnius
+  - pip install cython
   # Now install INDRA with all its extras
   - pip install .[all]
   - aws s3 cp s3://bigmech/travis/reach-82631d-biores-e9ee36.jar . --no-sign-request  --source-region us-east-1


### PR DESCRIPTION
This PR implements a temporary fix to get travis tests working again. For unknown reasons pyjnius installation was being attempted before cython was installed. Cython is now explictly installed in .travis.yml to ensure this doesn't happen. It remains to discover what caused the tests to begin failing.