### PR TITLE
Eidos processor and corpus upload fixes

### DIFF
--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -1,4 +1,5 @@
 import re
+import copy
 import logging
 import datetime
 import objectpath
@@ -70,6 +71,9 @@ class EidosProcessor(object):
             event = self.get_event(event_entry)
             evidence = self.get_evidence(event_entry)
             event.evidence = [evidence]
+            if not event.context and evidence.context:
+                event.context = copy.deepcopy(evidence.context)
+                evidence.context = None
             self.statements.append(event)
 
     def get_event_by_id(self, event_id):
@@ -178,7 +182,7 @@ class EidosProcessor(object):
 
         # If that fails, we can still get the text of the relation
         if text is None:
-            text = _sanitize(event.get('text'))
+            text = _sanitize(relation.get('text'))
 
         ev = Evidence(source_api='eidos', text=text, annotations=annotations,
                       context=context, epistemics=epistemics)

--- a/indra/statements/context.py
+++ b/indra/statements/context.py
@@ -282,7 +282,7 @@ class TimeContext(object):
         if self.end:
             pieces.append('end=%s' % self.end)
         if self.duration:
-            pieces.append('end=%s' % self.duration)
+            pieces.append('duration=%s' % self.duration)
         args = ', '.join(pieces)
         return 'TimeContext(%s)' % args
 

--- a/indra/tools/live_curation.py
+++ b/indra/tools/live_curation.py
@@ -100,29 +100,29 @@ class Corpus(object):
         """
         key_base = key_base_name + '/' + name + '/'
         key_base = key_base.replace('//', '/')  # # replace double slashes
+        keys = tuple(key_base + s + '.json' for s in ['raw_statements',
+                                                      'statements',
+                                                      'curations'])
         try:
             s3 = self._get_s3_client()
             # Structure and upload raw statements
+            logger.info('Uploading %s to S3' % keys[0])
             s3.put_object(
                 Body=json.dumps(stmts_to_json(self.raw_statements)),
-                Bucket=bucket, Key=key_base+'raw_statements.json')
+                Bucket=bucket, Key=keys[0])
 
             # Structure and upload assembled statements
+            logger.info('Uploading %s to S3' % keys[1])
             s3.put_object(
                 Body=_stmts_dict_to_json_str(self.statements),
-                Bucket=bucket, Key=key_base + 'statements.json')
+                Bucket=bucket, Key=keys[1])
 
             # Structure and upload curations
+            logger.info('Uploading %s to S3' % keys[2])
             s3.put_object(
                 Body=json.dumps(self.curations),
-                Bucket=bucket, Key=key_base + 'curations.json')
-            keys = tuple(key_base + s + '.json' for s in ['raw_statements',
-                                                          'statements',
-                                                          'curations'])
-            logger.info('Corpus uploaded as %s, %s and %s at %s.' %
-                        (*keys, key_base))
+                Bucket=bucket, Key=keys[2])
             return keys
-
         except Exception as e:
             logger.exception('Failed to put on s3: %s' % e)
             return None


### PR DESCRIPTION
This PR changes the extraction of standalone Events from Eidos such that context is moved to the Event level even if it is reported at the evidence level by the reader. It also tweaks the logging of corpus uploads to S3.