### PR TITLE
Fix typo in BioContext.__eq__()

### DIFF
--- a/indra/statements/context.py
+++ b/indra/statements/context.py
@@ -51,7 +51,7 @@ class BioContext(Context):
              'species']
 
     def __eq__(self, other):
-        return all([getattr(self, attr, None) == getattr(self, attr, None)
+        return all([getattr(self, attr, None) == getattr(other, attr, None)
                     for attr in self.attrs])
 
     def __ne__(self, other):

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -1998,12 +1998,18 @@ def test_agent_list_with_bound_condition_agents():
     assert agents[2].name == 'EGF'
 
 
-def test_context_bool():
+def test_context_bool_equal():
     assert not BioContext()
     assert BioContext(cell_type=RefContext(name='x'))
     assert not WorldContext()
     assert WorldContext(time=TimeContext())
     assert WorldContext(geo_location=RefContext(name='x'))
+    c1 = BioContext(cell_type=RefContext(name='x'))
+    c2 = BioContext(cell_type=RefContext(name='y'))
+    assert c1 != c2
+    assert not c1 == c2
+    assert c1 == c1
+    assert not c1 != c1
 
 
 def test_deprecated_cellular_location():


### PR DESCRIPTION
It looks like it was always comparing its own attrs to its own attrs, so this function would always return true when comparing any BioContext to any object at all.