### PR TITLE
Event extraction

### DIFF
--- a/indra/sources/cwms/api.py
+++ b/indra/sources/cwms/api.py
@@ -72,6 +72,7 @@ def process_ekb(ekb_str):
     # Process EKB XML into statements
     cp = CWMSProcessor(ekb_str)
     cp.extract_causal_relations()
+    cp.extract_events()
     return cp
 
 

--- a/indra/sources/cwms/api.py
+++ b/indra/sources/cwms/api.py
@@ -72,6 +72,7 @@ def process_ekb(ekb_str):
     # Process EKB XML into statements
     cp = CWMSProcessor(ekb_str)
     cp.extract_causal_relations()
+    cp.extract_correlations()
     cp.extract_events()
     return cp
 

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -175,6 +175,8 @@ class CWMSProcessor(object):
         """Return an Event from an EVENT element in the EKB."""
         arg_id, arg_term = self._get_term_by_role(event_term, 'AFFECTED',
                                                   False)
+        if arg_term is None:
+            return None
 
         # Make an Event statement if it is a standalone event
         evidence = self._get_evidence(event_term)
@@ -249,7 +251,7 @@ class CWMSProcessor(object):
         time_term = self.tree.find("*[@id='%s']" % time_id)
         if time_term is None:
             return None
-        text = time_term.findtext('text')
+        text = sanitize_name(time_term.findtext('text'))
         timex = time_term.find('timex')
         if timex is not None:
             year = timex.findtext('year')
@@ -348,7 +350,7 @@ class CWMSProcessor(object):
     def _remove_multi_extraction_artifacts(self):
         # Build up a dict of evidence matches keys with statement UUIDs
         evmks = {}
-        logger.info('Starting with %d Statements.' % len(self.statements))
+        logger.debug('Starting with %d Statements.' % len(self.statements))
         for stmt in self.statements:
             # Standalone Events will be handled later, so we do not add them
             if isinstance(stmt, Event):
@@ -380,7 +382,7 @@ class CWMSProcessor(object):
 
         # Remove all redundant statements
         if to_remove:
-            logger.info('Found %d Statements to remove' % len(to_remove))
+            logger.debug('Found %d Statements to remove' % len(to_remove))
         self.statements = [s for s in self.statements
                            if s.uuid not in to_remove]
 

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -145,8 +145,8 @@ class CWMSProcessor(object):
         if ev_type not in POLARITY_DICT['EVENT']:
             self._unhandled_events.append(ev_type)
             return None
-        subj_id, subj_term = self._get_term_by_role(event, 'AGENT', True)
-        obj_id, obj_term = self._get_term_by_role(event, 'AFFECTED', True)
+        subj_id, subj_term = self._get_term_by_role(event, 'AGENT', False)
+        obj_id, obj_term = self._get_term_by_role(event, 'AFFECTED', False)
         if subj_term is None or obj_term is None:
             return None
         subj = self._get_event(subj_term)
@@ -178,6 +178,12 @@ class CWMSProcessor(object):
         event = self._get_event(arg_term, evidence=[evidence])
         if event is None:
             return None
+        time, location = self._extract_time_loc(event_term)
+        if time or location:
+            context = WorldContext(time=time, geo_location=location)
+        else:
+            context = None
+        event.context = context
         event.delta['polarity'] = polarity
         return event
 

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -285,11 +285,11 @@ class CWMSProcessor(object):
         evmks = {}
         logger.info('Starting with %d Statements.' % len(self.statements))
         for stmt in self.statements:
-            # Standalone Events do not have evidences, so we do not add them
+            # Standalone Events will be handled later, so we do not add them
             if isinstance(stmt, Event):
                 continue
-            evmk = stmt.evidence[0].matches_key() + \
-                   stmt.subj.matches_key() + stmt.obj.matches_key()
+            evmk = (stmt.evidence[0].matches_key() +
+                    stmt.subj.matches_key() + stmt.obj.matches_key())
             if evmk not in evmks:
                 evmks[evmk] = [stmt.uuid]
             else:
@@ -300,8 +300,8 @@ class CWMSProcessor(object):
         to_remove = []
         # Influence statements to be removed
         for uuids in multi_evmks:
-            stmts = [s for s in self.statements if (s.uuid in uuids
-                                                    and isinstance(s, Influence))]
+            stmts = [s for s in self.statements if (s.uuid in uuids and
+                                                    isinstance(s, Influence))]
             stmts = sorted(stmts, key=lambda x: x.polarity_count(),
                            reverse=True)
             to_remove += [s.uuid for s in stmts[1:]]
@@ -318,7 +318,6 @@ class CWMSProcessor(object):
             logger.info('Found %d Statements to remove' % len(to_remove))
         self.statements = [s for s in self.statements
                            if s.uuid not in to_remove]
-
 
 
 def sanitize_name(txt):

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -112,6 +112,15 @@ class CWMSProcessor(object):
         logger.debug('Unhandled event types: %s' %
                      (', '.join(sorted(list(set(self._unhandled_events))))))
 
+    def extract_events(self):
+        events = self.tree.findall("EVENT/[type='ONT::INCREASE']") + (
+            self.tree.findall("EVENT/[type='ONT::DECREASE']"))
+        for event_entry in events:
+            event = self._get_event(event_entry, "*[@role=':AFFECTED']")
+            # ev = self._get_evidence(event_entry, context)
+            # event.evidence = ev
+            self.statements.append(event)
+
     def _get_event(self, event, find_str):
         """Get a concept referred from the event by the given string."""
         # Get the term with the given element id

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -90,6 +90,11 @@ class CWMSProcessor(object):
             if subj is None or obj is None:
                 continue
             obj.delta['polarity'] = POLARITY_DICT['CC'][ev_type]
+            time, location = self._extract_time_loc(event)
+            if time or location:
+                context = WorldContext(time=time, geo_location=location)
+            else:
+                context = None
             ev = self._get_evidence(event, context)
             st = Influence(subj, obj, evidence=[ev])
             self.statements.append(st)
@@ -105,6 +110,11 @@ class CWMSProcessor(object):
             if subj is None or obj is None:
                 continue
             obj.delta['polarity'] = POLARITY_DICT['EVENT'][ev_type]
+            time, location = self._extract_time_loc(event)
+            if time or location:
+                context = WorldContext(time=time, geo_location=location)
+            else:
+                context = None
             ev = self._get_evidence(event, context)
             st = Influence(subj, obj, evidence=[ev])
             self.statements.append(st)

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -391,6 +391,10 @@ class CWMSProcessor(object):
             elif isinstance(stmt, Influence):
                 evmk = (stmt.evidence[0].matches_key() +
                         stmt.subj.matches_key() + stmt.obj.matches_key())
+            elif isinstance(stmt, Association):
+                evmk = (stmt.evidence[0].matches_key() +
+                        stmt.members[0].matches_key() +
+                        stmt.members[1].matches_key())
             if evmk not in evmks:
                 evmks[evmk] = [stmt.uuid]
             else:
@@ -407,6 +411,11 @@ class CWMSProcessor(object):
             infl_stmts = sorted(infl_stmts, key=lambda x: x.polarity_count(),
                                 reverse=True)
             to_remove += [s.uuid for s in infl_stmts[1:]]
+            # Association statements to be removed
+            assn_stmts = [s for s in self.statements if (
+                            s.uuid in uuids and isinstance(s, Association))]
+            assn_stmts = sorted(assn_stmts, key=lambda x: x.polarity_count(),
+                                reverse=True)
             # Standalone events to be removed
             events = [s for s in self.statements if (
                         s.uuid in uuids and isinstance(s, Event))]

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -352,11 +352,11 @@ class CWMSProcessor(object):
         evmks = {}
         logger.debug('Starting with %d Statements.' % len(self.statements))
         for stmt in self.statements:
-            # Standalone Events will be handled later, so we do not add them
             if isinstance(stmt, Event):
