### PR TITLE
TRIPS mappings

### DIFF
--- a/indra/databases/uniprot_client.py
+++ b/indra/databases/uniprot_client.py
@@ -13,18 +13,14 @@ from protmapper.uniprot_client import *
 def _build_uniprot_subcell_loc():
     fname = os.path.dirname(os.path.abspath(__file__)) +\
                 '/../resources/uniprot_subcell_loc.tsv'
-    try:
-        csv_rows = read_unicode_csv(fname, delimiter='\t')
-        # Skip the header row
-        next(csv_rows)
-        subcell_loc = {}
-        for row in csv_rows:
-            loc_id = row[0]
-            loc_alias = row[3]
-            subcell_loc[loc_id] = loc_alias
-    except IOError:
-        subcell_loc = {}
-    return subcell_loc
+    csv_rows = read_unicode_csv(fname, delimiter='\t')
+    # Skip the header row
+    up_to_go = {}
+    for row in csv_rows:
+        upid = row[0]
+        goid = row[1]
+        up_to_go[upid] = goid
+    return up_to_go
 
 
 uniprot_subcell_loc = _build_uniprot_subcell_loc()

--- a/indra/resources/uniprot_subcell_loc.tsv
+++ b/indra/resources/uniprot_subcell_loc.tsv
@@ -1,516 +1,439 @@
-Subcellular location ID	Description	Category	Alias
-SL-0476	The appearance of the striated muscle is created by a pattern of alternating dark A bands and light I bands. A bands comprise thick filaments of myosin and proteins that bind myosin. They are bisected by the H zone, a paler region where the thick and the thin filaments do not overlap. The exact center of the A band is termed the M line.	Cellular component	A band
-SL-0002	The acidocalcisome is an electron-dense acidic organelle which contains a matrix of pyrophosphate and polyphosphates with bound calcium and other cations. Its limiting membrane possesses a number of pumps and exchangers for the uptake and release of these elements. The acidocalcisome does not belong to the endocytic pathway and may represent a branch of the secretory pathway in trypanosomatids and apicomplexan parasites. The acidocalcisome is possibly involved in polyphosphate and cation storage and in adaptation of these microoganisms to environmental stress.	Cellular component	Acidocalcisome
-SL-0316	The acidocalcisome compartment bounded by the acidocalcisomal membrane.	Cellular component	Acidocalcisome lumen
-SL-0003	The membrane of an acidocalcisome.	Cellular component	Acidocalcisome membrane
-SL-0007	The acrosome is a large lysosome-like vesicle overlying the sperm nucleus. This spermatid specific organelle, derived from the Golgi during spermatogenesis, contains both unique acrosomal enzymes and common enzymes associated with lysosomes in somatic cells. Only sperm that have undergone the acrosome reaction can fuse with egg plasma membrane. The acrosome reaction is characterized by multiple fusions of the outer acrosomal membrane with the sperm cell membrane.	Cellular component	acrosome
-SL-0004	The portion of the acrosomal membrane closely associated with the anterior region of the nuclear envelope.	Cellular component	acrosome inner membrane
-SL-0005	The lumen of the acrosome.	Cellular component	acrosome lumen
-SL-0006	The membrane of the acrosome.	Cellular component	acrosome membrane
-SL-0447	The portion of the acrosomal membrane just beneath the sperm cell membrane.	Cellular component	acrosome outer membrane
-SL-0008	The actin patch is a highly dynamic actin structure in fungi required primarily for endocytosis but possibly also coupled to exocytosis. Actin patches are highly motile, they first assemble at sites of polarized cell growth and then move slowly and nondirectionally along the cell cortex.	Cellular component	actin patch
-SL-0009	The adherens junction is an adhesion complex that localizes close to the apical membrane in epithelial cells. These junctions join the actin cytoskeleton to the plasma membrane to form adhesive contacts between cells or between cells and extracellular matrix. AJs mediate both cell adhesion and signaling.	Cellular component	adherens junction
-SL-0010	The aleurone grain (protein body), is a specialized dry vacuole where storage proteins accumulate in a stable form in seeds, usually in the endosperm. Cells containing aleurones form the aleurone layer. These act as a source of amino acids for various synthetic activities during germination, but also represent immensely important nutritional sources for humans and ruminants. In most seeds, the aleuron grains contain three morphologically distinct regions: the matrix, crystalloid, and globoid.	Cellular component	aleurone grain
-SL-0317	The aleurone grain compartment bounded by the aleurone grain membrane.	Cellular component	aleurone grain lumen
-SL-0011	The membrane of an aleurone grain.	Cellular component	aleurone grain membrane
-SL-0012	The amyloplast is a colorless plant plastid that forms and stores starch. Amyloplasts are found in many tissues, particularly in storage tissues. They are found in both photosynthetic and parasitic plants, i.e. even in plants that are not capable of photosynthesis. Many amyloplast proteins are also expressed in photosynthetic tissue.	Cellular component	amyloplast
-SL-0013	The inner membrane of an amyloplast.	Cellular component	amyloplast inner membrane
-SL-0014	The membrane surrounding the amyloplast. Also used when it is not clear in which amyloplast membrane a protein is found.	Cellular component	amyloplast membrane
-SL-0491	The anammoxosome is a large intracytoplasmic compartment bounded by a single bilayer ladderane lipid-containing membrane present in bacteria that perform anaerobic ammonium oxidation (anammox). This specific organelle is the site of anammox process, in which nitrite is used as the electron acceptor in the conversion of ammonium to dinitrogen (N2) gas and water. Anammox bacteria belong to the phylum Planctomycetes and are recognized as major players in the global nitrogen cycle.	Cellular component	Anammoxosome
-SL-0492	The membrane of the anammoxosome, a single bilayer membrane that contains unusual lipids, i.e. the so-called ladderane lipids, which appear to be unique for anammox bacteria.	Cellular component	Anammoxosome membrane
-SL-0015	The fraction of the cell membrane at the apical end of the cell, which faces the outside world or the lumen of the cavity.	Cellular component	Apical cell membrane
-SL-0016	In the sea urchin embryos the apical lamina is a fibrous meshwork that remains after removal of hyalin from the hyalin layer.	Cellular component	apical lamina
-SL-0017	The fraction of the cell membrane at the apical end of the lateral plasma membrane of the cell.	Cellular component	Apicolateral cell membrane
-SL-0018	The apicoplast is a plastid found in some apicocomplexan parasites which is a non-photosynthetic plastid relict. Apicoplasts do not contain thylakoids; it is not yet clear if they contain internal membranes.	Cellular component	apicoplast
-SL-0019	The apoplast is the "non-living" extracellular space that surrounds the symplast. It consists of cell walls and spaces between cells. Water and solutes can move freely in this framework, except at the endodermis in roots and stems where the apoplastic flow of ions is interrupted by the Casparian strip, forcing water to flow to symplast.	Cellular component	apoplast
-SL-0306	The flagellum of Archaea is a long hair-like cell surface appendage made of polymerized flagellin with an attached hook. This rotating structure with switches propels the cell through a liquid medium. The archaeal flagellum is distinct from its bacterial equivalent in terms of architecture, composition and mechanism of assembly. Thinner (10-15 nm) compared to the bacterial flagellum (18-24 nm), it is usually composed of several types of flagellins and is glycosylated. The archeal flagellum is considered as a type IV pilus-like structure.	Cellular component	Archaeal flagellum
-SL-0020	The attachment organelle is a multifunctional polar structure found in several Mycoplasma species. This large and complex cell extension, whose predicted mass is greater than that of a vertebrate nuclear pore complex, is essential for adherence to host cells, is involved in gliding motility, and is associated with cell division.	Cellular component	attachment organelle
-SL-0021	The membrane surrounding the attachment organelle.	Cellular component	attachment organelle membrane
-SL-0023	The autophagosome is a double membrane vesicle involved in the degradation of long-lived proteins, unnecessary or damaged organelles as well as other cellular constituents such as lipids or carbohydrates. Crescent-shape isolation membranes or phagophores can sequester cytoplasm and organelles giving rise to autophagosomes. The outer membrane of the autophagosomes then fuse with vacuoles and/or lysosomes and the inner membrane vesicles (termed autophagic bodies) are released into the vacuole/lysosome lumen. These vesicles are then lysed and the contents are degraded by resident hydrolases.	Cellular component	autophagosome
-SL-0318	The autophagosomal compartment bounded by the autophagosomal membrane.	Cellular component	autophagosome lumen
-SL-0022	The membrane surrounding the autophagosome.	Cellular component	autophagosome membrane
-SL-0279	The axon is the long process of a neuron that conducts nerve impulses, usually away from the cell body to the terminals and varicosities, which are sites of storage and release of neurotransmitter.	Cellular component	axon
-SL-0489	Small membrane vesicle (< 1 um) that buds off a prokaryotic cell's plasma membrane, able to carry proteins, phospholipids, lipopolysaccharides, nucleic acids, viruses, etc. Bacterial extracellular vesicles are important in intercellular communication and pathogenesis, and can exist within host cells.	Cellular component	Bacterial extracellular vesicle
-SL-0307	The flagellum of Bacteria is a long hair-like cell surface appendage. The flagellar apparatus consists of the flagellar filament made of polymerized flagellin (the propeller), the hook-like structure near the cell surface (the universal joint) and the basal body (the engine) which is a rod and a system of rings embedded in the cell envelope. The basal body and the hook anchor the whip-like filament to the cell surface. The flagellum is a rotating structure whose switches propels the cell through a liquid medium.	Cellular component	Bacterial flagellum
-SL-0142	The basal body of a bacterial flagellum is a rod and a system of rings embedded in the cell envelope. Gram-negative flagella usually have an L ring in the plane of the lipopolysaccharide in the outer membrane, a periplasmic P ring in the plane of the peptidoglycan around the flagellar rod and a MS ring that is located within and above the cytoplasmic membrane. A C ring extends into the cytoplasm. The rod is a major component of the flagellar basal body and it spans the bacterial periplasm. The L and P rings are not found in Gram-positive bacteria.	Cellular component	Bacterial flagellum basal body
-SL-0358	The bacterial flagellar filament is made of polymerized flagellin.	Cellular component	Bacterial flagellum filament
-SL-0357	The hook of a bacterial flagellum connects the basal body and the filament and acts as a universal joint. This flexible hinge relays the energy generated by the motor into torque formation that is transferred onto the rigid filament.	Cellular component	Bacterial flagellum hook
-SL-0454	The barrier septum, is a septum which spans a cell and does not allow exchange of organelles or cytoplasm between compartments.	Cellular component	Barrier septum
-SL-0024	The basal cell membrane is the fraction of the plasma membrane at the basal side of the cell, which faces the underlying connective tissue.	Cellular component	Basal cell membrane
-SL-0025	The basement membrane is a highly specialized extracellular matrix structure undelying the basal surface of cells exhibiting polarity (epithelial, endothelial and mesothelial cells) and surrounding certain cell types such as muscle, adipose and Schwann cells.	Cellular component	basement membrane
-SL-0026	The basolateral cell membrane is the fraction of the plasma membrane at the basolateral side of the cell, which faces adjacent cells and the underlying connective tissue.	Cellular component	Basolateral cell membrane
-SL-0472	These cellular membrane protrusions are the result of actomyosin contractions of the cortex, which cause either transient detachment of the cell membrane from the actin cortex or a rupture in the actin cortex. Then, cytosol streams out of the cell body and inflates the newly formed bleb. Once expansion slows, an actin cortex is reconstituted. Retraction is powered by myosin motor proteins. Blebbing is a common feature of cell physiology during cell movement, cytokinesis, cell spreading and apoptosis.	Cellular component	bleb
-SL-0027	A growing bud is an asexual reproductive structure, as in yeast or a hydra, that consists of an outgrowth capable of developing into a new individual.	Cellular component	Bud
-SL-0028	The membrane surrounding a bud.	Cellular component	Bud membrane
-SL-0029	The bud neck is a constriction between the mother and the daughter cell (bud) in an organism that reproduces by budding. This structure comprises the septin ring, an hourglass-shaped collar around the mother-bud neck, which splits into two rings flanking the division plane at cytokinesis and that acts as a diffusion barrier to maintain polarity factors in the bud and as a scaffold to recruit actomyosin contractile ring components.	Cellular component	Bud neck
-SL-0030	The bud tip is the distal tip of the bud opposite to the site of attachment to the mother cell.	Cellular component	Bud tip
-SL-0031	The nuclear Cajal bodies (CBs) are small subnuclear membraneless organelles present either free in the nucleoplasm and/or physically associated to specific regions of chromatin. CBs contain newly assembled small nuclear ribonucleoproteins (snRNPs) and small nucleolar ribonucleoproteins (snoRNPs) particles, which are involved in pre-mRNA splicing and in ribosomal RNA processing, respectively. Mammalian nucleus in interphase, show 2-6 CBs, as irregular, punctuate structures, which vary in size and shape and which are often juxtaposed to nucleoli. At the electronic-microscope level, they are composed of heterogeneous mixture of electro-dense particles with diameters ranging from 20-25 nm and are called coiled body. Structures similar to CBs have been identified in the amphibian oocyte nucleus (called sphere organelles) and in insect (called endobodies). CBs are motile and dynamic structures. Both their protein and RNA-protein components can cycle continuously between CBs and other nuclear locations depending on the transcriptional state of the cell.	Cellular component	Cajal body
-SL-0032	The calyx is a large cytoskeletal component of the perinuclear theca of the mammalian sperm head.	Cellular component	calyx
-SL-0033	The capsule is a protective structure surrounding some bacteria or fungi. The bacterial capsule is a layer of material, usually polysaccharide, attached to the cell wall possibly via covalent attachments to either phospholipid or lipid-A molecules. It has several functions: promote bacterial adhesion to surfaces or interaction with other organisms; act as a permeability barrier, as a defense mechanism against phagocytosis and/or as a nutrient reserve. Among pathogens, capsule formation often correlates with pathogenicity. The fungal capsule is an extracellular layer which lies outside the cell wall and it is usually composed of polysaccharides. It protects the cell from different environmental dangers such as phagocytosis, dessication, etc.	Cellular component	capsule
-SL-0034	The carboxysome is a small polyhedral inclusion body containing several polypeptides surrounded by a thin protein coat. They are cytoplasmic in cyanobacteria and are also found in the stroma of cyanelles. They contain most to all of the cellular complement of Rubisco. Carboxysomes appear to function as a microcompartment in which Rubisco-mediated CO(2) fixation occurs.	Cellular component	Carboxysome
-SL-0035	The caveola is a small (apparently) uncoated pit mostly found in the cell membrane of many highly differentiated mammalian cells, such as adipocytes, endothelial cells and muscle cells. These flask-shaped invaginations are defined by the presence of caveolins and contains a subset of lipid-raft components, including cholesterol and sphingolipids. Caveolae each comprise a caveolar bulb with a diameter of 60-80 nm, connected to an opening of fairly constant diameter. Caveolae might exists as single pits or can form a cluster of caveolae with non-caveolar membrane between the pits. In many tissues, and particularly in adipocytes, multiple caveolae are arranged around a central vacuolar domain. In developing muscle fibres, multiple caveolae are connected by a single neck to the cell membrane, producing large chains of interconnected caveolae. Another structural feature of caveolae in certain endothelia is the presence of a stomatal diaphragm, which consists of a central density and radial spikes, in the neck of the caveolae. Mature caveolae might be assembled in the Golgi apparatus. Caveolae can flatten out into the cell membrane, thereby loosing their caveolar identity.	Cellular component	caveola
-SL-0138	The cell cortex is the cytoplasmic region under the cell membrane.	Cellular component	cell cortex
-SL-0036	The cell envelope comprizes the cell membrane, the cell wall and an outer membrane if present. Gram positive bacteria cell envelope consists of the cytoplasmic membrane, cell wall and capsule. Gram negative envelope consists of the cytoplasmic membrane, cell wall, periplasmic space, outer membrane and capsule. Archeal cell envelope consists generally of single typical bilayer membrane covered by a surface layer (S-layer). Ignicoccus species have exceptionally an outer membrane which encloses a large periplasmic space. Extreme thermophiles and acidophiles have tetraether type glycerophospholipids with C40 isoprenoid chains. The yeast cell envelope is a protecting capsule which consists of the cytoplasmic membrane, the periplasmic space, and the cell wall.	Cellular component	Cell envelope
-SL-0037	The prokaryotic inner cell membrane is the selectively permeable membrane which separates the cytoplasm from the periplasm in prokaryotes with 2 membranes.	Cellular component	Cell inner membrane
-SL-0038	The cell junction is a cell-cell or cell-extracellular matrix contact within a tissue of a multicellular organism, especially abundant in epithelia. In vertebrates, there are three major types of cell junctions: anchoring junctions (e.g. adherens junctions), communicating junctions (e.g. gap junctions) and occluding junctions (e.g. tight junctions).	Cellular component	Cell junction
-SL-0039	The cell membrane is the selectively permeable membrane which separates the cytoplasm from its surroundings. Known as the cell inner membrane in prokaryotes with 2 membranes.	Cellular component	Cell membrane
-SL-0040	The prokaryotic outer cell membrane is the selectively permeable membrane which separates the prokaryotic periplasm from its cell surroundings. Traditionally only Gram-negative bacteria were thought of as having an outer membrane, but recent work has shown some Actinobacteria, including Mycobacterium tuberculosis, as well as at least 1 archaea (Ignicoccus hospitalis) have a cell outer membrane.	Cellular component	Cell outer membrane
-SL-0280	A cell projection is a cell protrusion such as pseudopodium, filopodium, lamellipodium, growth cone, flagellum, acrosome, axon, or bacterial comet tail. These membrane-cytoskeleton-coupled processes are involved in many biological functions, such as cell motility, cancer-cell invasion, endocytosis, phagocytosis, exocytosis, pathogen infection, neurite extension and cytokinesis.	Cellular component	Cell projection
-SL-0455	A structure composed of peptidoglycan and often chitin in addition to other materials. It usually forms perpendicular to the long axis of a cell or hypha and grows centripetally from the cell wall to the center of the cell and often functions in the compartmentalization of a cell into two daughter cells.	Cellular component	Cell septum
-SL-0310	The outermost side of the cell.	Cellular component	Cell surface
-SL-0456	The region at either end of the longest axis of a cylindrical or elongated cell, where polarized growth may occur.	Cellular component	Cell tip
-SL-0041	The complex and rigid layer surrounding the cell. Cell walls are found in bacteria, archaea, fungi, plants, and algae. The cell wall is surrounded by the outer membrane in gram-negative bacteria, and envelopes the inner or plasma membrane in gram-negative, gram-positive and acid-fast bacteria. Cell walls of bacteria contain peptidoglycan while those of archaea are not made of peptidoglycan, but some archaea may contain pseudopeptidoglycan, which is composed of N-acetyltalosaminuronic acid, instead of N-acetyl muramic acid in peptidoglycan. The plant cell wall is made of fibrils of cellulose embedded in a matrix of several other kinds of polymers such as pectin and lignin. Algal cell walls are usually composed of cellulose, glycoproteins, sporopollenin, calcium and various polysaccharides such as manosyl, xylanes, alginic acid. Diatom cell walls (or frustules) contain silica. The cell wall plays a role in cell shape, cell stability and development, and protection against environmental dangers.	Cellular component	cell wall
-SL-0042	The cellular chromatophore membrane is the plasma-membrane derived internal, photosynthetic membrane found in the cytoplasm in purple photosynthetic bacteria. They contain the reaction centers, antennae complexes, cytochrome bc1 complex and the F(0)F(1)-ATPase.	Cellular component	Cellular chromatophore membrane
-SL-0043	The cellular thylakoids are formed usually by extensive invaginations of the cell membrane. In Synechocystis sp. strain PCC 6803, the thylakoid membranes are physically discontinuous from the plasma membrane, and thus represent bona fide intracellular organelles.	Cellular component	Cellular thylakoid
-SL-0044	The lumen of the cellular thylakoid.	Cellular component	Cellular thylakoid lumen
-SL-0045	The membrane of the cellular thylakoid.	Cellular component	Cellular thylakoid membrane
-SL-0485	Centriolar satellites are nonmembranous, electron-dense and spherical cytoplasmic granules of about 70-100 nm in diameter, occurring around centrosomes in most vertebrate cell types. They contain a number of centrosomal proteins. Centriolar satellites have the ability to move along microtubules, toward their minus ends, i.e. toward centrosomes. Their number increase during interphase and decrease during mitosis.	Cellular component	centriolar satellite
-SL-0046	The centriole is a barrel-shaped microtubule-based structure. A pair of centrioles, embedded in the so-called pericentriolar material, constitute the centrosome, a microtubule organizing center of an eukaryotic cell. Centrioles are barrel-shaped microtubule-based structures organized in a 9-fold radial symmetry. Centriolar microtubule arrays usually consist of triplet microtubules, although doublets or singlets are present in some species. Centrioles are structurally related to (and often interconvertible with) basal bodies, the organelles required for the assembly of a cilium or flagellum.	Cellular component	centriole
-SL-0047	The centromere is a region of replicated eukaryotic chromosomes where the two chromatids are joined together.	Cellular component	centromere
-SL-0048	The centrosome is a microtubule organizing center (MTOC) responsible for the nucleation and organisation of  microtubules. It is composed of two orthogonally arranged centrioles, each one having a barrel shaped microtubule structure, and their surrounding pericentriolar material (PCM).	Cellular component	centrosome
-SL-0049	The most common form of plastid, the chloroplast is a photosynthetic organelle found in all photosynthetic eukaryotes except glaucocystophyte algae (where it is called a cyanelle) and Paulinella chromatophore (where it is called an organellar chromatophore). In green (photosynthetic) tissue they house the machinery necessary for pigment biosynthesis, amino acid synthesis, lipid metabolism etc, as well as the machinery for photosynthesis and CO(2) fixation. They are surrounded by between 2 and 4 membranes and contain thylakoids in green tissue.	Cellular component	chloroplast
-SL-0050	The envelope of a chloroplast comprises the inner and outer chloroplast membrane including the intermembrane space.	Cellular component	chloroplast envelope
-SL-0051	The inner membrane of a chloroplast is the membrane which separates the chloroplast stroma from the intermembrane space.	Cellular component	chloroplast inner membrane
-SL-0052	The intermembrane space between the inner and the outer chloroplast membranes.	Cellular component	chloroplast intermembrane space
-SL-0053	The membrane surrounding a chloroplast. Also used when it is not clear in which chloroplast membrane (outer membrane, inner membrane or thylakoid) a protein is found.	Cellular component	chloroplast membrane
-SL-0139	The chloroplast nucleoid is the chloroplastic pseudocompartment formed by the chromatin-dense area. This region, which is functionally equivalent to the eukaryotic nucleus, is not surrounded by a membrane.	Cellular component	chloroplast nucleoid
-SL-0054	The outer membrane of a chloroplast is the chloroplast membrane facing the cytoplasm.	Cellular component	chloroplast outer membrane
-SL-0055	The internal space enclosed by the chloroplast double membrane but excluding the thylakoid space. This space, filled with a colorless hydrophilic matrix, contains DNA, ribosomes and some temporary products of photosynthesis.	Cellular component	chloroplast stroma
-SL-0056	The thylakoid of a chloroplast is an internal system of interconnected membranes, that carry out the light reactions of photosynthesis. They are arranged into stacked and unstacked regions called grana and stroma thylakoids, respectively, that are differentially enriched in photosystem I and II complexes. Although extensive, the thylakoid network in an individual chloroplast is thought to comprise a single lumenal compartment.	Cellular component	chloroplast thylakoid
-SL-0057	The chloroplast thylakoid lumen is the chloroplast compartment bounded by the thylakoid membranes.	Cellular component	chloroplast thylakoid lumen
-SL-0058	The thylakoid membranes of a chloroplast is an internal system of interconnected membranes, that carry out the light reactions of photosynthesis. They are arranged into stacked and unstacked regions called grana and stroma thylakoids, respectively, that are differentially enriched in photosystem I and II complexes. Although extensive, the thylakoid network in an individual chloroplast is thought to comprise a single lumenal compartment.	Cellular component	chloroplast thylakoid membrane
-SL-0059	A chlorosome is a photosynthetic light-harvesting complex found in anoxygenic green bacteria. Chlorosomes are flattened ellipsoidal organelles appressed to the cytoplasmic face of the cell membrane. They contain typically highly aggregated bacteriochlorophyll c, d, or e, a small amount of bacteriochlorophyll a, carotenoids, quinones, and occasionally wax esters. The chlorosome envelope of green sulfur bacteria is an asymmetric membrane containing galactolipids with the galactosyl moieties exposed on the outer surface. The farnesyl tails of the BChl c molecules within the chlorosome probably comprise the inner leaflet of this membrane.	Cellular component	Chlorosome
-SL-0060	The chlorosome envelope of green sulfur bacteria is an asymmetric membrane containing galactolipids with the galactosyl moieties exposed on the outer surface. The farnesyl tails of the BChl c molecules within the chlorosome probably comprise the inner leaflet of this membrane.	Cellular component	chlorosome envelope
-SL-0061	A chromaffin granule is a specialized secretory vesicle characteristic of chromaffin cells.	Cellular component	chromaffin granule
-SL-0349	The chromaffin granule comparment bounded by the chromaffin granule membrane.	Cellular component	chromaffin granule lumen
-SL-0062	The chromaffin granule membrane is the membrane surrounding a chromaffin granule, a specialized secretory vesicle characteristic of chromaffin cells.	Cellular component	chromaffin granule membrane
-SL-0063	A chromoplast is a plastid containing pigments other than chlorophyll. Found in flower, petals and fruit.	Cellular component	chromoplast
-SL-0064	The membrane surrounding the chromoplast. Also used when it is not clear in which chromoplast membrane (outer membrane, inner membrane or thylakoid) a protein is found.	Cellular component	chromoplast membrane
-SL-0065	The chromoplast stroma is the space enclosed by the chromoplast double membrane but excluding the photosynthetic material. The chromoplast is a plastid containing pigments other than chlorophyll.	Cellular component	chromoplast stroma
-SL-0468	An organized structure composed of a single very long molecule of coiled DNA and associated proteins (e.g. histones) that carries hereditary information.	Cellular component	Chromosome
-SL-0066	The cilium is a cell surface projection found at the surface of a large proportion of eukaryotic cells. The two basic types of cilia, motile (alternatively named flagella) and non-motile, collectively perform a wide variety of functions broadly encompassing cell/fluid movement and sensory perception. Their most prominent structural component is the axoneme which consists of nine doublet microtubules, with all motile cilia - except those at the embryonic node - containing an additional central pair of microtubules. The axonemal microtubules of all cilia nucleate and extend from a basal body, a centriolar structure most often composed of a radial array of nine triplet microtubules. In most cells, basal bodies associate with cell membranes and cilia are assembled as 'extracellular' membrane-enclosed compartments.	Cellular component	cilium
-SL-0304	The cilium axoneme is the most prominent structural component of the cilium. It consists of nine doublet microtubules, with all motile cilia - except those at the embryonic node - containing an additional central pair of microtubules. The axonemal microtubules of all cilia nucleate and extend from a basal body, a centriolar structure most often composed of a radial array of nine triplet microtubules. In most cells, basal bodies associate with cell membranes and cilia are assembled as 'extracellular' membrane-enclosed compartments.	Cellular component	cilium axoneme
-SL-0087	The basal body is a barrel-shaped microtubule-based structure required for the formation of cilia. Basal bodies, structuraly related to and often interconvertible with centrioles, serves as a nucleation site for axoneme growth.	Cellular component	cilium basal body
-SL-0305	The portion of the cell membrane surrounding the cilium.	Cellular component	cilium membrane
-SL-0067	The cis-Golgi network is an extensive tubulovesicular network bound to the cis face of the Golgi stack and which function is to receive process the biosynthetic output from the ER.	Cellular component	cis-Golgi network
-SL-0068	The lipid bilayer surrounding any of the compartments that make up the cis-Golgi network.	Cellular component	cis-Golgi network membrane
-SL-0069	Coated pits are regions of the cell membrane specialized in receptor-mediated endocytosis. Their cytoplasmic surface is coated with a bristlelike structure made of clathrin. During the first steps of endocytosis, clathrin-coated pits are internalized to form clathrin-coated vesicles which transport proteins from organelle to organelle.	Cellular component	clathrin-coated pit
-SL-0070	Clathrin coated vesicles (CCVs) mediate the vesicular transport of cargo such as proteins between organelles in the post-Golgi network connecting the trans-Golgi network, endosomes, lysosomes and the cell membrane. CCVs that bud from the cell membrane reveal a striking polyhedral pattern reminiscent of a fullerene which arises from the outermost protein in the coat, clathrin. Clathrin assembles from three-legged individual components called triskelions to form a polygonal lattice around the vesicle. Clathrin is a large heterohexameric protein complex composed of three heavy chains and three light chains. Clathrin molecules self-assemble together to make a spherical clathrin lattice structure, a polyhedron made of regular pentagons and hexagons. The clathrin lattice serves as a mechanical scaffold but is itself unable to bind directly to membrane components. The connection of the clathrin scaffold to the membrane is mediated by clathrin adaptors, which can bind directly to both the clathrin lattice and to the lipid and protein components of membranes. Clathrin-associated adaptor protein (AP) complexes are a stoichiometric coat component of CCVs alongside clathrin itself, and are considered a major clathrin adaptor contributing the CCV formation.	Cellular component	clathrin-coated vesicle
-SL-0319	The clathrin-coated vesicle compartment bounded by the clathrin-coated vesicle membrane.	Cellular component	clathrin-coated vesicle lumen
-SL-0071	The membrane surrounding a clathrin-coated vesicle (CCV). CCVs mediate the vesicular transport of cargo such as proteins between organelles in the post-Golgi network connecting the trans-Golgi network, endosomes, lysosomes and the cell membrane. CCVs that bud from the cell membrane reveal a striking polyhedral pattern reminiscent of a fullerene which arises from the outermost protein in the coat, clathrin. Clathrin assembles from three-legged individual components called triskelions to form a polygonal lattice around the vesicle. Clathrin is a large heterohexameric protein complex composed of three heavy chains and three light chains. Clathrin molecules self-assemble together to make a spherical clathrin lattice structure, a polyhedron made of regular pentagons and hexagons. The clathrin lattice serves as a mechanical scaffold but is itself unable to bind directly to membrane components. The connection of the clathrin scaffold to the membrane is mediated by clathrin adaptors, which can bind directly to both the clathrin lattice and to the lipid and protein components of membranes. Clathrin-associated adaptor protein (AP) complexes are a stoichiometric coat component of CCVs alongside clathrin itself, and are considered a major clathrin adaptor contributing the CCV formation.	Cellular component	clathrin-coated vesicle membrane
-SL-0467	In fungal, amoeboid and animal cells, during the cytokinesis at the end of cell division, a cleavage furrow forms in the plasma membrane. A contractile ring containing actin and myosin is assembled at the selected site of the future cleavage furrow. Ring contraction produces the force to constrict the cleavage furrow and the daughter cells separate by membrane fusion.	Cellular component	Cleavage furrow
-SL-0072	Coated pits are regions of the donor membrane where the assembly of the vesicle coat take place. The coat assembles from soluble protomers such as coat protein complex-I and coat protein complex-II. The components of the coat often define the intracellular sorting station, and contribute to both membrane deformation and local movement of the resulting transport intermediate following scission. During the first steps of the vesicle-mediated membrane transport, coated pits are internalized to form coated vesicles which transport proteins between distinct membrane-bound organelles.	Cellular component	coated pit
-SL-0073	A contractile vacuole (CV) complex is a membrane-bound osmoregulatory organelle of fresh water and soil amoebae and protozoa which segregates excess cytosolic water, acquired osmotically, and expel it to the cell exterior, so that the cytosolic osmolarity is kept constant under a given osmotic condition. Depending on the organism, the CV complex (CVC) shows different degrees of specialization of its tubular and vesicular elements. In the most elaborate CVCs of certain ciliates, e.g. Paramecium, a central vacuole, the contractile vacuole or cisterna, is surrounded by radially oriented ampullae or radial arms. These ampullae are connected to a network of channels. Excess cytosolic water, acquired osmotically, is segregated by the radial arms and enters the vacuole, so that the vacuole swells (the fluid-filling phase). The vacuole then rounds (the rounding phase) and the radial arms sever from the vacuole. The vacuole membrane then fuses with the plasma membrane at the pore region and the pore opens. The vacuole shrinks as its fluid is discharged through the pore (the fluid-discharging phase). The pore closes when the fluid has been discharged. The radial arms then reattach to the vacuole, so that the vacuole swells again as the fluid enters from the arms (the next fluid-filling phase).	Cellular component	Contractile vacuole
-SL-0320	The contractile vacuole compartment bounded by the contractile vacuole membrane.	Cellular component	Contractile vacuole lumen
-SL-0074	The membrane surrounding a contractile vacuole. A contractile vacuole (CV) complex is a membrane-bound osmoregulatory organelle of fresh water and soil amoebae and protozoa which segregates excess cytosolic water, acquired osmotically, and expel it to the cell exterior, so that the cytosolic osmolarity is kept constant under a given osmotic condition.	Cellular component	Contractile vacuole membrane
-SL-0075	COPI-coated vesicles mediate the vesicular transport of cargo such as proteins. COPI-coated vesicles are believed to bud from the cis-cisternae of the Golgi apparatus, mediate traffic from the cis-Golgi back to the ER (retrograde), and govern the flow pattern of materials within the Golgi stack. COPI is composed of the coatomer, which is a seven-subunit protein complex that participates in the formation of Golgi-derived coated vesicles. Evidence has also been presented for anterograde intra-Golgi transport mediated by COPI in yeast and mammals.	Cellular component	COPI-coated vesicle
-SL-0321	The COPI-coated vesicle compartment bounded by the COPI-coated vesicle membrane.	Cellular component	COPI-coated vesicle lumen
-SL-0076	The membrane surrounding a COPI-coated vesicle. COPI-coated vesicles mediate the vesicular transport of cargo such as proteins. COPI-coated vesicles are believed to bud from the cis-cisternae of the Golgi apparatus, mediate traffic from the cis-Golgi back to the ER (retrograde), and govern the flow pattern of materials within the Golgi stack. COPI is composed of the coatomer, which is a seven-subunit protein complex that participates in the formation of Golgi-derived coated vesicles. Evidence has also been presented for anterograde intra-Golgi transport mediated by COPI in yeast and mammals.	Cellular component	COPI-coated vesicle membrane
-SL-0077	COPII-coated vesicles mediate the vesicular transport of cargo such as proteins. COPII-coated vesicles are believed to bud from the endoplasmic reticulum be involved in the anterograde transport between the ER to Golgi and travel toward the Endoplasmic reticulum-Golgi intermediate compartment, where they fuse and release their contents (anterograde transport). The COPII coat has five main functional components that are highly conserved in all eukaryotic cells.	Cellular component	COPII-coated vesicle
-SL-0322	The COPII-coated vesicle compartment bounded by the COPII-coated vesicle membrane.	Cellular component	COPII-coated vesicle lumen
-SL-0078	The membrane surrounding a COPII-coated vesicle. COPII-coated vesicles mediate the vesicular transport of cargo such as proteins. COPII-coated vesicles are believed to bud from the endoplasmic reticulum be involved in the anterograde transport between the ER to Golgi and travel toward the Endoplasmic reticulum-Golgi intermediate compartment, where they fuse and release their contents (anterograde transport). The COPII coat has five main functional components that are highly conserved in all eukaryotic cells.	Cellular component	COPII-coated vesicle membrane
-SL-0079	The cornified envelope is a structure which is formed beneath the plasma membrane in terminally differentiating stratified squamous epithelia. It provides a vital physical barrier to these tissues in mammals and consists of a 10 nm thick layer of highly crosslinked insoluble proteins. In the specialized case of the epidermis, a 5 nm thick layer of ceramide lipids is covalently bound to the proteins. These organize extracellular lipids into orderly lamellae and, together, the cell envelope and extracellular lipids are essential for effective physical and water barrier function in the skin.	Cellular component	Cornified envelope
-SL-0080	A cvt vesicle is a double membrane-layered vesicle implicated in the cytoplasm to vacuole targeting pathway.	Cellular component	cvt vesicle
-SL-0323	The cvt vesicle compartment bounded by the cvt vesicle membrane.	Cellular component	cvt vesicle lumen
-SL-0081	The membrane surrounding a cvt vesicle. A cvt vesicle is a double membrane-layered vesicle implicated in the cytoplasm to vacuole targeting pathway.	Cellular component	cvt vesicle membrane
-SL-0082	A cyanelle is a photosynthetic organelle of glaucocystophyte algae. Cyanelles are surrounded by a double membrane and, in between, a peptidoglycan wall. Thylakoid membrane architecture and the presence of carboxysomes are cyanobacteria-like. Historically, the term cyanelle is derived from a classification as endosymbiotic cyanobacteria, and thus is not fully correct.	Cellular component	cyanelle
-SL-0479	The envelope of a cyanelle comprises the inner and outer cyanelle membrane including the intermembrane space and the vestigal peptidoglycan layer.	Cellular component	cyanelle envelope
-SL-0480	The inner membrane of a cyanelle is the membrane which separates the cyanelle stroma from the intermembrane space.	Cellular component	cyanelle inner membrane
-SL-0481	The intermembrane space between the inner and the outer cyanelle membranes, it includes the vestigial peptidoglycan layer.	Cellular component	cyanelle intermembrane space
-SL-0083	The membrane surrounding a cyanelle, a photosynthetic organelle of glaucocystophyte algae. Also used when it is not clear in which cyanelle membrane (outer membrane, inner membrane or thylakoid) a protein is found.	Cellular component	cyanelle membrane
-SL-0482	The outer membrane of a cyanelle is the cyanelle membrane facing the cytoplasm.	Cellular component	cyanelle outer membrane
-SL-0350	The internal space enclosed by the cyanelle double membrane but excluding the thylakoid space. This space, filled with a colorless hydrophilic matrix, contains DNA, ribosomes and some temporary products of photosynthesis.	Cellular component	cyanelle stroma
-SL-0277	The cyanelle thylakoid is an internal system of interconnected photosynthetic membranes resembling that of cyanobacteria found in the cyanelles of certain algae.	Cellular component	cyanelle thylakoid
-SL-0084	The cyanelle thylakoid lumen is the cyanelle compartment bounded by the thylakoid membranes.	Cellular component	cyanelle thylakoid lumen
-SL-0085	The lipid bilayer membrane of any thylakoid within a cyanelle, a photosynthetic organelle of glaucocystophyte algae.	Cellular component	cyanelle thylakoid membrane
-SL-0086	The cytoplasm is the content of a cell within the plasma membrane and, in eukaryotics cells, surrounding the nucleus. This three-dimensional, jelly-like lattice interconnects and supports the other solid structures. The cytosol (the soluble portion of the cytoplasm outside the organelles) is mostly composed of water and many low molecular weight compounds. In eukaryotes, the cytoplasm also contains a network of cytoplasmic filaments (cytoskeleton).	Cellular component	Cytoplasm
-SL-0281	Protein found in or associated with cytoplasmic granules.	Cellular component	Cytoplasmic granule
-SL-0324	The cytoplasmic granule compartment bounded by the cytoplasmic granule membrane.	Cellular component	Cytoplasmic granule lumen
-SL-0282	The membrane surrounding a cytoplasmic granule.	Cellular component	Cytoplasmic granule membrane
-SL-0495	Cytoplasmic ribonucleoprotein granule is a collective term for distinct protein and RNA foci inside the cytoplasm, including processing bodies (P-bodies), stress granules, neuronal ribonucleoprotein granule (neuronal transport granule) and germ granules (germline granules).	Cellular component	Cytoplasmic ribonucleoprotein granule
-SL-9910	Protein found mostly on the cytoplasmic side of the membrane.	Orientation	Cytoplasmic side
-SL-0088	The cytoplasmic vesicles mediate vesicular transport among the organelles of secretory and endocytic systems. These transport vesicles are classified by the identity of the protein coat used in their formation and also by the cargo they contain, e.g. clathrin-, COPI-, and COPII-coated vesicles, synaptic vesicles, secretory vesicles, phagosomes, etc.	Cellular component	Cytoplasmic vesicle
-SL-0325	The cytoplasmic vesicle compartment bounded by the cytoplasmic vesicle membrane.	Cellular component	Cytoplasmic vesicle lumen
-SL-0089	The membrane surrounding a cytoplasmic vesicle. The cytoplasmic vesicles mediate vesicular transport among the organelles of secretory and endocytic systems.	Cellular component	Cytoplasmic vesicle membrane
-SL-0090	The cytoskeleton is a dynamic three-dimensional structure that fills the cytoplasm of cells. The cytoskeleton is responsible for cell movement, cytokinesis, and the organization of the organelles or organelle-like structures within the cell. The major components of the cytoskeleton are the microfilaments (of actin), microtubules (of tubulin), the intermediate filament systems and a fourth group, the MinD-ParA group, that appears to be unique to bacteria.	Cellular component	cytoskeleton
-SL-0091	The cytosol is the unstructured aqueous phase of the cytoplasm excluding organelles, membranes, and insoluble cytoskeletal components.	Cellular component	cytosol
-SL-0283	The dendrite is a short and typically branched process extending from the cell body of a neuron that receive and integrate signals coming from axons of other neurons, and convey the resulting signal to the body of the cell.	Cellular component	dendrite
-SL-0284	A dendritic spine is a small, club-like cell protrusion from neuronal dendrites that form the postsynaptic component of most excitatory synapses in the brain. Spines are complex, dynamic structures that contain a dense array of cytoskeletal, transmembrane, and scaffolding molecules. Despite their modest size, most spines contain at least some form of smooth endoplasmic reticulum, which in the largest spines takes the form of a specialized organelle called the "spine apparatus". These cell protrusions play a critical role in synaptic transmission and plasticity.	Cellular component	dendritic spine
-SL-0285	The portion of the cell membrane surrounding the dendritic spine, a small, club-like cell protrusion from neuronal dendrites that form the postsynaptic component of most excitatory synapses in the brain.	Cellular component	dendritic spine membrane
-SL-0092	A desmosome (DS) is a button-like adhesion complex that stabilizes epithelial sheets by anchoring the intermediate filament cytoskeleton to the cell junction. Desmosomes are found particularly in tissues subjected to mechanical stress.	Cellular component	desmosome
-SL-0094	Early endosomes form a tubulovesicular network spread throughout the cortical cytoplasm of the cell. Early endosomes are the primary sorting station in the endocytic pathway from which endocytosed molecules can be recycled back to the cell membrane or targeted to degradation in the lysosomes. Loaded by endocytosed molecules in 1 to 4 minutes, their acidic luminal pH around 6.0 allows ligand release from recycling receptors.	Cellular component	Early endosome
-SL-0337	The early endosomal compartment bounded by the membrane of early endosomes, which form a tubulovesicular network spread throughout the cortical cytoplasm of the cell.	Cellular component	Early endosome lumen
-SL-0093	The membrane surrounding the early endosomes, which form a tubulovesicular network spread throughout the cortical cytoplasm of the cell.	Cellular component	Early endosome membrane
-SL-0147	A collection of membranous structures involved in transport within the cell. The main components of the endomembrane system are endoplasmic reticulum, Golgi apparatus, vesicles and cell membrane and nuclear envelope. The endomembrane system does not include the membranes of mitochondria or plastids.	Cellular component	Endomembrane system
-SL-0095	The endoplasmic reticulum (ER) is an extensive network of membrane tubules, vesicles and flattened cisternae (sac-like structures) found throughout the eukaryotic cell, especially those responsible for the production of hormones and other secretory products. The membrane is a continuation of the outer nuclear membrane, it encloses the cytosol cisternal spaces (or internal lumen), which are continuous with the nuclear periplasmic space. The ER sustains many general functions, including protein synthesis, protein modification, protein folding, insertion of membrane proteins, sequestration of calcium, production of phospholipids and steroids and transport of proteins destined for membranes and secretion.	Cellular component	Endoplasmic reticulum
-SL-0096	The lumen of the endoplasmic reticulum (ER) is the area enclosed by the endoplasmic reticulum membrane, an extensive network of membrane tubules, vesicles and flattened cisternae (sac-like structures) found throughout the eukaryotic cell, especially those responsible for the production of hormones and other secretory products.	Cellular component	Endoplasmic reticulum lumen
-SL-0097	The membrane surrounding the endoplasmic reticulum (ER). The endoplasmic reticulum is an extensive network of membrane tubules, vesicles and flattened cisternae (sac-like structures) found throughout the eukaryotic cell, especially those responsible for the production of hormones and other secretory products.	Cellular component	Endoplasmic reticulum membrane
-SL-0098	The ER-Golgi intermediate compartment is a collection of tubulovesicular membrane clusters in the vicinity of ER exit sites. The ERGIC mediates transport between the endoplasmic reticulum and the Golgi and is the first anterograde/retrograde sorting station in the secretory pathway. ERGIC has not been observed in yeast and plants.	Cellular component	Endoplasmic reticulum-Golgi intermediate compartment
-SL-0326	The ERGIC compartment bounded by the ERGIC membrane.	Cellular component	Endoplasmic reticulum-Golgi intermediate compartment lumen
-SL-0099	The membrane surrounding the ER-Golgi intermediate compartment, which is a collection of tubulovesicular membrane clusters in the vicinity of ER exit sites.	Cellular component	Endoplasmic reticulum-Golgi intermediate compartment membrane
-SL-0101	Endosomes are highly dynamic membrane systems involved in transport within the cell, they receive endocytosed cell membrane molecules and sort them for either degradation or recycling back to the cell surface. They also receive newly synthesised proteins destined for vacuolar/lysosomal compartments. In certain cell types, endosomal multivesicular bodies may fuse with the cell surface in an exocytic manner. These released vesicles are called exosomes.	Cellular component	Endosome
-SL-0327	The endosomal compartment bounded by the endosomal membrane.	Cellular component	Endosome lumen
-SL-0100	The membrane surrounding the endosome. Endosomes are highly dynamic membrane systems involved in transport within the cell, they receive endocytosed cell membrane molecules and sort them for either degradation or recycling back to the cell surface.	Cellular component	Endosome membrane
-SL-0109	The esterosome is a crystalline inclusion body. This vesicle is filled with crystals of proteins showing sequence similarities with various esterases. The enclosing membrane has the characteristics of RER.	Cellular component	esterosome
-SL-0328	The esterosomal compartment bounded by the esterosomal membrane.	Cellular component	esterosome lumen
-SL-0108	The membrane surrounding the esterosome, a crystalline inclusion body is a vesicle filled with crystals of proteins showing sequence similarities with various esterases.	Cellular component	esterosome membrane
-SL-0110	The etioplast is a plastid found in plants grown in the dark.	Cellular component	etioplast
-SL-0329	The membrane surrounding the etioplast, a plastid found in plants grown in the dark. Also used when it is not clear in which etioplast membrane a protein is found.	Cellular component	etioplast membrane
-SL-0330	The etioplast stroma is the space enclosed by the double membrane of an etioplast but excluding the prothylakoid space. It contains the etioplast DNA.	Cellular component	etioplast stroma
-SL-0466	Exosomes are 30-120 nm microvesicles of endocytic origin secreted by most cell types and found in abundance in body fluids, including blood, saliva, urine, and breast milk. They contain various molecular constituents of their cell of origin, including proteins and nucleic acids, and carry this cargo between diverse locations in the body. These microvesicles form by budding into the lumen of the multivesicular bodies (MVBs) and are released to extracellular fluids by fusion of MVBs with the plasma membrane.	Cellular component	exosome
-SL-0111	The extracellular matrix (ECM) is a vague term used to refer to all the material surrounding cells in a multicellular organism, except circulating fluids such as blood or lymph. In some cases, the ECM accounts for more of the organism's bulk than its cells. In plants, arthropods and fungi the ECM is primarily composed of nonliving material such as cellulose or chitin. In vertebrates the ECM consists of a complex network including the basement membrane, collage, elastin, proteoglycans and hyaluronan.	Cellular component	extracellular matrix
-SL-9911	Protein found mostly on the extracellular side of the membrane.	Orientation	Extracellular side
-SL-0112	The extracellular space is the space outside of the cell membrane but part of a multicellular organism. The term is typically used for a secreted protein that remains associated with the cell, e.g. as part of the extracellular matrix. It is not used for a protein that is secreted into the blood stream (or other body fluids) of eukaryotic, multicellular organisms, such as insulin or fibroblast growth factors.	Cellular component	extracellular space
-SL-0499	Extracellular vesicles are vesicles that have been released by cells.	Cellular component	Extracellular vesicle
-SL-0500	The membrane surrounding an extracellular vesicle.	Cellular component	Extracellular vesicle membrane
-SL-9918	Protein found mostly on the extracellular side of the virion membrane.	Orientation	Extravirionic side
-SL-0286	The filopodium is a thin, tubular, finger-like cell protrusion filled with straight bundled, crosslinked actin filaments having their barbed ends directed towards the cell membrane. Filopodium are observed at the advancing front of the migrating cell and are implicated in cell motility as well as in cell-substrate adhesion. Filopodia explore the environment and form nascent adhesive structures in response to external signaling cues. These long and highly dynamic protrusions, which can extend and retract, are involved in mesenchymal migration. They are observed in many cell types, such as amoebae, keratinocytes, fibroblasts and in neurite growth cones.	Cellular component	filopodium
-SL-0287	The portion of the cell membrane surrounding the filopodium. The filopodium is a thin, tubular, finger-like cell protrusion filled with straight bundled, crosslinked actin filaments having their barbed ends directed towards the cell membrane.	Cellular component	filopodium membrane
-SL-0470	The end of the filopodium distal to the body of the cell. The filopodium is a thin, tubular, finger-like cell protrusion filled with straight bundled, crosslinked actin filaments having their barbed ends directed towards the cell membrane.	Cellular component	filopodium tip
-SL-0113	A fimbrium or pilus is a hair-like, non-flagellar, polymeric filamentous appendage that extend from the bacterial or archaeal cell surface, such as type 1 pili, P-pili, type IV pili or curli. Pili perform a variety of functions, including surface adhesion, motility, cell-cell interactions, biofilm formation, conjugation, DNA uptake, and twitching motility.	Cellular component	Fimbrium
-SL-0116	The flagellar pocket is a structure found in trypanosomes. The flagellar pocket is formed by an invagination in the plasma membrane where the flagellum emerges from the cell body. This pocket provides the portal through which most of the dynamic interactions with the host occur.	Cellular component	Flagellar pocket
-SL-0117	The flagellum is a long whip-like or feathery structure which propels the cell through a liquid medium. This motile cilium is produced by the unicellular eukaryotes, and by the motile male gametes of many eukaryotic organisms. The flagella commonly have a characteristic axial '9+2' microtubular array (axoneme) and bends are generated along the length of the flagellum by restricted sliding of the nine outer doublets.	Cellular component	flagellum
-SL-0114	The flagellum axoneme is the most prominent structural component of the flagellum, which is a long whip-like or feathery structure which propels the cell through a liquid medium. The flagellum axoneme consists of a characteristic axial '9+2' microtubular array.	Cellular component	flagellum axoneme
-SL-0308	The basal body is a barrel-shaped microtubule-based structure required for the formation of flagella. Basal bodies, structuraly related to and often interconvertible with centrioles, serves as a nucleation site for axoneme growth.	Cellular component	flagellum basal body
-SL-0115	The portion of the cell membrane surrounding the flagellum, a long whip-like or feathery structure which propels the cell through a liquid medium.	Cellular component	flagellum membrane
-SL-0118	Focal adhesions are sites of tightest adhesion made to the underlying extracellular matrix by cells in culture. They serve a structural role, linking the ECM on the outside to the actin cytoskeleton on the inside. In addition, they are sites of signal transduction, initiating signaling pathways in response to adhesion. Focal adhesions are formed around a transmembrane core of an alpha-beta integrin heterodimer, which binds to a component of the extracellular matrix on its extracellular region, constitutes the site of anchorage of the actin cytoskeleton to the cytoplasmic side of the membrane, and mediates various intracellular signaling pathways.	Cellular component	focal adhesion
-SL-0119	Sporulation leads to the formation of an asymmetrically positioned division septum (the polar septum) which divides the developing cell into two adjacent, but unequal-sized compartments called the forespore (the smaller cell) and the mother cell.	Cellular component	Forespore
-SL-0120	The inner membrane of the smaller compartment, the forespore, of a sporulating cell.	Cellular component	Forespore inner membrane
-SL-0121	The intermembrane space between the inner and outer forespore membranes.	Cellular component	Forespore intermembrane space
-SL-0122	The membrane surrounding a forespore. This term is used when it is not known if the protein is found in or associated with the inner or outer forespore membrane.	Cellular component	Forespore membrane
-SL-0123	The outer membrane of the smaller compartment, the forespore, of a sporulating cell.	Cellular component	Forespore outer membrane
-SL-0124	A gap junction (GJ) is a communicating junction between certain cell types that allows the passive passage of ions and small molecules providing a direct pathway for electrical and metabolic signaling. In vertebrates GJs are patches of channels, each cell membrane contains a 'hemichannel', so that each GJ channel is composed of two hemichannels (connexons), which in turn are composed of six membrane proteins (connexins (Cxs)). In invertebrates, GJ channels are formed by another large family of integral membrane proteins, the innexins. GJ exists in all metazoans (multi-cellular organisms) and in almost all cell types in these organisms.	Cellular component	gap junction
-SL-0125	Gas vesicles are rigid hollow structures found in five phyla of the Bacteria and two groups of the Archaea, but mostly restricted to planktonic microorganisms, in which they provide buoyancy. By regulating their relative gas vesicle content, aquatic microbes are able to perform vertical migrations. The gas vesicle is impermeable to liquid water, but is highly permeable to gases and is normally filled with air. Two proteins have been shown to be present in the gas vesicle: GVPa, which makes the ribs that form the structure, and GVPc, which binds to the outside of the ribs and stiffens the structure against collapse.	Cellular component	gas vesicle
-SL-0331	The gas vesicle compartment bounded by the membrane of a gas vesicle.	Cellular component	gas vesicle lumen
-SL-0126	The membrane surrounding a gas vesicle.	Cellular component	gas vesicle membrane
-SL-0127	Gems are nuclear bodies, often found paired or juxtaposed to Cajal bodies, called gems for "gemini of CBs". It is not clear if Cajal bodes and gems are distinct nuclear bodies or if they should be considered as two manifestations of the same structure.	Cellular component	gem
-SL-0129	The glycosome is a specialized peroxisome found in all members of the protist order Kinetoplastida examined. Nine enzymes involved in glucose and glycerol metabolism are associated with these organelles. These enzymes are involved in pathways which, in other organisms, are usually located in the cytosol.	Cellular component	Glycosome
-SL-0332	The glycosomal compartment bounded by the membrane of the glycosome, a specialized peroxisome found in all members of the protist order Kinetoplastida examined.	Cellular component	Glycosome matrix
-SL-0128	The membrane surrounding the the glycosome, a specialized peroxisome found in all members of the protist order Kinetoplastida examined.	Cellular component	Glycosome membrane
-SL-0131	The glyoxysome is a plant peroxisome, especially found in germinating seeds, involved in the breakdown and conversion of fatty acids to acetyl-CoA for the glyoxylate bypass. Since it is also rich in catalase, the glyoxysome may be related to the microbodies or peroxisomes or derived from them.	Cellular component	Glyoxysome
-SL-0333	The glyoxysomal compartment bounded by the membrane of the glyoxysome, a plant peroxisome, especially found in germinating seeds, involved in the breakdown and conversion of fatty acids to acetyl-CoA for the glyoxylate bypass.	Cellular component	Glyoxysome matrix
-SL-0130	The membrane surrounding the glyoxysome, a plant peroxisome, especially found in germinating seeds, involved in the breakdown and conversion of fatty acids to acetyl-CoA for the glyoxylate bypass.	Cellular component	Glyoxysome membrane
-SL-0132	The Golgi apparatus is a series of flattened, cisternal membranes and similar vesicles usually arranged in close apposition to each other to form stacks. In mammalian cells, the Golgi apparatus is juxtanuclear, often pericentriolar. The stacks are connected laterally by tubules to create a perinuclear ribbon structure, the 'Golgi ribbon'. In plants and lower animal cells, the Golgi exists as many copies of discrete stacks dispersed throughout the cytoplasm. The Golgi is a polarized structure with, in most higher eukaryotic cells, a cis-face associated with a tubular reticular network of membranes facing the endoplasmic reticulum, the cis-Golgi network (CGN), a medial area of disk-shaped flattened cisternae, and a trans-face associated with another tubular reticular membrane network, the trans-Golgi network (TGN) directed toward the plasma membrane and compartments of the endocytic pathway. The Golgi apparatus receives the entire output of de novo synthesized polypeptides from the ER, and functions to posttranslationally process and sort them within vesicles destined to their proper final destination (e.g. plasma membrane, endosomes, lysosomes).	Cellular component	Golgi apparatus
-SL-0133	The Golgi lumen consist of the cisternal spaces (or internal lumen) of the Golgi apparatus.	Cellular component	Golgi apparatus lumen
-SL-0134	The membrane surrounding the Golgi apparatus.	Cellular component	Golgi apparatus membrane
-SL-0135	The Golgi stack consist of a series of flattened curved and parallel series saccules, called cisternae or dictyosomes, that form the central portion of the Golgi complex. The stack usually comprises cis, medial, and trans cisternae; the cis- and trans-Golgi networks are not considered part of the stack.	Cellular component	Golgi stack
-SL-0334	The Golgi stack compartment bounded by the membrane of the Golgi stack.	Cellular component	Golgi stack lumen
-SL-0136	The membrane surrounding the Golgi stack.	Cellular component	Golgi stack membrane
-SL-9902	Protein bound to the lipid bilayer of a membrane through a GPI-anchor (glycosylphosphatidylinositol anchor), a complex oligoglycan linked to a phosphatidylinositol group, resulting in the attachment of the C-terminus of the protein to the membrane.	Topology	GPI-anchor
-SL-9920	Protein bound to the lipid bilayer of a membrane through a GPI-like-anchor, a complex oligoglycan linked to a sphingolipidinositol group, resulting in the attachment of the C-terminus of the protein to the membrane.	Topology	GPI-like-anchor
-SL-0288	The growth cone is a dynamic cell protrusion at the tip of the extending axon or dendrite. Neuron extends a specialized structure, the growth cone, to find targets in the wiring of the nervous system. The growth cone explores its environment by extending dynamic filopodia. Growth cone is composed of an ensemble of protruding and retracting veils (lamellipodia), net growth cone advance may be considered the vector sum of all veil's motility behavior in response to their local environments. Filopodia play a key role in delimiting veils and serving to nucleate the formation of new veils.	Cellular component	growth cone
-SL-0289	The portion of the cell membrane surrounding a growth cone.	Cellular component	growth cone membrane
-SL-0477	The A band of a sarcomer is bisected by a paler zone, the H zone, where the thick and the thin filaments do not overlap. At the center of the H zone is the M line.	Cellular component	H zone
-SL-0137	The hemidesmosome is an integrin-containing adhesive junction located along the basal layer of cells where they abut the basement membrane zone. As the name implies, only half the desmosome is present; only one cell is participating, the second cell being represented by the basement membrane.	Cellular component	hemidesmosome
-SL-0431	The host is any organism in which another organism, or symbiont, spends part or all of its life cycle. Most animals and plants live symbiotically with microorganisms. The larger organism is called the host and smaller organism the symbiont. When the interactions between the symbiont and the host benefits both partners, the symbiotic interaction is called mutualism. When there is a negative effect on one of the partners, it is called a parasitic symbiosis and if there is no beneficial or negative effect it is a commensal symbiosis. These clear-cut definitions are not always easy to apply in nature. Take the bacterium Pseudomonas aeruginosa for example. This bacterium can be found on the skin of humans and not cause disease, perhaps we would call it a commensial, but if the person has a severe burn P. aeruginosa can cause an infection and becomes a pathogen (a medicinal term for parasitism). This type of organism is called an opportunistic pathogen. Whether an association is a mutualist, commensal or parasitic depends on the relative "strengths" of the partners and the balance of power can change over time.	Cellular component	Host
-SL-0372	The fraction of the host cell membrane at the apical end of the host cell, which faces the outside world or the lumen of the host cavity.	Cellular component	Host apical cell membrane
-SL-0459	The fraction of the host cell membrane at the basolateral side of the cell, which faces adjacent host cells and the underlying host connective tissue.	Cellular component	Host basolateral cell membrane
-SL-0428	The host caveola is a small (apparently) uncoated pit found mostly in the host cell membrane of many highly differentiated mammalian cells, such as adipocytes, endothelial cells and muscle cells. These flask-shaped invaginations are defined by the presence of caveolins and contains a subset of lipid-raft components, including cholesterol and sphingolipids.	Cellular component	host caveola
-SL-0427	A cell within a host organism including the host cell membrane and any external encapsulating structures such as the host cell wall and cell envelope.	Cellular component	Host cell
-SL-0421	The host cell envelope comprises the cell membrane, the cell wall and an outer membrane if present. The Gram-positive bacteria host cell envelope consists of the cytoplasmic membrane, cell wall and capsule. The Gram-negative host envelope consists of the cytoplasmic membrane, cell wall, periplasmic space, outer membrane and capsule. The archaeal cell host envelope consists generally of single typical bilayer membrane covered by a surface layer (S-layer). Ignicoccus host species exceptionally have an outer membrane which encloses a large periplasmic space. Extreme host thermophiles and acidophiles have tetraether type glycerophospholipids with C40 isoprenoid chains. The yeast host cell envelope is a protecting capsule which consists of the cytoplasmic membrane, the periplasmic space, and the cell wall.	Cellular component	Host cell envelope
-SL-0373	The prokaryotic host cell inner membrane is the selectively permeable membrane which separates the host cytoplasm from the host periplasm in prokaryotes with 2 membranes.	Cellular component	Host cell inner membrane
-SL-0374	The host cell junction is a host cell-host cell or host cell-host extracellular matrix contact within a tissue of a host multicellular organism, especially abundant in host epithelia. In vertebrates, there are three major types of cell junctions: anchoring junctions (e.g. adherens junctions), communicating junctions (e.g. gap junctions) and occluding junctions (e.g. tight junctions).	Cellular component	Host cell junction
-SL-0375	The host cell membrane is the selectively permeable membrane which separates the host cytoplasm from its surroundings. Known as the host cell inner membrane in prokaryotes with 2 membranes.	Cellular component	Host cell membrane
-SL-0376	The prokaryotic host cell outer membrane is the selectively permeable membrane which separates the prokaryotic periplasm from its surroundings in prokaryotes with 2 membranes. Traditionally only Gram-negative bacteria were thought of as having an outer membrane, but recent work has shown some Actinobacteria, including Mycobacterium tuberculosis, as well as at least 1 archaea (Ignicoccus hospitalis) have a cell outer membrane.	Cellular component	Host cell outer membrane
-SL-0377	A host cell projection is a host cell protrusion such as pseudopodium, filopodium, lamellipodium, growth cone, flagellum, acrosome, axon, pili or bacterial comet tail. These membrane-cytoskeleton-coupled processes are involved in many biological functions, such as host cell motility, cancer-cell invasion, endocytosis, phagocytosis, exocytosis, pathogen infection, neurite extension and cytokinesis.	Cellular component	Host cell projection
-SL-0378	The outermost side of the host cell.	Cellular component	Host cell surface
-SL-0424	The complex and rigid layer surrounding the host cell. Host cell walls are found in bacteria, archaea, fungi, plants, and algae. The host cell wall is surrounded by an outer membrane in Gram-negative host bacteria, and envelopes the inner or plasma host membrane all host bacteria. It plays a role in host cell shape, cell stability and development, and protection against environmental dangers.	Cellular component	Host cell wall
-SL-0429	The host cellular thylakoids are formed usually by extensive invaginations of the host cyanobacterial cell membrane. In Synechocystis sp. strain PCC 6803, the thylakoid membranes are physically discontinuous from the plasma membrane, and thus represent bona fide intracellular organelles.	Cellular component	Host cellular thylakoid
-SL-0430	The membrane of the host cyanobacterial cellular thylakoid.	Cellular component	Host cellular thylakoid membrane
-SL-0483	The envelope of a host chloroplast comprises the inner and outer chloroplast membrane including the intermembrane space.	Cellular component	Host chloroplast envelope
-SL-0396	The host cis-Golgi network is an extensive tubulovesicular network bound to the cis face of the Golgi stack and whose function is to receive process the biosynthetic output from the ER.	Cellular component	host cis-Golgi network
-SL-0397	The lipid bilayer surrounding any of the compartments that make up the host cis-Golgi network.	Cellular component	host cis-Golgi network membrane
-SL-0381	The host cytoplasm is the content of a host cell within the plasma membrane and, in eukaryotics cells, surrounds the host nucleus.	Cellular component	Host cytoplasm
-SL-0386	The host cytoplasmic vesicles mediate vesicular transport among the organelles of host secretory and endocytic systems.	Cellular component	Host cytoplasmic vesicle
-SL-0387	The membrane surrounding a host cytoplasmic vesicle. These vesicles mediate vesicular transport among the organelles of secretory and endocytic systems.	Cellular component	Host cytoplasmic vesicle membrane
-SL-0383	The host cytoskeleton is a dynamic three-dimensional structure that fills the host cytoplasm of eukaryotic cells. It is responsible for cell movement, cytokinesis, and the organization of the organelles or organelle-like structures within the host cell.	Cellular component	host cytoskeleton
-SL-0384	The host cytosol is the unstructured aqueous phase of the host cytoplasm excluding organelles, membranes, and insoluble cytoskeletal components.	Cellular component	host cytosol
-SL-0461	The host early endosomes form a tubulovesicular network spread throughout the cortical cytoplasm of the host cell. Host early endosomes are the primary sorting station in the endocytic pathway from which endocytosed molecules can be recycled back to the host cell membrane or targeted to degradation in the host lysosomes.	Cellular component	Host early endosome
-SL-0462	The membrane surrounding the host early endosomes, which form a tubulovesicular network spread throughout the cortical cytoplasm of the host cell.	Cellular component	Host early endosome membrane
-SL-0398	A collection of membranous structures involved in transport within the host cell. The main components of the host endomembrane system are endoplasmic reticulum, Golgi apparatus, vesicles, and cell membrane and nuclear envelope. The endomembrane system does not include the membranes of mitochondria or plastids.	Cellular component	Host endomembrane system
-SL-0388	The host endoplasmic reticulum (ER) is an extensive network of membrane tubules, vesicles and flattened cisternae (sac-like structures) found throughout the eukaryotic host cell, especially those responsible for the production of hormones and other secretory products.	Cellular component	Host endoplasmic reticulum
-SL-0389	The lumen of the host endoplasmic reticulum (ER) is the area enclosed by the host endoplasmic reticulum membrane, an extensive network of membrane tubules, vesicles and flattened cisternae (sac-like structures) found throughout the eukaryotic cell, especially those responsible for the production of hormones and other secretory products.	Cellular component	Host endoplasmic reticulum lumen
-SL-0390	The membrane surrounding the host endoplasmic reticulum (ER). The host endoplasmic reticulum is an extensive network of membrane tubules, vesicles and flattened cisternae (sac-like structures) found throughout the eukaryotic host cell, especially those responsible for the production of hormones and other secretory products.	Cellular component	Host endoplasmic reticulum membrane
-SL-0391	The host ER-Golgi intermediate compartment is a collection of tubulovesicular membrane clusters in the vicinity of host ER exit sites. The host ERGIC mediates transport between the endoplasmic reticulum and the Golgi and is the first anterograde/retrograde sorting station in the host secretory pathway.	Cellular component	Host endoplasmic reticulum-Golgi intermediate compartment
-SL-0392	The membrane surrounding the host ER-Golgi intermediate compartment, which is a collection of tubulovesicular membrane clusters in the vicinity of host ER exit sites.	Cellular component	Host endoplasmic reticulum-Golgi intermediate compartment membrane
-SL-0393	Host endosomes are highly dynamic membrane systems involved in transport within the host cell, they receive endocytosed host cell membrane molecules and sort them for either degradation or recycling back to the host cell surface. They also receive newly synthesised proteins destined for host vacuolar/lysosomal compartments.	Cellular component	Host endosome
-SL-0394	The membrane surrounding the host endosome. Host endosomes are highly dynamic membrane systems involved in transport within the cell, they receive endocytosed host cell membrane molecules and sort them for either degradation or recycling back to the host cell surface.	Cellular component	Host endosome membrane
-SL-0425	The host extracellular space is the space outside of the host cell membrane but part of a multicellular host organism.	Cellular component	Host extracellular space
-SL-0379	The host filopodium is a thin, tubular, finger-like host cell protrusion filled with straight bundled, crosslinked actin filaments having their barbed ends directed towards the host cell membrane.	Cellular component	host filopodium
-SL-0474	The host glyoxysome is a plant peroxisome, especially found in germinating seeds, involved in the breakdown and conversion of fatty acids to acetyl-CoA for the glyoxylate bypass. Since it is also rich in catalase, the glyoxysome may be related to the microbodies or peroxisomes or derived from them.	Cellular component	Host glyoxysome
-SL-0395	The host Golgi apparatus is a series of flattened, cisternal membranes and similar vesicles usually arranged in close apposition to each other to form stacks. In mammalian cells, the host Golgi apparatus is juxtanuclear, often pericentriolar. The stacks are connected laterally by tubules to create a perinuclear ribbon structure, the 'Golgi ribbon'. In plants and lower animal cells, the host Golgi exists as many copies of discrete stacks dispersed throughout the host cytoplasm. It is a polarized structure with, in most higher eukaryotic cells, a cis-face associated with a tubular reticular network of membranes facing the endoplasmic reticulum, the cis-Golgi network (CGN), a medial area of disk-shaped flattened cisternae, and a trans-face associated with another tubular reticular membrane network, the trans-Golgi network (TGN) directed toward the host plasma membrane and compartments of the host endocytic pathway.	Cellular component	Host Golgi apparatus
-SL-0426	The host membrane surrounding the host Golgi apparatus.	Cellular component	Host Golgi apparatus membrane
-SL-0399	Host late endosomes are pleiomorphic with cisternal, tubular and multivesicular regions. They are found in juxtanuclear regions and concentrated at the host microtubule organizing center. They are an important sorting station in the endocytic pathway. Recycling to the plasma membrane and to the Golgi occurs in late endosomes.	Cellular component	Host late endosome
-SL-0400	The membrane surrounding the host late endosomes.	Cellular component	Host late endosome membrane
-SL-0401	The host lipid droplet is a dynamic cytoplasmic host organelle which consists of an heterogeneous macromolecular assembly of lipids and proteins covered by a unique phospholipid monolayer. They may play a role in host lipid metabolism and storage, and they may be involved in the regulation of intracellular trafficking and signal transduction.	Cellular component	Host lipid droplet
-SL-0403	The host lysosome is a membrane-limited organelle present in all eukaryotic cells, which contains a large number of hydrolytic enzymes that are used for degrading almost any kind of cellular constituent, including entire organelles. The mechanisms responsible for delivering cytoplasmic cargo to the host lysosome/vacuole are known collectively as autophagy and play an important role in the maintenance of homeostasis.	Cellular component	Host lysosome
-SL-0404	The membrane surrounding a host lysosome.	Cellular component	Host lysosome membrane
-SL-0380	A host membrane is a lipid bilayer which surrounds host enclosed spaces and compartments. This selectively permeable structure is essential for effective separation of a host cell or organelle from its surroundings.	Cellular component	Host membrane
-SL-0405	The host microsomes are a heterogenous set of vesicles 20-200nm in diameter and formed from the host endoplasmic reticulum when host cells are disrupted.	Cellular component	Host microsome
-SL-0406	The membrane surrounding the host microsome.	Cellular component	Host microsome membrane
-SL-0407	The host mitochondrion is a semiautonomous, self-reproducing organelle that occurs in the cytoplasm of all cells of most, but not all, host eukaryotes. Each host mitochondrion is surrounded by a double limiting membrane. The inner membrane is highly invaginated, and its projections are called cristae. They are the sites of the reactions of oxidative phosphorylation, which result in the formation of ATP.	Cellular component	Host mitochondrion
-SL-0408	The host mitochondrial envelope comprises the inner and outer host mitochondrial membrane including the mitochondrial intermembrane space.	Cellular component	Host mitochondrion envelope
-SL-0409	The host mitochondrion inner membrane is the membrane which separates the host mitochondrial matrix from the host mitochondrial intermembrane space.	Cellular component	Host mitochondrion inner membrane
-SL-0410	The membrane surrounding a host mitochondrion. This term is used when it is not known if the protein is found in or associated with the inner or outer host mitochondrial membrane.	Cellular component	Host mitochondrion membrane
-SL-0411	The host mitochondrion outer membrane is the host mitochondrial membrane facing the host cytoplasm.	Cellular component	Host mitochondrion outer membrane
-SL-0453	The host multivesicular bodies are a type of late endosome containing internal vesicles formed following the inward budding of the host outer endosomal membrane. The contents of the MVBs are then released into the lysosome lumen. The proteins found in the limiting membrane of MVBs are recycled to other compartments.	Cellular component	host multivesicular body
-SL-0412	The host nucleolus is a dark, dense, roughly spherical area of fibers and granules in the host nucleus. Only plant and animal nuclei contain one or more nucleoli, although some do not. No membrane separates the host nucleolus from the host nucleoplasm. It mediates ribosomal RNA biogenesis.	Cellular component	host nucleolus
-SL-0413	The host nucleoplasm is a highly viscous liquid contained within the host nucleus that surrounds the chromosomes and other subnuclear organelles. A network of fibers known as the host nuclear matrix can also be found in there.	Cellular component	host nucleoplasm
-SL-0414	The host nucleus is the most obvious organelle in any host eukaryotic cell. It is a membrane-bound organelle and is surrounded by double membranes. It communicates with the surrounding cytosol via numerous nuclear pores.	Cellular component	Host nucleus
-SL-0415	The host nuclear envelope is a membrane system which surrounds the host nucleoplasm of eukaryotic cells. It is composed of the nuclear lamina, nuclear pore complexes and two nuclear membranes. The space between the two membranes is called the host nuclear intermembrane space.	Cellular component	Host nucleus envelope
-SL-0419	The inner membrane surrounding the host nucleus is the membrane which separates the host nuclear matrix from the host intermembrane space.	Cellular component	Host nucleus inner membrane
-SL-0416	The host nuclear lamina is a meshwork of intermediate filament proteins called lamins and lamin-binding proteins that are embedded in the host inner nuclear membrane.	Cellular component	Host nucleus lamina
-SL-0417	The host nuclear matrix is a three-dimensional filamentous protein network, found in the host nucleoplasm, which provides a structural framework for organising host chromatin, while facilitating transcription and replication.	Cellular component	Host nucleus matrix
-SL-0418	The membrane surrounding the host nucleus. This term is used when it is not known if the protein is found in or associated with the inner or outer host nuclear membrane.	Cellular component	Host nucleus membrane
-SL-0446	The outer membrane of the host nucleus is the membrane facing the host cytoplasm. In host mammals, the host outer nuclear membrane is continuous in many places with the host rough endoplasmic reticulum and is dotted with ribosomes.	Cellular component	Host nucleus outer membrane
-SL-0382	The host perinuclear region is the host cytoplasmic region just around the host nucleus.	Cellular component	host perinuclear region
-SL-0420	The host periplasm is the space between the inner and outer membrane in host Gram-negative bacteria. In Gram-positive bacteria a smaller periplasmic space is found between the inner membrane and the peptidoglycan layer. Also used for the host intermembrane spaces of host fungi and host organelles.	Cellular component	Host periplasm
-SL-0475	The host peroxisome is a small eukaryotic organelle limited by a single membrane, specialized for carrying out oxidative reactions. Contains mainly peroxidases, several other oxidases and catalase. The catalase regulates the contents of the produced toxic hydrogen peroxide thus protecting the cell. Beta-oxidation of fatty acids is another major function of peroxisomes. In plants and fungi this degradation occurs only in this cellular compartment.	Cellular component	Host peroxisome
-SL-0432	The host phagosome is a phagocytic host cell-specific compartment. These large endocytic membrane-bound vesicles form upon ingestion by the host cell of extracellular materials.	Cellular component	host phagosome
-SL-0433	The membrane surrounding a host phagosome.	Cellular component	host phagosome membrane
-SL-0385	The host plasmodesma (plural host plasmodesmata) is a plasma membrane-lined channel that crosses the cell wall between two adjacent host plant cells and which allows a cytoplasmic exchange between the cells. It provides passage of ions and small molecules, but also of macromolecules such as RNA or proteins. Host plasmodesmata are sheathed by a host plasma membrane that is simply an extension of the cell membrane of the adjoining cells.	Cellular component	host plasmodesma
-SL-0434	In a host chemical synapse, the host presynaptic membrane is the cell membrane of an axon terminal that faces the receiving cell. The postsynaptic membrane is separated from the presynaptic membrane by the synaptic cleft.	Cellular component	host presynaptic cell membrane
-SL-0422	The host rough endoplasmic reticulum (host RER) is the portion of the host ER which is covered with ribosomes.	Cellular component	Host rough endoplasmic reticulum
-SL-0423	The membrane surrounding the host rough endoplasmic reticulum.	Cellular component	Host rough endoplasmic reticulum membrane
-SL-0504	The host secretory vesicle is a host vesicle that mediates the vesicular transport of cargo - e.g. hormones or neurotransmitters - from an organelle to specific sites at the host cell membrane, where it docks and fuses to release its content.	Cellular component	host secretory vesicle
-SL-0444	The host smooth endoplasmic reticulum (host SER) is the portion of the host ER which is free of ribosomes.	Cellular component	Host smooth endoplasmic reticulum
-SL-0445	The membrane surrounding the host smooth endoplasmic reticulum.	Cellular component	Host smooth endoplasmic reticulum membrane
-SL-0435	Host synapses are the communicating cell-cell junctions that allow signals to pass from a host nerve cell to a target cell. In a chemical synapse, the signal is carried by a neurotransmitter which diffuses across a narrow synaptic cleft and activates a receptor on the postsynaptic membrane of the target cell. The target may be a dendrite, cell body, neuronal axon, a specialized region of a muscle or a secretory cell. In an electrical synapse, a direct connection is made between the cytoplasms of two cells via gap junctions.	Cellular component	host synapse
-SL-0502	In a host synapse, host synaptic vesicles mediate the exocytosis of neurotransmitters and subsequent re-uptake by endocytosis of vesicular components. Re-uptake is a crucial element in the maintenance of host synaptic transmission in the nervous system.	Cellular component	host synaptic vesicle
-SL-0503	The host membrane surrounding a host synaptic vesicle	Cellular component	host synaptic vesicle membrane
-SL-0449	The host thylakoid is a membranous cellular structure containing the photosynthetic pigments, reaction centers and electron-transport chain. In host chloroplast, thylakoids stack up to form the grana or stay as single cisternae and interconnect the grana. Thylakoid, where photosynthesis occurs, are found in chloroplasts, cyanelles and in photosynthetic bacteria where they are the extensive invaginations of the plasma membrane.	Cellular component	Host thylakoid
-SL-0463	The host trans-Golgi network is a highly dynamic series of interconnected tubules and vesicles at the trans face of the host Golgi stack. The host trans-Golgi network functions in the processing and sorting of glycoproteins and glycolipids at the interface of the biosynthetic and endosomal pathways. The generation and maintenance of host apical and basolateral membranes rely on sorting events that occur in the host TGN.	Cellular component	host trans-Golgi network
-SL-0464	The membrane surrounding the host trans-Golgi network.	Cellular component	host trans-Golgi network membrane
-SL-0143	The hyaline layer is a multilayered extracellular matrix that coats the external surfaces of sea urchin and starfish embryos.	Cellular component	hyaline layer
-SL-0145	The hydrogenosome is a redox organelle of anaerobic unicellular eukaryotes which contains hydrogenase and produces hydrogen and ATP by glycolysis. They are found in various unrelated eukaryotes, such as anaerobic flagellates, chytridiomycete fungi and ciliates. Most hydrogenosomes lack a genome, but some like that of the anaerobic ciliate Nyctotherus ovalis, have retained a rudimentary genome.	Cellular component	Hydrogenosome
-SL-0335	The hydrogenosomal compartment bounded by the membrane of the hydrogenosome, a redox organelle found in anaerobic unicellular eukaryotes.	Cellular component	Hydrogenosome lumen
-SL-0144	The membrane surrounding the hydrogenosome, a redox organelle found in anaerobic unicellular eukaryotes.	Cellular component	Hydrogenosome membrane
-SL-0478	The appearance of the striated muscle is created by a pattern of alternating dark A bands and light I bands. I bands are composed of thin actin filaments and proteins that bind actin and they are bisected by the Z line. The thin filaments extend in each direction from the Z-disk, where they do not overlap the thick filaments, they create the light I band.	Cellular component	I band
-SL-0488	Inflammasomes are supramolecular micron-sized complexes that assemble in the cytosol adjacent to the nucleus in response to pathogens and other damage-associated signals. The inflammasome assembly leads to the activation of proinflammatory procaspases, hence is usually involved in innate immunity and inflammation. The core of inflammasomes consists of at least 2 components: a signal sensor and an effector inflammatory caspase (mostly CASP1). However, most inflammasomes contain a third element, an adaptor (often ASC/PYCARD). The interaction between the sensor component and the adaptor initiates speck formation (nucleation) which greatly enhances further addition of soluble adaptor molecules to the speck in a prion-like polymerization process. The kinetic properties of the adaptor aggregation have been shown to generate a rapid 'all-or-none' response, this is why only one speck by cell is observed.	Cellular component	Inflammasome
-SL-0362	The inner membrane complex, found in apicocomplexan parasites, is composed of flattened membrane cisternae closely associated to the cell membrane. Together, the cell membrane and the IMC form a triple lipid bilayer called the pellicle (or cell wall).	Cellular component	Inner membrane complex
-SL-9912	Protein found mostly on the intermembrane side of the membrane.	Orientation	Intermembrane side
-SL-0146	In vertebrates, the photoreceptors are separated from the retinal pigment epithelium by the subretinal space, which contains a specialized extracellular material referred to as interphotoreceptor matrix. The IPM mediates key interactions between the photoreceptors and RPE including adhesion, phagocytosis, outer segment stability, nutrient exchange, development, and vitamin A trafficking in the visual cycle.	Cellular component	interphotoreceptor matrix
-SL-9919	Protein found mostly on the intravirionic side of the virion membrane.	Orientation	Intravirionic side
-SL-0148	The invadopodium is a localized and persitent cell protrusion similar to the highly dynamic podosome, but larger. These structures protrudes into the extracellular matrix. Invadopodial protrusions are enriched in integrins, tyrosine kinase signaling machinery, soluble and membrane proteases including matrix metalloproteases, actin and actin-associated proteins. Essential for physiological and pathological cell invasion and metastasis these structures are involved in focalized degradation of the extracellular matrix. Invadopodia form underneath the cell body, often close to the nucleus and proximal to the Golgi complex, and are rarely found at the cell periphery. Their half-life is quite extended. As invadopodia and podosomes are similar in appearance, location and composition, it is likely that a thin line separates these two entities in time and function.	Cellular component	invadopodium
-SL-0290	The portion of the cell membrane surrounding an invadopodium.	Cellular component	invadopodium membrane
-SL-0149	The kinetochore is a protein complex assembled on the centromeric region of DNA. It provides the major attachement point for the spindle microtubules during mitotic or meiotic division to pull the chromosomes apart. In monocentric chromosomes, the kinetochores of point centromeres bind a single microtubule and the larger kinetochores of regional centromeres interact with a number of microtubules. In holocentric chromosomes, the kinetochores bind the diffuse centromere along the length of the chromosomes.	Cellular component	kinetochore
-SL-0150	The mitochondrial DNA of trypanosomatid protozoa is termed kinetoplast DNA (kDNA). kDNA is a massive network, composed of thousands of topologically interlocked DNA circles. Each cell contains one network condensed into a disk-shaped structure within the matrix of its single mitochondrion. The kDNA circles are of two types, maxicircles present in a few dozen copies and minicircles present in several thousand copies.	Cellular component	kinetoplast
-SL-0460	The kinocilium is an immotile primary cilium that is found at the apical surface of auditory receptor cells. Hair bundles, the mechanosensory device of the sensory hair cells, are composed of height-ranked rows of stereocilia and a single kinocilium that are interconnected by extracellular proteinaceous links.	Cellular component	kinocilium
-SL-0291	The lamellipodium is a broad, flat, veil-shaped cell protrusion formed at the leading edge of migrating cells. Lamellipodium contain a branched dendritic network of actin filaments having their barbed ends directed towards the cell membrane. It is associated with ameboid motility (or crawling motility).	Cellular component	lamellipodium
-SL-0292	The portion of the cell membrane surrounding a lamellipodium.	Cellular component	lamellipodium membrane
-SL-0152	Late endosomes are pleiomorphic with cisternal, tubular and multivesicular regions. They are found in juxtanuclear regions and concentrated at the microtubule organizing center. They are an important sorting station in the endocytic pathway. Recycling to the plasma membrane and to the Golgi occurs in late endosomes. More acidic than early endosomes they are also loaded more slowly in a range of 4 to 30 minutes depending on the cell type. They can be distinguished from lysosome for their enrichment in M6PR.	Cellular component	Late endosome
-SL-0336	The late endosomal comaprtment bounded by the membrane of the late endosome.	Cellular component	Late endosome lumen
-SL-0151	The membrane surrounding the late endosomes.	Cellular component	Late endosome membrane
-SL-0153	The portion of the plasma membrane at the lateral side of the cell.	Cellular component	Lateral cell membrane
-SL-0268	The trichocyst is an architecturally complex secretory granule having a highly constrained shape docked at specialized cortical sites in Paramecium and other ciliates. Each cell bears about 1'000 trichocysts, which are supposed to be defensive organelles against predators. Trichocyst consists of a spindle-shaped body bearing at its wide end a tip often compared to an inverted golf tee. An external stimulus can trigger massive and synchronous exocytosis. After exocytotic membrane fusion, contact with the H2O and calcium ions in the external medium leads to an extremely rapid (< 50 ms) and irreversible expansion of the trichocyst contents, to yield a second, needle-shaped form which remains insoluble.	Cellular component	Trichocyst
-SL-0141	The uropodium is a rigid membrane projection with related cytoskeletal components at the trailing edge of a lymphocyte or other cell in the process of migrating or being activated, found on the opposite side of the cell from the lamellipodium or immunological synapse, respectively.	Cellular component	uropodium
-SL-0272	The vacuole is a generally large fluid-filled membrane-bound compartment in the cytoplasm. The precise form and function of vacuoles may vary between phyla. Plant vacuoles are among the best characterized. They differ in terms of their lumenal contents and processing enzymes, as well as on the basis of the type of integral proteins in their membranes (tonoplast intrinsic proteins, TIPs). Examples include the lytic vacuole, the storage vacuole and the lutoid. One important function of plant vacuoles is the maintenance of hydrostatic pressure. Other eukaryotes employ vacuoles for a variety of purposes, including storage (as in the yeast lysosome/vacuole), secretion and phagocytosis. In Protozoa, contractile vacuoles can be used to discharge water from the cytoplasm to the external environment. Aquatic microorganisms may employ gas vacuoles (composed of clusters of inert gas vesicles) to provide buoyancy.	Cellular component	Vacuole
-SL-0270	The lumen of a vacuole is the area enclosed by the vacuolar membrane.	Cellular component	Vacuole lumen
-SL-0271	The membrane surrounding a vacuole.	Cellular component	Vacuole membrane
-SL-0498	A vesicle is a small structure consisting of fluid enclosed by a lipid bilayer. Vesicles form naturally during the processes of secretion (exocytosis), uptake (endocytosis) and transport of materials within the cytoplasm or between cells, and exist both within the cell and in the extracellular space.	Cellular component	Vesicle
-SL-0274	The virion is the complete fully infectious extracellular virus particle.	Cellular component	Virion
-SL-0275	The membrane surrounding the virion.	Cellular component	Virion membrane
-SL-0273	The viral tegument is a protein structure that resides between the capsid and envelope of herpesviruses and which appears amorphous in electron micrographs.	Cellular component	Virion tegument
-SL-0314	Z-disks are the lateral boundaries of a single sarcomere. In electron micrographs of cross striated muscle the Z line appears as a series of dark lines. They represent a key interface between the contractile apparatus and the cytoskeleton. The Z line (from the German "Zwischen") largely consists of alpha-actinin homodimers organized in an antiparallel fashion, thereby providing a backbone for the insertions of actin-based thin filaments, as well as titin and nebulin/nebulette. Z line of neighbouring sarcomeres are aligned in parallel and connected via the intermediate filament protein desmin. They maintain the actin filaments in a tetragonal lattice.	Cellular component	Z line
-SL-0154	The lipid droplet is a dynamic cytoplasmic organelle which consists of an heterogeneous macromolecular assembly of lipids and proteins covered by a unique phospholipid monolayer. Lipid droplets may play a role in lipid metabolism and storage, and they may be involved in the regulation of intracellular trafficking and signal transduction.	Cellular component	Lipid droplet
-SL-9901	Protein bound to the lipid bilayer of a membrane through a posttranslationally modification by the attachment of at least one lipid or fatty acid, e.g. farnesyl, palmitate and myristate.	Topology	Lipid-anchor
-SL-9914	Protein found mostly on the lumenal side of the membrane.	Orientation	Lumenal side
-SL-0158	The lysosome is a membrane-limited organelle present in all eukaryotic cells, which contains a large number of hydrolytic enzymes that are used for degrading almost any kind of cellular constituent, including entire organelles. The mechanisms responsible for delivering cytoplasmic cargo to the lysosome/vacuole are known collectively as autophagy and play an important role in the maintenance of homeostasis.	Cellular component	Lysosome
-SL-0156	The lumen of a lysosome is the volume enclosed within the lysosomal membrane.	Cellular component	Lysosome lumen
-SL-0157	The membrane surrounding a lysosome.	Cellular component	Lysosome membrane
-SL-0159	The lytic vacuole is a plant specialized vacuole equivalent to animal lysosomes or yeast vacuoles, functioning as compartments for degradation and waste storage.	Cellular component	Lytic vacuole
-SL-0315	In electron micrographs of the sarcomere, the M line appears as a series of parallel electron-dense lines in the central zone of the A band impliing that the M line is needed for the regular packing of the thick filaments. The M line maintains the myosin filaments in a hexagonal lattice.	Cellular component	M line
-SL-9913	Protein found mostly on the matrix side of the membrane.	Orientation	Matrix side
-SL-0161	The melanosome is a melanin-containing organelle found in melanocytes and melanophores. Fish and amphibians possess specialized cells, called melanophores, which contain hundreds of melanin-filled pigment granules, termed melanosomes. The sole function of these cells is pigment aggregation in the center of the cell or dispersion throughout the cytoplasm. This alternative transport of pigment allows the animal to effect color changes important for camouflage and social interactions. Melanophores transport their pigment in response to extracellular cues: neurotransmitters in the case of fish and hormonal stimuli in the case of frogs. In both cases, melanosome dispersion is induced by elevation of intracellular cAMP levels, while aggregation is triggered by depression of cAMP. The regulatory mechanisms downstream of these second-messengers are poorly understood. Mammalian melanocytes also produce melanosomes but, unlike melanophores, pigment in these cells is transported to the cell periphery for subsequent exocytosis to surrounding epithelial cells.	Cellular component	Melanosome
-SL-0338	The melanosomal compartment bounded by the membrane surrounding a melanosome.	Cellular component	Melanosome lumen
-SL-0160	The membrane surrounding a melanosome.	Cellular component	Melanosome membrane
-SL-0162	A membrane is a lipid bilayer which surrounds enclosed spaces and compartments. This selectively permeable structure is essential for effective separation of a cell or organelle from its surroundings. Membranes are composed of various types of molecules such as phospholipids, integral membrane proteins, peripheral proteins, glycoproteins, glycolipids, etc. The relative amounts of these components as well as the types of lipids are non-randomly distributed from membrane to membrane as well as between the two leaflets of a membrane.	Cellular component	Membrane
-SL-0370	Membrane rafts are small (10-200 nm), heterogeneous, highly dynamic, sterol- and sphingolipid-enriched domains that compartmentalize cellular processes. Small rafts can sometimes be stabilized to form larger platforms through protein-protein and protein-lipid interactions. Multiple types of rafts are likely to exist, based both on their lipid and protein composition.	Cellular component	Membrane raft
-SL-0163	The microneme is an Apicomplexan parasite organelle. Apicomplexa are named for the unique set of morphologically distinct secretory organelles (refered to as the apical complex)- micronemes, rhoptries and dense granules - whose sequential secretion is required for the invasion of host cells. Micronemes are the smallest, they are involved in the early stages of invasion.	Cellular component	microneme
-SL-0339	The micronemal compartment bounded by the membrane of a microneme.	Cellular component	microneme lumen
-SL-0164	The membrane surrounding a microneme.	Cellular component	microneme membrane
-SL-0166	The microsomes are a heterogenous set of vesicles 20-200nm in diameter and formed from the endoplasmic reticulum when cells are disrupted. The vesicles are isolated by differential centrifugation and are composed of three structural features: rough vesicles, smooth vesicles and ribosomes. Numerous enzyme activities are associated with the microsomal fraction.	Cellular component	Microsome
-SL-0165	The membrane surrounding the microsome.	Cellular component	Microsome membrane
-SL-0484	The microtubule organizing center (MTOC) is an intracellular structure that can catalyze gamma-tubulin-dependent microtubule nucleation and that can anchor microtubules.	Cellular component	microtubule organizing center
-SL-0293	Microvilli are thin cylindrical dynamic cell projections containing a core bundle of actin filaments. They serve a diverse set of functions, such as increasing absorptive surface area in the epithelial brush border, tethering leukocytes to the surface of endothelial cells or participate in sperm-oocyte fusion.	Cellular component	microvillus
-SL-0294	The portion of the cell membrane surrounding a microvillus.	Cellular component	microvillus membrane
-SL-0469	The midbody is the central region of the thin intercellular cytoplasmic bridge formed between daughter cells during cytokinesis. It consists of tightly bundled antiparallel microtubules, which embrace a phase-dense circular structure, called midbody ring. At the final stage of cytokinesis, the intercellular bridge is cleaved, in a process termed abscission, and two daughter cells are formed. Following abscission, the residual midbody structure, known as the midbody remnant or midbody derivative, can have different fates depending on the cell type. It can be either released to the extracellular medium, degraded by autophagy or persists in the cytoplasm, showing asymmetric accumulation in the daughter cells.	Cellular component	Midbody
-SL-0490	The midbody ring is the central region of the midbody characterized by a gap in alpha-tubulin staining, although interdigitating microtubules persist through the gap. It is thought that high local protein density masks tubulin epitopes known to be present. The midbody ring serves as a scaffold for a wide variety of structural and regulatory proteins required for completion of cytokinesis.	Cellular component	Midbody ring
-SL-0173	The mitochondrion is a semiautonomous, self-reproducing organelle that occurs in the cytoplasm of all cells of most, but not all, eukaryotes. Each mitochondrion is surrounded by a double limiting membrane. The inner membrane is highly invaginated, and its projections are called cristae. Mitochondria are the sites of the reactions of oxidative phosphorylation, which result in the formation of ATP. The size and coding capacity of the mitochondrial DNA varies considerably in different organisms, and encodes rRNAs, tRNAs and essential mitochondrial proteins.	Cellular component	Mitochondrion
-SL-0167	The mitochondrial envelope comprises the inner and outer mitochondrial membrane including the intermembrane space.	Cellular component	Mitochondrion envelope
-SL-0168	The inner membrane of a mitochondrion is the membrane which separates the mitochondrial matrix from the intermembrane space.	Cellular component	Mitochondrion inner membrane
-SL-0169	The mitochondrial intermembrane space is the space between inner and outer mitochondrial membrane.	Cellular component	Mitochondrion intermembrane space
-SL-0170	The matrix of a mitochondrion is the mitochondrion internal spaces enclosed by the inner membrane. Several of the steps in cellular respiration occur in the matrix due to its high concentration of enzymes.	Cellular component	Mitochondrion matrix
-SL-0171	The membrane surrounding a mitochondrion. This term is used when it is not known if the protein is found in or associated with the inner or outer mitochondrial membrane.	Cellular component	Mitochondrion membrane
-SL-0269	The mitochondrial nucleoid is the mitochondrial pseudocompartment formed by the chromatin-dense area. This region, which is functionally equivalent to the eukaryotic nucleus, is not surrounded by a membrane.	Cellular component	mitochondrion nucleoid
-SL-0172	The outer membrane of a mitochondrion is the mitochondrial membrane facing the cytoplasm.	Cellular component	Mitochondrion outer membrane
-SL-0437	The mitosome is an organelle found in "amitochondrial" unicellular organisms which do not have the capability of gaining energy from oxidative phosphorylation. Mitosomes are almost certainly derived from mitochondria, they have a double membrane and most proteins are delivered to them by a targeting sequence. Unlike mitochondria, mitosomes do not contain any DNA. The mitosome functions in iron-sulphur cluster assembly.	Cellular component	Mitosome
-SL-0438	The mitosomal envelope comprises the inner and outer mitosomal membrane including the intermembrane space.	Cellular component	Mitosome envelope
-SL-0439	The inner membrane of a mitosome is the membrane which separates the mitosomal matrix from the intermembrane space.	Cellular component	Mitosome inner membrane
-SL-0440	The mitosomal intermembrane space is the space between inner and outer mitosomal membranes.	Cellular component	Mitosome intermembrane space
-SL-0441	The matrix of a mitosome is the mitosomal internal spaces enclosed by the inner membrane.	Cellular component	Mitosome matrix
-SL-0442	The membrane surrounding a mitosome. This term is used when it is not known if the protein is found in or associated with the inner or outer mitosomal membrane.	Cellular component	Mitosome membrane
-SL-0443	The outer membrane of a mitosome is the mitosomal membrane facing the cytoplasm.	Cellular component	Mitosome outer membrane
-SL-9909	Protein spanning the membrane more than once.	Topology	Multi-pass membrane protein
-SL-0174	The multivesicular bodies are a type of late endosome containing internal vesicles formed following the inward budding of the outer endosomal membrane. The contents of the MVBs are then released into the lysosome lumen. The proteins found in the limiting membrane of MVBs are recycled to other compartments.	Cellular component	multivesicular body
-SL-0340	The multivesicular body compartment bounded by the membrane of the multivesicular bodies.	Cellular component	multivesicular body lumen
-SL-0175	The membrane surrounding the multivesicular bodies.	Cellular component	multivesicular body membrane
-SL-0176	The myelin membrane is the white matter coating our nerves, enabling them to conduct impulses between the brain and other parts of the body. It consists of a layer of proteins packed between two layers of lipids. This specialized cell membrane is produced by oligodendrocytes in the central nervous system, and Schwann cells in the peripheral nervous system. Myelin sheaths wrap themselves around axons, the threadlike extensions of neurons that make up nerve fibers. Each oligodendrocyte can myelinate several axons. The major function of myelin is to increase the velocity of propagation of nerve impulses.	Cellular component	Myelin membrane
-SL-0211	The inner membrane of a plastid separates the plastid stroma from the intermembrane space.	Cellular component	Plastid inner membrane
-SL-0312	A myofibril is a long cylindrical organelle found in muscle cells formed by two transverse filament systems: the thick and thin filaments. The thin filament is composed primarily of actin; it is tethered at one end to the Z-disk, and it interdigitates with the thick filaments. The main constituent of the thick filament is myosin; the direction of the myosin heads changes polarity at the M-line, allowing interaction with the thin filaments anchored from the next adjacent Z-disk. A third and a fourth filament complex exist, comprising the giant proteins titin and nebulin.	Cellular component	myofibril
-SL-0212	The plastid intermembrane space is the space between the plastid inner and outer membranes.	Cellular component	Plastid intermembrane space
-SL-0177	The nematocyst is an organelle found in nematoblast (cnidoblast) cells. When matured, these stinging organelles store toxins and can deliver them when the cnidocil (a short extension of the nematocyst) is stimulated by a prey or another stimulus. These proteins are principally found in anemones and jellyfishes.	Cellular component	Nematocyst
-SL-0213	The membrane surrounding or within a plastid. Also used when it is not clear in which plastid membrane (outer membrane, inner membrane or thylakoid) a protein is found.	Cellular component	Plastid membrane
-SL-0494	Nuclear body is a collective term for several nuclear, extra-nucleolar, non-membrane-bound sub-compartments, including, but not limited to Cajal bodies, Gemini of Cajal bodies (gems), nuclear speckles and PML bodies. Nuclear bodies are visible as distinct spots in the nucleoplasm. They can vary in number and size depending on the cell line and the type of nuclear body.	Cellular component	Nuclear body
-SL-0140	The plastid nucleoid is the plastidic pseudocompartment formed by the chromatin-dense area. This region, which is functionally equivalent to the eukaryotic nucleus, is not surrounded by a membrane.	Cellular component	plastid nucleoid
-SL-0214	The outer membrane of a plastid is the membrane facing the cytoplasm.	Cellular component	Plastid outer membrane
-SL-0185	The nuclear pore complex (NPC) constitutes the exclusive means of nucleocytoplasmic transport in eukaryotes during interphase. NPCs allow the passive diffusion of ions and small molecules (up to about 20 kDa or 5 nm) and the active, nuclear transport receptor (karyopherin: importin and exportin)-mediated bidirectional transport of macromolecules such as proteins, RNAs, ribonucleoprotein (RNPs), and ribosomal subunits (up to about 10 MDa) across the double-membrane nuclear envelope. NPC components, collectively referred to as nucleoporins (NUPs), can play the role of both NPC structural components and of docking or interaction partners for transiently associated nuclear transport factors. The NPC is composed of at least 30 distinct subunits, shows 8-fold rotational symmetry with specialized structures on the cyto- and nucleoplasmic side and in the nuclear envelope embedded core. The MW varies from about 44-60 MDa in S. cerevisiae to 60-120 MDa in vertebrates, yet the overall architecture is conserved.	Cellular component	nuclear pore complex
-SL-0215	The stroma of a plastid is the internal space enclosed by the plastid double membrane but excluding the thylakoid space. This space, filled with a colorless hydrophilic matrix.	Cellular component	Plastid stroma
-SL-0278	The thylakoid of a plastid is an internal system of interconnected membranes found within a plastid.	Cellular component	Plastid thylakoid
-SL-0187	The nucleoid is the prokaryotic pseudocompartment formed by the chromatin-dense area. This region, which is functionally equivalent to the eukaryotic nucleus, is not surrounded by a membrane.	Cellular component	nucleoid
-SL-0309	The plastid thylakoid lumen is the plastid compartment bounded by the thylakoid membranes.	Cellular component	Plastid thylakoid lumen
-SL-0188	The nucleolus is a non-membrane bound nuclear compartment found in eukaryotic cells which is the site of ribosome biogenesis. The interphase nucleolus is organized around the tandemly repeated genes for preribosomal RNA (rRNA). It is composed of at least 2 sub-compartments: the dense fibrillar component (DFC, also called pars fibrosa) and the granular component (GC or pars granulosa). The DFC contains newly synthesized preribosomal RNA and a collection of proteins; the GC is made up of nearly completed preribosomal particles destined for the cytoplasm. In most metazoans, but generally not in lower eukaryotes, a third component, the fibrillar center (FC), can be seen. Plant and animal nuclei can contain more than one nucleolus.	Cellular component	nucleolus
-SL-0216	The thylakoid membranes of a plastid is an internal system of interconnected membranes found in a plastid.	Cellular component	Plastid thylakoid membrane
-SL-0217	A plastoglobule is a conspicuous lipid-containing structure in the chloroplast stroma thought to serve as lipid reservoirs for thylakoid membranes.	Cellular component	plastoglobule
-SL-0497	The nucleolus fibrillar center (FC) is a sub-compartment of most metazoan nucleoli. The transcription of ribosomal RNA (rRNA) genes generates 2 structures that are found in all nucleoli: the dense fibrillar component (DFC) and the granular component (GC). The DFC contains newly synthesized preribosomal RNA and a collection of proteins; the GC is made up of nearly completed preribosomal particles destined for the cytoplasm. In most metazoans, but generally not in lower eukaryotes, a third component, the FC, can be seen. The FC is surrounded by the DFC. The zone of transcription from multiple copy rRNA genes is in the border region between these 2 structures.	Cellular component	Nucleolus fibrillar center
-SL-0189	Nucleomorphs are vestigial endosymbiont found in cryptomonads and chlorachniophytes algae. These organisms respectively retain an enslaved red or green algal nucleus.	Cellular component	Nucleomorph
-SL-0465	The PML bodies are dynamic nuclear protein aggregates interspersed between chromatin. These punctate nuclear structures are call PML bodies because the PML gene is essential for their formation. These discrete nuclear foci, 0.2-1.0 micrometer wide, are present in most mammalian cell nuclei and typically number 1 to 30 bodies per nucleus, depending on the cell type, cell-cycle phase and differentiation stage. Recent evidence implies that, although they appear to be uniform, PML-NBs are structurally and functionally heterogeneous and are dynamic structures.	Cellular component	PML body
-SL-0190	The nucleoplasm is a highly viscous liquid contained within the nucleus that surrounds the chromosomes and other subnuclear organelles. A network of fibers known as the nuclear matrix can also be found in the nucleoplasm.	Cellular component	nucleoplasm
-SL-0295	The podosome is a ring-like cell protrusion which mediates cell-extracellular matrix interactions. Podosomes are composed of an actin-bundle core, flanked by a ring containing adhesion proteins connected to the core via dome-like radial actin fibers. Podosomes are rich in actin filaments, matrix-degrading enzymes, focal adhesion molecules and molecules involved in vesicle trafficking. These structures protrudes into the extracellular matrix and are essential for invasion and metastasis. Classical podosomes are highly dynamic structures formed by cell types of monocytic origin, such as macrophages, dendritic cells, and osteoclasts.	Cellular component	podosome
-SL-9915	Protein found mostly on the nucleoplasmic side of the membrane.	Orientation	Nucleoplasmic side
-SL-0296	The portion of the cell membrane surrounding a podosome.	Cellular component	podosome membrane
-SL-0191	The nucleus is the most obvious organelle in any eukaryotic cell. It is a membrane-bound organelle surrounded by double membranes which contains most of the cell's genetic material. It communicates with the surrounding cytosol via numerous nuclear pores.	Cellular component	Nucleus
-SL-0371	The relatively impermeable, lipidic layer which surrounds the outer exine layer of a pollen grain.	Cellular component	pollen coat
-SL-0178	The nuclear envelope is a membrane system which surrounds the nucleoplasm of eukaryotic cells. It is composed of the nuclear lamina, nuclear pore complexes and two nuclear membranes. The space between the two membranes is called the nuclear intermembrane space.	Cellular component	Nucleus envelope
-SL-0179	The inner membrane of the nucleus is the membrane which separates the nuclear matrix from the intermembrane space. In mammals, the inner nuclear membrane is associated with heterochromatin and the nuclear lamina.	Cellular component	Nucleus inner membrane
-SL-0218	The porosome is an actin-regulated dynamic structure at the cell membrane, where membrane-bound secretory vesicles dock and fuse to release their contents.	Cellular component	porosome
-SL-0184	The nuclear intermembrane space is the space between the inner and outer nuclear membranes.	Cellular component	Nucleus intermembrane space
-SL-0219	In a chemical synapse, the postsynaptic membrane is the membrane that receives a signal (binds neurotransmitter) from the presynaptic cell and responds via depolarisation or hyperpolarisation. The postsynaptic membrane is separated from the presynaptic membrane by the synaptic cleft.	Cellular component	postsynaptic cell membrane
-SL-0180	The nuclear lamina is a meshwork of intermediate filament proteins called lamins and lamin-binding proteins that are embedded in the inner nuclear membrane.	Cellular component	Nucleus lamina
-SL-0297	The postsynaptic membrane contains a high concentration of glutamate receptors, associated signaling proteins, and cytoskeletal elements, all assembled by a variety of scaffold proteins into an organized structure called the postsynaptic density (PSD). A complex machine made of hundreds of distinct proteins, the PSD dynamically changes its structure and composition during development and in response to synaptic activity.	Cellular component	postsynaptic density
-SL-0181	The nuclear matrix is a three-dimensional filamentous protein network, found in the nucleoplasm, which provides a structural framework for organising chromatin, while facilitating transcription and replication.	Cellular component	Nucleus matrix
-SL-0182	The membrane surrounding the nucleus. This term is used when it is not known if the protein is found in or associated with the inner or outer nuclear membrane.	Cellular component	Nucleus membrane
-SL-0220	The pre-autophagosomal structure is the potential site of organization for autophagosome formation located near the vacuole.	Cellular component	Preautophagosomal structure
-SL-0183	The outer membrane of the nucleus is the membrane facing the cytoplasm. In mammals, the outer nuclear membrane is continuous in many places with the rough endoplasmic reticulum and is dotted with ribosomes.	Cellular component	Nucleus outer membrane
-SL-0221	The membrane surrounding the pre-autophagosomal structure.	Cellular component	Preautophagosomal structure membrane
-SL-0222	In a chemical synapse, the presynaptic membrane is the cell membrane of an axon terminal that faces the receiving cell. The postsynaptic membrane is separated from the presynaptic membrane by the synaptic cleft.	Cellular component	presynaptic cell membrane
-SL-0223	The prevacuolar compartment is an endocytic multivesiculate compartment involved in Golgi-vacuole trafficking.	Cellular component	Prevacuolar compartment
-SL-0186	The nuclear speckles are small subnuclear membraneless organelles or structures, also called the splicing factor (SF) compartments that correspond to nuclear domains located in interchromatin regions of the nucleoplasm of mammalian cells. Protein found in speckles serves as a reservoir of factors that participate in transcription and pre-mRNA processing. Speckles appear, at the immunofluorescence-microscope level, as irregular, punctuate structures, which vary in size and shape. Usually 25-50 speckles are observed per interphase mammalian nucleus. At the electronic-microscope level, they are composed of heterogeneous mixture of electro-dense particles with diameters ranging from 20-25 nm and are called interchromatin granules clusters (IGCs). Speckles are dynamic structures. Both their protein and RNA-protein components can cycle continuously between speckles and other nuclear locations depending on the transcriptional state of the cell. Structures similar to nuclear speckles have been identified in the amphibian oocyte nucleus (called B snurposomes) and in Drosophila melanogaster embryos, but not in yeast.	Cellular component	Nucleus speckle
-SL-0343	The PVC compartment bounded by the membrane of the PVC.	Cellular component	Prevacuolar compartment lumen
-SL-0351	The organellar chromatophore is the photosynthetic inclusion found in Paulinella chromatophora, a photosynthetic thecate amoeba. It probably derives from a different endosymbiotic event than that which led to all other plastids; the question is open as to whether or not this is a true plastid. Houses the machinery necessary for photosynthesis and CO(2) fixation and may also be able to make a few amino acids, a few fatty acid and 2 cofactors. They are surrounded by 2 membranes, between which is found a residual peptidoglycan wall, and contain thylakoids.	Cellular component	organellar chromatophore
-SL-0224	The membrane surrounding the prevacuolar compartment.	Cellular component	Prevacuolar compartment membrane
-SL-0359	The organellar chromatophore inner membrane is the membrane which separates the chromatophore stroma from the intermembrane space. Found exclusively in Paulinella chromatophora, a photosynthetic thecate amoeba.	Cellular component	organellar chromatophore inner membrane
-SL-0360	The intermembrane space between the inner and the outer organellar chromatophore membranes. Found exclusively in Paulinella chromatophora, a photosynthetic thecate amoeba.	Cellular component	organellar chromatophore intermembrane space
-SL-0225	Trimary cell wall is the first-formed wall layer of still growing plant cells (at least potentially). This wall is part of the apoplast which itself is largely self-contiguous and contains everything that is located between the plasma membrane and the cuticle. Primary walls are composed predominantly of polysaccharides, smaller proportions of glycoproteins and, in some specialized cell types, various noncarbohydrate substances such as lignin, suberin, cutin, cutan or silica. It is strong but usually thin, flexible, and capable of both plastic and elastic extension. It governs the rate and direction of cell expansion, and thus the ultimate size and shape of the cell.	Cellular component	primary cell wall
-SL-0352	One of the membranes of an organellar chromatophore. This term is used when it is not known with which membrane (outer membrane, inner membrane or thylakoid) a protein is associated. Found exclusively in Paulinella chromatophora, a photosynthetic thecate amoeba.	Cellular component	organellar chromatophore membrane
-SL-0226	The prolamellar body is a paracrystalline lattice found in the plastids of etiolated plants (etioplasts). Upon greening it gives rise to thylakoids.	Cellular component	prolamellar body
-SL-0361	The organellar chromatophore outer membrane is the organellar chromatophore membrane facing the cytoplasm. Found exclusively in Paulinella chromatophora, a photosynthetic thecate amoeba.	Cellular component	organellar chromatophore outer membrane
-SL-0369	The prospore or immature spore is formed during sporulation by the engulfment of the post-meiotic nuclei by the prospore double membrane. These prospores are then maturated into spores with the synthesis of the spore wall.	Cellular component	Prospore
-SL-0353	The internal space enclosed by the organellar chromatophore double membrane but excluding the thylakoid space. This space, filled with a colorless hydrophilic matrix, contains DNA, ribosomes and some temporary products of photosynthesis; other biosynthetic functions that could also occur there include amino acid, fatty acid and some cofactor biosynthesis. Found exclusively in Paulinella chromatophora, a photosynthetic thecate amoeba.	Cellular component	organellar chromatophore stroma
-SL-0368	The prospore membrane is a double membrane which forms at the spindle pole body outer plaque during the second meiotic division of the sporulation process. The prospore membrane grows larger and finally engulfs the post-meiotic nuclei to form immature spores called prospores. The de novo synthesis of the spore wall occurs in the prospore intermembrane space and leads to mature spores.	Cellular component	Prospore membrane
-SL-0228	The protein storage vacuole (PSV) is a specialized vacuole where storage proteins accumulate. These act as a source of amino acids for various SYnthetic activities.	Cellular component	Protein storage vacuole
-SL-0344	The protein storage vacuolar compartment bounded by the membrane of the protein storage vacuole.	Cellular component	Protein storage vacuole lumen
-SL-0227	The membrane surrounding a protein storage vacuole.	Cellular component	Protein storage vacuole membrane
-SL-0229	The protoplasm is the viscid, translucent, polyphasic colloid with water as the continuous phase that makes up the essential material of all plant and animal cells. It is composed mainly of nucleic acids, proteins, lipids, carbohydrates, and inorganic salts. The protoplasm surrounding the nucleus is known as the cytoplasm and that composing the nucleus is the nucleoplasm.	Cellular component	Protoplasm
-SL-0298	The pseudopodium is a thick knobby cell protrusion. Pseudopodia are produced by polymerization of extensive dendritic meshwork of actin filaments along broad sectors of the cell surface. These temporary irregular and dynamic protrusion or retractile processes of a cell, are associated with ameboid movement (crawling). Pseudopodium, or "false foot", mostly used for motile protozoans is comparable to the 'lamellipodium' in vertebrate cells.	Cellular component	pseudopodium
-SL-0299	The portion of the cell membrane surrounding a pseudopodium.	Cellular component	pseudopodium membrane
-SL-0471	The end of the pseudopodium distal to the body of the cell.	Cellular component	pseudopodium tip
-SL-0354	The thylakoid of an organellar chromatophore is an internal system of interconnected membranes that carry the complexes for the light reactions of photosynthesis. Found exclusively in Paulinella chromatophora, a photosynthetic thecate amoeba.	Cellular component	organellar chromatophore thylakoid
-SL-0232	The recycling endosome is a membrane network composed of narrow diameters tubules which concentrate in the vicinity of the microtubule organizing center. Recycling receptors after release of their ligands accumulate in those membranes which are devoid of fluid markers. Recycling endosomes may be an intermediate station for receptors before recycling back to the cell surface.	Cellular component	Recycling endosome
-SL-0355	The organellar chromatophore thylakoid lumen is the compartment bounded by the thylakoid membrane. Found exclusively in Paulinella chromatophora, a photosynthetic thecate amoeba.	Cellular component	organellar chromatophore thylakoid lumen
-SL-0345	The recycling endosomal compartment bounded by the membrane of the recycling endosome.	Cellular component	Recycling endosome lumen
-SL-0356	The organellar chromatophore thylakoid membrane is an internal system of interconnected membranes that house the complexes which carry out the light reactions of photosynthesis. Found exclusively in Paulinella chromatophora, a photosynthetic thecate amoeba.	Cellular component	organellar chromatophore thylakoid membrane
-SL-0231	The membrane surrounding the recycling endosomes.	Cellular component	Recycling endosome membrane
-SL-0233	The rhoptry is an Apicomplexan parasite organelle. Apicomplexa are named for the unique set of morphologically distinct secretory organelles (refered to as the apical complex)- micronemes, rhoptries and dense granules - whose sequential secretion is required for the invasion of host cells. Rhoptries are twin, membrane-bound, pear-shaped organelles that secrete proteins through their elongated necks at the apical tip of the parasite.	Cellular component	rhoptry
-SL-0230	P-bodies are dynamic non-membrane bound cytoplasmic structures. These discrete foci function in mRNA decay (decapping and breakdown), RNA-mediated gene silencing (microRNA and siRNA-based gene silencing), mRNA surveillance (or quality control) and translational control. In addition to being sites of mRNA degradation, P-bodies can temporarily sequester mRNAs away from the translation machinery. P-bodies are present in unstressed cells, but are further induced in response to various stresses.	Cellular component	P-body
-SL-0346	The rhoptry compartment bounded by the membrane of a rhoptry.	Cellular component	rhoptry lumen
-SL-0234	The membrane surrounding a rhoptry.	Cellular component	rhoptry membrane
-SL-0192	The paranodal septate junction (PSJ) in vertebrate species is an occluding complex which occurs between neurons and the glial cells that myelinate them, the oligodendrocytes and the Schwann cells. Each glial cell wraps around and contacts the neuron multiple times in a spiral pattern to form the paranodal loops. The paranodal loops tightly adhere to the axon through a continuous spiral of axo-glial junctions that resemble invertebrate septate junctions (SJs). The paranodal loops are a spiraled cytoplasmic channel that is contiguous with the perikaryon of the myelin forming cell and thus can serve as a conduit for transmitting axonally induced signals that could regulate glial gene transcription. These junctions also form a physical barrier that prevents diffusion of nodal sodium channels and juxtaparanodal potassium channels. Axo-glial paranodal junctions, therefore, share adhesion, diffusion barrier and putative intercellular communication functions with invertebrate SJs.	Cellular component	paranodal septate junction
-SL-0235	The rough endoplasmic reticulum (RER) is the portion of the ER which is covered with ribosomes.	Cellular component	Rough endoplasmic reticulum
-SL-0194	The parasitophorous vacuole is a vacuole found in the host cells where most apicomplexan parasites reside and develop. During host cell invasion, the apicomplexan parasites initiate the formation of a membrane (the parasitophorous vacuolar membrane), which surrounds the intracellular parasite. of phagolysosomes.	Cellular component	Parasitophorous vacuole
-SL-0236	The rough endoplasmic reticulum lumen is the area enclosed by the rough endoplasmic reticulum membrane.	Cellular component	Rough endoplasmic reticulum lumen
-SL-0341	The parasitophorous vacuole compartment bounded by the membrane of the parasitophorous vacuole.	Cellular component	Parasitophorous vacuole lumen
-SL-0237	The membrane surrounding the rough endoplasmic reticulum.	Cellular component	Rough endoplasmic reticulum membrane
-SL-0193	The membrane surrounding the parasitophorous vacuole.	Cellular component	Parasitophorous vacuole membrane
-SL-0300	A ruffle is a cell protrusion at the leading edge of a crawling cell. Ruffles are supported by a microfilament meshwork.	Cellular component	ruffle
-SL-9900	Surface protein of a Gram-positive bacteria anchored to the cell wall envelope by a transpeptidation mechanism which requires a C-terminal sorting signal with a conserved LPXTG motif. An amide bond is created between the carboxyl-group of the conserved threonine and the amino-group of peptidoglycan cross-bridges.	Topology	Peptidoglycan-anchor
-SL-0301	The portion of the cell membrane surrounding a ruffle.	Cellular component	ruffle membrane
-SL-0195	Symbiosis leads to the formation of a new compartment in the plant cell when bacteria enter the plant cell by endocytosis, the symbiosome. This compartment harbours the bacteroids surrounded by a peribacteroid membrane (PMB) originating from the plant plasma membrane. The space between this membrane and the bacteroid membrane is called the peribacteroid space.	Cellular component	peribacteroid membrane
-SL-0262	A S-layer is a paracrystalline protein thin layer attached to the outermost portion of the cell wall. Found in some bacteria and common in archaea where it can constitute the only cell wall structure outside the plasma membrane. In gram-negative bacteria, the S-layer is directly attached to the outer membrane. In gram-positive bacteria, the S-layer is attached to the peptidoglycan layer. The S-layer may protect the cell from aggressions such as phagocytosis, harmful enzymes, etc. It also allows bacteria to adhere to host cells or other environmental surfaces and to mantain shape and envelope rigidity.	Cellular component	S-layer
-SL-0196	Symbiosis lead to the formation of a new compartment in the plant cell when bacteria enter the plant cell by endocytosis. This compartment harbours the bacteroids surrounded by a peribacteroid membrane (PMB) originating from the plant plasma membrane. The space between this membrane and the bacteroid membrane is called the peribacteroid space.	Cellular component	peribacteroid space
-SL-0238	The sarcolemma is the delicate cell membrane of a muscle fiber or muscle cell.	Cellular component	sarcolemma
-SL-0197	The perikaryon is the cell body of a neuron.	Cellular component	Perikaryon
-SL-0198	The perinuclear region is the cytoplasmic region just around the nucleus.	Cellular component	perinuclear region
-SL-0313	The sarcomere represent the basal contractile unit of striated mucles. A single myofibril is composed of these short structural units arranged end to end, which contract due to the relative sliding of thick (myosin) over thin (actin) filaments. The mammalian sarcomere is ~ 2 mm in length, and can shorten to ~ 70% of its original length during contraction. Structural features of the sarcomere include bundles of parallel thick and thin filaments assembled by two transverse structures, the Z lines and M lines. The Z lines and the M lines are connected by transverse filaments to the sarcolemma or to the neighboring myofibrils. Sarcomeres give to skeletal and cardiac muscles their striated appearance with I bands surrounding the Z lines, followed by A bands. The A bands contain a paler region called the H zone and in the middle the M line.	Cellular component	sarcomere
-SL-0311	The sarcoplasm is the cytoplasm of a muscle fiber or muscle cell or myofiber.	Cellular component	sarcoplasm
-SL-0199	The perinuclear theca is a cytoskeletal structure that covers the nucleus of mammalian spermatozoa except for a narrow zone around the insertion of the tail. It shows two distinct regions, a subacrosomal layer or perforatorium and, continuing caudally beyond the acrosomic system, the postacrosomal sheath.	Cellular component	perinuclear theca
-SL-9903	Protein that is physically associated with a membrane, via interactions with lipid headgroups at the membrane surface or with another membrane protein. Peripheral membrane proteins are typically bound to the membrane surface, but may dip slightly into the lipid bilayer. Peripheral membrane protein.	Topology	Peripheral membrane protein
-SL-0239	The sarcoplasmic reticulum (SR) is a highly specialized form of the smooth endoplasmic reticulum which is dedicated to the regulation of intracellular calcium homeostasis. The SR can be subdivided in at least two well-characterized regions: the terminal cisternae, where the calcium ions are released, and the longitudinal tubules specialized in the uptake of the calcium ions.	Cellular component	Sarcoplasmic reticulum
-SL-0240	The lumen of the sarcoplasmic reticulum is the area enclosed by the sarcoplasmic reticulum membrane.	Cellular component	Sarcoplasmic reticulum lumen
-SL-0200	The periplasm is the space between the inner and outer membrane in Gram-negative bacteria. In Gram-positive bacteria a smaller periplasmic space is found between the inner membrane and the peptidoglycan layer. Also used for the intermembrane spaces of fungi and organelles.	Cellular component	Periplasm
-SL-0241	The membrane surrounding the sarcoplasmic reticulum (SR).	Cellular component	Sarcoplasmic reticulum membrane
-SL-0201	Spirochetes have a flagellum that resides inside the cell within the periplasmic space. The number of flagella varies from species to species. The rotation of these structures results in specific movements of the cell body, which in turn enable the locomotion of the cell. In particular they impart spirochetes the ability to propel themselves through viscous media that would inhibit the rotation of external flagellar filaments.	Cellular component	Periplasmic flagellum
-SL-0242	In some plants, and cell types after a maximum size or point in development has been reached, a secondary wall, often layered, is constructed below the primary wall. Unlike the primary wall, it losts plasticity and is made usually of cellulose, hemicellulose and lignin.	Cellular component	secondary cell wall
-SL-9916	Protein found mostly on the periplasmic side of the membrane.	Orientation	Periplasmic side
-SL-0243	Protein located outside the cell membrane(s).	Cellular component	Secreted
-SL-0367	Protein found in the perispore. The perispore corresponds to the outer surface layer of mature bacterial spores and eukaryotic spores. The perispore, also called perine or exosporium, represents the primary contact surface between the spore and environment/host and is a site of spore antigens.	Cellular component	perispore
-SL-0244	The secretory vesicle is a vesicle that mediates the vesicular transport of cargo - e.g. hormones or neurotransmitters - from an organelle to specific sites at the cell membrane, where it docks and fuses to release its content. It has been demonstrated that membrane-bound secretory vesicles dock and fuse at porosomes, which are specialized supramolecular structures at the cell membrane.	Cellular component	secretory vesicle
-SL-0347	The secretory vesicle compartment bounded by the membrane of the secretory vesicle.	Cellular component	secretory vesicle lumen
-SL-0204	The peroxisome is a small eukaryotic organelle limited by a single membrane, specialized for carrying out oxidative reactions. Contains mainly peroxidases, several other oxidases and catalase. The catalase regulates the contents of the produced toxic hydrogen peroxide thus protecting the cell. Beta-oxidation of fatty acids is another major function of peroxisomes. In plants and fungi this degradation occurs only in this cellular compartment.	Cellular component	Peroxisome
-SL-0245	The membrane surrounding secretory vesicles.	Cellular component	secretory vesicle membrane
-SL-0202	The matrix of a peroxisome is the area enclosed by the peroxisomal membrane.	Cellular component	Peroxisome matrix
-SL-0246	The septate junction (SJ) in invertebrates is an occluding complex located basolateral to the adherens junction which have regularly spaced septa bridging a circa 15-nm intercellular space. SJs form the paracellular barrier that regulates passage of solutes through the spaces between adjacent cells in an epithelium for proper nutrient absorption or secretion.	Cellular component	septate junction
-SL-0203	The membrane surrounding a peroxysome.	Cellular component	Peroxisome membrane
-SL-9904	Protein spanning the membrane once.	Topology	Single-pass membrane protein
-SL-0473	Cup-shaped invaginations of the cell membrane that subsequently close at their distal margins to form phagosomes during phagocytosis. By progression of its rim along the particle surface, this phagocytic cup envelops and eventually encloses the particle by separation of the phagosome membrane from the cell membrane. Filamentous actin accumulates between the outer and inner leaflet of the cup membrane and is most strongly enriched at the rim of the cup, the site of its protrusion.	Cellular component	phagocytic cup
-SL-9905	Protein spanning the membrane once, with its N-terminus on the extracellular side of the membrane and removal of its signal sequence.	Topology	Single-pass type I membrane protein
-SL-0206	The phagosome is a phagocytic cell-specific compartment. These large endocytic membrane-bound vesicles form upon ingestion by the cell of extracellular materials.	Cellular component	phagosome
-SL-9906	Protein spanning the membrane once, with its N-terminus on the cytoplasmic side of the membrane. The transmembrane domain is located close to the N-terminus and it functions as an anchor.	Topology	Single-pass type II membrane protein
-SL-0342	The phagosomal compartment bounded by the membrane a phagosome.	Cellular component	phagosome lumen
-SL-9907	Protein spanning the membrane once, with its N-terminus on the extracellular side of the membrane and no signal sequence.	Topology	Single-pass type III membrane protein
-SL-0205	The membrane surrounding a phagosome.	Cellular component	phagosome membrane
-SL-9908	Protein spanning the membrane once, with its N-terminus on the cytoplasmic side of the membrane. The transmembrane domain is located close to the C-terminus and it functions as an anchor.	Topology	Single-pass type IV membrane protein
-SL-0457	The inner segment of a vertebrate photoreceptor containing mitochondria, ribosomes and membranes where opsin molecules are assembled and passed to be part of the outer segment discs.	Cellular component	Photoreceptor inner segment
-SL-0247	The slime layer is an easily removed, diffuse, unorganized layer of extracellular material which surrounds the bacterial cell. It is usually composed of polysaccharides and it may serve to trap nutrients, to aid in cell motility, to bind cells together or to adhere to smooth surfaces. Slime layers are a more-diffuse glycocalyx than capsules.	Cellular component	slime layer
-SL-0458	The outer segment of a vertebrate photoreceptor that contains discs of photoreceptive membranes.	Cellular component	photoreceptor outer segment
-SL-0248	The smooth endoplasmic reticulum (SER) is the portion of the ER which is free of ribosomes.	Cellular component	Smooth endoplasmic reticulum
-SL-0207	The phragmoplast is a plant cell specific structure that forms during late cytokinesis. This complex assembly of microtubules, actin filaments and associated molecules acts as a framework for cell plate assembly and subsequent formation of the future cell wall separating the two daughter cells.	Cellular component	phragmoplast
-SL-0249	The smooth endoplasmic reticulum lumen is the area enclosed by the smooth endoplasmic reticulum membrane.	Cellular component	Smooth endoplasmic reticulum lumen
-SL-0208	The plasmodesma (plural plasmodesmata) is a plasma membrane-lined channel that crosses the cell wall between two adjacent plant cells and which allows a cytoplasmic exchange between the cells. It provides passage of ions and small molecules, but also of macromolecules such as RNA or proteins. Plasmodesmata are sheathed by a plasma membrane that is simply an extension of the cell membrane of the adjoining cells. Most plasmodesmata have a narrow cylindrical desmotubule at the center that is derived from the ER and appears to be continuous with the ER of both cells.	Cellular component	plasmodesma
-SL-0250	The membrane surrounding the smooth endoplasmic reticulum.	Cellular component	Smooth endoplasmic reticulum membrane
-SL-0251	The spindle is a specialized microtubule structure designed to attach and capture chromosomes in order to partition them evenly to each daughter cells.	Cellular component	spindle
-SL-0209	The plastid is a semi-autonomous, self-reproducing organelle. Plastids are remnants of a photosynthetic organism that was engulfed by the host, although not all are now photosynthetic. Plastid genomes encode genes for rRNAs, tRNAs and between about 28 and 150 proteins. Plastids can be categorized in 4 main groups: chloroplasts, cyanelles, apicoplasts and non-photosynthetic. The later is found is some land plants (Epifagus virginiana), chlorophyte algae (Prototheca wickerhamii) and euglenoids (Astasis longa), which do not encode the genes necessary for photosynthesis and so are not photosynthetic but still contain a plastid. They probably do not contain thylakoids.	Cellular component	Plastid
-SL-0448	Either of the ends of a spindle, a specialized microtubule structure designed to attach and capture chromosomes in order to partition them evenly to each daughter cells.	Cellular component	spindle pole
-SL-0210	The envelope of a plastid comprises the inner and outer plastid membrane including the intermembrane space.	Cellular component	Plastid envelope
-SL-0252	The spindle pole body is the microtubule organizing center (MTOC) in fungi, functionally equivalent to the animal cell centrosome. The SPB is responsible for the nucleation and organisation of microtubules. This may include the spindle microtubules required for chromosome segregation in mitosis and meiosis as well as the cytoplasmic interphase microtubules.	Cellular component	spindle pole body
-SL-0366	Protein found in the spore coat. The spore coat is the thick layer found beneath the perispore of some eukaryotic spores and bacterial mature spores. It is made up of highly cross-linked keratin and layers of specific proteins. The coat is composed of several electron-dense and lamella-like layers, differing between species.	Cellular component	spore coat
-SL-0253	Protein found in the spore core. The core also called spore matrix is the central part of the spore and contains normal cell structures, such as DNA, proteins and ribosomes, but is metabolically inactive.	Cellular component	Spore core
-SL-0363	Protein associated with the spore core membrane. The spore core membrane is the membrane surrounding the innermost spore cell or spore core.	Cellular component	Spore core membrane
-SL-0364	Protein found in the spore cortex. The spore cortex is a loosely cross-linked peptidoglycan layer localized between the spore core and the outer membrane or cortex membrane of bacterial mature spores. The cortex maintains heat resistance and dormancy.	Cellular component	spore cortex
-SL-0365	Protein associated with the spore outer membrane. The outer membrane, also called the cortex membrane, is a membrane localized between the cortex and the inner layer of the coat of bacterial mature spores.	Cellular component	spore outer membrane
-SL-0436	The polar tube is a highly specialised structure unique to Microsporidia and required for host cell invasion. In the spore, the polar tube is connected at the anterior end, and then coils around the sporoplasm. Upon appropriate environmental stimulation, the polar tube rapidly discharges out of the spore, pierces a cell membrane and serves as a conduit for sporoplasm passage into the new host cell.	Cellular component	Spore polar tube
-SL-0254	Protein found in the spore wall. The spore wall is the main element of the spore's resistance to environmental stress. It is usually composed of several layers of different sugar polymers like mannans and glucans which are associated to glycoproteins. The composition, structure and number of layers are very different between bacteria, plants, protozoans or fungi.	Cellular component	Spore wall
-SL-0302	The stereocilium is a finger-like projection forming the hair bundle on the apical surface of sensory hair cells in the cochlea. Stereocilia stiffness and function depend on the several hundreds of uniformly polarized and tightly cross-linked actin filaments. Stereocilia cytoskeleton shows continuous turnover with actin filament assembly occuring at the stereocilium tip and its disassembly at the base so that stereocilium length is maintained in a dynamic steady-state. This staircase-like bundle of stereocilia is responsible for mechanosensation and ultimately the perception of sound.	Cellular component	stereocilium
-SL-0303	The stereocilium membrane is the portion of the cell membrane surrounding a stereocilium.	Cellular component	stereocilium membrane
-SL-0501	Stress fibers are contractile actomyosin bundles found in non-muscle cells, in eukaryotes, mostly in animals. They are composed of bundles of 10 to 30 actin filaments (microfilaments), crosslinked by alpha-actinin, and non-muscle myosin. They are often anchored to focal adhesions, that connect the extracellular matrix to the actin cytoskeleton. Stress fibers play an essential role in cell contractility, governing cell morphology, adhesion, and migration. In non-motile cells, stress fibers are usually thick and relatively stable. By contrast, highly motile cells typically contain fewer, thinner and more dynamic stress fibers. Stress fibers can be divided into at least 4 different categories : dorsal and ventral stress fibers, transverse arcs and the perinuclear actin cap.	Cellular component	stress fiber
-SL-0496	Stress granules are dense non-membrane bound aggregations in the cytosol composed of proteins and RNAs that appear when the cell is under stress. The aggregates are mostly composed of stalled translation initiation complexes. They are 100-200 nm in size. Stress granules can also precipitate the formation of toxic protein aggregates such as those seen during the progression of certain types of neurological disease.	Cellular component	Stress granule
-SL-9917	Protein found mostly on the stromal side of the membrane.	Orientation	Stromal side
-SL-0255	The film of pulmonary surfactants which cover the alveolar surface of the mammalian lung. These surfactants are composed of 90% phospholipids and 10% proteins.	Cellular component	surface film
-SL-0256	Symbiosis lead to the formation of a new compartment in the plant cell when bacteria enter the plant cell by endocytosis, the symbiosome. This compartment harbours the bacteroids surrounded by a peribacteroid membrane (PMB) originating from the plant plasma membrane. The space between this membrane and the bacteroid membrane is called the peribacteroid space.	Cellular component	Symbiosome
-SL-0257	The symplast is a highly ordered and connected space within plants formed by the cytoplasms of individual cells connected by plasmodesmata. The symplast is held in place by a rigid framework, the apoplast.	Cellular component	Symplast
-SL-0258	Synapses are the communicating cell-cell junctions that allow signals to pass from a nerve cell to a target cell. In a chemical synapse, the signal is carried by a neurotransmitter which diffuses across a narrow synaptic cleft and activates a receptor on the postsynaptic membrane of the target cell. The target may be a dendrite, cell body, neuronal axon, a specialized region of a muscle or a secretory cell. In an electrical synapse, a direct connection is made between the cytoplasms of two cells via gap junctions.	Cellular component	synapse
-SL-0259	The synaptic vesicles mediate the exocytosis of neurotransmitters and subsequent re-uptake by endocytosis of vesicular components. Re-uptake is a crucial element in the maintenance of synaptic transmission in the nervous system.	Cellular component	synaptic vesicle
-SL-0348	The synaptic vesicle compartment bounded by the membrane of a synaptic vesicle.	Cellular component	synaptic vesicle lumen
-SL-0260	The membrane surrounding a synaptic vesicle.	Cellular component	synaptic vesicle membrane
-SL-0261	Synaptosomes are the pinched-off nerve endings and their contents of vesicles and cytoplasm together with the attached subsynaptic area of the membrane of the postsynaptic cell. They are largely artificial structures produced by fractionation after selective centrifugation of nervous tissue homogenates.	Cellular component	synaptosome
-SL-0487	A cell including the cell membrane and any external encapsulating of another cell. This term is used to describe a toxin located in the structures such as the cell wall and cell envelope that is the target.	Cellular component	Target cell
-SL-0486	The contents of a target cell within the plasma membrane and which, in eukaryotic cells, surrounds the host nucleus. This term is used to describe a toxin located in the cytoplasm of a target cell.	Cellular component	target cell cytoplasm
-SL-0451	The target cell membrane is the selectively permeable membrane which separates the target cell cytoplasm from its surroundings. This term is used to describe a toxin located to the cell membrane of a target cell.	Cellular component	Target cell membrane
-SL-0452	A target membrane is a lipid bilayer which surrounds target cell enclosed spaces and compartments. This selectively permeable structure is essential for effective separation of a target cell or target cell organelle from its surroundings. This term is used to describe a toxin located to a membrane of a target cell.	Cellular component	Target membrane
-SL-0263	The tegument of schistosomes is an outer-surface covering blood-dwelling flatworms. This unique structure consists of a double phospholipid bilayer (also known as the heptalaminar outer-surface structure) that ovelay a syncytium of fused cells surrounding the entire worm. These outer-tegumental membranes form many surface pits that substantially increase the surface area of the schistosome. The underlying syncytial-matrix contains some mitochondria, many vesicular structures and an extensive cytoskeleton. A basal lamina separates the syncytium from a layer of muscle cells. Nuclei and ribosomes are located in cytons, which are located underneath the muscle layer and connected by microtubule-lined cytoplasmic connections.	Cellular component	Tegument
-SL-0264	The membrane suroounding the tegument of schistosomes.	Cellular component	Tegument membrane
-SL-0276	The telomere is a nucleoprotein structure comprising the terminal section of a eukaryotic chromosome. It has a specialized structure which is replicated by a special process, thereby counteracting the tendency of a chromosome to be shortened during each round of replication.	Cellular component	telomere
-SL-0450	The thylakoid is a membranous cellular structure containing the photosynthetic pigments, reaction centers and electron-transport chain. In chloroplast, thylakoids stack up to form the grana or stay as single cisternae and interconnect the grana. Thylakoid, where photosynthesis occurs, are found in chloroplasts, cyanelles and in photosynthetic bacteria where they are the extensive invaginations of the plasma membrane.	Cellular component	Thylakoid
-SL-0265	The tight junction (TJ) is a dynamic, multifunctional complex which, together with adherens junctions and desmosomes, maintains the integrity of the epithelial cell layer(s) that protects multicellular organisms. TJ is located at the apical-most portion of the intercellular junction. It separates the apical and basolateral compartments of epithelia (preventing the lateral diffusion of lipids and proteins between the apical and basolateral domains of plasma membrane) and plays a key role in limiting paracellular permeability to ions and solutes in a charge and size selective manner. TJs appear as multiple strands of fibrils forming a continuous circumferential seal around cells.	Cellular component	tight junction
-SL-0266	The trans-Golgi network is a highly dynamic series of interconnected tubules and vesicles at the trans face of the Golgi stack. The trans-Golgi network functions in the processing and sorting of glycoproteins and glycolipids at the interface of the biosynthetic and endosomal pathways. The generation and maintenance of apical and basolateral membranes rely on sorting events that occur in the TGN.	Cellular component	trans-Golgi network
-SL-0267	The membrane surrounding the trans-Golgi network.	Cellular component	trans-Golgi network membrane
+SL-0476	GO:0031672
+SL-0002	GO:0020022
+SL-0316	GO:0033985
+SL-0003	GO:0033102
+SL-0007	GO:0001669
+SL-0004	GO:0002079
+SL-0005	GO:0043160
+SL-0006	GO:0002080
+SL-0447	GO:0002081
+SL-0008	GO:0030479
+SL-0009	GO:0005912
+SL-0010	GO:0033095
+SL-0317	GO:0034422
+SL-0011	GO:0032578
+SL-0012	GO:0009501
+SL-0013	GO:0033098
+SL-0014	GO:0033097
+SL-0015	GO:0016324
+SL-0016	GO:0032579
+SL-0017	GO:0016327
+SL-0018	GO:0020011
+SL-0019	GO:0048046
+SL-0306	GO:0009288
+SL-0020	GO:0033099
+SL-0021	GO:0033111
+SL-0023	GO:0005776
+SL-0318	GO:0034423
+SL-0022	GO:0000421
+SL-0279	GO:0030424
+SL-0489	GO:0097691
+SL-0307	GO:0009288
+SL-0142	GO:0009425
+SL-0358	GO:0009420
+SL-0357	GO:0009424
+SL-0454	GO:0000935
+SL-0024	GO:0009925
+SL-0025	GO:0005604
+SL-0026	GO:0016323
+SL-0472	GO:0032059
+SL-0027	GO:0005933
+SL-0028	GO:0033101
+SL-0029	GO:0005935
+SL-0030	GO:0005934
+SL-0031	GO:0015030
+SL-0032	GO:0033150
+SL-0033	GO:0042603
+SL-0034	GO:0031470
+SL-0035	GO:0005901
+SL-0138	GO:0005938
+SL-0036	GO:0031975
+SL-0037	GO:0005886
+SL-0038	GO:0030054
+SL-0039	GO:0005886
+SL-0040	GO:0009279
+SL-0280	GO:0042995
+SL-0455	GO:0030428
+SL-0310	GO:0009986
+SL-0456	GO:0051286
+SL-0041	GO:0005618
+SL-0042	GO:0042717
+SL-0043	GO:0009579
+SL-0044	GO:0031977
+SL-0045	GO:0042651
+SL-0046	GO:0005814
+SL-0047	GO:0000775
+SL-0048	GO:0005815
+SL-0049	GO:0009507
+SL-0050	GO:0009941
+SL-0051	GO:0009706
+SL-0052	GO:0031972
+SL-0053	GO:0031969
+SL-0139	GO:0042644
+SL-0054	GO:0009707
+SL-0055	GO:0009570
+SL-0056	GO:0009534
+SL-0057	GO:0009543
+SL-0058	GO:0009535
+SL-0059	GO:0046858
+SL-0060	GO:0033105
+SL-0061	GO:0042583
+SL-0349	GO:0034466
+SL-0062	GO:0042584
+SL-0063	GO:0009509
+SL-0064	GO:0046862
+SL-0065	GO:0009575
+SL-0468	GO:0005694
+SL-0066	GO:0005929
+SL-0305	GO:0060170
+SL-0067	GO:0005801
+SL-0068	GO:0033106
+SL-0069	GO:0005905
+SL-0070	GO:0030136
+SL-0071	GO:0030665
+SL-0467	GO:0032154
+SL-0072	GO:0005905
+SL-0073	GO:0000331
+SL-0074	GO:0031164
+SL-0075	GO:0030137
+SL-0076	GO:0030663
+SL-0077	GO:0030134
+SL-0078	GO:0012507
+SL-0079	GO:0001533
+SL-0080	GO:0033107
+SL-0081	GO:0033110
+SL-0082	GO:0009842
+SL-0479	GO:0033112
+SL-0480	GO:0036012
+SL-0481	GO:0036014
+SL-0083	GO:0033113
+SL-0482	GO:0036013
+SL-0350	GO:0034060
+SL-0277	GO:0009843
+SL-0084	GO:0033114
+SL-0085	GO:0033115
+SL-0086	GO:0005737
+SL-0495	GO:0036464
+SL-0325	GO:0060205
+SL-0089	GO:0030659
+SL-0090	GO:0005856
+SL-0091	GO:0005829
+SL-0283	GO:0030425
+SL-0284	GO:0043197
+SL-0285	GO:0032591
+SL-0092	GO:0030057
+SL-0094	GO:0005769
+SL-0337	GO:0031905
+SL-0093	GO:0031901
+SL-0147	GO:0012505
+SL-0095	GO:0005783
+SL-0096	GO:0005788
+SL-0097	GO:0005789
+SL-0098	GO:0005793
+SL-0099	GO:0033116
+SL-0101	GO:0005768
+SL-0327	GO:0031904
+SL-0100	GO:0010008
+SL-0109	GO:0033117
+SL-0328	GO:0034467
+SL-0108	GO:0033118
+SL-0110	GO:0009513
+SL-0329	GO:0034426
+SL-0330	GO:0009578
+SL-0466	GO:0070062
+SL-0112	GO:0005615
+SL-0286	GO:0030175
+SL-0287	GO:0031527
+SL-0470	GO:0032433
+SL-0113	GO:0009289
+SL-0116	GO:0020016
+SL-0117	GO:0031514
+SL-0118	GO:0005925
+SL-0119	GO:0042763
+SL-0124	GO:0005921
+SL-0125	GO:0031411
+SL-0126	GO:0033172
+SL-0127	GO:0097504
+SL-0129	GO:0020015
+SL-0332	GO:0034468
+SL-0128	GO:0046860
+SL-0131	GO:0009514
+SL-0333	GO:0031908
+SL-0130	GO:0046861
+SL-0132	GO:0005794
+SL-0133	GO:0005796
+SL-0134	GO:0000139
+SL-0135	GO:0005795
+SL-0334	GO:0034469
+SL-0136	GO:0032580
+SL-0288	GO:0030426
+SL-0289	GO:0032584
+SL-0477	GO:0031673
+SL-0137	GO:0030056
+SL-0431	GO:0018995
+SL-0372	GO:0020002
+SL-0428	GO:0044155
+SL-0427	GO:0043657
+SL-0421	GO:0044230
+SL-0373	GO:0020002
+SL-0374	GO:0044156
+SL-0375	GO:0020002
+SL-0376	GO:0020002
+SL-0377	GO:0044157
+SL-0378	GO:0044228
+SL-0424	GO:0044158
+SL-0429	GO:0044159
+SL-0430	GO:0044160
+SL-0381	GO:0030430
+SL-0386	GO:0044161
+SL-0387	GO:0044162
+SL-0383	GO:0044163
+SL-0384	GO:0044164
+SL-0398	GO:0033645
+SL-0388	GO:0044165
+SL-0389	GO:0044166
+SL-0390	GO:0044167
+SL-0391	GO:0044172
+SL-0392	GO:0044173
+SL-0393	GO:0044174
+SL-0394	GO:0044175
+SL-0425	GO:0043655
+SL-0379	GO:0044176
+SL-0395	GO:0044177
+SL-0426	GO:0044178
+SL-0399	GO:0044184
+SL-0400	GO:0044185
+SL-0401	GO:0044186
+SL-0403	GO:0044187
+SL-0404	GO:0044188
+SL-0380	GO:0033644
+SL-0405	GO:0033648
+SL-0406	GO:0033648
+SL-0407	GO:0033650
+SL-0408	GO:0044190
+SL-0409	GO:0044192
+SL-0410	GO:0044191
+SL-0411	GO:0044193
+SL-0453	GO:0072494
+SL-0412	GO:0044196
+SL-0413	GO:0044095
+SL-0414	GO:0042025
+SL-0415	GO:0044199
+SL-0419	GO:0044201
+SL-0416	GO:0044203
+SL-0417	GO:0044204
+SL-0418	GO:0044200
+SL-0446	GO:0044202
+SL-0507	GO:0140220
+SL-0508	GO:0140222
+SL-0509	GO:0140221
+SL-0382	GO:0044220
+SL-0420	GO:0044229
+SL-0385	GO:0044219
+SL-0434	GO:0044231
+SL-0422	GO:0044168
+SL-0423	GO:0044169
+SL-0444	GO:0044170
+SL-0445	GO:0044171
+SL-0435	GO:0044221
+SL-0449	GO:0044159
+SL-0143	GO:0033166
+SL-0145	GO:0042566
+SL-0335	GO:0034492
+SL-0144	GO:0046859
+SL-0478	GO:0031674
+SL-0488	GO:0061702
+SL-0362	GO:0070258
+SL-0146	GO:0033165
+SL-0148	GO:0071437
+SL-0290	GO:0071438
+SL-0149	GO:0000777
+SL-0150	GO:0020023
+SL-0460	GO:0060091
+SL-0291	GO:0030027
+SL-0292	GO:0031258
+SL-0152	GO:0005770
+SL-0336	GO:0031906
+SL-0151	GO:0031902
+SL-0153	GO:0016328
+SL-0154	GO:0005811
+SL-0158	GO:0005764
+SL-0156	GO:0043202
+SL-0157	GO:0005765
+SL-0159	GO:0000323
+SL-0315	GO:0031430
+SL-0161	GO:0042470
+SL-0338	GO:0034493
+SL-0160	GO:0033162
+SL-0162	GO:0016020
+SL-0370	GO:0045121
+SL-0163	GO:0020009
+SL-0339	GO:0034494
+SL-0164	GO:0033163
+SL-0166	GO:0043231
+SL-0165	GO:0031090
+SL-0293	GO:0005902
+SL-0294	GO:0031528
+SL-0469	GO:0030496
+SL-0490	GO:0090543
+SL-0173	GO:0005739
+SL-0167	GO:0005740
+SL-0168	GO:0005743
+SL-0169	GO:0005758
+SL-0170	GO:0005759
+SL-0171	GO:0031966
+SL-0269	GO:0042645
+SL-0172	GO:0005741
+SL-0437	GO:0032047
+SL-0174	GO:0005771
+SL-0175	GO:0032585
+SL-0176	GO:0043209
+SL-0312	GO:0030016
+SL-0177	GO:0042151
+SL-0494	GO:0016604
+SL-0185	GO:0005643
+SL-0187	GO:0009295
+SL-0188	GO:0005730
+SL-0497	GO:0001650
+SL-0189	GO:0033009
+SL-0190	GO:0005654
+SL-0191	GO:0005634
+SL-0178	GO:0005635
+SL-0179	GO:0005637
+SL-0184	GO:0005641
+SL-0180	GO:0005652
+SL-0181	GO:0016363
+SL-0182	GO:0031965
+SL-0183	GO:0005640
+SL-0186	GO:0016607
+SL-0351	GO:0070111
+SL-0359	GO:0070113
+SL-0360	GO:0070115
+SL-0352	GO:0070112
+SL-0361	GO:0070114
+SL-0354	GO:0070116
+SL-0355	GO:0070117
+SL-0356	GO:0070118
+SL-0230	GO:0000932
+SL-0192	GO:0033010
+SL-0194	GO:0020003
+SL-0193	GO:0020005
+SL-0195	GO:0043661
+SL-0196	GO:0043662
+SL-0197	GO:0043204
+SL-0198	GO:0048471
+SL-0199	GO:0033011
+SL-0200	GO:0042597
+SL-0201	GO:0055040
+SL-0367	GO:0031160
+SL-0204	GO:0005777
+SL-0202	GO:0005782
+SL-0203	GO:0005778
+SL-0473	GO:0001891
+SL-0206	GO:0045335
+SL-0205	GO:0030670
+SL-0457	GO:0001917
+SL-0458	GO:0001750
+SL-0207	GO:0009524
+SL-0208	GO:0009506
+SL-0209	GO:0009536
+SL-0210	GO:0009526
+SL-0211	GO:0009528
+SL-0212	GO:0009529
+SL-0213	GO:0042170
+SL-0140	GO:0042646
+SL-0214	GO:0009527
+SL-0215	GO:0009532
+SL-0278	GO:0031976
+SL-0309	GO:0031978
+SL-0216	GO:0055035
+SL-0217	GO:0010287
+SL-0465	GO:0016605
+SL-0295	GO:0002102
+SL-0296	GO:0005886
+SL-0371	GO:0070505
+SL-0218	GO:0033012
+SL-0219	GO:0045211
+SL-0297	GO:0014069
+SL-0220	GO:0000407
+SL-0221	GO:0034045
+SL-0222	GO:0042734
+SL-0223	GO:0005770
+SL-0343	GO:0031906
+SL-0224	GO:0031902
+SL-0225	GO:0009530
+SL-0226	GO:0009541
+SL-0369	GO:0042763
+SL-0368	GO:0005628
+SL-0228	GO:0000326
+SL-0344	GO:0034495
+SL-0227	GO:0032586
+SL-0229	GO:0005622
+SL-0298	GO:0031143
+SL-0299	GO:0031260
+SL-0232	GO:0055037
+SL-0345	GO:0034777
+SL-0231	GO:0055038
+SL-0233	GO:0020008
+SL-0346	GO:0034591
+SL-0234	GO:0033016
+SL-0235	GO:0005791
+SL-0236	GO:0048237
+SL-0237	GO:0030867
+SL-0300	GO:0001726
+SL-0301	GO:0032587
+SL-0262	GO:0030115
+SL-0238	GO:0042383
+SL-0313	GO:0030017
+SL-0311	GO:0016528
+SL-0239	GO:0016529
+SL-0240	GO:0033018
+SL-0241	GO:0033017
+SL-0242	GO:0009531
+SL-0243	GO:0005576
+SL-0244	GO:0030133
+SL-0245	GO:0030658
+SL-0246	GO:0005918
+SL-0247	GO:0030114
+SL-0248	GO:0005790
+SL-0249	GO:0048238
+SL-0250	GO:0030868
+SL-0251	GO:0005819
+SL-0448	GO:0000922
+SL-0252	GO:0005816
+SL-0366	GO:0031160
+SL-0363	GO:0005886
+SL-0364	GO:0043595
+SL-0365	GO:0043594
+SL-0436	GO:0044099
+SL-0254	GO:0031160
+SL-0302	GO:0032420
+SL-0303	GO:0060171
+SL-0496	GO:0010494
+SL-0255	GO:0005615
+SL-0256	GO:0043659
+SL-0257	GO:0055044
+SL-0258	GO:0045202
+SL-0259	GO:0008021
+SL-0348	GO:0034592
+SL-0260	GO:0030672
+SL-0261	GO:0043005
+SL-0505	GO:0030315
+SL-0487	GO:0044216
+SL-0486	GO:0097679
+SL-0451	GO:0044218
+SL-0452	GO:0044279
+SL-0276	GO:0000781
+SL-0450	GO:0009579
+SL-0265	GO:0005923
+SL-0266	GO:0005802
+SL-0267	GO:0032588
+SL-0268	GO:0055039
+SL-0141	GO:0001931
+SL-0272	GO:0005773
+SL-0270	GO:0005775
+SL-0271	GO:0005774
+SL-0274	GO:0019012
+SL-0275	GO:0055036
+SL-0273	GO:0019033
+SL-0314	GO:0030018

