### PR TITLE
Add hypothesis and context.species information in index_cards

### DIFF
--- a/indra/assemblers/index_card/assembler.py
+++ b/indra/assemblers/index_card/assembler.py
@@ -430,7 +430,9 @@ def get_evidence_info(stmt):
                 obj['name'] = species.name
                 obj['taxonomy'] = species.db_refs.get('TAXONOMY') \
                     if species.db_refs is not None else None
-                contexts.append(obj)
+            else:
+                obj = None
+            contexts.append(obj)
 
             hypothesis = ev.epistemics.get('hypothesis')
             hypotheses.append(hypothesis)

--- a/indra/assemblers/index_card/assembler.py
+++ b/indra/assemblers/index_card/assembler.py
@@ -48,12 +48,13 @@ class IndexCardAssembler(object):
     def make_model(self):
         """Assemble statements into index cards."""
         for stmt in self.statements:
-            card = self.assemble_one_card(stmt)
+            card = self.assemble_one_card(stmt, self.pmc_override)
             if card is not None:
                 self.cards.append(card)
         return self.cards
 
-    def assemble_one_card(self, stmt):
+    @staticmethod
+    def assemble_one_card(stmt, pmc_override):
         if isinstance(stmt, Modification):
             card = assemble_modification(stmt)
         elif isinstance(stmt, SelfModification):
@@ -76,8 +77,8 @@ class IndexCardAssembler(object):
             card.card['interaction']['context'] = ev_info['context']
             card.card['evidence'] = ev_info['text']
             card.card['submitter'] = global_submitter
-            if self.pmc_override is not None:
-                card.card['pmc_id'] = self.pmc_override
+            if pmc_override is not None:
+                card.card['pmc_id'] = pmc_override
             else:
                 card.card['pmc_id'] = get_pmc_id(stmt)
         return card

--- a/indra/assemblers/index_card/assembler.py
+++ b/indra/assemblers/index_card/assembler.py
@@ -134,7 +134,6 @@ class IndexCard(object):
 def assemble_complex(stmt):
     card = IndexCard()
     card.card['submitter'] = global_submitter
-    card.card['evidence'] = get_evidence_text(stmt)
     card.card['interaction']['interaction_type'] = 'complexes_with'
     card.card['interaction'].pop('participant_b', None)
     # NOTE: fill out entity_text
@@ -152,7 +151,6 @@ def assemble_regulate_activity(stmt):
     # Top level card
     card = IndexCard()
     card.card['submitter'] = global_submitter
-    card.card['evidence'] = get_evidence_text(stmt)
     int_type = ('increases' if stmt.is_activation else 'decreases')
     card.card['interaction']['interaction_type'] = int_type
     card.card['interaction']['participant_a'] = get_participant(stmt.subj)
@@ -181,7 +179,6 @@ def assemble_regulate_amount(stmt):
     # Top level card
     card = IndexCard()
     card.card['submitter'] = global_submitter
-    card.card['evidence'] = get_evidence_text(stmt)
     if isinstance(stmt, IncreaseAmount):
         int_type = 'increases'
     else:
@@ -195,7 +192,6 @@ def assemble_regulate_amount(stmt):
 def assemble_modification(stmt):
     card = IndexCard()
     card.card['submitter'] = global_submitter
-    card.card['evidence'] = get_evidence_text(stmt)
 
     mod_type = modclass_to_modtype[stmt.__class__]
     interaction = {}
@@ -237,7 +233,6 @@ def assemble_modification(stmt):
 def assemble_selfmodification(stmt):
     card = IndexCard()
     card.card['submitter'] = global_submitter
-    card.card['evidence'] = get_evidence_text(stmt)
 
     mod_type = stmt.__class__.__name__.lower()
     if mod_type.endswith('phosphorylation'):
@@ -274,7 +269,6 @@ def assemble_translocation(stmt):
         return None
     card = IndexCard()
     card.card['submitter'] = global_submitter
-    card.card['evidence'] = get_evidence_text(stmt)
     interaction = {}
     interaction['negative_information'] = False
     interaction['interaction_type'] = 'translocates'
@@ -411,60 +405,6 @@ def get_pmc_id(stmt):
         else:
             pmc_id = ''
     return str(pmc_id)
