### PR TITLE
Handle multiword concept names in ModelChecking

### DIFF
--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -172,6 +172,7 @@ def grounded_monomer_patterns(model, agent, ignore_activities=False):
     # If it's not a molecular agent
     if not isinstance(agent, ist.Agent):
         monomer = model.monomers.get(agent.name)
+        # monomers have underscores between words
         if not monomer:
             monomer = model.monomers.get('_'.join(agent.name.split()))
         if not monomer:

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -173,6 +173,8 @@ def grounded_monomer_patterns(model, agent, ignore_activities=False):
     if not isinstance(agent, ist.Agent):
         monomer = model.monomers.get(agent.name)
         if not monomer:
+            monomer = model.monomers.get('_'.join(agent.name.split()))
+        if not monomer:
             return
         yield monomer()
     # Iterate over all model annotations to identify the monomer associated


### PR DESCRIPTION
This PR fixes an issue with multiword Concept names when subject monomers are not found because PySB Monomers have underscores between words and standardized Concept names don't.