### PR TITLE
Fix Java installation on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,16 @@ cache:
 python:
   - "3.5"
 before_install:
-  - sudo add-apt-repository --yes ppa:linuxuprising/java
+  - sudo add-apt-repository -y ppa:webupd8team/java
   - sudo apt-get update
-  - echo debconf shared/accepted-oracle-license-v1-2 select true | sudo debconf-set-selections
-  - echo debconf shared/accepted-oracle-license-v1-2 seen true | sudo debconf-set-selections
+  - sudo apt-get install -y oracle-java8-installer
+  #- sudo add-apt-repository --yes ppa:linuxuprising/java
+  #- sudo apt-get update
+  #- echo debconf shared/accepted-oracle-license-v1-2 select true | sudo debconf-set-selections
+  #- echo debconf shared/accepted-oracle-license-v1-2 seen true | sudo debconf-set-selections
+  #- sudo apt-get install -y oracle-java11-installer || true
+  #- sudo update-java-alternatives -s java-11-oracle
   - sudo apt-get install libstdc++6 graphviz
-  - sudo apt-get install -y oracle-java11-installer || true
-  - sudo update-java-alternatives -s java-11-oracle
 install:
   # Install test/Travis-specific dependencies not covered elsewhere
   - pip install pydot jsonschema coverage python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,6 @@ before_install:
   - sudo add-apt-repository -y ppa:webupd8team/java
   - sudo apt-get update
   - sudo apt-get install -y oracle-java8-installer
-  #- sudo add-apt-repository --yes ppa:linuxuprising/java
-  #- sudo apt-get update
-  #- echo debconf shared/accepted-oracle-license-v1-2 select true | sudo debconf-set-selections
-  #- echo debconf shared/accepted-oracle-license-v1-2 seen true | sudo debconf-set-selections
-  #- sudo apt-get install -y oracle-java11-installer || true
-  #- sudo update-java-alternatives -s java-11-oracle
   - sudo apt-get install libstdc++6 graphviz
 install:
   # Install test/Travis-specific dependencies not covered elsewhere

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -99,11 +99,10 @@ via the REACH and Eidos APIs, an additional package called
 classes from Python. This is only strictly required in these input sources and
 the rest of INDRA will work without pyjnius.
 
-
-
 1. Install JDK from Oracle: `<https://www.oracle.com/technetwork/java/javase/downloads/index.html>`_.
-INDRA is currently tested against Java 11 but is expected to be compatible with
-versions of Java 8 or higher.
+We recommend using Java 8 (INDRA is regularly tested with Java 8),
+however, Java 11 is also expected to be compatible, with possible extra
+configuration steps needed that are not described here.
 
 4. Set JAVA\_HOME to your JDK home directory, for instance
 


### PR DESCRIPTION
It looks like #860 was not sufficient to fix the Java issues on Travis since further errors cropped up after I deleted the caches. In fact, it now seems like the Java 11 configuration added in #777 wouldn't have worked, were it not for old caches being around in some Travis repos. Therefore, this PR goes back to the stable Java 8 build which works as needed.