-                continue
-            evmk = (stmt.evidence[0].matches_key() +
-                    stmt.subj.matches_key() + stmt.obj.matches_key())
+                evmk = stmt.evidence[0].matches_key()
+            elif isinstance(stmt, Influence):
+                evmk = (stmt.evidence[0].matches_key() +
+                        stmt.subj.matches_key() + stmt.obj.matches_key())
             if evmk not in evmks:
                 evmks[evmk] = [stmt.uuid]
             else:

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -120,14 +120,16 @@ class CWMSProcessor(object):
         events = self.tree.findall("EVENT/[type='ONT::INCREASE']") + (
             self.tree.findall("EVENT/[type='ONT::DECREASE']"))
         for event_entry in events:
-            event = self._get_event(event_entry, "*[@role=':AFFECTED']")
+            evid = self._get_evidence(event_entry, context=None)
+            event = self._get_event(event_entry, "*[@role=':AFFECTED']",
+                                    evidence=[evid])
             if event is None:
                 continue
             self.statements.append(event)
 
         self._remove_multi_extraction_artifacts()
 
-    def _get_event(self, event, find_str):
+    def _get_event(self, event, find_str, evidence=None):
         """Get a concept referred from the event by the given string."""
         # Get the term with the given element id
         element = event.find(find_str)
@@ -163,7 +165,7 @@ class CWMSProcessor(object):
             context = WorldContext(time=time, geo_location=location)
         else:
             context = None
-        event_obj = Event(concept, context=context)
+        event_obj = Event(concept, context=context, evidence=evidence)
         return event_obj
 
     def _extract_time_loc(self, term):

--- a/indra/sources/cwms/processor.py
+++ b/indra/sources/cwms/processor.py
@@ -148,11 +148,14 @@ class CWMSProcessor(object):
             if event_id in self.relation_subj_obj_ids:
                 continue
             # Make an Event statement if it is a standalone event
+            ev_type = event_entry.find('type').text
+            polarity = POLARITY_DICT['EVENT'][ev_type]
             evidence = self._get_evidence(event_entry, context=None)
             event = self._get_event(event_entry, "*[@role=':AFFECTED']",
                                     evidence=[evidence])
             if event is None:
                 continue
+            event.delta['polarity'] = polarity
             self.statements.append(event)
 
         self._remove_multi_extraction_artifacts()

--- a/indra/sources/hume/api.py
+++ b/indra/sources/hume/api.py
@@ -42,4 +42,5 @@ def process_jsonld(jsonld):
     """
     hp = processor.HumeJsonLdProcessor(jsonld)
     hp.extract_relations()
+    hp.extract_events()
     return hp

--- a/indra/sources/hume/processor.py
+++ b/indra/sources/hume/processor.py
@@ -69,7 +69,9 @@ class HumeJsonLdProcessor(object):
     def extract_events(self):
         events = self._find_events()
         for event in events:
-            stmt = self._get_event_and_context(event, eid=event['@id'])
+            evidence = self._get_evidence(event, get_states(event))
+            stmt = self._get_event_and_context(event, eid=event['@id'],
+                                               evidence=evidence)
             self.eid_stmt_dict[event['@id']] = stmt
             self.statements.append(stmt)
 
@@ -199,7 +201,8 @@ class HumeJsonLdProcessor(object):
 
         return concept, metadata
 
-    def _get_event_and_context(self, event, eid=None, arg_type=None):
+    def _get_event_and_context(self, event, eid=None, arg_type=None,
+                               evidence=None):
         """Return an INDRA Event based on an event entry."""
         if not eid:
             eid = _choose_id(event, arg_type)
@@ -209,7 +212,8 @@ class HumeJsonLdProcessor(object):
                     'states': get_states(ev),
                     'polarity': get_polarity(ev)}
         context = self._make_context(ev)
-        event_obj = Event(concept, delta=ev_delta, context=context)
+        event_obj = Event(concept, delta=ev_delta, context=context,
+                          evidence=evidence)
         return event_obj
 
     def _get_evidence(self, event, adjectives):

--- a/indra/sources/sofia/__init__.py
+++ b/indra/sources/sofia/__init__.py
@@ -1,3 +1,3 @@
 """Sofia is a general purpose natural language processing system developed
 at UPitt and CMU by N. Miskov et al."""
-from .api import process_table, process_text, process_json
+from .api import process_table, process_text, process_json, process_json_file

--- a/indra/sources/sofia/api.py
+++ b/indra/sources/sofia/api.py
@@ -27,8 +27,12 @@ def process_table(fname):
         rel_sheet = book['Causal']
     event_sheet = book['Events']
     entities_sheet = book['Entities']
-    sp = SofiaExcelProcessor(rel_sheet.rows, event_sheet.rows,
-                             entities_sheet.rows)
+    # Create a different copy of a generator for every method
+    relation_rows_1, relation_rows_2 = itertools.tee(rel_sheet.rows)
+    event_rows_1, event_rows_2 = itertools.tee(event_sheet.rows)
+    sp = SofiaExcelProcessor(event_rows_1)
+    sp.extract_relations(relation_rows_1)
+    sp.extract_events(event_rows_2, relation_rows_2)
     return sp
 
 

--- a/indra/sources/sofia/api.py
+++ b/indra/sources/sofia/api.py
@@ -27,12 +27,11 @@ def process_table(fname):
         rel_sheet = book['Causal']
     event_sheet = book['Events']
     entities_sheet = book['Entities']
-    # Create a different copy of a generator for every method
-    relation_rows_1, relation_rows_2 = itertools.tee(rel_sheet.rows)
-    event_rows_1, event_rows_2 = itertools.tee(event_sheet.rows)
-    sp = SofiaExcelProcessor(event_rows_1)
-    sp.extract_relations(relation_rows_1)
-    sp.extract_events(event_rows_2, relation_rows_2)
+
+    sp = SofiaExcelProcessor(rel_sheet.rows, event_sheet.rows,
+                             entities_sheet.rows)
+    sp.extract_relations(rel_sheet.rows)
+    sp.extract_events(event_sheet.rows, rel_sheet.rows)
     return sp
 
 
@@ -99,6 +98,8 @@ def process_json(json_obj):
         Statements as its statements attribute.
     """
     sp = SofiaJsonProcessor(json_obj)
+    sp.extract_relations(json_obj)
+    sp.extract_events(json_obj)
     return sp
 
 

--- a/indra/sources/sofia/api.py
+++ b/indra/sources/sofia/api.py
@@ -103,6 +103,25 @@ def process_json(json_obj):
     return sp
 
 
+def process_json_file(fname):
+    """Return processor by processing a JSON file produced by Sofia.
+
+    Parameters
+    ----------
+    fname : str
+        The name of the JSON file to process
+
+    Returns
+    -------
+    indra.sources.sofia.processor.SofiaProcessor
+        A SofiaProcessor object which has a list of extracted INDRA
+        Statements as its statements attribute.
+    """
+    with open(fname, 'r') as fh:
+        jd = json.load(fh)
+    return process_json(jd)
+
+
 def _get_sofia_auth():
     sofia_username = get_config('SOFIA_USERNAME')
     sofia_password = get_config('SOFIA_PASSWORD')

--- a/indra/sources/sofia/processor.py
+++ b/indra/sources/sofia/processor.py
@@ -14,7 +14,9 @@ class SofiaProcessor(object):
         return {'Event_Type': event_dict.get('Event_Type'),
                 'Relation': event_dict.get('Relation'),
                 'Location': event_dict.get('Location'),
-                'Time': event_dict.get('Time')}
+                'Time': event_dict.get('Time'),
+                'Source': event_dict.get('Source_File'),
+                'Text': event_dict.get('Sentence')}
 
     def _build_influences(self, rel_dict):
         stmt_list = []
@@ -72,7 +74,12 @@ class SofiaProcessor(object):
         loc = event_entry.get('Location')
         if loc:
             context.geo_location = RefContext(name=loc)