-
-
-def _get_hypothesis_information(stmt):
-    """Returns hypothesis information of the evidences in the same order as in
-    the evidence field."""
-
-    ev_txts = get_evidence_text(stmt)
-    if len(ev_txts) == 0:
-        return None
-
-    hypothesis_array = []
-    for ev_txt in ev_txts:
-        if ev_txt.startswith('PARTIAL: '):
-            evidence = next((ev for ev in stmt.partial_evidence
-                             if ev.text == ev_txt), None)
-        else:
-            evidence = next((ev for ev in stmt.evidence if ev.text == ev_txt),
-                            None)
-        hypothesis = evidence.epistemics.get('hypothesis')
-
-        hypothesis_array.append(hypothesis)
-
-    return hypothesis_array
-
-
-def _get_context_information(stmt):
-    """Returns context information of the evidences in same order as in
-    evidence field."""
-
-    ev_txts = get_evidence_text(stmt)
-    if len(ev_txts) == 0:
-        return None
-
-    context_array = []
-    for ev_txt in ev_txts:
-        if(ev_txt.startswith('PARTIAL: ')):
-            evidence = next((ev for ev in stmt.partial_evidence
-                             if ev.text == ev_txt), None)
-        else:
-            evidence = next((ev for ev in stmt.evidence if ev.text == ev_txt),
-                            None)
-
-        if evidence.context and evidence.context.species:
-            species = evidence.context.species
-            obj = {}
-            obj['name'] = species.name
-            obj['taxonomy'] = species.db_refs.get('TAXONOMY') \
-                if species.db_refs is not None else None
-        else:
-            obj = None
-
-        context_array.append(obj)
-
-    return context_array
 
 
 def get_evidence_info(stmt):

--- a/indra/assemblers/index_card/assembler.py
+++ b/indra/assemblers/index_card/assembler.py
@@ -29,7 +29,7 @@ class IndexCardAssembler(object):
 
     def __init__(self, statements=None, pmc_override=None):
         if statements is None:
-            self.statements =  []
+            self.statements = []
         else:
             self.statements = statements
         self.cards = []
@@ -64,8 +64,10 @@ class IndexCardAssembler(object):
                 continue
             if card is not None:
                 card.card['meta'] = {'id': stmt.uuid, 'belief': stmt.belief}
-                card.card['interaction']['hypothesis_information'] = _get_hypothesis_information(stmt)
-                card.card['interaction']['context'] = _get_context_information(stmt)
+                card.card['interaction']['hypothesis_information'] = \
+                    _get_hypothesis_information(stmt)
+                card.card['interaction']['context'] = \
+                    _get_context_information(stmt)
                 if self.pmc_override is not None:
                     card.card['pmc_id'] = self.pmc_override
                 else:
@@ -100,6 +102,7 @@ class IndexCardAssembler(object):
         with open(file_name, 'wt') as fh:
             fh.write(self.print_model())
 
