### PR TITLE
Fix batch submission

### DIFF
--- a/indra/tools/reading/readers.py
+++ b/indra/tools/reading/readers.py
@@ -248,22 +248,12 @@ class ReadingData(object):
 
             # Map to the different processors.
             if self.reader == ReachReader.name:
-                if self.format == formats.JSON:
-                    # Process the reach json into statements.
-                    json_str = json.dumps(self.content)
-                    processor = reach.process_json_str(json_str)
-                else:
-                    raise ReadingError("Incorrect format for Reach output: %s."
-                                       % self.format)
+                json_str = json.dumps(self.content)
+                processor = reach.process_json_str(json_str)
             elif self.reader == SparserReader.name:
-                if self.format == formats.JSON:
-                    # Process the sparser content into statements
-                    processor = sparser.process_json_dict(self.content)
-                    if processor is not None:
-                        processor.set_statements_pmid(None)
-                else:
-                    raise ReadingError("Sparser should only ever be JSON, not "
-                                       "%s." % self.format)
+                processor = sparser.process_json_dict(self.content)
+                if processor is not None:
+                    processor.set_statements_pmid(None)
             elif self.reader == TripsReader.name:
                 processor = trips.process_xml(self.content)
             else:

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -82,7 +82,7 @@ def wait_for_complete(queue_name, job_list=None, job_name_prefix=None,
         result_record = {}
 
     def get_jobs_by_status(status, job_id_filter=None, job_name_prefix=None):
-        logger.info("Specifically tracked jobs: %s" % job_id_filter)
+        logger.info("Specifically tracked jobs: %s" % len(job_id_filter))
         res = batch_client.list_jobs(jobQueue=queue_name,
                                      jobStatus=status, maxResults=10000)
         jobs = res['jobSummaryList']

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -544,6 +544,7 @@ class Submitter(object):
             logger.info("Waiting for just a sec...")
             sleep(1)
             wait_params['wait_for_first_job'] = True
+            wait_params['kill_on_exception'] = True
             self.watch_and_wait(**wait_params)
             submit_thread.join(0)
             if submit_thread.is_alive():

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -157,7 +157,6 @@ def wait_for_complete(queue_name, job_list=None, job_name_prefix=None,
     stashed_id_set = set()
     found_a_job = False
     while True:
-        print('.')
         pre_run = []
         job_id_list = get_job_ids()
         for status in ('SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING'):
@@ -190,7 +189,6 @@ def wait_for_complete(queue_name, job_list=None, job_name_prefix=None,
                     terminated_jobs.add(jid)
 
         # Check for end-conditions.
-        print(found_a_job, wait_for_first_job)
         if found_a_job or not wait_for_first_job:
             if job_id_list:
                 if (len(failed) + len(done)) == len(job_id_list):

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -78,7 +78,6 @@ def wait_for_complete(queue_name, job_list=None, job_name_prefix=None,
         result_record = {}
 
     def get_jobs_by_status(status, job_id_filter=None, job_name_prefix=None):
-        logger.info("Specifically tracked jobs: %s" % len(job_id_filter))
         res = batch_client.list_jobs(jobQueue=queue_name,
                                      jobStatus=status, maxResults=10000)
         jobs = res['jobSummaryList']
@@ -155,6 +154,7 @@ def wait_for_complete(queue_name, job_list=None, job_name_prefix=None,
     while True:
         pre_run = []
         job_id_list = get_ids(job_list)
+        logger.info("Specifically tracked jobs: %s" % len(job_id_list))
         for status in ('SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING'):
             pre_run += get_jobs_by_status(status, job_id_list, job_name_prefix)
         running = get_jobs_by_status('RUNNING', job_id_list, job_name_prefix)
@@ -508,7 +508,7 @@ class Submitter(object):
 
     def watch_and_wait(self, poll_interval=10, idle_log_timeout=None,
                        kill_on_timeout=False, stash_log_method=None,
-                       tag_instances=False, kill_on_exception=False, **kwargs):
+                       tag_instances=False, kill_on_exception=True, **kwargs):
         """This provides shortcut access to the wait_for_complete_function."""
         try:
             res = wait_for_complete(self._job_queue, job_list=self.job_list,

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -62,7 +62,7 @@ def wait_for_complete(queue_name, job_list=None, job_name_prefix=None,
     result_record : dict
         A dict which will be modified in place to record the results of the job
     wait_for_first_job : bool
-        Don't exit until at least on job has been found. This is good if you
+        Don't exit until at least one job has been found. This is good if you
         are monitoring jobs that are submitted periodically, but can be a
         problem if there is a chance you might call this when no jobs will
         ever be run.


### PR DESCRIPTION
Fix several issues with the staggered async submission of batch jobs. This also adds the feature that when `watch_and_wait` exits with an error (or by keyboard interrupt), the jobs being monitored will be killed, by default. This can be disabled by setting `kill_on_exception` to False.