--- a/indra/resources/update_resources.py
+++ b/indra/resources/update_resources.py
@@ -122,10 +122,25 @@ def update_kinases():
 def update_uniprot_subcell_loc():
     # TODO: This file could be stored as a tsv instead after some processing
     logger.info('--Updating UniProt subcellular location--')
-    url = 'http://www.uniprot.org/locations/?' + \
-        '%20sort=&desc=&compress=no&query=&force=no&format=tab&columns=id'
+    url = 'https://www.uniprot.org/docs/subcell.txt'
+    res = requests.get(url)
+    res.raise_for_status()
+    header, entry_block = res.text.split('_' * 75)
+    entries = entry_block.split('//')
+    mappings = []
+    for entry in entries:
+        slid = None
+        goid = None
+        lines = entry.split('\n')
+        for line in lines:
+            if line.startswith('AC'):
+                slid = line[5:].strip()
+            if line.startswith('GO'):
+                goid = line[5:].split(';')[0]
+        if slid and goid:
+            mappings.append((slid, goid))
     fname = os.path.join(path, 'uniprot_subcell_loc.tsv')
-    save_from_http(url, fname)
+    write_unicode_csv(fname, mappings, delimiter='\t')
 
 
 def update_chebi_entries():

--- a/indra/resources/update_resources.py
+++ b/indra/resources/update_resources.py
@@ -120,7 +120,6 @@ def update_kinases():
 
 
 def update_uniprot_subcell_loc():