-        event = Event(concept, context=context)
+
+        text = event_entry.get('Text')
+        ref = event_entry.get('Source')
+        ev = Evidence(source_api='sofia', pmid=ref, text=text)
+
+        event = Event(concept, context=context, evidence=[ev])
         return event
 
 

--- a/indra/sources/sofia/processor.py
+++ b/indra/sources/sofia/processor.py
@@ -16,7 +16,8 @@ class SofiaProcessor(object):
                 'Location': event_dict.get('Location'),
                 'Time': event_dict.get('Time'),
                 'Source': event_dict.get('Source_File'),
-                'Text': event_dict.get('Sentence')}
+                'Text': event_dict.get('Sentence'),
+                'Patient_index': event_dict.get('Patient Index')}
 
     def _build_influences(self, rel_dict):
         stmt_list = []
@@ -138,7 +139,18 @@ class SofiaJsonProcessor(SofiaProcessor):
         # Only make Event Statements from standalone events
         for event_index in self._events:
             if event_index not in self.relation_subj_obj_ids:
-                event = self.get_event(self._events[event_index])
+                if self._events[event_index]['Patient_index']:
+                    patient_index = self._events[event_index]['Patient_index']
+                    event = self.get_event(self._events[patient_index])
+                    if self._events[event_index]['Relation'].startswith(
+                            'increas'):
+                                pol = 1
+                    elif self._events[event_index]['Relation'].startswith(
+                            'decreas'):
+                                pol = -1
+                    event.delta['polarity'] = pol
+                else:
+                    event = self.get_event(self._events[event_index])
                 self.statements.append(event)
 
 

--- a/indra/sources/sofia/processor.py
+++ b/indra/sources/sofia/processor.py
@@ -100,7 +100,7 @@ class SofiaJsonProcessor(SofiaProcessor):
     def __init__(self, json_list):
         self._events = self.process_events(json_list)
         self.statements = []
-        self.relation_event_indexes = []
+        self.relation_subj_obj_ids = []
 
     def process_events(self, json_list):
         event_dict = {}
@@ -120,7 +120,7 @@ class SofiaJsonProcessor(SofiaProcessor):
                 # Save indexes of causes and effects
                 current_relation_events = self.get_relation_events(rel_dict)
                 for ix in current_relation_events:
-                    self.relation_event_indexes.append(ix)
+                    self.relation_subj_obj_ids.append(ix)
                 # Make Influence Statements
                 stmt_list = self._build_influences(rel_dict)
                 if not stmt_list:
@@ -133,11 +133,11 @@ class SofiaJsonProcessor(SofiaProcessor):
         # First confirm we have extracted event information and relation events
         if not self._events:
             self.process_events(json_list)
-        if not self.relation_event_indexes:
+        if not self.relation_subj_obj_ids:
             self.extract_relations(json_list)
         # Only make Event Statements from standalone events
         for event_index in self._events:
-            if event_index not in self.relation_event_indexes:
+            if event_index not in self.relation_subj_obj_ids:
                 event = self.get_event(self._events[event_index])
                 self.statements.append(event)
 
@@ -146,7 +146,7 @@ class SofiaExcelProcessor(SofiaProcessor):
     def __init__(self, relation_rows, event_rows, entity_rows):
         self._events = self.process_events(event_rows)
         self.statements = []
-        self.relation_event_indexes = []
+        self.relation_subj_obj_ids = []
 
     def process_events(self, event_rows):
         header = [cell.value for cell in next(event_rows)]
@@ -167,7 +167,7 @@ class SofiaExcelProcessor(SofiaProcessor):
             # Save indexes of causes and effects
             current_relation_events = self.get_relation_events(row_dict)
             for ix in current_relation_events:
-                self.relation_event_indexes.append(ix)
+                self.relation_subj_obj_ids.append(ix)
             # Make Influence Statements
             stmt_list = self._build_influences(row_dict)
             if not stmt_list:
@@ -180,11 +180,11 @@ class SofiaExcelProcessor(SofiaProcessor):
         # First confirm we have extracted event information and relation events
         if not self._events:
             self.process_events(event_rows)
-        if not self.relation_event_indexes:
+        if not self.relation_subj_obj_ids:
             self.extract_relations(relation_rows)
         # Only make Event Statements from standalone events
         for event_index in self._events:
-            if event_index not in self.relation_event_indexes:
+            if event_index not in self.relation_subj_obj_ids:
                 event = self.get_event(self._events[event_index])
                 self.statements.append(event)
 

--- a/indra/sources/sofia/processor.py
+++ b/indra/sources/sofia/processor.py
@@ -86,7 +86,7 @@ class SofiaProcessor(object):
 class SofiaJsonProcessor(SofiaProcessor):
     def __init__(self, json_list):
         self._events = self.process_events(json_list)
-        self.statements = self.process_relations(json_list)
+        self.statements = []
 
     def process_events(self, json_list):
         event_dict = {}
@@ -107,7 +107,8 @@ class SofiaJsonProcessor(SofiaProcessor):
                 if not stmt_list:
                     continue
                 stmts = stmts + stmt_list
-        return stmts
+        for stmt in stmts:
+            self.statements.append(stmt)
 
 
 class SofiaExcelProcessor(SofiaProcessor):

--- a/indra/tests/cwms_tests_data/association.ekb
+++ b/indra/tests/cwms_tests_data/association.ekb
@@ -1,0 +1,31 @@
+<ekb complete="true" domain="CWMS" id="TEXT00140_IO-256214" timestamp="20190501T114258">
+  <input type="">
+    <documents>
+      <document id="D0001" file="/Users/wbeaumont/cwms/etc/Data/TEXT00140_IO-256214"/>
+    </documents>
+    <paragraphs>
+      <paragraph id="paragraph139" docid="D0001">rain is associated with floods
+</paragraph>
+    </paragraphs>
+    <sentences>
+      <sentence id="1" pid="paragraph139">rain is associated with floods</sentence>
+    </sentences>
+  </input>
+  <EPI end="30" id="V256258" paragraph="paragraph139" rule="-NORMASSOC,-RULE50_0_NEUTRAL1_NEUTRAL2,-ADD-SPEC" start="0" uttnum="1">
+    <type>ONT::ASSOCIATE</type>
+    <force>ONT::TRUE</force>
+    <arg1 id="V256218" role=":NEUTRAL1"/>
+    <arg2 id="V256291" role=":NEUTRAL2"/>
+    <text>rain is associated with floods</text>
+  </EPI>
+  <TERM end="5" id="V256218" paragraph="paragraph139" rule="-NORMASSOC,-ADD-SPEC" start="0" uttnum="1">
+    <type>ONT::PRECIPITATION</type>
+    <text normalization="RAIN">rain</text>
+    <spec>ONT::BARE</spec>
+  </TERM>
+  <TERM end="30" id="V256291" paragraph="paragraph139" rule="-NORMASSOC,-RULE50_0_NEUTRAL1_NEUTRAL2-EVENT,-ADD-SPEC" start="0" uttnum="1">
+    <type>ONT::FLOODING</type>
+    <text normalization="FLOOD">rain is associated with floods</text>
+    <spec>ONT::INDEF-SET</spec>
+  </TERM>
+</ekb>