+
 class IndexCard(object):
     def __init__(self):
         self.card  = {
@@ -124,6 +127,7 @@ class IndexCard(object):
 
     def get_string(self):
         return json.dumps(self.card)
+
 
 def assemble_complex(stmt):
     card = IndexCard()
@@ -169,6 +173,7 @@ def assemble_regulate_activity(stmt):
     else:
         return None
     return card
+
 
 def assemble_regulate_amount(stmt):
     # Top level card
@@ -226,6 +231,7 @@ def assemble_modification(stmt):
 
     return card
 
+
 def assemble_selfmodification(stmt):
     card = IndexCard()
     card.card['submitter'] = global_submitter
@@ -259,6 +265,7 @@ def assemble_selfmodification(stmt):
 
     return card
 
+
 def assemble_translocation(stmt):
     # Index cards don't allow missing to_location
     if stmt.to_location is None:
@@ -281,6 +288,7 @@ def assemble_translocation(stmt):
     card.card['interaction'] = interaction
     return card
 
+
 def get_generic(entity_type='protein'):
     participant = {
         'entity_text': [''],
@@ -288,6 +296,7 @@ def get_generic(entity_type='protein'):
         'identifier': 'GENERIC'
         }
     return participant
+
 
 def get_participant(agent):
     # Handle missing Agent as generic protein
@@ -389,6 +398,7 @@ def get_participant(agent):
         participant['not_features'] = not_features
     return participant
 
+
 def get_pmc_id(stmt):
     pmc_id = ''
     for ev in stmt.evidence:
@@ -400,8 +410,10 @@ def get_pmc_id(stmt):
             pmc_id = ''
     return str(pmc_id)
 
+
 def _get_hypothesis_information(stmt):
-    '''Returns hypothesis information of the evidences in same order as in evidence field'''
+    """Returns hypothesis information of the evidences in the same order as in
+    the evidence field."""
 
     ev_txts = get_evidence_text(stmt)
     if len(ev_txts) == 0:
@@ -409,22 +421,22 @@ def _get_hypothesis_information(stmt):
 
     hypothesis_array = []
     for ev_txt in ev_txts:
-        if(ev_txt.startswith('PARTIAL: ')):
-            evidence = next((ev for ev in stmt.partial_evidence if ev.text == ev_txt), None)
+        if ev_txt.startswith('PARTIAL: '):
+            evidence = next((ev for ev in stmt.partial_evidence
+                             if ev.text == ev_txt), None)
         else:
-            evidence = next((ev for ev in stmt.evidence if ev.text == ev_txt), None)
-
-        try:
-            hypothesis = evidence.epistemics.get('hypothesis')
-        except:
-            hypothesis = None
+            evidence = next((ev for ev in stmt.evidence if ev.text == ev_txt),
+                            None)
+        hypothesis = evidence.epistemics.get('hypothesis')
 
         hypothesis_array.append(hypothesis)
 
     return hypothesis_array
 
+
 def _get_context_information(stmt):
-    '''Returns context information of the evidences in same order as in evidence field'''
+    """Returns context information of the evidences in same order as in
+    evidence field."""
 
     ev_txts = get_evidence_text(stmt)
     if len(ev_txts) == 0:
@@ -433,21 +445,25 @@ def _get_context_information(stmt):
     context_array = []
     for ev_txt in ev_txts:
         if(ev_txt.startswith('PARTIAL: ')):
-            evidence = next((ev for ev in stmt.partial_evidence if ev.text == ev_txt), None)
+            evidence = next((ev for ev in stmt.partial_evidence
+                             if ev.text == ev_txt), None)
         else:
-            evidence = next((ev for ev in stmt.evidence if ev.text == ev_txt), None)
+            evidence = next((ev for ev in stmt.evidence if ev.text == ev_txt),
+                            None)
 
         if evidence.context and evidence.context.species:
             species = evidence.context.species
             obj = {}
             obj['name'] = species.name
-            obj['taxonomy']  = species.db_refs.get('TAXONOMY') if species.db_refs is not None else None
+            obj['taxonomy'] = species.db_refs.get('TAXONOMY') \
+                if species.db_refs is not None else None
         else:
             obj = None
 
         context_array.append(obj)
 
     return context_array
+
 
 def get_evidence_text(stmt):
     ev_txts = [ev.text for ev in stmt.evidence if ev.text]
@@ -467,12 +483,13 @@ def get_evidence_text(stmt):
                 ev_txts.append(txt)
     return ev_txts
 
+
 def _get_is_direct(stmt):
-    '''Returns true if there is evidence that the statement is a direct
+    """Returns true if there is evidence that the statement is a direct
     interaction. If any of the evidences associated with the statement
     indicates a direct interatcion then we assume the interaction
     is direct. If there is no evidence for the interaction being indirect
-    then we default to direct.'''
+    then we default to direct."""
     any_indirect = False
     for ev in stmt.evidence:
         if ev.epistemics.get('direct') is True:

--- a/indra/assemblers/index_card/assembler.py
+++ b/indra/assemblers/index_card/assembler.py
@@ -54,7 +54,7 @@ class IndexCardAssembler(object):
         return self.cards
 
     @staticmethod
-    def assemble_one_card(stmt, pmc_override):
+    def assemble_one_card(stmt, pmc_override=None):
         if isinstance(stmt, Modification):
             card = assemble_modification(stmt)
         elif isinstance(stmt, SelfModification):
@@ -412,14 +412,14 @@ def get_evidence_info(stmt):
     ev_txts = []
     contexts = []
     hypotheses = []
-    evs = (('', stmt.evidence), 'PARTIAL: ', ([] if not
-                                              hasattr(stmt, 'partial_evidence')
-                                              else stmt.partial_evidence))
+    evs = (('', stmt.evidence),
+           ('PARTIAL: ', ([] if not hasattr(stmt, 'partial_evidence')
+                          else stmt.partial_evidence)))
     for prefix, ev_list in evs:
         for ev in ev_list:
             if ev.text is None:
                 ev_txts.append(
-                    '%sEvidence text not available for %s entry: %s' % \
+                    '%sEvidence text not available for %s entry: %s' %
                     (prefix, ev.source_api, ev.source_id))
             else:
                 ev_txts.append('%s%s' % (prefix, ev.text))

--- a/indra/tests/test_index_card_assembler.py
+++ b/indra/tests/test_index_card_assembler.py
@@ -1,10 +1,6 @@
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str
-import json
 import jsonschema
-from indra.statements import *
-from indra.assemblers.index_card.assembler import *
 from os.path import dirname, abspath, join
+from indra.assemblers.index_card.assembler import *
 
 schema_path = join(dirname(abspath(__file__)),
                    '../resources/index_card_schema.json')
@@ -38,13 +34,13 @@ def test_get_pmc_id():
 
 
 def test_get_evidence_text():
-    ev_txt = get_evidence_text(stmt_phos)
-    assert len(ev_txt) == 1
-    assert ev_txt[0] == 'BRAF phosphorylates MAP2K1.'
+    ev_info = get_evidence_info(stmt_phos)
+    assert len(ev_info['text']) == 1
+    assert ev_info['text'][0] == 'BRAF phosphorylates MAP2K1.'
 
 
 def test_assemble_phosphorylation():
-    card = assemble_modification(stmt_phos)
+    card = IndexCardAssembler.assemble_one_card(stmt_phos)
     card.card['pmc_id'] = get_pmc_id(stmt_phos)
     print(card.get_string())
     print()
@@ -52,7 +48,7 @@ def test_assemble_phosphorylation():
 
 
 def test_assemble_phosphorylation2():
-    card = assemble_modification(stmt_phos2)
+    card = IndexCardAssembler.assemble_one_card(stmt_phos2)
     card.card['pmc_id'] = get_pmc_id(stmt_phos2)
     print(card.get_string())
     print()
@@ -60,7 +56,7 @@ def test_assemble_phosphorylation2():
 
 
 def test_assemble_phosphorylation_indirect():
-    card = assemble_modification(stmt_phos_indirect)
+    card = IndexCardAssembler.assemble_one_card(stmt_phos_indirect)
     card.card['pmc_id'] = get_pmc_id(stmt_phos_indirect)
     print(card.get_string())
     print()
@@ -68,7 +64,7 @@ def test_assemble_phosphorylation_indirect():
 
 
 def test_assemble_dephosphorylation():
-    card = assemble_modification(stmt_dephos)
+    card = IndexCardAssembler.assemble_one_card(stmt_dephos)
     card.card['pmc_id'] = get_pmc_id(stmt_dephos)
     print(card.get_string())
     print()
@@ -76,7 +72,7 @@ def test_assemble_dephosphorylation():
 
 
 def test_assemble_autophosphorylation():
-    card = assemble_selfmodification(stmt_autophos)
+    card = IndexCardAssembler.assemble_one_card(stmt_autophos)
     card.card['pmc_id'] = get_pmc_id(stmt_autophos)
     print(card.get_string())
     print()
@@ -85,7 +81,7 @@ def test_assemble_autophosphorylation():
 
 def test_assemble_complex():
     st_complex = Complex([braf, brafmut, map2k1], evidence=ev)
-    card = assemble_complex(st_complex)
+    card = IndexCardAssembler.assemble_one_card(st_complex)
     card.card['pmc_id'] = get_pmc_id(st_complex)
     print(card.get_string())
     print()
@@ -106,7 +102,7 @@ def test_get_participant():
 
 
 def test_chemical():
-    card = assemble_complex(stmt_complex)
+    card = IndexCardAssembler.assemble_one_card(stmt_complex)
     card.card['pmc_id'] = get_pmc_id(stmt_complex)
     print(card.get_string())
     print()
@@ -115,7 +111,7 @@ def test_chemical():
 
 def test_assemble_regulateactivity_kin():
     stmt = Activation(braf, map2k1, 'kinase', evidence=ev)
-    card = assemble_regulate_activity(stmt)
+    card = IndexCardAssembler.assemble_one_card(stmt)
     card.card['pmc_id'] = get_pmc_id(stmt)
     print(card.get_string())
     print()
@@ -124,7 +120,7 @@ def test_assemble_regulateactivity_kin():
 
 def test_assemble_regulateactivity_trans():
     stmt = Activation(braf, map2k1, 'transcription', evidence=ev)
-    card = assemble_regulate_activity(stmt)
+    card = IndexCardAssembler.assemble_one_card(stmt)
     card.card['pmc_id'] = get_pmc_id(stmt)
     print(card.get_string())
     print()
@@ -133,7 +129,7 @@ def test_assemble_regulateactivity_trans():
 
 def test_assemble_regulateamount():
     stmt = IncreaseAmount(braf, map2k1, evidence=ev)
-    card = assemble_regulate_amount(stmt)
+    card = IndexCardAssembler.assemble_one_card(stmt)
     card.card['pmc_id'] = get_pmc_id(stmt)
     print(card.get_string())
     print()

--- a/indra/tests/test_index_card_assembler.py
+++ b/indra/tests/test_index_card_assembler.py
@@ -31,14 +31,17 @@ ev2 = Evidence(source_api='reach', text='BRAF phosphorylates MAP2K1.',
 stmt_phos_indirect = Phosphorylation(brafmut, map2k1, evidence=ev2)
 stmt_autophos = Autophosphorylation(brafmut, 'S', '564', evidence=ev)
 
+
 def test_get_pmc_id():
     pmc_id = get_pmc_id(stmt_phos)
     assert pmc_id == 'PMC4849135'
+
 
 def test_get_evidence_text():
     ev_txt = get_evidence_text(stmt_phos)
     assert len(ev_txt) == 1
     assert ev_txt[0] == 'BRAF phosphorylates MAP2K1.'
+
 
 def test_assemble_phosphorylation():
     card = assemble_modification(stmt_phos)
@@ -47,12 +50,14 @@ def test_assemble_phosphorylation():
     print()
     jsonschema.validate(card.card, schema)
 
+
 def test_assemble_phosphorylation2():
     card = assemble_modification(stmt_phos2)
     card.card['pmc_id'] = get_pmc_id(stmt_phos2)
     print(card.get_string())
     print()
     jsonschema.validate(card.card, schema)
+
 
 def test_assemble_phosphorylation_indirect():
     card = assemble_modification(stmt_phos_indirect)
@@ -61,6 +66,7 @@ def test_assemble_phosphorylation_indirect():
     print()
     jsonschema.validate(card.card, schema)
 
+
 def test_assemble_dephosphorylation():
     card = assemble_modification(stmt_dephos)
     card.card['pmc_id'] = get_pmc_id(stmt_dephos)
@@ -68,12 +74,14 @@ def test_assemble_dephosphorylation():
     print()
     jsonschema.validate(card.card, schema)
 
+
 def test_assemble_autophosphorylation():
     card = assemble_selfmodification(stmt_autophos)
     card.card['pmc_id'] = get_pmc_id(stmt_autophos)
     print(card.get_string())
     print()
     jsonschema.validate(card.card, schema)
+
 
 def test_assemble_complex():
     st_complex = Complex([braf, brafmut, map2k1], evidence=ev)
@@ -83,6 +91,7 @@ def test_assemble_complex():
     print()
     jsonschema.validate(card.card, schema)
 
+
 def test_assemble_multiple():
     ia = IndexCardAssembler(pmc_override='PMC1234567')
     ia.add_statements([stmt_phos, stmt_dephos])
@@ -90,9 +99,11 @@ def test_assemble_multiple():
     ia.print_model()
     ia.save_model('/dev/null')
 
+
 def test_get_participant():
     participant = get_participant(brafmut)
     print(participant)
+
 
 def test_chemical():
     card = assemble_complex(stmt_complex)
@@ -100,6 +111,7 @@ def test_chemical():
     print(card.get_string())
     print()
     jsonschema.validate(card.card, schema)
+
 
 def test_assemble_regulateactivity_kin():
     stmt = Activation(braf, map2k1, 'kinase', evidence=ev)
@@ -109,6 +121,7 @@ def test_assemble_regulateactivity_kin():
     print()
     jsonschema.validate(card.card, schema)
 
+
 def test_assemble_regulateactivity_trans():
     stmt = Activation(braf, map2k1, 'transcription', evidence=ev)
     card = assemble_regulate_activity(stmt)
@@ -116,6 +129,7 @@ def test_assemble_regulateactivity_trans():
     print(card.get_string())
     print()
     jsonschema.validate(card.card, schema)
+
 
 def test_assemble_regulateamount():
     stmt = IncreaseAmount(braf, map2k1, evidence=ev)


### PR DESCRIPTION
@bgyori , @johnbachman  , I have added `hypothesis_information` and `context.species` following the email conversation.
As the `evidence` is of `list` type, hence to maintain the order in both lists ie `evidence` and `hypothesis_information` ( or `context` ) I have used the `get_evidence_text()` method.
Requesting feedback regarding the stability of my implementation.
Also, it would be helpful if you could add some tests for this.
Please note that `None` ( `null` in JSON ) is returned if any of these fields are absent.

Thanks