-    # TODO: This file could be stored as a tsv instead after some processing
     logger.info('--Updating UniProt subcellular location--')
     url = 'https://www.uniprot.org/docs/subcell.txt'
     res = requests.get(url)

--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -2065,6 +2065,16 @@ def _get_db_mappings(dbname, dbid):
         target = ncit_map.get(dbid)
         if target is not None:
             db_mappings.append((target[0], target[1]))
+            if target[0] == 'UP':
+                gene_name = up_client.get_gene_name(target[1])
+                if gene_name:
+                    hgnc_id = hgnc_client.get_hgnc_id(gene_name)
+                    if hgnc_id:
+                        db_mappings.append(('HGNC', hgnc_id))
+            elif target[0] == 'HGNC':
+                standard_up_id = hgnc_client.get_uniprot_id(target[1])
+                if standard_up_id:
+                    db_mappings.append(('UP', standard_up_id))
     elif dbname == 'HGNC':
         standard_up_id = hgnc_client.get_uniprot_id(dbid)
         # standard_up_id will be None if the gene doesn't have a corresponding

--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -1128,20 +1128,16 @@ class TripsProcessor(object):
         db_refs_dict = dict([d.split(':') for d in dbids])
         upid = db_refs_dict.get('UP')
         goid = db_refs_dict.get('GO')