--- a/indra/tests/cwms_tests_data/cause_decrease_event.ekb
+++ b/indra/tests/cwms_tests_data/cause_decrease_event.ekb
@@ -1,0 +1,49 @@
+<ekb complete="true" domain="CWMS" id="TEXT00083_IO-167665" timestamp="20190426T140413">
+  <input type="">
+    <documents>
+      <document file="/Users/wbeaumont/cwms/etc/Data/TEXT00083_IO-167665" id="D0001"/>
+    </documents>
+    <paragraphs>
+      <paragraph id="paragraph82" docid="D0001">rainfall caused a decrease in water trucking
+</paragraph>
+    </paragraphs>
+    <sentences>
+      <sentence id="1" pid="paragraph82">rainfall caused a decrease in water trucking</sentence>
+    </sentences>
+  </input>
+  <CC end="44" id="V167672" paragraph="paragraph82" rule="-NORMASSOC,-RULE5_3_AGENT_AFFECTED,-ADD-SPEC" start="0" uttnum="1">
+    <type>ONT::CAUSE</type>
+    <text normalization="">rainfall caused a decrease in water trucking</text>
+    <force>ONT::TRUE</force>
+    <arg id="V167666" role=":FACTOR"/>
+    <arg id="V167758" role=":OUTCOME"/>
+  </CC>
+  <TERM end="9" id="V167666" paragraph="paragraph82" rule="-NORMASSOC,-ADD-SPEC" start="0" uttnum="1">
+    <type>ONT::PRECIPITATING</type>
+    <text normalization="RAINFALL">rainfall</text>
+    <spec>ONT::BARE</spec>
+  </TERM>
+  <EVENT end="44" id="V167758" paragraph="paragraph82" rule="-NORMASSOC,-RULE20_1_AGENT_AFFECTED-AFFECTED,-ADD-SPEC" start="16" uttnum="1">
+    <type>ONT::DECREASE</type>
+    <text normalization="">a decrease in water trucking</text>
+    <predicate end="44" start="16">
+      <type>ONT::DECREASE</type>
+      <text>a decrease in water trucking</text>
+    </predicate>
+    <arg2 id="V167886" role=":AFFECTED"/>
+  </EVENT>
+  <EVENT end="44" id="V167886" paragraph="paragraph82" rule="-NORMASSOC,-RULE10_4_AGENT_AFFECTED-AFFECTED,-ADD-SPEC" start="27" uttnum="1">
+    <type>ONT::MOVE</type>
+    <text normalization="">in water trucking</text>
+    <predicate end="44" start="27">
+      <type>ONT::MOVE</type>
+      <text>in water trucking</text>
+    </predicate>
+    <arg2 id="V167881" role=":AFFECTED"/>
+  </EVENT>
+  <TERM end="36" id="V167881" paragraph="paragraph82" rule="-NORMASSOC,-ADD-SPEC" start="30" uttnum="1">
+    <type>ONT::WATER</type>
+    <text normalization="WATER">water</text>
+    <spec>ONT::BARE</spec>
+  </TERM>
+</ekb>

--- a/indra/tests/cwms_tests_data/cause_increase_event.ekb
+++ b/indra/tests/cwms_tests_data/cause_increase_event.ekb
@@ -1,0 +1,40 @@
+<ekb complete="true" domain="CWMS" id="TEXT00054_IO-107170" timestamp="20190429T193506">
+  <input type="">
+    <documents>
+      <document file="/Users/wbeaumont/cwms/etc/Data/TEXT00054_IO-107170" id="D0001"/>
+    </documents>
+    <paragraphs>
+      <paragraph id="paragraph53" docid="D0001">rainfall causes an increase of floods
+</paragraph>
+    </paragraphs>
+    <sentences>
+      <sentence id="1" pid="paragraph53">rainfall causes an increase of floods</sentence>
+    </sentences>
+  </input>
+  <CC end="37" id="V107176" paragraph="paragraph53" rule="-NORMASSOC,-RULE5_3_AGENT_AFFECTED,-ADD-SPEC" start="0" uttnum="1">
+    <type>ONT::CAUSE</type>
+    <text normalization="">rainfall causes an increase of floods</text>
+    <force>ONT::TRUE</force>
+    <arg id="V107171" role=":FACTOR"/>
+    <arg id="V107194" role=":OUTCOME"/>
+  </CC>
+  <TERM end="9" id="V107171" paragraph="paragraph53" rule="-NORMASSOC,-ADD-SPEC" start="0" uttnum="1">
+    <type>ONT::PRECIPITATING</type>
+    <text normalization="RAINFALL">rainfall</text>
+    <spec>ONT::BARE</spec>
+  </TERM>
+  <EVENT end="37" id="V107194" paragraph="paragraph53" rule="-NORMASSOC,-RULE20_1_AGENT_AFFECTED-AFFECTED,-ADD-SPEC" start="16" uttnum="1">
+    <type>ONT::INCREASE</type>
+    <text normalization="">an increase of floods</text>
+    <predicate end="37" start="16">
+      <type>ONT::INCREASE</type>
+      <text>an increase of floods</text>
+    </predicate>
+    <arg2 id="V107228" role=":AFFECTED"/>
+  </EVENT>
+  <TERM end="37" id="V107228" paragraph="paragraph53" rule="-NORMASSOC,-ADD-SPEC" start="28" uttnum="1">
+    <type>ONT::FLOODING</type>
+    <text normalization="FLOOD">of floods</text>
+    <spec>ONT::INDEF-SET</spec>
+  </TERM>
+</ekb>

--- a/indra/tests/cwms_tests_data/cwms_increase.ekb
+++ b/indra/tests/cwms_tests_data/cwms_increase.ekb
@@ -1,0 +1,51 @@
+<ekb complete="true" domain="CWMS" id="TEXT00080_IO-162807" timestamp="20190426T094255">
+  <input type="">
+    <documents>
+      <document file="/Users/wbeaumont/cwms/etc/Data/TEXT00080_IO-162807" id="D0001"/>
+    </documents>
+    <paragraphs>
+      <paragraph id="paragraph79" docid="D0001">food insecurity increased in South Sudan in 2019
+</paragraph>
+    </paragraphs>
+    <sentences>
+      <sentence id="1" pid="paragraph79">food insecurity increased in South Sudan in 2019</sentence>
+    </sentences>
+  </input>
+  <EVENT end="48" id="V162823" paragraph="paragraph79" rule="-NORMASSOC,-TIME,-RULE20_1_AGENT_AFFECTED-AFFECTED,-ADD-SPEC" start="0" uttnum="1">
+    <type>ONT::INCREASE</type>
+    <text normalization="">food insecurity increased in South Sudan in 2019</text>
+    <force>ONT::TRUE</force>
+    <predicate end="48" start="0">
+      <type>ONT::INCREASE</type>
+      <text>food insecurity increased in South Sudan in 2019</text>
+    </predicate>
+    <arg2 id="V162813" role=":AFFECTED"/>
+    <time id="V163091" mod="ONT::TIME-IN-REL"/>
+    <location id="V162980" mod="ONT::IN-LOC"/>
+  </EVENT>
+  <TERM end="16" id="V162813" paragraph="paragraph79" rule="-NORMASSOC,-ASSOC,-ADD-SPEC" start="0" uttnum="1">
+    <type>ONT::UNSAFE-SCALE</type>
+    <text normalization="INSECURITY">food insecurity</text>
+    <spec>ONT::BARE</spec>
+    <assoc-with id="V162808"/>
+  </TERM>
+  <TERM end="16" id="V162808" paragraph="paragraph79" rule="-NORMASSOC,-ADD-SPEC" start="0" uttnum="1">
+    <type>ONT::FOOD</type>
+    <text normalization="FOOD">food insecurity</text>
+    <spec>ONT::KIND</spec>
+  </TERM>
+  <TERM end="41" id="V162980" paragraph="paragraph79" rule="-NORMASSOC,-SIMPLE-REF,-ADD-SPEC" start="29" uttnum="1">
+    <type>ONT::COUNTRY</type>
+    <text normalization="">South Sudan</text>
+    <spec>ONT::THE</spec>
+    <name>SOUTH-SUDAN</name>
+  </TERM>
+  <TERM end="48" id="V163091" paragraph="paragraph79" rule="-NORMASSOC,-ADD-SPEC" start="44" uttnum="1">
+    <type>ONT::TIME-LOC</type>
+    <text normalization="">2019</text>
+    <spec>ONT::THE</spec>
+    <timex type="DATE">
+      <year>2019</year>
+    </timex>
+  </TERM>
+</ekb>

