### PR TITLE
Deft mapping fix

### DIFF
--- a/indra/preassembler/grounding_mapper.py
+++ b/indra/preassembler/grounding_mapper.py
@@ -727,7 +727,7 @@ def run_deft_disambiguation(stmt, agent_list, idx, new_agent, agent_txt):
         # doesn't match any of the choices?
         if ns_and_id == 'ungrounded':
             return
-        db_ns, db_id = ns_and_id.split(':')
+        db_ns, db_id = ns_and_id.split(':', maxsplit=1)
         new_agent.db_refs = {'TEXT': agent_txt, db_ns: db_id}
         new_agent.name = standard_name
         logger.info('Disambiguated %s to: %s, %s:%s' %

--- a/indra/tests/test_groundingmapper.py
+++ b/indra/tests/test_groundingmapper.py
@@ -313,7 +313,7 @@ def test_deft_mapping():
 
     mapped_stmts2 = gm.map_agents([stmt2])
     assert mapped_stmts2[0].obj.name == 'Endoplasmic Reticulum'
-    assert mapped_stmts2[0].obj.db_refs['GO'] == '0005783'
+    assert mapped_stmts2[0].obj.db_refs['GO'] == 'GO:0005783'
 
     annotations = mapped_stmts2[0].evidence[0].annotations
-    assert 'GO:0005783' in annotations['agents']['deft'][1]
+    assert 'GO:GO:0005783' in annotations['agents']['deft'][1]


### PR DESCRIPTION
This PR updates deft mapping to account for namespace ids that contain a semicolon: The labels in deft's classifiers consist of namespace and id joined by a semicolon, (i.e. HGNC:24934, GO:GO:0090734). When updating db_refs in indra agents after deft mapping, previously these labels were split by semicolon and the first entry of the resulting list was taken as the namespace and the second entry taken as the id. This does not work when the id itself contains a semicolon, as happens in GO and CHEBI ids for instance. The splitting has been updated to use maxsplit=1 so that the split only occurs on the first semicolon.