### PR TITLE
Custom matches/refinement function in preassembly

### DIFF
--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -423,7 +423,7 @@ def _get_belief_package(stmt, matches_fun):
     # Iterate over all the support parents
     for st in stmt.supports:
         # Recursively get all the belief packages of the parent
-        parent_packages = _get_belief_package(st)
+        parent_packages = _get_belief_package(st, matches_fun)
         package_stmt_keys = [pkg.statement_key for pkg in belief_packages]
         for package in parent_packages:
             # Only add this belief package if it hasn't already been added

--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -302,11 +302,14 @@ class BeliefEngine(object):
         verifies that the scorer has all the information it needs to score
         every statement in the list, and raises an exception if not.
     """
-    def __init__(self, scorer=None):
+    def __init__(self, scorer=None, matches_fun=None):
         if scorer is None:
             scorer = default_scorer
         assert(isinstance(scorer, BeliefScorer))
         self.scorer = scorer
+
+        self.matches_fun = matches_fun if matches_fun else \
+            lambda stmt: stmt.matches_key()
 
     def set_prior_probs(self, statements):
         """Sets the prior belief probabilities for a list of INDRA Statements.
@@ -349,10 +352,11 @@ class BeliefEngine(object):
             """Return a DiGraph based on matches keys and Statement supports"""
             g = networkx.DiGraph()
             for st1 in stmts:
-                g.add_node(st1.matches_key(), stmt=st1)
+                g.add_node(self.matches_fun(st1), stmt=st1)
                 for st2 in st1.supported_by:
-                    g.add_node(st2.matches_key(), stmt=st2)
-                    g.add_edge(st2.matches_key(), st1.matches_key())
+                    g.add_node(self.matches_fun(st2), stmt=st2)
+                    g.add_edge(self.matches_fun(st2),
+                               self.matches_fun(st1))
             return g
 
         def get_ranked_stmts(g):
@@ -376,7 +380,7 @@ class BeliefEngine(object):
         assert_no_cycle(g)
         ranked_stmts = get_ranked_stmts(g)
         for st in ranked_stmts:
-            bps = _get_belief_package(st)
+            bps = _get_belief_package(st, self.matches_fun)
             supporting_evidences = []
             # NOTE: the last belief package in the list is this statement's own
             for bp in bps[:-1]:
@@ -412,7 +416,7 @@ class BeliefEngine(object):
 BeliefPackage = namedtuple('BeliefPackage', 'statement_key evidences')
 
 
-def _get_belief_package(stmt):
+def _get_belief_package(stmt, matches_fun):
     """Return the belief packages of a given statement recursively."""
     # This list will contain the belief packages for the given statement
     belief_packages = []
@@ -426,7 +430,7 @@ def _get_belief_package(stmt):
             if package.statement_key not in package_stmt_keys:
                 belief_packages.append(package)
     # Now make the Statement's own belief package and append it to the list
-    belief_package = BeliefPackage(stmt.matches_key(), stmt.evidence)
+    belief_package = BeliefPackage(matches_fun(stmt), stmt.evidence)
     belief_packages.append(belief_package)
     return belief_packages
 