--- a/indra/tests/sofia_event_decreased.json
+++ b/indra/tests/sofia_event_decreased.json
@@ -1,0 +1,49 @@
+[
+ {
+  "Causal": [],
+  "Entities": [],
+  "Events": [
+   {
+    "Agent": "",
+    "Agent Index": "",
+    "Event Index": "E1",
+    "Event_Type": "event1/Natural_Phenomena/Weather",
+    "FrameNet_Frame": "['Precipitation']",
+    "Indicator": "",
+    "Location": "",
+    "Patient": "",
+    "Patient Index": "",
+    "Query": "None",
+    "Relation": "rainfall",
+    "Score": "0.0",
+    "Sentence": "rainfall was significantly decreased ",
+    "Source_File": "userinput",
+    "Time": ""
+   },
+   {
+    "Agent": "",
+    "Agent Index": "",
+    "Event Index": "E2",
+    "Event_Type": "event2/Change",
+    "FrameNet_Frame": "['Change_position_on_a_scale', 'Cause_change_of_position_on_a_scale']",
+    "Indicator": "",
+    "Location": "",
+    "Patient": "rainfall",
+    "Patient Index": "E1",
+    "Query": "None",
+    "Relation": "decreased",
+    "Score": "0.0",
+    "Sentence": "rainfall was significantly decreased ",
+    "Source_File": "userinput",
+    "Time": ""
+   }
+  ],
+  "Variables": {
+   "Index": "V1",
+   "Indicator": "None",
+   "Scoring": "",
+   "Sentence": "rainfall was significantly decreased ",
+   "Source_File": "userinput"
+  }
+ }
+]

--- a/indra/tests/sofia_infl_polarities.json
+++ b/indra/tests/sofia_infl_polarities.json
@@ -1,0 +1,98 @@
+[
+ {
+  "Causal": [
+   {
+    "Cause": "rainfall",
+    "Cause Index": "E1",
+    "Effect": "drought",
+    "Effect Index": "E2",
+    "Indicator": "",
+    "Query": "None",
+    "Relation": "caused",
+    "Relation Index": "R1",
+    "Relation_Type": "CausalRelation",
+    "Score": "0.0",
+    "Sentence": "increase in rainfall caused an decrease in drought ",
+    "Source_File": "userinput"
+   }
+  ],
+  "Entities": [],
+  "Events": [
+   {
+    "Agent": "",
+    "Agent Index": "",
+    "Event Index": "E1",
+    "Event_Type": "event1/Natural_Phenomena/Weather",
+    "FrameNet_Frame": "['Precipitation']",
+    "Indicator": "",
+    "Location": "",
+    "Patient": "",
+    "Patient Index": "",
+    "Query": "None",
+    "Relation": "rainfall",
+    "Score": "0.0",
+    "Sentence": "increase in rainfall caused an decrease in drought ",
+    "Source_File": "userinput",
+    "Time": ""
+   },
+   {
+    "Agent": "",
+    "Agent Index": "",
+    "Event Index": "E2",
+    "Event_Type": "event1/Natural_Phenomena/Weather",
+    "FrameNet_Frame": "",
+    "Indicator": "",
+    "Location": "",
+    "Patient": "",
+    "Patient Index": "",
+    "Query": "None",
+    "Relation": "drought",
+    "Score": "0.0",
+    "Sentence": "increase in rainfall caused an decrease in drought ",
+    "Source_File": "userinput",
+    "Time": ""
+   },
+   {
+    "Agent": "",
+    "Agent Index": "",
+    "Event Index": "E3",
+    "Event_Type": "event2/Change",
+    "FrameNet_Frame": "['Change_position_on_a_scale']",
+    "Indicator": "",
+    "Location": "",
+    "Patient": "rainfall",
+    "Patient Index": "E1",
+    "Query": "None",
+    "Relation": "increase",
+    "Score": "0.0",
+    "Sentence": "increase in rainfall caused an decrease in drought ",
+    "Source_File": "userinput",
+    "Time": ""
+   },
+   {
+    "Agent": "",
+    "Agent Index": "",
+    "Event Index": "E4",
+    "Event_Type": "event2/Change",
+    "FrameNet_Frame": "['Change_position_on_a_scale']",
+    "Indicator": "",
+    "Location": "",
+    "Patient": "drought",
+    "Patient Index": "E2",
+    "Query": "None",
+    "Relation": "an decrease",
+    "Score": "0.0",
+    "Sentence": "increase in rainfall caused an decrease in drought ",
+    "Source_File": "userinput",
+    "Time": ""
+   }
+  ],
+  "Variables": {
+   "Index": "V1",
+   "Indicator": "None",
+   "Scoring": "",
+   "Sentence": "increase in rainfall caused an decrease in drought ",
+   "Source_File": "userinput"
+  }
+ }
+]

--- a/indra/tests/sofia_test.json
+++ b/indra/tests/sofia_test.json
@@ -42,6 +42,23 @@
     "Patient Index": "",
     "Patient": "",
     "Sentence": "rainfall causes floods "
