### PR TITLE
Integrate source counts into INDRA DB REST

### DIFF
--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -209,7 +209,7 @@ class IndraDBRestProcessor(object):
         # Where there is overlap, there _should_ be agreement.
         self.__evidence_counts.update(ev_counts)
         # We turn source counts into a simple dict and update it that way
-        self.__source_counts.update({k: dict(v) for k,
+        self.__source_counts.update({int(k): v for k,
                                      v in source_counts.items()})
 
         for k, sj in stmt_json.items():

--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -4,6 +4,7 @@ from builtins import dict, str
 __all__ = ['IndraDBRestProcessor']
 
 import logging
+from copy import deepcopy
 from threading import Thread
 from datetime import datetime
 from collections import OrderedDict, defaultdict
@@ -94,6 +95,7 @@ class IndraDBRestProcessor(object):
         self.__statement_jsons = {}
         self.__done_dict = defaultdict(lambda: False)
         self.__evidence_counts = {}
+        self.__source_counts = {}
         self.__started = False
         self.__page_dict = defaultdict(lambda: 0)
         self.__th = None
@@ -124,17 +126,17 @@ class IndraDBRestProcessor(object):
 
         # Handle the content if we were limited.
         args = [agent_strs, stmt_types, params, persist]
-        logger.info("The remainder of the query will be performed in a "
-                    "thread...")
+        logger.debug("The remainder of the query will be performed in a "
+                     "thread...")
         self.__th = Thread(target=self._run_queries, args=args)
         self.__th.start()
 
         if timeout is None:
-            logger.info("Waiting for thread to complete...")
+            logger.debug("Waiting for thread to complete...")
             self.__th.join()
         elif timeout:  # is not 0
-            logger.info("Waiting at most %d seconds for thread to complete..."
-                        % timeout)
+            logger.debug("Waiting at most %d seconds for thread to complete..."
+                         % timeout)
             self.__th.join(timeout)
         return
 
@@ -151,6 +153,10 @@ class IndraDBRestProcessor(object):
     def get_ev_count_by_hash(self, stmt_hash):
         """Get the total evidence count for a statement hash."""
         return self.__evidence_counts.get(str(stmt_hash))
+
+    def get_source_counts(self):
+        """Get the total evidence count for a statement hash."""
+        return deepcopy(self.__source_counts)
 
     def get_ev_counts(self):
         """Get a dictionary of evidence counts."""
@@ -175,7 +181,8 @@ class IndraDBRestProcessor(object):
                 self.statements_sample.extend(other_processor.statements_sample)
 
         self._merge_json(other_processor.__statement_jsons,
-                         other_processor.__evidence_counts)
+                         other_processor.__evidence_counts,
+                         other_processor.__source_counts)
         return
 
     def wait_until_done(self, timeout=None):
@@ -192,15 +199,18 @@ class IndraDBRestProcessor(object):
                            "statement load to complete." % dt.total_seconds())
             ret = False
         else:
-            logger.info("Waited %0.3f seconds for statements to finish loading."
-                        % dt.total_seconds())
+            logger.info("Waited %0.3f seconds for statements to finish"
+                        "loading." % dt.total_seconds())
             ret = True
         return ret
 
-    def _merge_json(self, stmt_json, ev_counts):
+    def _merge_json(self, stmt_json, ev_counts, source_counts):
         """Merge these statement jsons with new jsons."""
         # Where there is overlap, there _should_ be agreement.
         self.__evidence_counts.update(ev_counts)
+        # We turn source counts into a simple dict and update it that way
+        self.__source_counts.update({k: dict(v) for k,
+                                     v in source_counts.items()})
 
         for k, sj in stmt_json.items():
             if k not in self.__statement_jsons:
@@ -236,11 +246,12 @@ class IndraDBRestProcessor(object):
         resp_dict = resp.json(object_pairs_hook=OrderedDict)
         stmts_json = resp_dict['statements']
         ev_totals = resp_dict['evidence_totals']
