### PR TITLE
Mini PR: Handle case where returned value is not bytes.

### DIFF
--- a/indra/util/get_version.py
+++ b/indra/util/get_version.py
@@ -48,8 +48,10 @@ def get_version(with_git_hash=True, refresh_hash=False):
                     ret = check_output(['git', 'rev-parse', 'HEAD'],
                                        cwd=dirname(__file__), stderr=nul)
                 except CalledProcessError:
-                    ret = 'UNHASHED'
-            INDRA_GITHASH = ret.strip().decode('utf-8')
+                    ret = b'UNHASHED'
+            INDRA_GITHASH = ret.strip()
+            if isinstance(INDRA_GITHASH, bytes):
+                INDRA_GITHASH = INDRA_GITHASH.decode('utf-8')
         version = '%s-%s' % (version, INDRA_GITHASH)
     return version
 


### PR DESCRIPTION
This code was failing on travis (db tests) because of attempting to use `decode` on a string. Either the return was for some reason not bytes on the travis build (not impossible) or else the issue was that the failure-mode ret of 'UNHASHED' was not bytes. I decided to remedy both potential issues. This function should be essentially failure-proof.