### PR TITLE
Trips db mappings fix

### DIFF
--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -2040,7 +2040,8 @@ def _get_grounding_terms(term):
                         'FPLX' in t['refs']:
                         it['comment'] = None
                     for k, v in t['refs'].items():
-                        it['refs'][k] = v
+                        if k not in it['refs'].keys():
+                            it['refs'][k] = v
             if not any_match:
                 independent_terms.append(t)
         terms = independent_terms


### PR DESCRIPTION
This PR makes a change to the way grounding terms are selected from EKB in TRIPS. If there's a match in some of groundings between different terms, we only want to add missing groundings to the independent term rather than replace all groundings. This fixes the failing test in `bio agents/tests/mra_test/TestBuildModelAmbiguity`. 