+        if goid and not goid.startswith('GO:'):
+            goid = 'GO:%s' % goid
         if not goid and upid is not None and upid.startswith('SL'):
             goid = up_client.uniprot_subcell_loc.get(upid)
         if goid is not None:
             try:
-                loc_name = get_valid_location('GO:' + goid)
+                loc_name = get_valid_location(goid)
                 return loc_name
             except InvalidLocationError:
                 pass
-            if loc_name is not None:
-                try:
-                    loc_name = get_valid_location(loc_name.lower())
-                    return loc_name
-                except InvalidLocationError:
-                    pass
         # Check if the raw name is a valid cellular component
         if name is not None:
             try:

--- a/indra/tests/test_trips_ekbs.py
+++ b/indra/tests/test_trips_ekbs.py
@@ -872,3 +872,22 @@ def test_gene_assoc_with_gene():
     assert len(agents) == 1, agents
     agent = agents[0]
     assert agent.name == 'EGFR', agent.name
+
+
+def test_up_go_location():
+    fname = os.path.join(path_this, 'trips_ekbs', 'endoplasmic_reticulum.ekb')
+    tp = trips.process_xml(open(fname, 'r').read())
+    agents = tp.get_agents()
+    assert len(agents) == 1, agents
+    agent = agents[0]
+    assert 'GO' in agent.db_refs, agent.db_refs
+
+
+def test_ncit_up_hgnc_mapping():
+    fname = os.path.join(path_this, 'trips_ekbs',
+                         'estrogen_receptor_alpha.ekb')
+    tp = trips.process_xml(open(fname, 'r').read())
+    agents = tp.get_agents()
+    assert len(agents) == 1, agents
+    agent = agents[0]
+    assert 'HGNC' in agent.db_refs, agent.db_refs

