### PR TITLE
Stagger batch job submissions

### DIFF
--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -1,11 +1,8 @@
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str
-
-import os
+mport os
 import boto3
 import logging
 import argparse
-import botocore.session
+
 from time import sleep
 from datetime import datetime
 from indra.literature import elsevier_client as ec

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -1,4 +1,4 @@
-mport os
+import os
 import boto3
 import logging
 import argparse
@@ -394,7 +394,29 @@ class Submitter(object):
         return []
 
     def submit_reading(self, input_fname, start_ix, end_ix, ids_per_job,
-                       num_tries=1):
+                       num_tries=1, stagger=0):
+        """Submit a batch of reading jobs
+
+        Parameters
+        ----------
+        input_fname : str
+            The name of the file containing the ids to be read.
+        start_ix : int
+            The line index of the first item in the list to read.
+        end_ix : int
+            The line index of the last item in the list to be read.
+        ids_per_job : int
+            The number of ids to be given to each job.
+        num_tries : int
+            The number of times a job may be attempted.
+        stagger : float
+            The number of seconds to wait between job submissions.
+
+        Returns
+        -------
+        job_list : list[str]
+            A list of job id strings.
+        """
         # stash this for later.
         self.ids_per_job = ids_per_job
 


### PR DESCRIPTION
Allow the user to stagger batch job submissions to avoid overlapping demands on resources. This PR also introduces the `run` method which includes both the job submission `submit_reading`, which is run on a thread (to better support staggering), and `watch_and_wait`.