### PR TITLE
Handle outdated HGNC symbols

### DIFF
--- a/indra/resources/update_resources.py
+++ b/indra/resources/update_resources.py
@@ -71,7 +71,26 @@ def save_from_http(url, fname):
 
 def update_hgnc_entries():
     logger.info('--Updating HGNC entries-----')
-    url = 'http://tinyurl.com/y83dx5s6'
+
+    # Select relevant columns and parameters
+    cols = ['gd_hgnc_id', 'gd_app_sym', 'gd_app_name', 'gd_status',
+            'gd_prev_sym', 'gd_aliases', 'gd_mgd_id', 'md_rgd_id',
+            'gd_pub_eg_id']
+    statuses = ['Approved', 'Entry%20Withdrawn']
+    params = {
+            'hgnc_dbtag': 'on',
+            'order_by': 'gd_app_sym_sort',
+            'format': 'text',
+            'submit': 'submit'
+            }
+
+    # Construct a download URL from the above parameters
+    url = 'https://www.genenames.org/cgi-bin/download/custom?'
+    url += '&'.join(['col=%s' % c for c in cols]) + '&'
+    url += '&'.join(['status=%s' % s for s in statuses]) + '&'
+    url += '&'.join(['%s=%s' % (k, v) for k, v in params.items()])
+
+    # Save the download into a file
     fname = os.path.join(path, 'hgnc_entries.tsv')
     save_from_http(url, fname)
 

--- a/indra/resources/update_resources.py
+++ b/indra/resources/update_resources.py
@@ -74,8 +74,8 @@ def update_hgnc_entries():
 
     # Select relevant columns and parameters
     cols = ['gd_hgnc_id', 'gd_app_sym', 'gd_app_name', 'gd_status',
-            'gd_prev_sym', 'gd_aliases', 'gd_mgd_id', 'md_rgd_id',
-            'gd_pub_eg_id']
+            'gd_aliases', 'md_eg_id', 'md_prot_id',
+            'md_mgd_id', 'md_rgd_id', 'gd_prev_sym']
     statuses = ['Approved', 'Entry%20Withdrawn']
     params = {
             'hgnc_dbtag': 'on',

--- a/indra/tests/test_hgnc_client.py
+++ b/indra/tests/test_hgnc_client.py
@@ -71,3 +71,14 @@ def test_is_category():
     assert not hgnc_client.is_phosphatase('KRAS')
     assert hgnc_client.is_transcription_factor('FOXO3')
     assert not hgnc_client.is_transcription_factor('AKT1')
+
+
+def test_get_current_id():
+    # Current symbol
+    assert hgnc_client.get_current_hgnc_id('BRAF') == '1097'
+    # Outdated symbol, one ID
+    assert hgnc_client.get_current_hgnc_id('SEPT7') == '1717'
+    # Outdated symbol, multiple IDs
+    ids = hgnc_client.get_current_hgnc_id('HOX1')
+    assert len(ids) == 10
+    assert '5101' in ids


### PR DESCRIPTION
This PR extends the HGNC entries resource file with outdated symbols and processes these to make them available in the HGNC client. The PR then adds a new function in the client which is able to map any current or outdated HGNC symbol to an HGNC ID (or in case of ambiguities, e.g., in the case of "HOX1") to a list of HGNC IDs. This makes available to downstream applications an alternative to get_hgnc_id which is also able to map outdated symbols.

Fixes #142, it also fixes #297 though in a conservative way, by adding a new function rather than changing the behavior of the (extremely widely used) existing one. Where advantageous, we can change the code that uses these mappings to use the new function and handle ambiguities as needed in the given context.