--- a/indra/preassembler/custom_preassembly.py
+++ b/indra/preassembler/custom_preassembly.py
@@ -1,0 +1,120 @@
+from indra.statements import *
+
+
+def has_location(stmt):
+    if not stmt.context or not stmt.context.geo_location or \
+            not stmt.context.geo_location.db_refs.get('GEOID'):
+        return False
+    return True
+
+def has_time(stmt):
+    if not stmt.context or not stmt.context.time:
+        return False
+    return True
+
+
+def get_location(stmt):
+    if not has_location(stmt):
+        loc = None
+    else:
+        loc = stmt.context.geo_location.db_refs['GEOID']
+    return loc
+
+
+def get_time(stmt):
+    if not has_time(stmt):
+        time = None
+    else:
+        time = stmt.context.time
+    return time
+
+
+def location_matches(stmt):
+    if isinstance(stmt, Event):
+        context_key = get_location(stmt)
+        matches_key = str((stmt.concept.matches_key(), context_key))
+    elif isinstance(stmt, Influence):
+        subj_context_key = get_location(stmt.subj)
+        obj_context_key = get_location(stmt.obj)
+        matches_key = str(stmt.matches_key(), subj_context_key,
+                          obj_context_key)
+    else:
+        matches_key = stmt.matches_key()
+    return matches_key
+
+
+def event_location_refinement(st1, st2, hierarchies):
+    ref = st1.refinement_of(st2, hierarchies)
+    if not ref:
+        return False
+    if not has_location(st2):
+        return True
+    elif not has_location(st1):
+        return False
+    else:
+        return st1.context.geo_location.db_refs['GEOID'] == \
+               st2.context.geo_location.db_refs['GEOID']
+
+
+def location_refinement(st1, st2, hierarchies):
+    if type(st1) != type(st2):
+        return False
+    if isinstance(st1, Event):
+        event_ref = event_location_refinement(st1, st2, hierarchies)
+        return event_ref
+    elif isinstance(st1, Influence):
+        subj_ref = event_location_refinement(st1.subj, st2.subj,
+                                             hierarchies)
+        obj_ref = event_location_refinement(st1.obj, st2.obj,
+                                            hierarchies)
+        return subj_ref and obj_ref
+    else:
+        return st1.refinement_of(st2, hierarchies)
+
+
+def event_location_time_matches(event):
+    mk = location_matches(event)
+    if not has_time(event):
+        return mk
+    time = get_time(stmt)
+    matches_key = str((mk, time.start, time.end, time.duration))
+    return matches_key
+
+
+def location_time_matches(stmt):
+    if isinstance(stmt, Event):
+        return event_location_time_matches(stmt)
+    elif isinstance(stmt, Influence):
+        subj_mk = event_location_time_matches(stmt.subj)
+        obj_mk = event_location_time_matches(stmt.obj)
+        return str((stmt.matches_key(), subj_mk, obj_mk))
+    else:
+        return stmt.matches_key()
+
+
+def event_location_time_refinement(st1, st2, hierarchies):
+    ref = location_refinement(st1, st2, hierarchies)
+    if not ref:
+        return False
+    if not has_time(st2):
+        return True
+    elif not has_time(st1) :
+        return False
+    else:
+        return st1.context.time.refinement_of(st2.context.time)
+
+
+def location_time_refinement(st1, st2, hierarchies):
+    if type(st1) != type(st2):
+        return False
+    if isinstance(st1, Event):
+        return event_location_time_refinement(st1, st2, hierarchies)
+    elif isinstance(st1, Influence):
+        ref = st1.refinement_of(st2, hierarchies)
+        if not ref:
+            return False
+        subj_ref = event_location_time_refinement(st1.subj, st2.subj,
+                                                  hierarchies)
+        obj_ref = event_location_time_refinement(st1.obj, st2.obj,
+                                                 hierarchies)
+        return subj_ref and obj_ref

--- a/indra/preassembler/custom_preassembly.py
+++ b/indra/preassembler/custom_preassembly.py
@@ -7,6 +7,7 @@ def has_location(stmt):
         return False
     return True
 
+
 def has_time(stmt):
     if not stmt.context or not stmt.context.time:
         return False
@@ -76,7 +77,7 @@ def event_location_time_matches(event):
     mk = location_matches(event)
     if not has_time(event):
         return mk
-    time = get_time(stmt)
+    time = get_time(event)
     matches_key = str((mk, time.start, time.end, time.duration))
     return matches_key
 
@@ -98,7 +99,7 @@ def event_location_time_refinement(st1, st2, hierarchies):
         return False
     if not has_time(st2):
         return True
-    elif not has_time(st1) :
+    elif not has_time(st1):
         return False
     else:
         return st1.context.time.refinement_of(st2.context.time)

--- a/indra/preassembler/custom_preassembly.py
+++ b/indra/preassembler/custom_preassembly.py
@@ -2,6 +2,7 @@ from indra.statements import *
 
 
 def has_location(stmt):
+    """Return True if a Statement has grounded geo-location context."""
     if not stmt.context or not stmt.context.geo_location or \
             not stmt.context.geo_location.db_refs.get('GEOID'):
         return False
@@ -9,12 +10,14 @@ def has_location(stmt):
 
 
 def has_time(stmt):
+    """Return True if a Statement has time context."""
     if not stmt.context or not stmt.context.time:
         return False
     return True
 
 
 def get_location(stmt):
+    """Return the grounded geo-location context associated with a Statement."""
     if not has_location(stmt):
         loc = None
     else:
@@ -23,6 +26,7 @@ def get_location(stmt):
 
 
 def get_time(stmt):
+    """Return the time context associated with a Statement."""
     if not has_time(stmt):
         time = None
     else:
@@ -31,6 +35,7 @@ def get_time(stmt):
 
 
 def location_matches(stmt):
+    """Return a matches_key which takes geo-location into account."""
     if isinstance(stmt, Event):
         context_key = get_location(stmt)
         matches_key = str((stmt.concept.matches_key(), context_key))
@@ -45,6 +50,7 @@ def location_matches(stmt):
 
 
 def event_location_refinement(st1, st2, hierarchies):
+    """Return True if there is a location-aware refinement between Events."""
     ref = st1.refinement_of(st2, hierarchies)
     if not ref:
         return False
