### PR TITLE
Update Elsevier client

### DIFF
--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -3,11 +3,7 @@ For information on the Elsevier API, see:
   - API Specification: http://dev.elsevier.com/api_docs.html
   - Authentication: https://dev.elsevier.com/tecdoc_api_authentication.html
 """
-
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str
 import os
-import re
 import logging
 import textwrap
 import datetime
@@ -16,13 +12,7 @@ import requests
 from time import sleep
 from indra.util import flatten
 from indra import has_config, get_config
-# Python3
-try:
-    from functools import lru_cache, wraps
-# Python2
-except ImportError:
-    from functools32 import lru_cache, wraps
-from indra.util import read_unicode_csv
+from functools import lru_cache, wraps
 from indra.util import UnicodeXMLTreeBuilder as UTB
 
 logger = logging.getLogger(__name__)
@@ -164,9 +154,9 @@ def download_article_from_ids(**id_dict):
     Parameters
     ----------
     <id_type> : str
-        You can enter any combination of eid, doi, pmid, and/or pii. Ids will be
-        checked in that order, until either content has been found or all ids
-        have been checked.
+        You can enter any combination of eid, doi, pmid, and/or pii. Ids will
+        be checked in that order, until either content has been found or all
+        ids have been checked.
 
     Returns
     -------
@@ -268,15 +258,15 @@ def get_dois(query_str, year=None, loaded_after=None):
     ----------
     query_str : str
         The query string to search with.
-    date : Optional[str]
+    year : Optional[str]
         The year to constrain the search to.
     loaded_after : Optional[str]
         Date formatted as 'yyyy-MM-dd'T'HH:mm:ssX' to constrain the search
-        to articles loaded after this date.
+        to articles loaded after this date. Example: 2019-06-01T00:00:00Z
 
     Returns
     -------
-    DOIs : list[str]
+    dois : list[str]
         The list of DOIs identifying the papers returned by the search.
     """
     dois = search_science_direct(
@@ -316,11 +306,11 @@ def get_piis_for_date(query_str, year=None, loaded_after=None):
     ----------
     query_str : str
         The query string to search with.
-    date : Optional[str]
+    year : Optional[str]
         The year to constrain the search to.
     loaded_after : Optional[str]
         Date formatted as 'yyyy-MM-dd'T'HH:mm:ssX' to constrain the search
-        to articles loaded after this date.
+        to articles loaded after this date. Example: 2019-06-01T00:00:00Z
 
     Returns
     -------

--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -330,7 +330,8 @@ def get_piis_for_date(query_str, year=None, loaded_after=None):
     params = {'qs': query_str,
               'display': {
                   'offset': 0,
-                  'show': count},
+                  'show': count,
+                  'sortBy': 'date'},
               'field': 'pii'}
     if year:
         params['date'] = year

--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 # THE ELSEVIER API URL: ***MUST BE HTTPS FOR SECURITY***
 elsevier_api_url = 'https://api.elsevier.com/content' # <--- HTTPS
 elsevier_article_url_fmt = '%s/article/%%s' % elsevier_api_url
-elsevier_search_url = '%s/search/scidir' % elsevier_api_url
+elsevier_search_url = '%s/search/sciencedirect' % elsevier_api_url
 elsevier_entitlement_url = '%s/article/entitlement/doi' % elsevier_api_url
 
 # Namespaces for Elsevier XML elements

--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -262,6 +262,7 @@ def extract_paragraphs(xml_string):
 @lru_cache(maxsize=100)
 @_ensure_api_keys('perform search')
 def get_dois(query_str, count=100):
+    # TODO This code is deprecated, need to update this function
     """Search ScienceDirect through the API for articles.
 
     See http://api.elsevier.com/content/search/fields/scidir for constructing a

--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -347,7 +347,6 @@ def get_piis_for_date(query_str, year=None, loaded_after=None):
             break
         res_json = res.json()
         total_results = res_json['resultsFound']
-        logger.info(total_results)
         if total_results == 0:
             logger.info('Search result was empty')
             return []
@@ -358,9 +357,7 @@ def get_piis_for_date(query_str, year=None, loaded_after=None):
         cont = False
         # We can only set offset up to 6000
         if (params['display']['offset'] + count) <= min(total_results, 6000):
-            logger.info('Getting results from next batch.')
             params['display']['offset'] += count
-            logger.info(params)
             cont = True
             # There is a quota on number of requests, wait to continue
             sleep(1)


### PR DESCRIPTION
This PR updates Elsevier client `get_piis_for_date` according to new Elsevier ScienceDIrect search API format. P.S. This API is also used by `get_dois` function which also needs to be updated.