### PR TITLE
Elsevier problems2

### DIFF
--- a/indra/tests/test_adeft_tools.py
+++ b/indra/tests/test_adeft_tools.py
@@ -1,9 +1,12 @@
 import re
+import logging
 from nose.plugins.attrib import attr
 
 from indra.literature.adeft_tools import universal_extract_paragraphs, \
     filter_paragraphs
 from indra.literature import pmc_client, elsevier_client, pubmed_client
+
+logger = logging.getLogger(__name__)
 
 
 @attr('nonpublic', 'webservice')
@@ -11,6 +14,9 @@ def test_universal_extract_paragraphs_elsevier():
     doi = '10.1016/B978-0-12-416673-8.00004-6'
     xml_str = elsevier_client.download_article(doi)
     paragraphs = universal_extract_paragraphs(xml_str)
+    if len(paragraphs) <= 1:
+        logger.warning('Unable to extract paragraphs from XML string:\n'
+                       '%s...' % xml_str[:2000])
     assert len(paragraphs) > 1
 
 

--- a/indra/tests/test_elsevier_client.py
+++ b/indra/tests/test_elsevier_client.py
@@ -38,7 +38,7 @@ def test_get_converted_article_body():
     body = ec.extract_text(xml_str)
     if not body:
         logger.warning('Unable to extract text from XML string:\n'
-                       '%s' % xml_str[:2000])
+                       '%s...' % xml_str[:2000])
     assert body
 
 
@@ -52,7 +52,7 @@ def test_get_rawtext():
     body = ec.extract_text(xml_str)
     if not body:
         logger.warning('Unable to extract text from XML string:\n'
-                       '%s' % xml_str[:2000])
+                       '%s...' % xml_str[:2000])
     assert body
 
 


### PR DESCRIPTION
This PR adds logging to a test using the elsevier client that was missed in #889

Ellipses have also been added after the truncated xml strings in warning messages to better show they're truncated.