### PR TITLE
Distinguish Autophosphorylation in RLIMS-P processor

### DIFF
--- a/indra/tests/test_rlimsp.py
+++ b/indra/tests/test_rlimsp.py
@@ -54,6 +54,7 @@ def test_grounded_endpoint_with_pmids_on_medline():
                                             source='medline',
                                             with_grounding=False)
 
+
 def test_tyrosine_grounding():
     here = os.path.dirname(os.path.abspath(__file__))
     fname = os.path.join(here, 'rlimsp_site.json')


### PR DESCRIPTION
This PR detects autophosphorylations extracted by RLIMS-P, and extracts them as Autophosphorylation(X) Statements instead of Phosphorylation(X, X). Note that only cases where "auto" phosphorylation is explicit are considered, not ones where X is reported to phosphorylate X in general.