@@ -58,6 +64,7 @@ def event_location_refinement(st1, st2, hierarchies):
 
 
 def location_refinement(st1, st2, hierarchies):
+    """Return True if there is a location-aware refinement between stmts."""
     if type(st1) != type(st2):
         return False
     if isinstance(st1, Event):
@@ -74,6 +81,7 @@ def location_refinement(st1, st2, hierarchies):
 
 
 def event_location_time_matches(event):
+    """Return Event matches key which takes location and time into account."""
     mk = location_matches(event)
     if not has_time(event):
         return mk
@@ -83,6 +91,7 @@ def event_location_time_matches(event):
 
 
 def location_time_matches(stmt):
+    """Return matches key which takes location and time into account."""
     if isinstance(stmt, Event):
         return event_location_time_matches(stmt)
     elif isinstance(stmt, Influence):
@@ -94,6 +103,7 @@ def location_time_matches(stmt):
 
 
 def event_location_time_refinement(st1, st2, hierarchies):
+    """Return True if there is a location/time refinement between Events."""
     ref = location_refinement(st1, st2, hierarchies)
     if not ref:
         return False
@@ -106,6 +116,7 @@ def event_location_time_refinement(st1, st2, hierarchies):
 
 
 def location_time_refinement(st1, st2, hierarchies):
+    """Return True if there is a location/time refinement between stmts."""
     if type(st1) != type(st2):
         return False
     if isinstance(st1, Event):

--- a/indra/statements/context.py
+++ b/indra/statements/context.py
@@ -211,6 +211,27 @@ class TimeContext(object):
         self.end = end
         self.duration = duration
 
+    def refinement_of(self, other):
+        # If both starts are given
+        if self.start and other.start:
+            # If this started earlier, it can't be a refinement
+            if self.start <= other.start:
+                return False
+            # If it ended later, it can't be a refinement
+            elif self.end and other.end:
+                if self.end >= other.end:
+                    return False
+            # If the other end is not given, it's a refinement
+            elif self.end and not other.end:
+                return True
+            # If neither end is given, it's also a refinement at this point
+            return True
+        # If we have a start time and other doesn't, it's a refinement
+        elif self.start and not other.start:
+            return True
+        # Otherwise it's not a refinement
+        return False
+
     def __eq__(self, other):
         return (self.text == other.text) and \
                (self.start == other.start) and \

--- a/indra/tests/test_belief_engine.py
+++ b/indra/tests/test_belief_engine.py
@@ -127,8 +127,9 @@ def test_hierarchy_probs4():
 
 
 def test_get_belief_package1():
+    matches_fun = lambda st: st.matches_key()
     st1 = Phosphorylation(None, Agent('a'), evidence=[ev1])
-    package = _get_belief_package(st1)
+    package = _get_belief_package(st1, matches_fun)
     assert len(package) == 1
     assert package[0][0] == st1.matches_key()
 
@@ -138,18 +139,20 @@ def test_get_belief_package2():
     st2 = Phosphorylation(None, Agent('A'), evidence=[ev2])
     st1.supported_by = [st2]
     st2.supports = [st1]
-    package = _get_belief_package(st1)
+    matches_fun = lambda st: st.matches_key()
+    package = _get_belief_package(st1, matches_fun)
     assert len(package) == 1
     assert package[0].statement_key == st1.matches_key()
     assert len(package[0].evidences) == 1, package[0][1]
     assert package[0].evidences[0].source_api == 'reach'
-    package = _get_belief_package(st2)
+    package = _get_belief_package(st2, matches_fun)
     assert len(package) == 2, package
     assert package[0].statement_key == st1.matches_key()
     assert package[1].statement_key == st2.matches_key()
 
 
 def test_get_belief_package3():
+    matches_fun = lambda st: st.matches_key()
     st1 = Phosphorylation(Agent('B'), Agent('A1'), evidence=[ev1])
     st2 = Phosphorylation(None, Agent('A1'), evidence=[ev2])
     st3 = Phosphorylation(None, Agent('A'), evidence=[ev4])
@@ -157,11 +160,11 @@ def test_get_belief_package3():
     st2.supported_by = [st3]
     st2.supports = [st1]
     st3.supports = [st1, st2]
-    package = _get_belief_package(st1)
+    package = _get_belief_package(st1, matches_fun)
     assert len(package) == 1
-    package = _get_belief_package(st2)
+    package = _get_belief_package(st2, matches_fun)
     assert len(package) == 2
-    package = _get_belief_package(st3)
+    package = _get_belief_package(st3, matches_fun)
     assert len(package) == 3
     sources = [pkg.evidences[0].source_api for pkg in package]
     assert sources == ['reach', 'trips', 'biopax']

