### PR TITLE
Pubmed search by MeSH ID

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,3 +13,4 @@ jinja2
 protmapper
 pyyaml
 networkx>=2.1
+obonet

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -136,7 +136,7 @@ def get_ids_for_gene(hgnc_name, **kwargs):
 
     Parameters
     ----------
-    hgnc_name : string
+    hgnc_name : str
         The HGNC name of the gene. This is used to obtain the HGNC ID
         (using the hgnc_client module) and in turn used to obtain the Entrez
         ID associated with the gene. Entrez is then queried for that ID.
@@ -368,13 +368,13 @@ def get_metadata_from_xml_tree(tree, get_issns_from_nlm=False,
     ----------
     tree : xml.etree.ElementTree
         ElementTree containing one or more PubmedArticle elements.
-    get_issns_from_nlm : boolean
+    get_issns_from_nlm : bool
         Look up the full list of ISSN number for the journal associated with
         the article, which helps to match articles to CrossRef search results.
         Defaults to False, since it slows down performance.
-    get_abstracts : boolean
+    get_abstracts : bool
         Indicates whether to include the Pubmed abstract in the results.
-    prepend_title : boolean
+    prepend_title : bool
         If get_abstracts is True, specifies whether the article title should
         be prepended to the abstract text.
     mesh_annotations : bool
@@ -451,15 +451,15 @@ def get_metadata_for_ids(pmid_list, get_issns_from_nlm=False,
 
     Parameters
     ----------
-    pmid_list : list of PMIDs as strings
+    pmid_list : list of str
         Can contain 1-200 PMIDs.
-    get_issns_from_nlm : boolean
+    get_issns_from_nlm : bool
         Look up the full list of ISSN number for the journal associated with
         the article, which helps to match articles to CrossRef search results.
         Defaults to False, since it slows down performance.
-    get_abstracts : boolean
+    get_abstracts : bool
         Indicates whether to include the Pubmed abstract in the results.
-    prepend_title : boolean
+    prepend_title : bool
         If get_abstracts is True, specifies whether the article title should
         be prepended to the abstract text.
 

--- a/indra/tests/test_literature.py
+++ b/indra/tests/test_literature.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str
+import time
 from indra.literature import id_lookup, get_full_text
 from indra.util import unicode_strs
 from nose.plugins.attrib import attr
@@ -32,6 +31,7 @@ def test_get_full_text_pubmed_abstract():
 
 @attr('webservice')
 def test_id_lookup():
+    time.sleep(0.5)
     res = id_lookup('17513615', 'pmid')
     assert res['doi'] == '10.1158/1535-7163.MCT-06-0807'
 
@@ -39,6 +39,7 @@ def test_id_lookup():
 @attr('webservice')
 def test_id_lookup_no_pmid():
     """Look up a paper that has a PMCID and DOI but not PMID."""
+    time.sleep(0.5)
     res = id_lookup('10.1083/jcb.1974if', 'doi')
     assert res['pmcid'] == 'PMC3352949'
     res = id_lookup('PMC3352949', 'pmcid')

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -35,6 +35,15 @@ def test_get_id_count():
 
 
 @attr('webservice')
+def test_get_id_mesh():
+    time.sleep(0.5)
+    ids = pubmed_client.get_ids_for_mesh('D009101')
+    assert len(ids) > 35000
+    ids_maj = pubmed_client.get_ids_for_mesh('D009101', major_topic=True)
+    assert len(ids_maj) < len(ids)
+
+
+@attr('webservice')
 def test_get_pmc_ids():
     time.sleep(0.5)
     ids = pubmed_client.get_ids('braf', retmax=10, db='pmc')


### PR DESCRIPTION
This PR adds a search endpoint to the PubMed client by MeSH ID. ID to name conversion is done internally, and a list of PMIDs tagged with the given MeSH term are returned. An additional argument allows constraining to PMIDs for which the given MeSH term was set as a major topic.