+        source_counts = resp_dict['source_counts']
         page_step = resp_dict['statement_limit']
         num_returned = len(stmts_json)
 
         # Update the result
-        self._merge_json(stmts_json, ev_totals)
+        self._merge_json(stmts_json, ev_totals, source_counts)
 
         # NOTE: this is technically not a direct conclusion, and could be
         # wrong, resulting in a single unnecessary extra query, but that

--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -208,7 +208,7 @@ class IndraDBRestProcessor(object):
         """Merge these statement jsons with new jsons."""
         # Where there is overlap, there _should_ be agreement.
         self.__evidence_counts.update(ev_counts)
-        # We turn source counts into a simple dict and update it that way
+        # We turn source counts into an int-keyed dict and update it that way
         self.__source_counts.update({int(k): v for k,
                                      v in source_counts.items()})
 

--- a/indra/sources/indra_db_rest/util.py
+++ b/indra/sources/indra_db_rest/util.py
@@ -30,10 +30,12 @@ def submit_statement_request(meth, end_point, query_str='', data=None,
                              tries=2, **params):
     """Even lower level function to make the request."""
     full_end_point = 'statements/' + end_point.lstrip('/')
-    return make_db_rest_request(meth, full_end_point, query_str, data, params, tries)
+    return make_db_rest_request(meth, full_end_point, query_str, data,
+                                params, tries)
 
 
-def make_db_rest_request(meth, end_point, query_str, data=None, params=None, tries=2):
+def make_db_rest_request(meth, end_point, query_str, data=None, params=None,
+                         tries=2):
     if params is None:
         params = {}
 
@@ -53,11 +55,11 @@ def make_db_rest_request(meth, end_point, query_str, data=None, params=None, tri
     else:
         json_data = None
     params['api_key'] = api_key
-    logger.info('url and query string: %s',
-                url_path.replace(str(api_key), '[api-key]'))
-    logger.info('headers: %s', str(headers).replace(str(api_key), '[api-key]'))
-    logger.info('data: %s', str(data).replace(str(api_key), '[api-key]'))
+    logger.info('query: %s', url_path.replace(str(api_key), '[api-key]'))
     logger.info('params: %s', str(params).replace(str(api_key), '[api-key]'))
+    logger.debug('headers: %s', str(headers).replace(str(api_key),
+                                                     '[api-key]'))
+    logger.debug('data: %s', str(data).replace(str(api_key), '[api-key]'))
     method_func = getattr(requests, meth.lower())
     while tries > 0:
         tries -= 1

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -53,6 +53,9 @@ def group_and_sort_statements(stmt_list, ev_totals=None, source_counts=None):
         A dictionary, keyed by statement hash (shallow) with counts of total
         evidence as the values. Including this will allow statements to be
         better sorted.
+    source_counts : dict{int: OrderedDict}
+        A dictionary, keyed by statement hash, with an OrderedDict of
+        counts per source (ordered).
 
     Returns
     -------
@@ -81,7 +84,7 @@ def group_and_sort_statements(stmt_list, ev_totals=None, source_counts=None):
         else:
             tot = ev_totals[sh]
 
-        if src_arrays and sh in src_arrays.keys():
+        if src_arrays and sh in src_arrays:
             return concatenate([array([tot]), src_arrays[sh]])
         else:
             return array([tot])
@@ -121,7 +124,8 @@ def group_and_sort_statements(stmt_list, ev_totals=None, source_counts=None):
                     continue
             new_key = (arg_count, inps, sub_count, verb)
             stmts = sorted(stmts,
-                           key=lambda s: _counts(s)[0] + 1/(1+len(s.agent_list())),
+                           key=(lambda s:
+                                _counts(s)[0] + 1 / (1+len(s.agent_list()))),
                            reverse=True)
             if source_counts:
                 yield new_key, verb, stmts,\


### PR DESCRIPTION
This PR adds handling for source counts coming from the DB REST in the client processor. It also makes some small docstring and PEP8 fixes. Finally, some of the more technical logs from the client are changed from info to debug.