--- a/indra/tests/test_custom_preassembly.py
+++ b/indra/tests/test_custom_preassembly.py
@@ -1,0 +1,22 @@
+from indra.statements import *
+from indra.preassembler import Preassembler
+from indra.preassembler.hierarchy_manager import hierarchies
+from indra.preassembler.custom_preassembly import *
+
+
+def test_event_assemble_location():
+    rainfall = Concept('rainfall')
+    loc1 = RefContext(name='x', db_refs={'GEOID': '1'})
+    loc2 = RefContext(name='x', db_refs={'GEOID': '2'})
+    ev1 = Event(rainfall, context=WorldContext(geo_location=loc1))
+    ev2 = Event(rainfall, context=WorldContext(geo_location=loc2))
+
+    pa = Preassembler(hierarchies=hierarchies, stmts=[ev1, ev2],
+                      matches_fun=None)
+    unique_stmts = pa.combine_duplicates()
+
+    assert len(unique_stmts) == 1
+    pa = Preassembler(hierarchies=hierarchies, stmts=[ev1, ev2],
+                      matches_fun=location_matches)
+    unique_stmts = pa.combine_duplicates()
+    assert len(unique_stmts) == 2

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -360,6 +360,9 @@ def run_preassembly(stmts_in, **kwargs):
         Dict of hierarchy managers to use for preassembly
     matches_fun : function
         A function to override the built-in matches_key function of statements.
+    refinement_fun : function
+        A function to override the built-in refinement_of function of
+        statements.
     flatten_evidence : Optional[bool]
         If True, evidences are collected and flattened via supports/supported_by
         links. Default: False
@@ -381,12 +384,13 @@ def run_preassembly(stmts_in, **kwargs):
     dump_pkl_unique = kwargs.get('save_unique')
     belief_scorer = kwargs.get('belief_scorer')
     matches_fun = kwargs.get('matches_fun')
+    refinement_fun = kwargs.get('refinement_fun')
     use_hierarchies = kwargs['hierarchies'] if 'hierarchies' in kwargs else \
         hierarchies
     be = BeliefEngine(scorer=belief_scorer)
-    pa = Preassembler(hierarchies, stmts_in)
-    run_preassembly_duplicate(pa, be, save=dump_pkl_unique,
-                              matches_fun=matches_fun)
+    pa = Preassembler(hierarchies, stmts_in, matches_fun=matches_fun,
+                      refinement_fun=refinement_fun)
+    run_preassembly_duplicate(pa, be, save=dump_pkl_unique)
 
     dump_pkl = kwargs.get('save')
     return_toplevel = kwargs.get('return_toplevel', True)

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -358,6 +358,8 @@ def run_preassembly(stmts_in, **kwargs):
         scorer is used.
     hierarchies : Optional[dict]
         Dict of hierarchy managers to use for preassembly
+    matches_fun : function
+        A function to override the built-in matches_key function of statements.
     flatten_evidence : Optional[bool]
         If True, evidences are collected and flattened via supports/supported_by
         links. Default: False
@@ -378,11 +380,13 @@ def run_preassembly(stmts_in, **kwargs):
     """
     dump_pkl_unique = kwargs.get('save_unique')
     belief_scorer = kwargs.get('belief_scorer')
+    matches_fun = kwargs.get('matches_fun')
     use_hierarchies = kwargs['hierarchies'] if 'hierarchies' in kwargs else \
         hierarchies
     be = BeliefEngine(scorer=belief_scorer)
     pa = Preassembler(hierarchies, stmts_in)
-    run_preassembly_duplicate(pa, be, save=dump_pkl_unique)
+    run_preassembly_duplicate(pa, be, save=dump_pkl_unique,
+                              matches_fun=matches_fun)
 
     dump_pkl = kwargs.get('save')
     return_toplevel = kwargs.get('return_toplevel', True)

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -387,7 +387,7 @@ def run_preassembly(stmts_in, **kwargs):
     refinement_fun = kwargs.get('refinement_fun')
     use_hierarchies = kwargs['hierarchies'] if 'hierarchies' in kwargs else \
         hierarchies
-    be = BeliefEngine(scorer=belief_scorer)
+    be = BeliefEngine(scorer=belief_scorer, matches_fun=matches_fun)
     pa = Preassembler(hierarchies, stmts_in, matches_fun=matches_fun,
                       refinement_fun=refinement_fun)
     run_preassembly_duplicate(pa, be, save=dump_pkl_unique)


### PR DESCRIPTION
This PR looks like a small change but it has important implications - it adds two optional arguments to the Preassembler which allow supplying a custom function to generate matches keys for Statements, and a custom function to determine refinements between two statements. This allows running duplicate recognition with custom rules for matching, and hierarchical refinement with custom rules for establishing a refinement.

The PR also adds an initial library of reusable custom matches/refinement functions geared towards Events and Influences, and their context-aware assembly.