--- a/indra/tests/trips_ekbs/endoplasmic_reticulum.ekb
+++ b/indra/tests/trips_ekbs/endoplasmic_reticulum.ekb
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<ekb>
+	<input type="">
+		<paragraphs>
+			<paragraph file="/Users/wbeaumont/drum-dev/etc/Data/WP/TEXT00018_IO-37204" id="paragraph17">endoplasmic reticulum</paragraph>
+		</paragraphs>
+		<sentences>
+			<sentence id="18" pid="paragraph17">endoplasmic reticulum</sentence>
+		</sentences>
+	</input>
+	<TERM dbid="GO:0005783|UP:SL-0095" end="21" id="V37220" lisp="(ONT::TERM ONT::V37220 ONT::CELL-PART :NAME W::ENDOPLASMIC-RETICULUM :DRUM ((:DRUM (TERM :ID UP::SL-0095 :NAME &quot;Endoplasmic reticulum&quot; :SCORE 0.85542 :MATCHES ((MATCH :SCORE 0.85542 :MATCHED &quot;endoplasmic reticulum&quot; :STATUS &quot;I*&quot; :EXACT 2) (MATCH :SCORE 0.85267 :MATCHED &quot;endoplasmic reticulum&quot; :STATUS &quot;I*&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.35435992 :EXACT 1 :MIXED-CAPS-NO-CAPS 1)) :ONT-TYPES (ONT::CELL-PART)) (TERM :ID GO::|0005783| :NAME &quot;endoplasmic reticulum&quot; :SCORE 0.85542 :MATCHES ((MATCH :SCORE 0.85542 :MATCHED &quot;endoplasmic reticulum&quot; :STATUS &quot;name&quot; :EXACT 2) (MATCH :SCORE 0.85267 :MATCHED &quot;endoplasmic reticulum&quot; :STATUS &quot;name&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.35435992 :EXACT 1 :MIXED-CAPS-NO-CAPS 1)) :ONT-TYPES (ONT::CELL-PART)))))" paragraph="paragraph17" rule="-SIMPLE-REF,-ADD-SPEC" start="0" uttnum="18">
+		<type>ONT::CELL-PART</type>
+		<text normalization="">endoplasmic reticulum</text>
+		<name>ENDOPLASMIC-RETICULUM</name>
+		<drum-terms>
+			<drum-term dbid="UP:SL-0095" match-score="0.85542" matched-name="endoplasmic reticulum" name="Endoplasmic reticulum">
+				<types>
+					<type>ONT::CELL-PART</type>
+				</types>
+			</drum-term>
+			<drum-term dbid="GO:0005783" match-score="0.85542" matched-name="endoplasmic reticulum" name="endoplasmic reticulum">
+				<types>
+					<type>ONT::CELL-PART</type>
+				</types>
+			</drum-term>
+		</drum-terms>
+	</TERM>
+</ekb>