+   },
+   {
+    "Source_File": "userinput",
+    "Query": "None",
+    "Score": "0.0",
+    "Event Index": "E3",
+    "Relation": "inflation",
+    "Event_Type": "event1/Economy/Market",
+    "FrameNet_Frame": "",
+    "Indicator": "",
+    "Location": "South Sudan",
+    "Time": "28, JULY, 2016",
+    "Agent Index": "",
+    "Agent": "",
+    "Patient Index": "",
+    "Patient": "",
+    "Sentence": "UNICEF SOUTH SUDAN SITUATION REPORT - 28 JULY 2016 Situation Overview & Humanitarian Needs In parallel to the increasing the economic situation has severely with a dramatic drop in the value of the South Sudanese pound and inflation estimated at close to 300 per cent . "
    }
   ],
   "Causal": [

--- a/indra/tests/test_cwms.py
+++ b/indra/tests/test_cwms.py
@@ -254,3 +254,14 @@ def test_process_cause_increase_event_ekb():
     stmt = cp.statements[0]
     assert isinstance(stmt, Influence), stmt
     assert stmt.obj.delta['polarity'] == 1, stmt.obj.delta
+
+
+def test_process_correlation():
+    fname = join(data_folder, 'association.ekb')
+    cp = process_ekb_file(fname)
+    assert len(cp.statements) == 1, cp.statements
+    stmt = cp.statements[0]
+    assert isinstance(stmt, Association), stmt
+    assert stmt.members[0].concept.db_refs['CWMS'] == 'ONT::PRECIPITATION'
+    assert stmt.members[1].concept.db_refs['CWMS'] == 'ONT::FLOODING'
+    assert stmt.overall_polarity() is None

--- a/indra/tests/test_cwms.py
+++ b/indra/tests/test_cwms.py
@@ -216,6 +216,11 @@ def test_process_increase_event_ekb():
     assert stmt.delta['polarity'] == 1, stmt.delta
     assert stmt.concept.name == 'food insecurity', stmt.concept.name
     assert stmt.context, stmt.context
+    assert len(stmt.evidence) == 1
+    ev = stmt.evidence[0]
+    assert ev.source_api == 'cwms'
+    assert ev.context is None
+    assert ev.text is not None
 
 
 def test_process_cause_decrease_event_ekb():

--- a/indra/tests/test_cwms.py
+++ b/indra/tests/test_cwms.py
@@ -190,16 +190,31 @@ def test_three_sentences():
 
 
 @attr('slow', 'webservice')
-def test_contextual_sentence():
-    text = "Hunger causes displacement in 2018 in South Sudan."
+def test_context_influence_obj():
+    text = 'Hunger causes displacement in 2018 in South Sudan.'
     cp = process_text(text)
-    assert cp is not None
-    assert len(cp.statements) == 1, len(cp.statements)
     stmt = cp.statements[0]
-    assert len(stmt.evidence) == 1, len(stmt.evidence)
     cont = stmt.obj.context
     assert cont is not None
     assert cont.time and cont.geo_location
+
+
+@attr('slow', 'webservice')
+def test_context_influence_subj():
+    text = 'Hunger in 2018 in South Sudan causes displacement.'
+    cp = process_text(text)
+    stmt = cp.statements[0]
+    cont = stmt.subj.context
+    assert cont is not None
+    assert cont.time and cont.geo_location, cont
+
+
+@attr('slow', 'webservice')
+def test_context_influence_subj_obj():
+    text = 'Hunger in 2018 causes displacement in South Sudan.'
+    cp = process_text(text)
+    stmt = cp.statements[0]
+    assert stmt.subj.context.time and stmt.obj.context.geo_location
 
 
 def test_ekb_process():
@@ -230,3 +245,12 @@ def test_process_cause_decrease_event_ekb():
     stmt = cp.statements[0]
     assert isinstance(stmt, Influence), stmt
     assert stmt.obj.delta['polarity'] == -1, stmt.obj.delta
+
+
+def test_process_cause_increase_event_ekb():
+    fname = join(data_folder, 'cause_increase_event.ekb')
+    cp = process_ekb_file(fname)
+    assert len(cp.statements) == 1, cp.statements
+    stmt = cp.statements[0]
+    assert isinstance(stmt, Influence), stmt
+    assert stmt.obj.delta['polarity'] == 1, stmt.obj.delta

--- a/indra/tests/test_cwms.py
+++ b/indra/tests/test_cwms.py
@@ -216,3 +216,12 @@ def test_process_increase_event_ekb():
     assert stmt.delta['polarity'] == 1, stmt.delta
     assert stmt.concept.name == 'food insecurity', stmt.concept.name
     assert stmt.context, stmt.context
+
+
+def test_process_cause_decrease_event_ekb():
+    fname = join(data_folder, 'cause_decrease_event.ekb')
+    cp = process_ekb_file(fname)
+    assert len(cp.statements) == 1
+    stmt = cp.statements[0]
+    assert isinstance(stmt, Influence)
+    assert stmt.obj.delta['polarity'] == -1, stmt.obj.delta

--- a/indra/tests/test_cwms.py
+++ b/indra/tests/test_cwms.py
@@ -226,7 +226,7 @@ def test_process_increase_event_ekb():
 def test_process_cause_decrease_event_ekb():
     fname = join(data_folder, 'cause_decrease_event.ekb')
     cp = process_ekb_file(fname)
-    assert len(cp.statements) == 1
+    assert len(cp.statements) == 1, cp.statements
     stmt = cp.statements[0]
-    assert isinstance(stmt, Influence)
+    assert isinstance(stmt, Influence), stmt
     assert stmt.obj.delta['polarity'] == -1, stmt.obj.delta

--- a/indra/tests/test_cwms.py
+++ b/indra/tests/test_cwms.py
@@ -205,3 +205,14 @@ def test_contextual_sentence():
 def test_ekb_process():
     cp = process_ekb_file(ekb_processing_test_file)
     assert len(cp.statements) == 1
+
+
+def test_process_increase_event_ekb():
+    fname = join(data_folder, 'cwms_increase.ekb')
+    cp = process_ekb_file(fname)
+    assert len(cp.statements) == 1
+    stmt = cp.statements[0]
+    assert isinstance(stmt, Event)
+    assert stmt.delta['polarity'] == 1, stmt.delta
+    assert stmt.concept.name == 'food insecurity', stmt.concept.name
+    assert stmt.context, stmt.context

--- a/indra/tests/test_hume.py
+++ b/indra/tests/test_hume.py
@@ -59,15 +59,13 @@ def test_standalone_events():
     bp = process_jsonld_file(standalone_events)
     assert bp, "Processor is none."
     assert len(bp.statements) == 3, len(bp.statements)
-    food_stmt = bp.statements[2]
-    conflict_stmt = bp.statements[1]
+    food_stmt = [st for st in bp.statements if st.concept.name == 'insecurity'][0]
+    conflict_stmt = [st for st in bp.statements if st.concept.name == 'Conflict'][0]
     assert isinstance(food_stmt, Event)
-    assert food_stmt.concept.name == 'insecurity', food_stmt.concept.name
     assert food_stmt.context.geo_location.name == 'South Sudan', food_stmt.context.geo_location.name
     assert food_stmt.context.time.text == '2019', food_stmt.context.time.text
     assert food_stmt.delta['polarity'] == 1
     assert len(food_stmt.evidence) == 1, len(stmt.evidence)
     assert isinstance(conflict_stmt, Event)
-    assert conflict_stmt.concept.name == 'Conflict', conflict_stmt.concept.name
     assert conflict_stmt.context.time.text == 'May 2017', conflict_stmt.context.time.text
     assert len(conflict_stmt.evidence) == 1, len(stmt.evidence)

--- a/indra/tests/test_hume.py
+++ b/indra/tests/test_hume.py
@@ -12,6 +12,8 @@ path_this = os.path.dirname(os.path.abspath(__file__))
 
 test_file_new_simple = os.path.join(path_this, 'wm_m12.ben_sentence.json-ld')
 
+standalone_events = os.path.join(path_this, 'wm_ben_event_sentences.v1.json-ld')
+
 
 @unittest.skip('Need updated JSON-LD file')
 def test_bbn_on_ben_paragraph():
@@ -51,3 +53,21 @@ def test_for_context():
     assert stmt.obj.context.geo_location is not None
     loc = stmt.obj.context.geo_location
     assert loc.name == 'South Sudan', loc.name
+
+
+def test_standalone_events():
+    bp = process_jsonld_file(standalone_events)
+    assert bp, "Processor is none."
+    assert len(bp.statements) == 3, len(bp.statements)
+    food_stmt = bp.statements[2]
+    conflict_stmt = bp.statements[1]
+    assert isinstance(food_stmt, Event)
+    assert food_stmt.concept.name == 'insecurity', food_stmt.concept.name
+    assert food_stmt.context.geo_location.name == 'South Sudan', food_stmt.context.geo_location.name
+    assert food_stmt.context.time.text == '2019', food_stmt.context.time.text
+    assert food_stmt.delta['polarity'] == 1
+    assert len(food_stmt.evidence) == 1, len(stmt.evidence)
+    assert isinstance(conflict_stmt, Event)
+    assert conflict_stmt.concept.name == 'Conflict', conflict_stmt.concept.name
+    assert conflict_stmt.context.time.text == 'May 2017', conflict_stmt.context.time.text
+    assert len(conflict_stmt.evidence) == 1, len(stmt.evidence)

--- a/indra/tests/test_sofia.py
+++ b/indra/tests/test_sofia.py
@@ -51,3 +51,13 @@ def test_event_decrease():
     assert isinstance(stmt, Event), stmt
     assert stmt.delta['polarity'] == -1, stmt.delta
     assert stmt.concept.name == 'rainfall', stmt.concept
+
+
+def test_influence_event_polarity():
+    test_file = os.path.join(path_here, 'sofia_infl_polarities.json')
+    sp = sofia.process_json_file(test_file)
+    assert len(sp.statements) == 1, sp.statements
+    stmt = sp.statements[0]
+    assert isinstance(stmt, Influence)
+    assert stmt.subj.delta['polarity'] == 1, stmt.subj.delta
+    assert stmt.obj.delta['polarity'] == -1, stmt.obj.delta

--- a/indra/tests/test_sofia.py
+++ b/indra/tests/test_sofia.py
@@ -6,6 +6,14 @@ import json
 from nose.plugins.attrib import attr
 
 from indra.sources import sofia
+from indra.statements.statements import Influence, Event
+from indra.statements.context import WorldContext
+
+
+# Tell nose to not run tests in the imported modules
+Influence.__test__ = False
+Event.__test__ = False
+WorldContext.__test__ = False
 
 
 @attr('webservice', 'nonpublic')
@@ -23,6 +31,13 @@ def test_process_json():
     with open(test_file, 'r') as fh:
         js = json.load(fh)
     sp = sofia.process_json(js)
-    assert len(sp.statements) == 1
+    assert len(sp.statements) == 2
+    assert isinstance(sp.statements[0], Influence)
     assert sp.statements[0].subj.concept.name == 'rainfall'
     assert sp.statements[0].obj.concept.name == 'floods'
+    assert len(sp.statements[0].evidence) == 1, len(sp.statements[0].evidence)
+    assert isinstance(sp.statements[1], Event)
+    assert sp.statements[1].concept.name == 'inflation'
+    assert isinstance(sp.statements[1].context, WorldContext)
+    assert sp.statements[1].context.time.text == '28, JULY, 2016'
+    assert sp.statements[1].context.geo_location.name == 'South Sudan'

--- a/indra/tests/test_sofia.py
+++ b/indra/tests/test_sofia.py
@@ -16,6 +16,9 @@ Event.__test__ = False
 WorldContext.__test__ = False
 
 
+path_here = os.path.abspath(os.path.dirname(__file__))
+
+
 @attr('webservice', 'nonpublic')
 def test_text_process_webservice():
     txt = 'rainfall causes floods'
@@ -26,11 +29,8 @@ def test_text_process_webservice():
 
 
 def test_process_json():
-    path_here = os.path.abspath(os.path.dirname(__file__))
     test_file = os.path.join(path_here, 'sofia_test.json')
-    with open(test_file, 'r') as fh:
-        js = json.load(fh)
-    sp = sofia.process_json(js)
+    sp = sofia.process_json_file(test_file)
     assert len(sp.statements) == 2
     assert isinstance(sp.statements[0], Influence)
     assert sp.statements[0].subj.concept.name == 'rainfall'
@@ -41,3 +41,13 @@ def test_process_json():
     assert isinstance(sp.statements[1].context, WorldContext)
     assert sp.statements[1].context.time.text == '28, JULY, 2016'
     assert sp.statements[1].context.geo_location.name == 'South Sudan'
+
+
+def test_event_decrease():
+    test_file = os.path.join(path_here, 'sofia_event_decreased.json')
+    sp = sofia.process_json_file(test_file)
+    assert len(sp.statements) == 1, sp.statements
+    stmt = sp.statements[0]
+    assert isinstance(stmt, Event), stmt
+    assert stmt.delta['polarity'] == -1, stmt.delta
+    assert stmt.concept.name == 'rainfall', stmt.concept

--- a/indra/tests/wm_ben_event_sentences.v1.json-ld
+++ b/indra/tests/wm_ben_event_sentences.v1.json-ld
@@ -1,0 +1,539 @@
+{
+    "@context": {
+        "Argument": "https://w3id.org/wm/cag/Argument", 
+        "Corpus": "https://w3id.org/wm/cag/Corpus", 
+        "Dependency": "https://w3id.org/wm/cag/Dependency", 
+        "Document": "https://w3id.org/wm/cag/Document", 
+        "Entity": "https://w3id.org/wm/cag/Entity", 
+        "Event": "https://w3id.org/wm/cag/Event", 
+        "Interval": "https://w3id.org/wm/cag/Interval", 
+        "Modifier": "https://w3id.org/wm/cag/Modifier", 
+        "Provenance": "https://w3id.org/wm/cag/Provenance", 
+        "Sentence": "https://w3id.org/wm/cag/Sentence", 
+        "State": "https://w3id.org/wm/cag/State", 
+        "Trigger": "https://w3id.org/wm/cag/Trigger", 
+        "Word": "https://w3id.org/wm/cag/Word"
+    }, 
+    "@type": "Corpus", 
+    "documents": [
+        {
+            "@id": "ENG_NW_20180102", 
+            "@type": "Document", 
+            "location": "dummy.pdf", 
+            "sentences": [
+                {
+                    "@id": "Sentence-ENG_NW_20180102-0", 
+                    "@type": "Sentence", 
+                    "text": "Food insecurity significantly increased in South Sudan in 2019."
+                }, 
+                {
+                    "@id": "Sentence-ENG_NW_20180102-1", 
+                    "@type": "Sentence", 
+                    "text": "Conflict slightly decreased in Ethiopia in May 2017."
+                }
+            ]
+        }
+    ], 
+    "extractions": [
+        {
+            "@id": "Entity-ENG_NW_20180102-2-1", 
+            "@type": "Extraction", 
+            "canonicalName": "Federal Democratic Republic of Ethiopia", 
+            "geoname_id": "337996", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/entity/location/geopolitical entities/nation", 
+                    "value": 0.8
+                }
+            ], 
+            "labels": [
+                "Entity"
+            ], 
+            "provenance": {
+                "@type": "Provenance", 
+                "document": {
+                    "@id": "ENG_NW_20180102"
+                }, 
+                "documentCharPositions": {
+                    "@type": "Interval", 
+                    "end": 166, 
+                    "start": 159
+                }, 
+                "sentence": "Sentence-ENG_NW_20180102-1"
+            }, 
+            "subtype": "entity", 
+            "text": "Ethiopia", 
+            "type": "concept"
+        }, 
+        {
+            "@id": "Entity-ENG_NW_20180102-0-1", 
+            "@type": "Extraction", 
+            "canonicalName": "Food", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/entity", 
+                    "value": 0.8
+                }
+            ], 
+            "labels": [
+                "Entity"
+            ], 
+            "provenance": {
+                "@type": "Provenance", 
+                "document": {
+                    "@id": "ENG_NW_20180102"
+                }, 
+                "documentCharPositions": {
+                    "@type": "Interval", 
+                    "end": 67, 
+                    "start": 64
+                }, 
+                "sentence": "Sentence-ENG_NW_20180102-0"
+            }, 
+            "subtype": "entity", 
+            "text": "Food", 
+            "type": "concept"
+        }, 
+        {
+            "@id": "Entity-ENG_NW_20180102-1-1", 
+            "@type": "Extraction", 
+            "canonicalName": "South Sudan", 
+            "geoname_id": "7909807", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/entity/location/geopolitical entities/nation", 
+                    "value": 0.8
+                }
+            ], 
+            "labels": [
+                "Entity"
+            ], 
+            "provenance": {
+                "@type": "Provenance", 
+                "document": {
+                    "@id": "ENG_NW_20180102"
+                }, 
+                "documentCharPositions": {
+                    "@type": "Interval", 
+                    "end": 117, 
+                    "start": 107
+                }, 
+                "sentence": "Sentence-ENG_NW_20180102-0"
+            }, 
+            "subtype": "entity", 
+            "text": "South Sudan", 
+            "type": "concept"
+        }, 
+        {
+            "@id": "Event-ENG_NW_20180102-5", 
+            "@type": "Extraction", 
+            "arguments": [
+                {
+                    "@type": "Argument", 
+                    "type": "actor", 
+                    "value": {
+                        "@id": "Entity-ENG_NW_20180102-2-1"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "place", 
+                    "value": {
+                        "@id": "Entity-ENG_NW_20180102-2-1"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "time", 
+                    "value": {
+                        "@id": "Time-1"
+                    }
+                }
+            ], 
+            "canonicalName": "decreased", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/event", 
+                    "value": 1.0
+                }
+            ], 
+            "labels": [
+                "Event"
+            ], 
+            "provenance": [
+                {
+                    "@type": "Provenance", 
+                    "document": {
+                        "@id": "ENG_NW_20180102"
+                    }, 
+                    "documentCharPositions": {
+                        "@type": "Interval", 
+                        "end": 154, 
+                        "start": 146
+                    }, 
+                    "sentence": "Sentence-ENG_NW_20180102-1"
+                }
+            ], 
+            "states": [
+                {
+                    "@type": "State", 
+                    "text": "Asserted", 
+                    "type": "modality"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Specific", 
+                    "type": "genericity"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Positive", 
+                    "type": "polarity"
+                }
+            ], 
+            "subtype": "event", 
+            "text": "decreased", 
+            "trigger": {
+                "@type": "Trigger", 
+                "head text": "decreased", 
+                "provenance": [
+                    {
+                        "@type": "Provenance", 
+                        "document": {
+                            "@id": "ENG_NW_20180102"
+                        }, 
+                        "documentCharPositions": {
+                            "@type": "Interval", 
+                            "end": 154, 
+                            "start": 146
+                        }, 
+                        "sentence": "Sentence-ENG_NW_20180102-1"
+                    }
+                ], 
+                "text": "decreased"
+            }, 
+            "type": "concept"
+        }, 
+        {
+            "@id": "Time-1", 
+            "@type": "Extraction", 
+            "canonicalName": "2017-05", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/entity/temporal", 
+                    "value": 0.75
+                }
+            ], 
+            "labels": [
+                "Entity"
+            ], 
+            "mentions": [
+                {
+                    "provenance": {
+                        "@type": "Provenance", 
+                        "document": {
+                            "@id": "ENG_NW_20180102"
+                        }, 
+                        "documentCharPositions": {
+                            "@type": "Interval", 
+                            "end": 178, 
+                            "start": 171
+                        }, 
+                        "sentence": "Sentence-ENG_NW_20180102-1"
+                    }, 
+                    "text": "May 2017"
+                }
+            ], 
+            "subtype": "entity", 
+            "timeInterval": [
+                {
+                    "duration": 2678399, 
+                    "end": "2017-05-31T23:59", 
+                    "start": "2017-05-01T00:00"
+                }
+            ], 
+            "type": "concept"
+        }, 
+        {
+            "@id": "Event-ENG_NW_20180102-6", 
+            "@type": "Extraction", 
+            "arguments": [
+                {
+                    "@type": "Argument", 
+                    "type": "actor", 
+                    "value": {
+                        "@id": "Entity-ENG_NW_20180102-2-1"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "time", 
+                    "value": {
+                        "@id": "Time-2"
+                    }
+                }
+            ], 
+            "canonicalName": "Conflict", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/indicator/Conflict/Population Displacement", 
+                    "value": 0.75
+                }
+            ], 
+            "labels": [
+                "Event"
+            ], 
+            "provenance": [
+                {
+                    "@type": "Provenance", 
+                    "document": {
+                        "@id": "ENG_NW_20180102"
+                    }, 
+                    "documentCharPositions": {
+                        "@type": "Interval", 
+                        "end": 135, 
+                        "start": 128
+                    }, 
+                    "sentence": "Sentence-ENG_NW_20180102-1"
+                }
+            ], 
+            "states": [
+                {
+                    "@type": "State", 
+                    "text": "Asserted", 
+                    "type": "modality"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Specific", 
+                    "type": "genericity"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Positive", 
+                    "type": "polarity"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Decrease", 
+                    "type": "direction_of_change"
+                }
+            ], 
+            "subtype": "event", 
+            "text": "Conflict", 
+            "trigger": {
+                "@type": "Trigger", 
+                "head text": "Conflict", 
+                "provenance": [
+                    {
+                        "@type": "Provenance", 
+                        "document": {
+                            "@id": "ENG_NW_20180102"
+                        }, 
+                        "documentCharPositions": {
+                            "@type": "Interval", 
+                            "end": 135, 
+                            "start": 128
+                        }, 
+                        "sentence": "Sentence-ENG_NW_20180102-1"
+                    }
+                ], 
+                "text": "Conflict"
+            }, 
+            "type": "concept"
+        }, 
+        {
+            "@id": "Time-2", 
+            "@type": "Extraction", 
+            "canonicalName": "2017-05", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/entity/temporal", 
+                    "value": 0.75
+                }
+            ], 
+            "labels": [
+                "Entity"
+            ], 
+            "mentions": [
+                {
+                    "provenance": {
+                        "@type": "Provenance", 
+                        "document": {
+                            "@id": "ENG_NW_20180102"
+                        }, 
+                        "documentCharPositions": {
+                            "@type": "Interval", 
+                            "end": 178, 
+                            "start": 171
+                        }, 
+                        "sentence": "Sentence-ENG_NW_20180102-1"
+                    }, 
+                    "text": "May 2017"
+                }
+            ], 
+            "subtype": "entity", 
+            "timeInterval": [
+                {
+                    "duration": 2678399, 
+                    "end": "2017-05-31T23:59", 
+                    "start": "2017-05-01T00:00"
+                }
+            ], 
+            "type": "concept"
+        }, 
+        {
+            "@id": "Event-ENG_NW_20180102-0", 
+            "@type": "Extraction", 
+            "arguments": [
+                {
+                    "@type": "Argument", 
+                    "type": "actor", 
+                    "value": {
+                        "@id": "Entity-ENG_NW_20180102-1-1"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "place", 
+                    "value": {
+                        "@id": "Entity-ENG_NW_20180102-1-1"
+                    }
+                }, 
+                {
+                    "@type": "Argument", 
+                    "type": "time", 
+                    "value": {
+                        "@id": "Time-3"
+                    }
+                }
+            ], 
+            "canonicalName": "insecurity", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/event", 
+                    "value": 1.0
+                }
+            ], 
+            "labels": [
+                "Event"
+            ], 
+            "provenance": [
+                {
+                    "@type": "Provenance", 
+                    "document": {
+                        "@id": "ENG_NW_20180102"
+                    }, 
+                    "documentCharPositions": {
+                        "@type": "Interval", 
+                        "end": 78, 
+                        "start": 69
+                    }, 
+                    "sentence": "Sentence-ENG_NW_20180102-0"
+                }
+            ], 
+            "states": [
+                {
+                    "@type": "State", 
+                    "text": "Asserted", 
+                    "type": "modality"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Specific", 
+                    "type": "genericity"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Positive", 
+                    "type": "polarity"
+                }, 
+                {
+                    "@type": "State", 
+                    "text": "Increase", 
+                    "type": "direction_of_change"
+                }
+            ], 
+            "subtype": "event", 
+            "text": "insecurity", 
+            "trigger": {
+                "@type": "Trigger", 
+                "head text": "insecurity", 
+                "provenance": [
+                    {
+                        "@type": "Provenance", 
+                        "document": {
+                            "@id": "ENG_NW_20180102"
+                        }, 
+                        "documentCharPositions": {
+                            "@type": "Interval", 
+                            "end": 78, 
+                            "start": 69
+                        }, 
+                        "sentence": "Sentence-ENG_NW_20180102-0"
+                    }
+                ], 
+                "text": "insecurity"
+            }, 
+            "type": "concept"
+        }, 
+        {
+            "@id": "Time-3", 
+            "@type": "Extraction", 
+            "canonicalName": "2019", 
+            "grounding": [
+                {
+                    "@type": "Grounding", 
+                    "name": "bbn", 
+                    "ontologyConcept": "/entity/temporal", 
+                    "value": 0.75
+                }
+            ], 
+            "labels": [
+                "Entity"
+            ], 
+            "mentions": [
+                {
+                    "provenance": {
+                        "@type": "Provenance", 
+                        "document": {
+                            "@id": "ENG_NW_20180102"
+                        }, 
+                        "documentCharPositions": {
+                            "@type": "Interval", 
+                            "end": 125, 
+                            "start": 122
+                        }, 
+                        "sentence": "Sentence-ENG_NW_20180102-0"
+                    }, 
+                    "text": "2019"
+                }
+            ], 
+            "subtype": "entity", 
+            "timeInterval": [
+                {
+                    "duration": 31535999, 
+                    "end": "2019-12-31T23:59", 
+                    "start": "2019-01-01T00:00"
+                }
+            ], 
+            "type": "concept"
+        }
+    ]
+}


### PR DESCRIPTION
This PR is extracting standalone Events in CWMS, Sofia and Hume readers. Extraction in all processing is implemented with the following logic:
- While extracting the causal relations the processor saves a list of subjects and objects and appends self.statements with Influence statements
- While extracting individual events, each one of them is checked against the list of subjects and objects and only standalone Events that are not part of causal relations are added to self.statements

Standalone Events have their own context, while Influences can have context in Evidence and also context at their Events (subject and object) level.

SofiaJsonProcessor is currently being tested for extracting standalone Events, while other processors need additional test files to add more tests.