--- a/indra/tests/trips_ekbs/estrogen_receptor_alpha.ekb
+++ b/indra/tests/trips_ekbs/estrogen_receptor_alpha.ekb
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<ekb>
+	<input type="">
+		<paragraphs>
+			<paragraph file="/Users/wbeaumont/drum-dev/etc/Data/WP/TEXT00019_IO-37270" id="paragraph18">estrogen-receptor alpha</paragraph>
+		</paragraphs>
+		<sentences>
+			<sentence id="19" pid="paragraph18">estrogen-receptor alpha</sentence>
+		</sentences>
+	</input>
+	<TERM dbid="NCIT:C38361" end="23" id="V37353" lisp="(ONT::TERM ONT::V37353 ONT::PROTEIN :NAME W::ESTROGEN-PUNC-MINUS-RECEPTOR-ALPHA :DRUM ((:DRUM (TERM :ID NCIT::C38361 :NAME &quot;estrogen receptor&quot; :SCORE 0.71084 :MATCHES ((MATCH :SCORE 0.71084 :MATCHED &quot;estrogen receptor alpha&quot; :STATUS &quot;synonym&quot; :EXACT 3)) :ONT-TYPES (ONT::PROTEIN)))))" paragraph="paragraph18" rule="-SIMPLE-REF,-ADD-SPEC" start="0" uttnum="19">
+		<type>ONT::PROTEIN</type>
+		<text normalization="">estrogen-receptor alpha</text>
+		<name>ESTROGEN-RECEPTOR-ALPHA</name>
+		<drum-terms>
+			<drum-term dbid="NCIT:C38361" match-score="0.71084" matched-name="estrogen receptor alpha" name="estrogen receptor">
+				<types>
+					<type>ONT::PROTEIN</type>
+				</types>
+			</drum-term>
+		</drum-terms>
+	</TERM>
+</ekb>


### PR DESCRIPTION
This PR improves some ID mappings in the TRIPS processor, including when mapping to UP/HGNC from NCIT and when mapping UP subcellular locations to GO.