### PR TITLE
Improvements to Eidos input processing

### DIFF
--- a/indra/sources/eidos/api.py
+++ b/indra/sources/eidos/api.py
@@ -20,7 +20,7 @@ except Exception as e:
 
 
 def process_text(text, out_format='json_ld', save_json='eidos_output.json',
-                 webservice=None):
+                 webservice=None, grounding_ns=None):
     """Return an EidosProcessor by processing the given text.
 
     This constructs a reader object via Java and extracts mentions
@@ -40,6 +40,11 @@ def process_text(text, out_format='json_ld', save_json='eidos_output.json',
         An Eidos reader web service URL to send the request to.
         If None, the reading is assumed to be done with the Eidos JAR rather
         than via a web service. Default: None
+    grounding_ns : Optional[list]
+        A list of name spaces for which INDRA should represent groundings, when
+        given. If not specified or None, all grounding name spaces are
+        propagated. If an empty list, no groundings are propagated.
+        Example: ['UN', 'WM'], Default: None
 
     Returns
     -------
@@ -61,10 +66,10 @@ def process_text(text, out_format='json_ld', save_json='eidos_output.json',
     if save_json:
         with open(save_json, 'wt') as fh:
             json.dump(json_dict, fh, indent=2)
-    return process_json(json_dict)
+    return process_json(json_dict, grounding_ns=grounding_ns)
 
 
-def process_json_file(file_name):
+def process_json_file(file_name, grounding_ns=None):
     """Return an EidosProcessor by processing the given Eidos JSON-LD file.
 
     This function is useful if the output from Eidos is saved as a file and
@@ -74,6 +79,11 @@ def process_json_file(file_name):
     ----------
     file_name : str
         The name of the JSON-LD file to be processed.
+    grounding_ns : Optional[list]
+        A list of name spaces for which INDRA should represent groundings, when
+        given. If not specified or None, all grounding name spaces are
+        propagated. If an empty list, no groundings are propagated.
+        Example: ['UN', 'WM'], Default: None
 
     Returns
     -------
@@ -84,18 +94,23 @@ def process_json_file(file_name):
     try:
         with open(file_name, 'rb') as fh:
             json_str = fh.read().decode('utf-8')
-            return process_json_str(json_str)
+            return process_json_str(json_str, grounding_ns=grounding_ns)
     except IOError:
         logger.exception('Could not read file %s.' % file_name)
 
 
-def process_json_str(json_str):
+def process_json_str(json_str, grounding_ns=None):
     """Return an EidosProcessor by processing the Eidos JSON-LD string.
 
     Parameters
     ----------
     json_str : str
         The JSON-LD string to be processed.
+    grounding_ns : Optional[list]
+        A list of name spaces for which INDRA should represent groundings, when
+        given. If not specified or None, all grounding name spaces are
+        propagated. If an empty list, no groundings are propagated.
+        Example: ['UN', 'WM'], Default: None
 
     Returns
     -------
@@ -104,16 +119,21 @@ def process_json_str(json_str):
         in its statements attribute.
     """
     json_dict = json.loads(json_str)
-    return process_json(json_dict)
+    return process_json(json_dict, grounding_ns=grounding_ns)
 
 
-def process_json(json_dict):
+def process_json(json_dict, grounding_ns=None):
     """Return an EidosProcessor by processing a Eidos JSON-LD dict.
 
     Parameters
     ----------
     json_dict : dict
         The JSON-LD dict to be processed.
+    grounding_ns : Optional[list]
+        A list of name spaces for which INDRA should represent groundings, when
+        given. If not specified or None, all grounding name spaces are
+        propagated. If an empty list, no groundings are propagated.
+        Example: ['UN', 'WM'], Default: None
 
     Returns
     -------
@@ -121,7 +141,7 @@ def process_json(json_dict):
         A EidosProcessor containing the extracted INDRA Statements
         in its statements attribute.
     """
-    ep = EidosProcessor(json_dict)
+    ep = EidosProcessor(json_dict, grounding_ns=grounding_ns)
     ep.extract_causal_relations()
     ep.extract_correlations()
     ep.extract_events()

--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -138,22 +138,6 @@ class EidosProcessor(object):
                 sentence = self.doc.sentences.get(sentence_id)
                 if sentence is not None:
                     text = _sanitize(sentence['text'])
-                # Get temporal constraints if available
-                timexes = sentence.get('timexes', [])
-                if timexes:
-                    # We currently handle just one timex per statement
-                    timex = timexes[0]
-                    tc = time_context_from_timex(timex)
-                    context = WorldContext(time=tc)
-                # Get geolocation if available
-                geolocs = sentence.get('geolocs', [])
-                if geolocs:
-                    geoloc = geolocs[0]
-                    rc = ref_context_from_geoloc(geoloc)
-                    if context:
-                        context.geo_location = rc
-                    else:
-                        context = WorldContext(geo_location=rc)
 
             # Here we try to get the title of the document and set it
             # in the provenance
@@ -243,7 +227,12 @@ class EidosProcessor(object):
             if state['type'] == 'TIMEX':
                 time_context = self.time_context_from_ref(state)
             elif state['type'] == 'LocationExp':
-                geo_context = self.geo_context_from_ref(state)
+                # TODO: here we take only the first geo_context occurrence.
+                # Eidos sometimes provides a list of locations, it may
+                # make sense to break those up into multiple statements
+                # each with one location
+                if not geo_context:
+                    geo_context = self.geo_context_from_ref(state)
         return {'polarity': polarity, 'adjectives': adjectives,
                 'time_context': time_context, 'geo_context': geo_context}
 

--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -379,9 +379,10 @@ class EidosDocument(object):
         time_text = dct.get('text')
         start = _get_time_stamp(dct.get('start'))
         end = _get_time_stamp(dct.get('end'))
-        duration = dct.get('duration')
+        duration = _get_duration(start, end)
         tc = TimeContext(text=time_text, start=start, end=end,
                          duration=duration)
+        logger.info(tc)
         return tc
 
 
@@ -406,6 +407,18 @@ def _get_time_stamp(entry):
     return dt
 
 
+def _get_duration(start, end):
+    if not start or not end:
+        return None
+    try:
+        duration = int((end - start).total_seconds())
+    except Exception as e:
+        logger.debug('Failed to get duration from %s and %s' %
+                     (str(start), str(end)))
+        duration = None
+    return duration
+
+
 def ref_context_from_geoloc(geoloc):
     """Return a RefContext object given a geoloc entry."""
     text = geoloc.get('text')
@@ -420,9 +433,10 @@ def time_context_from_timex(timex):
     constraint = timex['intervals'][0]
     start = _get_time_stamp(constraint.get('start'))
     end = _get_time_stamp(constraint.get('end'))
-    duration = constraint['duration']
+    duration = _get_duration(start, end)
     tc = TimeContext(text=time_text, start=start, end=end,
                      duration=duration)
+    logger.info(tc)
     return tc
 
 

--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -430,10 +430,14 @@ def ref_context_from_geoloc(geoloc):
 def time_context_from_timex(timex):
     """Return a TimeContext object given a timex entry."""
     time_text = timex.get('text')
-    constraint = timex['intervals'][0]
-    start = _get_time_stamp(constraint.get('start'))
-    end = _get_time_stamp(constraint.get('end'))
-    duration = _get_duration(start, end)
+    intervals = timex.get('intervals')
+    if not intervals:
+        start = end = duration = None
+    else:
+        constraint = intervals[0]
+        start = _get_time_stamp(constraint.get('start'))
+        end = _get_time_stamp(constraint.get('end'))
+        duration = _get_duration(start, end)
     tc = TimeContext(text=time_text, start=start, end=end,
                      duration=duration)
     logger.info(tc)

--- a/indra/tests/eidos_geoid.json
+++ b/indra/tests/eidos_geoid.json
@@ -1,5950 +1,968 @@
 {
-  "@context" : {
-    "Argument" : "https://github.com/clulab/eidos/wiki/JSON-LD#Argument",
-    "Corpus" : "https://github.com/clulab/eidos/wiki/JSON-LD#Corpus",
-    "Dependency" : "https://github.com/clulab/eidos/wiki/JSON-LD#Dependency",
-    "Document" : "https://github.com/clulab/eidos/wiki/JSON-LD#Document",
-    "Extraction" : "https://github.com/clulab/eidos/wiki/JSON-LD#Extraction",
-    "GeoLocation" : "https://github.com/clulab/eidos/wiki/JSON-LD#GeoLocation",
-    "Interval" : "https://github.com/clulab/eidos/wiki/JSON-LD#Interval",
-    "Provenance" : "https://github.com/clulab/eidos/wiki/JSON-LD#Provenance",
-    "Sentence" : "https://github.com/clulab/eidos/wiki/JSON-LD#Sentence",
-    "State" : "https://github.com/clulab/eidos/wiki/JSON-LD#State",
-    "Trigger" : "https://github.com/clulab/eidos/wiki/JSON-LD#Trigger",
-    "Word" : "https://github.com/clulab/eidos/wiki/JSON-LD#Word"
+  "@context": {
+    "Argument": "https://w3id.org/wm/cag/argument",
+    "Grounding": "https://w3id.org/wm/cag/grounding",
+    "Interval": "https://w3id.org/wm/cag/interval",
+    "Extraction": "https://w3id.org/wm/cag/extraction",
+    "Provenance": "https://w3id.org/wm/cag/provenance",
+    "Groundings": "https://w3id.org/wm/cag/groundings",
+    "GeoLocation": "https://w3id.org/wm/cag/geolocation",
+    "State": "https://w3id.org/wm/cag/state",
+    "Dependency": "https://w3id.org/wm/cag/dependency",
+    "Corpus": "https://w3id.org/wm/cag/corpus",
+    "Trigger": "https://w3id.org/wm/cag/trigger",
+    "Sentence": "https://w3id.org/wm/cag/sentence",
+    "Word": "https://w3id.org/wm/cag/word",
+    "Document": "https://w3id.org/wm/cag/document"
   },
-  "@type" : "Corpus",
-  "documents" : [ {
-    "@type" : "Document",
-    "@id" : "_:Document_1",
-    "text" : "Floods caused by rain have displaced more than 100,000 people in South Sudan, an official said, raising fears about the devastating impact this could have on food security in the war-torn nation.\n\n\"We are talking of over 70,000 individuals and 1,590 households affected in Awiel and 40,000 others in Maban county. Other regions like Jonglei and Lol have also reported high figures,\" Gatwech Peter Kulang, the undersecretary for the Ministry of Humanitarian Affairs and Disaster Risk Management told Xinhua Tuesday.\n\n\"The situation is alarming which demands urgent intervention,\" he added.\n\nThe official expressed concerns that the floods could worsen the already dire humanitarian situation across the country, including the spread of cholera, which has killed over 300 people and infected nearly 20,000 others last year.\n\n\"We call upon the humanitarian community to join hands with the government to rescue this alarming situation,\" stressed Kulang.\n\nMuch of South Sudan receives little rainfall and only 5% of the arable land is currently cultivated. Nonetheless, the country has significant potential for increased cereal production, especially in the southern regions with the highest annual rainfall. Accurate data on crop area and production for South Sudan are scarce, and there is considerable uncertainty in estimates.\n\nNearly 5 million people or more than 40% of the population in South Sudan were in need of urgent food, agriculture and nutrition assistance, the Integrated Food Security Phase Classification (IPC) projected early this year.\n",
-    "sentences" : [ {
-      "@type" : "Sentence",
-      "@id" : "_:Sentence_1",
-      "text" : "Floods caused by rain have displaced more than 100,000 people in South Sudan , an official said , raising fears about the devastating impact this could have on food security in the war-torn nation .",
-      "words" : [ {
-        "@type" : "Word",
-        "@id" : "_:Word_1",
-        "text" : "Floods",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 0,
-        "endOffset" : 6,
-        "lemma" : "flood",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_2",
-        "text" : "caused",
-        "tag" : "VBN",
-        "entity" : "O",
-        "startOffset" : 7,
-        "endOffset" : 13,
-        "lemma" : "cause",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_3",
-        "text" : "by",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 14,
-        "endOffset" : 16,
-        "lemma" : "by",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_4",
-        "text" : "rain",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 17,
-        "endOffset" : 21,
-        "lemma" : "rain",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_5",
-        "text" : "have",
-        "tag" : "VBP",
-        "entity" : "O",
-        "startOffset" : 22,
-        "endOffset" : 26,
-        "lemma" : "have",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_6",
-        "text" : "displaced",
-        "tag" : "VBN",
-        "entity" : "O",
-        "startOffset" : 27,
-        "endOffset" : 36,
-        "lemma" : "displace",
-        "chunk" : "I-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_7",
-        "text" : "more",
-        "tag" : "JJR",
-        "entity" : "O",
-        "startOffset" : 37,
-        "endOffset" : 41,
-        "lemma" : "more",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_8",
-        "text" : "than",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 42,
-        "endOffset" : 46,
-        "lemma" : "than",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_9",
-        "text" : "100,000",
-        "tag" : "CD",
-        "entity" : "NUMBER",
-        "startOffset" : 47,
-        "endOffset" : 54,
-        "lemma" : "100,000",
-        "chunk" : "I-NP",
-        "norm" : ">100000.0"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_10",
-        "text" : "people",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 55,
-        "endOffset" : 61,
-        "lemma" : "people",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_11",
-        "text" : "in",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 62,
-        "endOffset" : 64,
-        "lemma" : "in",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_12",
-        "text" : "South",
-        "tag" : "NNP",
-        "entity" : "LOCATION",
-        "startOffset" : 65,
-        "endOffset" : 70,
-        "lemma" : "South",
-        "chunk" : "B-NP",
-        "norm" : "LOC"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_13",
-        "text" : "Sudan",
-        "tag" : "NNP",
-        "entity" : "LOCATION",
-        "startOffset" : 71,
-        "endOffset" : 76,
-        "lemma" : "Sudan",
-        "chunk" : "I-NP",
-        "norm" : "LOC"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_14",
-        "text" : ",",
-        "tag" : ",",
-        "entity" : "O",
-        "startOffset" : 76,
-        "endOffset" : 77,
-        "lemma" : ",",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_15",
-        "text" : "an",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 78,
-        "endOffset" : 80,
-        "lemma" : "a",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_16",
-        "text" : "official",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 81,
-        "endOffset" : 89,
-        "lemma" : "official",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_17",
-        "text" : "said",
-        "tag" : "VBD",
-        "entity" : "O",
-        "startOffset" : 90,
-        "endOffset" : 94,
-        "lemma" : "say",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_18",
-        "text" : ",",
-        "tag" : ",",
-        "entity" : "O",
-        "startOffset" : 94,
-        "endOffset" : 95,
-        "lemma" : ",",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_19",
-        "text" : "raising",
-        "tag" : "VBG",
-        "entity" : "O",
-        "startOffset" : 96,
-        "endOffset" : 103,
-        "lemma" : "raise",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_20",
-        "text" : "fears",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 104,
-        "endOffset" : 109,
-        "lemma" : "fear",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_21",
-        "text" : "about",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 110,
-        "endOffset" : 115,
-        "lemma" : "about",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_22",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 116,
-        "endOffset" : 119,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_23",
-        "text" : "devastating",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 120,
-        "endOffset" : 131,
-        "lemma" : "devastating",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_24",
-        "text" : "impact",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 132,
-        "endOffset" : 138,
-        "lemma" : "impact",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_25",
-        "text" : "this",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 139,
-        "endOffset" : 143,
-        "lemma" : "this",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_26",
-        "text" : "could",
-        "tag" : "MD",
-        "entity" : "O",
-        "startOffset" : 144,
-        "endOffset" : 149,
-        "lemma" : "could",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_27",
-        "text" : "have",
-        "tag" : "VB",
-        "entity" : "O",
-        "startOffset" : 150,
-        "endOffset" : 154,
-        "lemma" : "have",
-        "chunk" : "I-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_28",
-        "text" : "on",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 155,
-        "endOffset" : 157,
-        "lemma" : "on",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_29",
-        "text" : "food",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 158,
-        "endOffset" : 162,
-        "lemma" : "food",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_30",
-        "text" : "security",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 163,
-        "endOffset" : 171,
-        "lemma" : "security",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_31",
-        "text" : "in",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 172,
-        "endOffset" : 174,
-        "lemma" : "in",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_32",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 175,
-        "endOffset" : 178,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_33",
-        "text" : "war-torn",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 179,
-        "endOffset" : 187,
-        "lemma" : "war-torn",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_34",
-        "text" : "nation",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 188,
-        "endOffset" : 194,
-        "lemma" : "nation",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_35",
-        "text" : ".",
-        "tag" : ".",
-        "entity" : "O",
-        "startOffset" : 194,
-        "endOffset" : 195,
-        "lemma" : ".",
-        "chunk" : "O",
-        "norm" : "O"
-      } ],
-      "dependencies" : [ {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_1"
-        },
-        "destination" : {
-          "@id" : "_:Word_2"
-        },
-        "relation" : "acl"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_2"
-        },
-        "destination" : {
-          "@id" : "_:Word_4"
-        },
-        "relation" : "nmod_by"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_4"
-        },
-        "destination" : {
-          "@id" : "_:Word_3"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_6"
-        },
-        "destination" : {
-          "@id" : "_:Word_1"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_6"
-        },
-        "destination" : {
-          "@id" : "_:Word_18"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_6"
-        },
-        "destination" : {
-          "@id" : "_:Word_19"
-        },
-        "relation" : "xcomp"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_6"
-        },
-        "destination" : {
-          "@id" : "_:Word_35"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_6"
-        },
-        "destination" : {
-          "@id" : "_:Word_5"
-        },
-        "relation" : "aux"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_6"
-        },
-        "destination" : {
-          "@id" : "_:Word_10"
-        },
-        "relation" : "dobj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_6"
-        },
-        "destination" : {
-          "@id" : "_:Word_13"
-        },
-        "relation" : "nmod_in"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_7"
-        },
-        "destination" : {
-          "@id" : "_:Word_8"
-        },
-        "relation" : "mwe"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_9"
-        },
-        "destination" : {
-          "@id" : "_:Word_7"
-        },
-        "relation" : "advmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_10"
-        },
-        "destination" : {
-          "@id" : "_:Word_9"
-        },
-        "relation" : "nummod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_13"
-        },
-        "destination" : {
-          "@id" : "_:Word_17"
-        },
-        "relation" : "acl:relcl"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_13"
-        },
-        "destination" : {
-          "@id" : "_:Word_11"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_13"
-        },
-        "destination" : {
-          "@id" : "_:Word_12"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_13"
-        },
-        "destination" : {
-          "@id" : "_:Word_14"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_16"
-        },
-        "destination" : {
-          "@id" : "_:Word_15"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_17"
-        },
-        "destination" : {
-          "@id" : "_:Word_16"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_19"
-        },
-        "destination" : {
-          "@id" : "_:Word_20"
-        },
-        "relation" : "dobj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_19"
-        },
-        "destination" : {
-          "@id" : "_:Word_27"
-        },
-        "relation" : "dep"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_20"
-        },
-        "destination" : {
-          "@id" : "_:Word_24"
-        },
-        "relation" : "nmod_about"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_24"
-        },
-        "destination" : {
-          "@id" : "_:Word_21"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_24"
-        },
-        "destination" : {
-          "@id" : "_:Word_22"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_24"
-        },
-        "destination" : {
-          "@id" : "_:Word_23"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_27"
-        },
-        "destination" : {
-          "@id" : "_:Word_25"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_27"
-        },
-        "destination" : {
-          "@id" : "_:Word_26"
-        },
-        "relation" : "aux"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_27"
-        },
-        "destination" : {
-          "@id" : "_:Word_30"
-        },
-        "relation" : "nmod_on"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_30"
-        },
-        "destination" : {
-          "@id" : "_:Word_34"
-        },
-        "relation" : "nmod_in"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_30"
-        },
-        "destination" : {
-          "@id" : "_:Word_28"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_30"
-        },
-        "destination" : {
-          "@id" : "_:Word_29"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_34"
-        },
-        "destination" : {
-          "@id" : "_:Word_32"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_34"
-        },
-        "destination" : {
-          "@id" : "_:Word_33"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_34"
-        },
-        "destination" : {
-          "@id" : "_:Word_31"
-        },
-        "relation" : "case"
-      } ],
-      "geolocs" : [ {
-        "@type" : "GeoLocation",
-        "@id" : "_:GeoLocation_1",
-        "startOffset" : 65,
-        "endOffset" : 76,
-        "text" : "South Sudan",
-        "geoID" : "7909807"
-      } ]
-    }, {
-      "@type" : "Sentence",
-      "@id" : "_:Sentence_2",
-      "text" : "\" We are talking of over 70,000 individuals and 1,590 households affected in Awiel and 40,000 others in Maban county .",
-      "words" : [ {
-        "@type" : "Word",
-        "@id" : "_:Word_36",
-        "text" : "\"",
-        "tag" : "``",
-        "entity" : "O",
-        "startOffset" : 197,
-        "endOffset" : 198,
-        "lemma" : "``",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_37",
-        "text" : "We",
-        "tag" : "PRP",
-        "entity" : "O",
-        "startOffset" : 198,
-        "endOffset" : 200,
-        "lemma" : "we",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_38",
-        "text" : "are",
-        "tag" : "VBP",
-        "entity" : "O",
-        "startOffset" : 201,
-        "endOffset" : 204,
-        "lemma" : "be",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_39",
-        "text" : "talking",
-        "tag" : "VBG",
-        "entity" : "O",
-        "startOffset" : 205,
-        "endOffset" : 212,
-        "lemma" : "talk",
-        "chunk" : "I-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_40",
-        "text" : "of",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 213,
-        "endOffset" : 215,
-        "lemma" : "of",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_41",
-        "text" : "over",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 216,
-        "endOffset" : 220,
-        "lemma" : "over",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_42",
-        "text" : "70,000",
-        "tag" : "CD",
-        "entity" : "NUMBER",
-        "startOffset" : 221,
-        "endOffset" : 227,
-        "lemma" : "70,000",
-        "chunk" : "I-NP",
-        "norm" : ">70000.0"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_43",
-        "text" : "individuals",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 228,
-        "endOffset" : 239,
-        "lemma" : "individual",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_44",
-        "text" : "and",
-        "tag" : "CC",
-        "entity" : "O",
-        "startOffset" : 240,
-        "endOffset" : 243,
-        "lemma" : "and",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_45",
-        "text" : "1,590",
-        "tag" : "CD",
-        "entity" : "NUMBER",
-        "startOffset" : 244,
-        "endOffset" : 249,
-        "lemma" : "1,590",
-        "chunk" : "B-NP",
-        "norm" : "1590.0"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_46",
-        "text" : "households",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 250,
-        "endOffset" : 260,
-        "lemma" : "household",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_47",
-        "text" : "affected",
-        "tag" : "VBN",
-        "entity" : "O",
-        "startOffset" : 261,
-        "endOffset" : 269,
-        "lemma" : "affect",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_48",
-        "text" : "in",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 270,
-        "endOffset" : 272,
-        "lemma" : "in",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_49",
-        "text" : "Awiel",
-        "tag" : "NNP",
-        "entity" : "LOCATION",
-        "startOffset" : 273,
-        "endOffset" : 278,
-        "lemma" : "Awiel",
-        "chunk" : "B-NP",
-        "norm" : "LOC"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_50",
-        "text" : "and",
-        "tag" : "CC",
-        "entity" : "O",
-        "startOffset" : 279,
-        "endOffset" : 282,
-        "lemma" : "and",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_51",
-        "text" : "40,000",
-        "tag" : "CD",
-        "entity" : "NUMBER",
-        "startOffset" : 283,
-        "endOffset" : 289,
-        "lemma" : "40,000",
-        "chunk" : "B-NP",
-        "norm" : "40000.0"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_52",
-        "text" : "others",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 290,
-        "endOffset" : 296,
-        "lemma" : "other",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_53",
-        "text" : "in",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 297,
-        "endOffset" : 299,
-        "lemma" : "in",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_54",
-        "text" : "Maban",
-        "tag" : "NNP",
-        "entity" : "LOCATION",
-        "startOffset" : 300,
-        "endOffset" : 305,
-        "lemma" : "Maban",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_55",
-        "text" : "county",
-        "tag" : "NN",
-        "entity" : "LOCATION",
-        "startOffset" : 306,
-        "endOffset" : 312,
-        "lemma" : "county",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_56",
-        "text" : ".",
-        "tag" : ".",
-        "entity" : "O",
-        "startOffset" : 312,
-        "endOffset" : 313,
-        "lemma" : ".",
-        "chunk" : "O",
-        "norm" : "O"
-      } ],
-      "dependencies" : [ {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_39"
-        },
-        "destination" : {
-          "@id" : "_:Word_38"
-        },
-        "relation" : "aux"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_39"
-        },
-        "destination" : {
-          "@id" : "_:Word_56"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_39"
-        },
-        "destination" : {
-          "@id" : "_:Word_43"
-        },
-        "relation" : "nmod_of"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_39"
-        },
-        "destination" : {
-          "@id" : "_:Word_46"
-        },
-        "relation" : "nmod_of"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_39"
-        },
-        "destination" : {
-          "@id" : "_:Word_37"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_42"
-        },
-        "destination" : {
-          "@id" : "_:Word_41"
-        },
-        "relation" : "advmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_43"
-        },
-        "destination" : {
-          "@id" : "_:Word_40"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_43"
-        },
-        "destination" : {
-          "@id" : "_:Word_42"
-        },
-        "relation" : "nummod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_43"
-        },
-        "destination" : {
-          "@id" : "_:Word_44"
-        },
-        "relation" : "cc"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_43"
-        },
-        "destination" : {
-          "@id" : "_:Word_46"
-        },
-        "relation" : "conj_and"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_43"
-        },
-        "destination" : {
-          "@id" : "_:Word_47"
-        },
-        "relation" : "acl"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_46"
-        },
-        "destination" : {
-          "@id" : "_:Word_45"
-        },
-        "relation" : "nummod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_47"
-        },
-        "destination" : {
-          "@id" : "_:Word_55"
-        },
-        "relation" : "nmod_in"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_47"
-        },
-        "destination" : {
-          "@id" : "_:Word_49"
-        },
-        "relation" : "nmod_in"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_47"
-        },
-        "destination" : {
-          "@id" : "_:Word_52"
-        },
-        "relation" : "nmod_in"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_49"
-        },
-        "destination" : {
-          "@id" : "_:Word_48"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_49"
-        },
-        "destination" : {
-          "@id" : "_:Word_50"
-        },
-        "relation" : "cc"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_49"
-        },
-        "destination" : {
-          "@id" : "_:Word_52"
-        },
-        "relation" : "conj_and"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_52"
-        },
-        "destination" : {
-          "@id" : "_:Word_51"
-        },
-        "relation" : "nummod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_55"
-        },
-        "destination" : {
-          "@id" : "_:Word_54"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_55"
-        },
-        "destination" : {
-          "@id" : "_:Word_53"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_36"
-        },
-        "destination" : {
-          "@id" : "_:Word_39"
-        },
-        "relation" : "root"
-      } ],
-      "geolocs" : [ {
-        "@type" : "GeoLocation",
-        "@id" : "_:GeoLocation_2",
-        "startOffset" : 273,
-        "endOffset" : 278,
-        "text" : "Awiel"
-      } ]
-    }, {
-      "@type" : "Sentence",
-      "@id" : "_:Sentence_3",
-      "text" : "Other regions like Jonglei and Lol have also reported high figures , \" Gatwech Peter Kulang , the undersecretary for the Ministry of Humanitarian Affairs and Disaster Risk Management told Xinhua Tuesday .",
-      "words" : [ {
-        "@type" : "Word",
-        "@id" : "_:Word_57",
-        "text" : "Other",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 314,
-        "endOffset" : 319,
-        "lemma" : "other",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_58",
-        "text" : "regions",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 320,
-        "endOffset" : 327,
-        "lemma" : "region",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_59",
-        "text" : "like",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 328,
-        "endOffset" : 332,
-        "lemma" : "like",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_60",
-        "text" : "Jonglei",
-        "tag" : "NNP",
-        "entity" : "LOCATION",
-        "startOffset" : 333,
-        "endOffset" : 340,
-        "lemma" : "Jonglei",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_61",
-        "text" : "and",
-        "tag" : "CC",
-        "entity" : "O",
-        "startOffset" : 341,
-        "endOffset" : 344,
-        "lemma" : "and",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_62",
-        "text" : "Lol",
-        "tag" : "NNP",
-        "entity" : "O",
-        "startOffset" : 345,
-        "endOffset" : 348,
-        "lemma" : "Lol",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_63",
-        "text" : "have",
-        "tag" : "VBP",
-        "entity" : "O",
-        "startOffset" : 349,
-        "endOffset" : 353,
-        "lemma" : "have",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_64",
-        "text" : "also",
-        "tag" : "RB",
-        "entity" : "O",
-        "startOffset" : 354,
-        "endOffset" : 358,
-        "lemma" : "also",
-        "chunk" : "I-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_65",
-        "text" : "reported",
-        "tag" : "VBN",
-        "entity" : "O",
-        "startOffset" : 359,
-        "endOffset" : 367,
-        "lemma" : "report",
-        "chunk" : "I-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_66",
-        "text" : "high",
-        "tag" : "JJ",
-        "entity" : "B-Quantifier",
-        "startOffset" : 368,
-        "endOffset" : 372,
-        "lemma" : "high",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_67",
-        "text" : "figures",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 373,
-        "endOffset" : 380,
-        "lemma" : "figure",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_68",
-        "text" : ",",
-        "tag" : ",",
-        "entity" : "O",
-        "startOffset" : 380,
-        "endOffset" : 381,
-        "lemma" : ",",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_69",
-        "text" : "\"",
-        "tag" : "''",
-        "entity" : "O",
-        "startOffset" : 381,
-        "endOffset" : 382,
-        "lemma" : "''",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_70",
-        "text" : "Gatwech",
-        "tag" : "NNP",
-        "entity" : "PERSON",
-        "startOffset" : 383,
-        "endOffset" : 390,
-        "lemma" : "Gatwech",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_71",
-        "text" : "Peter",
-        "tag" : "NNP",
-        "entity" : "PERSON",
-        "startOffset" : 391,
-        "endOffset" : 396,
-        "lemma" : "Peter",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_72",
-        "text" : "Kulang",
-        "tag" : "NNP",
-        "entity" : "PERSON",
-        "startOffset" : 397,
-        "endOffset" : 403,
-        "lemma" : "Kulang",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_73",
-        "text" : ",",
-        "tag" : ",",
-        "entity" : "O",
-        "startOffset" : 403,
-        "endOffset" : 404,
-        "lemma" : ",",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_74",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 405,
-        "endOffset" : 408,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_75",
-        "text" : "undersecretary",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 409,
-        "endOffset" : 423,
-        "lemma" : "undersecretary",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_76",
-        "text" : "for",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 424,
-        "endOffset" : 427,
-        "lemma" : "for",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_77",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 428,
-        "endOffset" : 431,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_78",
-        "text" : "Ministry",
-        "tag" : "NNP",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 432,
-        "endOffset" : 440,
-        "lemma" : "Ministry",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_79",
-        "text" : "of",
-        "tag" : "IN",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 441,
-        "endOffset" : 443,
-        "lemma" : "of",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_80",
-        "text" : "Humanitarian",
-        "tag" : "NNP",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 444,
-        "endOffset" : 456,
-        "lemma" : "Humanitarian",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_81",
-        "text" : "Affairs",
-        "tag" : "NNP",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 457,
-        "endOffset" : 464,
-        "lemma" : "Affairs",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_82",
-        "text" : "and",
-        "tag" : "CC",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 465,
-        "endOffset" : 468,
-        "lemma" : "and",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_83",
-        "text" : "Disaster",
-        "tag" : "NN",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 469,
-        "endOffset" : 477,
-        "lemma" : "disaster",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_84",
-        "text" : "Risk",
-        "tag" : "NN",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 478,
-        "endOffset" : 482,
-        "lemma" : "risk",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_85",
-        "text" : "Management",
-        "tag" : "NN",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 483,
-        "endOffset" : 493,
-        "lemma" : "management",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_86",
-        "text" : "told",
-        "tag" : "VBD",
-        "entity" : "O",
-        "startOffset" : 494,
-        "endOffset" : 498,
-        "lemma" : "tell",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_87",
-        "text" : "Xinhua",
-        "tag" : "NNP",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 499,
-        "endOffset" : 505,
-        "lemma" : "Xinhua",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_88",
-        "text" : "Tuesday",
-        "tag" : "NNP",
-        "entity" : "DATE",
-        "startOffset" : 506,
-        "endOffset" : 513,
-        "lemma" : "Tuesday",
-        "chunk" : "I-NP",
-        "norm" : "XXXX-WXX-2"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_89",
-        "text" : ".",
-        "tag" : ".",
-        "entity" : "O",
-        "startOffset" : 513,
-        "endOffset" : 514,
-        "lemma" : ".",
-        "chunk" : "O",
-        "norm" : "O"
-      } ],
-      "dependencies" : [ {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_65"
-        },
-        "destination" : {
-          "@id" : "_:Word_63"
-        },
-        "relation" : "aux"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_65"
-        },
-        "destination" : {
-          "@id" : "_:Word_64"
-        },
-        "relation" : "advmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_65"
-        },
-        "destination" : {
-          "@id" : "_:Word_67"
-        },
-        "relation" : "dobj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_65"
-        },
-        "destination" : {
-          "@id" : "_:Word_58"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_67"
-        },
-        "destination" : {
-          "@id" : "_:Word_66"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_72"
-        },
-        "destination" : {
-          "@id" : "_:Word_70"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_72"
-        },
-        "destination" : {
-          "@id" : "_:Word_71"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_72"
-        },
-        "destination" : {
-          "@id" : "_:Word_73"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_72"
-        },
-        "destination" : {
-          "@id" : "_:Word_75"
-        },
-        "relation" : "appos"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_75"
-        },
-        "destination" : {
-          "@id" : "_:Word_78"
-        },
-        "relation" : "nmod_for"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_75"
-        },
-        "destination" : {
-          "@id" : "_:Word_85"
-        },
-        "relation" : "nmod_for"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_75"
-        },
-        "destination" : {
-          "@id" : "_:Word_74"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_78"
-        },
-        "destination" : {
-          "@id" : "_:Word_81"
-        },
-        "relation" : "nmod_of"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_78"
-        },
-        "destination" : {
-          "@id" : "_:Word_82"
-        },
-        "relation" : "cc"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_78"
-        },
-        "destination" : {
-          "@id" : "_:Word_85"
-        },
-        "relation" : "conj_and"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_78"
-        },
-        "destination" : {
-          "@id" : "_:Word_76"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_78"
-        },
-        "destination" : {
-          "@id" : "_:Word_77"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_81"
-        },
-        "destination" : {
-          "@id" : "_:Word_79"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_81"
-        },
-        "destination" : {
-          "@id" : "_:Word_80"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_85"
-        },
-        "destination" : {
-          "@id" : "_:Word_83"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_85"
-        },
-        "destination" : {
-          "@id" : "_:Word_84"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_86"
-        },
-        "destination" : {
-          "@id" : "_:Word_65"
-        },
-        "relation" : "ccomp"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_86"
-        },
-        "destination" : {
-          "@id" : "_:Word_68"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_86"
-        },
-        "destination" : {
-          "@id" : "_:Word_69"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_86"
-        },
-        "destination" : {
-          "@id" : "_:Word_72"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_86"
-        },
-        "destination" : {
-          "@id" : "_:Word_88"
-        },
-        "relation" : "nmod:tmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_86"
-        },
-        "destination" : {
-          "@id" : "_:Word_89"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_88"
-        },
-        "destination" : {
-          "@id" : "_:Word_87"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_58"
-        },
-        "destination" : {
-          "@id" : "_:Word_62"
-        },
-        "relation" : "nmod_like"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_58"
-        },
-        "destination" : {
-          "@id" : "_:Word_57"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_58"
-        },
-        "destination" : {
-          "@id" : "_:Word_60"
-        },
-        "relation" : "nmod_like"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_60"
-        },
-        "destination" : {
-          "@id" : "_:Word_62"
-        },
-        "relation" : "conj_and"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_60"
-        },
-        "destination" : {
-          "@id" : "_:Word_59"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_60"
-        },
-        "destination" : {
-          "@id" : "_:Word_61"
-        },
-        "relation" : "cc"
-      } ]
-    }, {
-      "@type" : "Sentence",
-      "@id" : "_:Sentence_4",
-      "text" : "\" The situation is alarming which demands urgent intervention , \" he added .",
-      "words" : [ {
-        "@type" : "Word",
-        "@id" : "_:Word_90",
-        "text" : "\"",
-        "tag" : "``",
-        "entity" : "O",
-        "startOffset" : 516,
-        "endOffset" : 517,
-        "lemma" : "``",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_91",
-        "text" : "The",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 517,
-        "endOffset" : 520,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_92",
-        "text" : "situation",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 521,
-        "endOffset" : 530,
-        "lemma" : "situation",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_93",
-        "text" : "is",
-        "tag" : "VBZ",
-        "entity" : "O",
-        "startOffset" : 531,
-        "endOffset" : 533,
-        "lemma" : "be",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_94",
-        "text" : "alarming",
-        "tag" : "JJ",
-        "entity" : "B-Quantifier",
-        "startOffset" : 534,
-        "endOffset" : 542,
-        "lemma" : "alarming",
-        "chunk" : "B-ADJP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_95",
-        "text" : "which",
-        "tag" : "WDT",
-        "entity" : "O",
-        "startOffset" : 543,
-        "endOffset" : 548,
-        "lemma" : "which",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_96",
-        "text" : "demands",
-        "tag" : "VBZ",
-        "entity" : "O",
-        "startOffset" : 549,
-        "endOffset" : 556,
-        "lemma" : "demand",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_97",
-        "text" : "urgent",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 557,
-        "endOffset" : 563,
-        "lemma" : "urgent",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_98",
-        "text" : "intervention",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 564,
-        "endOffset" : 576,
-        "lemma" : "intervention",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_99",
-        "text" : ",",
-        "tag" : ",",
-        "entity" : "O",
-        "startOffset" : 576,
-        "endOffset" : 577,
-        "lemma" : ",",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_100",
-        "text" : "\"",
-        "tag" : "''",
-        "entity" : "O",
-        "startOffset" : 577,
-        "endOffset" : 578,
-        "lemma" : "''",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_101",
-        "text" : "he",
-        "tag" : "PRP",
-        "entity" : "O",
-        "startOffset" : 579,
-        "endOffset" : 581,
-        "lemma" : "he",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_102",
-        "text" : "added",
-        "tag" : "VBD",
-        "entity" : "O",
-        "startOffset" : 582,
-        "endOffset" : 587,
-        "lemma" : "add",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_103",
-        "text" : ".",
-        "tag" : ".",
-        "entity" : "O",
-        "startOffset" : 587,
-        "endOffset" : 588,
-        "lemma" : ".",
-        "chunk" : "O",
-        "norm" : "O"
-      } ],
-      "dependencies" : [ {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_98"
-        },
-        "destination" : {
-          "@id" : "_:Word_97"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_102"
-        },
-        "destination" : {
-          "@id" : "_:Word_99"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_102"
-        },
-        "destination" : {
-          "@id" : "_:Word_100"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_102"
-        },
-        "destination" : {
-          "@id" : "_:Word_101"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_102"
-        },
-        "destination" : {
-          "@id" : "_:Word_103"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_102"
-        },
-        "destination" : {
-          "@id" : "_:Word_90"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_102"
-        },
-        "destination" : {
-          "@id" : "_:Word_94"
-        },
-        "relation" : "ccomp"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_92"
-        },
-        "destination" : {
-          "@id" : "_:Word_91"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_94"
-        },
-        "destination" : {
-          "@id" : "_:Word_92"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_94"
-        },
-        "destination" : {
-          "@id" : "_:Word_93"
-        },
-        "relation" : "cop"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_94"
-        },
-        "destination" : {
-          "@id" : "_:Word_96"
-        },
-        "relation" : "ccomp"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_96"
-        },
-        "destination" : {
-          "@id" : "_:Word_98"
-        },
-        "relation" : "dobj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_96"
-        },
-        "destination" : {
-          "@id" : "_:Word_95"
-        },
-        "relation" : "nsubj"
-      } ]
-    }, {
-      "@type" : "Sentence",
-      "@id" : "_:Sentence_5",
-      "text" : "The official expressed concerns that the floods could worsen the already dire humanitarian situation across the country , including the spread of cholera , which has killed over 300 people and infected nearly 20,000 others last year .",
-      "words" : [ {
-        "@type" : "Word",
-        "@id" : "_:Word_104",
-        "text" : "The",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 590,
-        "endOffset" : 593,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_105",
-        "text" : "official",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 594,
-        "endOffset" : 602,
-        "lemma" : "official",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_106",
-        "text" : "expressed",
-        "tag" : "VBD",
-        "entity" : "O",
-        "startOffset" : 603,
-        "endOffset" : 612,
-        "lemma" : "express",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_107",
-        "text" : "concerns",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 613,
-        "endOffset" : 621,
-        "lemma" : "concern",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_108",
-        "text" : "that",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 622,
-        "endOffset" : 626,
-        "lemma" : "that",
-        "chunk" : "B-SBAR",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_109",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 627,
-        "endOffset" : 630,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_110",
-        "text" : "floods",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 631,
-        "endOffset" : 637,
-        "lemma" : "flood",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_111",
-        "text" : "could",
-        "tag" : "MD",
-        "entity" : "O",
-        "startOffset" : 638,
-        "endOffset" : 643,
-        "lemma" : "could",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_112",
-        "text" : "worsen",
-        "tag" : "VB",
-        "entity" : "O",
-        "startOffset" : 644,
-        "endOffset" : 650,
-        "lemma" : "worsen",
-        "chunk" : "I-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_113",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 651,
-        "endOffset" : 654,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_114",
-        "text" : "already",
-        "tag" : "RB",
-        "entity" : "O",
-        "startOffset" : 655,
-        "endOffset" : 662,
-        "lemma" : "already",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_115",
-        "text" : "dire",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 663,
-        "endOffset" : 667,
-        "lemma" : "dire",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_116",
-        "text" : "humanitarian",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 668,
-        "endOffset" : 680,
-        "lemma" : "humanitarian",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_117",
-        "text" : "situation",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 681,
-        "endOffset" : 690,
-        "lemma" : "situation",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_118",
-        "text" : "across",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 691,
-        "endOffset" : 697,
-        "lemma" : "across",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_119",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 698,
-        "endOffset" : 701,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_120",
-        "text" : "country",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 702,
-        "endOffset" : 709,
-        "lemma" : "country",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_121",
-        "text" : ",",
-        "tag" : ",",
-        "entity" : "O",
-        "startOffset" : 709,
-        "endOffset" : 710,
-        "lemma" : ",",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_122",
-        "text" : "including",
-        "tag" : "VBG",
-        "entity" : "O",
-        "startOffset" : 711,
-        "endOffset" : 720,
-        "lemma" : "include",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_123",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 721,
-        "endOffset" : 724,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_124",
-        "text" : "spread",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 725,
-        "endOffset" : 731,
-        "lemma" : "spread",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_125",
-        "text" : "of",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 732,
-        "endOffset" : 734,
-        "lemma" : "of",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_126",
-        "text" : "cholera",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 735,
-        "endOffset" : 742,
-        "lemma" : "cholera",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_127",
-        "text" : ",",
-        "tag" : ",",
-        "entity" : "O",
-        "startOffset" : 742,
-        "endOffset" : 743,
-        "lemma" : ",",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_128",
-        "text" : "which",
-        "tag" : "WDT",
-        "entity" : "O",
-        "startOffset" : 744,
-        "endOffset" : 749,
-        "lemma" : "which",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_129",
-        "text" : "has",
-        "tag" : "VBZ",
-        "entity" : "O",
-        "startOffset" : 750,
-        "endOffset" : 753,
-        "lemma" : "have",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_130",
-        "text" : "killed",
-        "tag" : "VBN",
-        "entity" : "O",
-        "startOffset" : 754,
-        "endOffset" : 760,
-        "lemma" : "kill",
-        "chunk" : "I-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_131",
-        "text" : "over",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 761,
-        "endOffset" : 765,
-        "lemma" : "over",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_132",
-        "text" : "300",
-        "tag" : "CD",
-        "entity" : "NUMBER",
-        "startOffset" : 766,
-        "endOffset" : 769,
-        "lemma" : "300",
-        "chunk" : "B-NP",
-        "norm" : ">300.0"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_133",
-        "text" : "people",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 770,
-        "endOffset" : 776,
-        "lemma" : "people",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_134",
-        "text" : "and",
-        "tag" : "CC",
-        "entity" : "O",
-        "startOffset" : 777,
-        "endOffset" : 780,
-        "lemma" : "and",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_135",
-        "text" : "infected",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 781,
-        "endOffset" : 789,
-        "lemma" : "infected",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_136",
-        "text" : "nearly",
-        "tag" : "RB",
-        "entity" : "O",
-        "startOffset" : 790,
-        "endOffset" : 796,
-        "lemma" : "nearly",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_137",
-        "text" : "20,000",
-        "tag" : "CD",
-        "entity" : "NUMBER",
-        "startOffset" : 797,
-        "endOffset" : 803,
-        "lemma" : "20,000",
-        "chunk" : "I-NP",
-        "norm" : "~20000.0"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_138",
-        "text" : "others",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 804,
-        "endOffset" : 810,
-        "lemma" : "other",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_139",
-        "text" : "last",
-        "tag" : "JJ",
-        "entity" : "DATE",
-        "startOffset" : 811,
-        "endOffset" : 815,
-        "lemma" : "last",
-        "chunk" : "B-NP",
-        "norm" : "THIS P1Y OFFSET P-1Y"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_140",
-        "text" : "year",
-        "tag" : "NN",
-        "entity" : "DATE",
-        "startOffset" : 816,
-        "endOffset" : 820,
-        "lemma" : "year",
-        "chunk" : "I-NP",
-        "norm" : "THIS P1Y OFFSET P-1Y"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_141",
-        "text" : ".",
-        "tag" : ".",
-        "entity" : "O",
-        "startOffset" : 820,
-        "endOffset" : 821,
-        "lemma" : ".",
-        "chunk" : "O",
-        "norm" : "O"
-      } ],
-      "dependencies" : [ {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_115"
-        },
-        "destination" : {
-          "@id" : "_:Word_114"
-        },
-        "relation" : "advmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_117"
-        },
-        "destination" : {
-          "@id" : "_:Word_115"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_117"
-        },
-        "destination" : {
-          "@id" : "_:Word_116"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_117"
-        },
-        "destination" : {
-          "@id" : "_:Word_120"
-        },
-        "relation" : "nmod_across"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_117"
-        },
-        "destination" : {
-          "@id" : "_:Word_121"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_117"
-        },
-        "destination" : {
-          "@id" : "_:Word_124"
-        },
-        "relation" : "nmod_including"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_117"
-        },
-        "destination" : {
-          "@id" : "_:Word_113"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_120"
-        },
-        "destination" : {
-          "@id" : "_:Word_118"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_120"
-        },
-        "destination" : {
-          "@id" : "_:Word_119"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_124"
-        },
-        "destination" : {
-          "@id" : "_:Word_122"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_124"
-        },
-        "destination" : {
-          "@id" : "_:Word_123"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_124"
-        },
-        "destination" : {
-          "@id" : "_:Word_126"
-        },
-        "relation" : "nmod_of"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_124"
-        },
-        "destination" : {
-          "@id" : "_:Word_127"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_124"
-        },
-        "destination" : {
-          "@id" : "_:Word_128"
-        },
-        "relation" : "ref"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_124"
-        },
-        "destination" : {
-          "@id" : "_:Word_130"
-        },
-        "relation" : "acl:relcl"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_126"
-        },
-        "destination" : {
-          "@id" : "_:Word_125"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_130"
-        },
-        "destination" : {
-          "@id" : "_:Word_133"
-        },
-        "relation" : "nmod_over"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_130"
-        },
-        "destination" : {
-          "@id" : "_:Word_135"
-        },
-        "relation" : "nmod_over"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_130"
-        },
-        "destination" : {
-          "@id" : "_:Word_124"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_130"
-        },
-        "destination" : {
-          "@id" : "_:Word_129"
-        },
-        "relation" : "aux"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_133"
-        },
-        "destination" : {
-          "@id" : "_:Word_131"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_133"
-        },
-        "destination" : {
-          "@id" : "_:Word_132"
-        },
-        "relation" : "nummod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_133"
-        },
-        "destination" : {
-          "@id" : "_:Word_134"
-        },
-        "relation" : "cc"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_133"
-        },
-        "destination" : {
-          "@id" : "_:Word_135"
-        },
-        "relation" : "conj_and"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_135"
-        },
-        "destination" : {
-          "@id" : "_:Word_138"
-        },
-        "relation" : "dep"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_135"
-        },
-        "destination" : {
-          "@id" : "_:Word_140"
-        },
-        "relation" : "nmod:tmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_137"
-        },
-        "destination" : {
-          "@id" : "_:Word_136"
-        },
-        "relation" : "advmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_138"
-        },
-        "destination" : {
-          "@id" : "_:Word_137"
-        },
-        "relation" : "nummod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_140"
-        },
-        "destination" : {
-          "@id" : "_:Word_139"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_105"
-        },
-        "destination" : {
-          "@id" : "_:Word_104"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_106"
-        },
-        "destination" : {
-          "@id" : "_:Word_105"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_106"
-        },
-        "destination" : {
-          "@id" : "_:Word_107"
-        },
-        "relation" : "dobj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_106"
-        },
-        "destination" : {
-          "@id" : "_:Word_141"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_107"
-        },
-        "destination" : {
-          "@id" : "_:Word_112"
-        },
-        "relation" : "ccomp"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_110"
-        },
-        "destination" : {
-          "@id" : "_:Word_109"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_112"
-        },
-        "destination" : {
-          "@id" : "_:Word_117"
-        },
-        "relation" : "dobj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_112"
-        },
-        "destination" : {
-          "@id" : "_:Word_108"
-        },
-        "relation" : "mark"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_112"
-        },
-        "destination" : {
-          "@id" : "_:Word_110"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_112"
-        },
-        "destination" : {
-          "@id" : "_:Word_111"
-        },
-        "relation" : "aux"
-      } ]
-    }, {
-      "@type" : "Sentence",
-      "@id" : "_:Sentence_6",
-      "text" : "\" We call upon the humanitarian community to join hands with the government to rescue this alarming situation , \" stressed Kulang .",
-      "words" : [ {
-        "@type" : "Word",
-        "@id" : "_:Word_142",
-        "text" : "\"",
-        "tag" : "``",
-        "entity" : "O",
-        "startOffset" : 823,
-        "endOffset" : 824,
-        "lemma" : "``",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_143",
-        "text" : "We",
-        "tag" : "PRP",
-        "entity" : "O",
-        "startOffset" : 824,
-        "endOffset" : 826,
-        "lemma" : "we",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_144",
-        "text" : "call",
-        "tag" : "VBP",
-        "entity" : "O",
-        "startOffset" : 827,
-        "endOffset" : 831,
-        "lemma" : "call",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_145",
-        "text" : "upon",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 832,
-        "endOffset" : 836,
-        "lemma" : "upon",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_146",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 837,
-        "endOffset" : 840,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_147",
-        "text" : "humanitarian",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 841,
-        "endOffset" : 853,
-        "lemma" : "humanitarian",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_148",
-        "text" : "community",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 854,
-        "endOffset" : 863,
-        "lemma" : "community",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_149",
-        "text" : "to",
-        "tag" : "TO",
-        "entity" : "O",
-        "startOffset" : 864,
-        "endOffset" : 866,
-        "lemma" : "to",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_150",
-        "text" : "join",
-        "tag" : "VB",
-        "entity" : "O",
-        "startOffset" : 867,
-        "endOffset" : 871,
-        "lemma" : "join",
-        "chunk" : "I-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_151",
-        "text" : "hands",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 872,
-        "endOffset" : 877,
-        "lemma" : "hand",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_152",
-        "text" : "with",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 878,
-        "endOffset" : 882,
-        "lemma" : "with",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_153",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 883,
-        "endOffset" : 886,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_154",
-        "text" : "government",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 887,
-        "endOffset" : 897,
-        "lemma" : "government",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_155",
-        "text" : "to",
-        "tag" : "TO",
-        "entity" : "O",
-        "startOffset" : 898,
-        "endOffset" : 900,
-        "lemma" : "to",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_156",
-        "text" : "rescue",
-        "tag" : "VB",
-        "entity" : "O",
-        "startOffset" : 901,
-        "endOffset" : 907,
-        "lemma" : "rescue",
-        "chunk" : "I-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_157",
-        "text" : "this",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 908,
-        "endOffset" : 912,
-        "lemma" : "this",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_158",
-        "text" : "alarming",
-        "tag" : "JJ",
-        "entity" : "B-Quantifier",
-        "startOffset" : 913,
-        "endOffset" : 921,
-        "lemma" : "alarming",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_159",
-        "text" : "situation",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 922,
-        "endOffset" : 931,
-        "lemma" : "situation",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_160",
-        "text" : ",",
-        "tag" : ",",
-        "entity" : "O",
-        "startOffset" : 931,
-        "endOffset" : 932,
-        "lemma" : ",",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_161",
-        "text" : "\"",
-        "tag" : "''",
-        "entity" : "O",
-        "startOffset" : 932,
-        "endOffset" : 933,
-        "lemma" : "''",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_162",
-        "text" : "stressed",
-        "tag" : "VBD",
-        "entity" : "O",
-        "startOffset" : 934,
-        "endOffset" : 942,
-        "lemma" : "stress",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_163",
-        "text" : "Kulang",
-        "tag" : "NNP",
-        "entity" : "PERSON",
-        "startOffset" : 943,
-        "endOffset" : 949,
-        "lemma" : "Kulang",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_164",
-        "text" : ".",
-        "tag" : ".",
-        "entity" : "O",
-        "startOffset" : 949,
-        "endOffset" : 950,
-        "lemma" : ".",
-        "chunk" : "O",
-        "norm" : "O"
-      } ],
-      "dependencies" : [ {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_156"
-        },
-        "destination" : {
-          "@id" : "_:Word_159"
-        },
-        "relation" : "dobj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_156"
-        },
-        "destination" : {
-          "@id" : "_:Word_155"
-        },
-        "relation" : "mark"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_159"
-        },
-        "destination" : {
-          "@id" : "_:Word_157"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_159"
-        },
-        "destination" : {
-          "@id" : "_:Word_158"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_162"
-        },
-        "destination" : {
-          "@id" : "_:Word_142"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_162"
-        },
-        "destination" : {
-          "@id" : "_:Word_144"
-        },
-        "relation" : "ccomp"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_162"
-        },
-        "destination" : {
-          "@id" : "_:Word_160"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_162"
-        },
-        "destination" : {
-          "@id" : "_:Word_161"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_162"
-        },
-        "destination" : {
-          "@id" : "_:Word_163"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_162"
-        },
-        "destination" : {
-          "@id" : "_:Word_164"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_144"
-        },
-        "destination" : {
-          "@id" : "_:Word_143"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_144"
-        },
-        "destination" : {
-          "@id" : "_:Word_148"
-        },
-        "relation" : "nmod_upon"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_144"
-        },
-        "destination" : {
-          "@id" : "_:Word_150"
-        },
-        "relation" : "xcomp"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_148"
-        },
-        "destination" : {
-          "@id" : "_:Word_145"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_148"
-        },
-        "destination" : {
-          "@id" : "_:Word_146"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_148"
-        },
-        "destination" : {
-          "@id" : "_:Word_147"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_150"
-        },
-        "destination" : {
-          "@id" : "_:Word_156"
-        },
-        "relation" : "advcl_to"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_150"
-        },
-        "destination" : {
-          "@id" : "_:Word_143"
-        },
-        "relation" : "nsubj:xsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_150"
-        },
-        "destination" : {
-          "@id" : "_:Word_149"
-        },
-        "relation" : "mark"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_150"
-        },
-        "destination" : {
-          "@id" : "_:Word_151"
-        },
-        "relation" : "dobj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_150"
-        },
-        "destination" : {
-          "@id" : "_:Word_154"
-        },
-        "relation" : "nmod_with"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_154"
-        },
-        "destination" : {
-          "@id" : "_:Word_152"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_154"
-        },
-        "destination" : {
-          "@id" : "_:Word_153"
-        },
-        "relation" : "det"
-      } ]
-    }, {
-      "@type" : "Sentence",
-      "@id" : "_:Sentence_7",
-      "text" : "Much of South Sudan receives little rainfall and only 5 % of the arable land is currently cultivated .",
-      "words" : [ {
-        "@type" : "Word",
-        "@id" : "_:Word_165",
-        "text" : "Much",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 952,
-        "endOffset" : 956,
-        "lemma" : "much",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_166",
-        "text" : "of",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 957,
-        "endOffset" : 959,
-        "lemma" : "of",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_167",
-        "text" : "South",
-        "tag" : "NNP",
-        "entity" : "LOCATION",
-        "startOffset" : 960,
-        "endOffset" : 965,
-        "lemma" : "South",
-        "chunk" : "B-NP",
-        "norm" : "LOC"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_168",
-        "text" : "Sudan",
-        "tag" : "NNP",
-        "entity" : "LOCATION",
-        "startOffset" : 966,
-        "endOffset" : 971,
-        "lemma" : "Sudan",
-        "chunk" : "I-NP",
-        "norm" : "LOC"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_169",
-        "text" : "receives",
-        "tag" : "VBZ",
-        "entity" : "O",
-        "startOffset" : 972,
-        "endOffset" : 980,
-        "lemma" : "receive",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_170",
-        "text" : "little",
-        "tag" : "JJ",
-        "entity" : "B-Quantifier",
-        "startOffset" : 981,
-        "endOffset" : 987,
-        "lemma" : "little",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_171",
-        "text" : "rainfall",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 988,
-        "endOffset" : 996,
-        "lemma" : "rainfall",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_172",
-        "text" : "and",
-        "tag" : "CC",
-        "entity" : "O",
-        "startOffset" : 997,
-        "endOffset" : 1000,
-        "lemma" : "and",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_173",
-        "text" : "only",
-        "tag" : "RB",
-        "entity" : "O",
-        "startOffset" : 1001,
-        "endOffset" : 1005,
-        "lemma" : "only",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_174",
-        "text" : "5",
-        "tag" : "CD",
-        "entity" : "PERCENT",
-        "startOffset" : 1006,
-        "endOffset" : 1007,
-        "lemma" : "5",
-        "chunk" : "I-NP",
-        "norm" : "%5.0"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_175",
-        "text" : "%",
-        "tag" : "NN",
-        "entity" : "PERCENT",
-        "startOffset" : 1007,
-        "endOffset" : 1008,
-        "lemma" : "%",
-        "chunk" : "I-NP",
-        "norm" : "%5.0"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_176",
-        "text" : "of",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 1009,
-        "endOffset" : 1011,
-        "lemma" : "of",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_177",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 1012,
-        "endOffset" : 1015,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_178",
-        "text" : "arable",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 1016,
-        "endOffset" : 1022,
-        "lemma" : "arable",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_179",
-        "text" : "land",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1023,
-        "endOffset" : 1027,
-        "lemma" : "land",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_180",
-        "text" : "is",
-        "tag" : "VBZ",
-        "entity" : "O",
-        "startOffset" : 1028,
-        "endOffset" : 1030,
-        "lemma" : "be",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_181",
-        "text" : "currently",
-        "tag" : "RB",
-        "entity" : "DATE",
-        "startOffset" : 1031,
-        "endOffset" : 1040,
-        "lemma" : "currently",
-        "chunk" : "I-VP",
-        "norm" : "PRESENT_REF"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_182",
-        "text" : "cultivated",
-        "tag" : "VBN",
-        "entity" : "O",
-        "startOffset" : 1041,
-        "endOffset" : 1051,
-        "lemma" : "cultivate",
-        "chunk" : "I-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_183",
-        "text" : ".",
-        "tag" : ".",
-        "entity" : "O",
-        "startOffset" : 1051,
-        "endOffset" : 1052,
-        "lemma" : ".",
-        "chunk" : "O",
-        "norm" : "O"
-      } ],
-      "dependencies" : [ {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_182"
-        },
-        "destination" : {
-          "@id" : "_:Word_183"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_182"
-        },
-        "destination" : {
-          "@id" : "_:Word_169"
-        },
-        "relation" : "csubjpass"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_182"
-        },
-        "destination" : {
-          "@id" : "_:Word_180"
-        },
-        "relation" : "auxpass"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_182"
-        },
-        "destination" : {
-          "@id" : "_:Word_181"
-        },
-        "relation" : "advmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_165"
-        },
-        "destination" : {
-          "@id" : "_:Word_168"
-        },
-        "relation" : "nmod_of"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_168"
-        },
-        "destination" : {
-          "@id" : "_:Word_166"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_168"
-        },
-        "destination" : {
-          "@id" : "_:Word_167"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_169"
-        },
-        "destination" : {
-          "@id" : "_:Word_171"
-        },
-        "relation" : "dobj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_169"
-        },
-        "destination" : {
-          "@id" : "_:Word_175"
-        },
-        "relation" : "dobj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_169"
-        },
-        "destination" : {
-          "@id" : "_:Word_165"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_171"
-        },
-        "destination" : {
-          "@id" : "_:Word_170"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_171"
-        },
-        "destination" : {
-          "@id" : "_:Word_172"
-        },
-        "relation" : "cc"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_171"
-        },
-        "destination" : {
-          "@id" : "_:Word_175"
-        },
-        "relation" : "conj_and"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_174"
-        },
-        "destination" : {
-          "@id" : "_:Word_173"
-        },
-        "relation" : "advmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_175"
-        },
-        "destination" : {
-          "@id" : "_:Word_174"
-        },
-        "relation" : "nummod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_175"
-        },
-        "destination" : {
-          "@id" : "_:Word_179"
-        },
-        "relation" : "nmod_of"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_179"
-        },
-        "destination" : {
-          "@id" : "_:Word_176"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_179"
-        },
-        "destination" : {
-          "@id" : "_:Word_177"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_179"
-        },
-        "destination" : {
-          "@id" : "_:Word_178"
-        },
-        "relation" : "amod"
-      } ],
-      "geolocs" : [ {
-        "@type" : "GeoLocation",
-        "@id" : "_:GeoLocation_3",
-        "startOffset" : 960,
-        "endOffset" : 971,
-        "text" : "South Sudan",
-        "geoID" : "7909807"
-      } ]
-    }, {
-      "@type" : "Sentence",
-      "@id" : "_:Sentence_8",
-      "text" : "Nonetheless , the country has significant potential for increased cereal production , especially in the southern regions with the highest annual rainfall .",
-      "words" : [ {
-        "@type" : "Word",
-        "@id" : "_:Word_184",
-        "text" : "Nonetheless",
-        "tag" : "RB",
-        "entity" : "O",
-        "startOffset" : 1053,
-        "endOffset" : 1064,
-        "lemma" : "nonetheless",
-        "chunk" : "B-ADVP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_185",
-        "text" : ",",
-        "tag" : ",",
-        "entity" : "O",
-        "startOffset" : 1064,
-        "endOffset" : 1065,
-        "lemma" : ",",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_186",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 1066,
-        "endOffset" : 1069,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_187",
-        "text" : "country",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1070,
-        "endOffset" : 1077,
-        "lemma" : "country",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_188",
-        "text" : "has",
-        "tag" : "VBZ",
-        "entity" : "O",
-        "startOffset" : 1078,
-        "endOffset" : 1081,
-        "lemma" : "have",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_189",
-        "text" : "significant",
-        "tag" : "JJ",
-        "entity" : "B-Quantifier",
-        "startOffset" : 1082,
-        "endOffset" : 1093,
-        "lemma" : "significant",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_190",
-        "text" : "potential",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1094,
-        "endOffset" : 1103,
-        "lemma" : "potential",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_191",
-        "text" : "for",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 1104,
-        "endOffset" : 1107,
-        "lemma" : "for",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_192",
-        "text" : "increased",
-        "tag" : "VBN",
-        "entity" : "O",
-        "startOffset" : 1108,
-        "endOffset" : 1117,
-        "lemma" : "increase",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_193",
-        "text" : "cereal",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1118,
-        "endOffset" : 1124,
-        "lemma" : "cereal",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_194",
-        "text" : "production",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1125,
-        "endOffset" : 1135,
-        "lemma" : "production",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_195",
-        "text" : ",",
-        "tag" : ",",
-        "entity" : "O",
-        "startOffset" : 1135,
-        "endOffset" : 1136,
-        "lemma" : ",",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_196",
-        "text" : "especially",
-        "tag" : "RB",
-        "entity" : "O",
-        "startOffset" : 1137,
-        "endOffset" : 1147,
-        "lemma" : "especially",
-        "chunk" : "B-ADVP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_197",
-        "text" : "in",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 1148,
-        "endOffset" : 1150,
-        "lemma" : "in",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_198",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 1151,
-        "endOffset" : 1154,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_199",
-        "text" : "southern",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 1155,
-        "endOffset" : 1163,
-        "lemma" : "southern",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_200",
-        "text" : "regions",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 1164,
-        "endOffset" : 1171,
-        "lemma" : "region",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_201",
-        "text" : "with",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 1172,
-        "endOffset" : 1176,
-        "lemma" : "with",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_202",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 1177,
-        "endOffset" : 1180,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_203",
-        "text" : "highest",
-        "tag" : "JJS",
-        "entity" : "O",
-        "startOffset" : 1181,
-        "endOffset" : 1188,
-        "lemma" : "highest",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_204",
-        "text" : "annual",
-        "tag" : "JJ",
-        "entity" : "SET",
-        "startOffset" : 1189,
-        "endOffset" : 1195,
-        "lemma" : "annual",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_205",
-        "text" : "rainfall",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 1196,
-        "endOffset" : 1204,
-        "lemma" : "rainfall",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_206",
-        "text" : ".",
-        "tag" : ".",
-        "entity" : "O",
-        "startOffset" : 1204,
-        "endOffset" : 1205,
-        "lemma" : ".",
-        "chunk" : "O",
-        "norm" : "O"
-      } ],
-      "dependencies" : [ {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_205"
-        },
-        "destination" : {
-          "@id" : "_:Word_204"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_205"
-        },
-        "destination" : {
-          "@id" : "_:Word_201"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_205"
-        },
-        "destination" : {
-          "@id" : "_:Word_202"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_205"
-        },
-        "destination" : {
-          "@id" : "_:Word_203"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_187"
-        },
-        "destination" : {
-          "@id" : "_:Word_186"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_188"
-        },
-        "destination" : {
-          "@id" : "_:Word_190"
-        },
-        "relation" : "dobj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_188"
-        },
-        "destination" : {
-          "@id" : "_:Word_206"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_188"
-        },
-        "destination" : {
-          "@id" : "_:Word_195"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_188"
-        },
-        "destination" : {
-          "@id" : "_:Word_184"
-        },
-        "relation" : "advmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_188"
-        },
-        "destination" : {
-          "@id" : "_:Word_200"
-        },
-        "relation" : "nmod_in"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_188"
-        },
-        "destination" : {
-          "@id" : "_:Word_185"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_188"
-        },
-        "destination" : {
-          "@id" : "_:Word_187"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_190"
-        },
-        "destination" : {
-          "@id" : "_:Word_189"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_190"
-        },
-        "destination" : {
-          "@id" : "_:Word_194"
-        },
-        "relation" : "nmod_for"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_194"
-        },
-        "destination" : {
-          "@id" : "_:Word_191"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_194"
-        },
-        "destination" : {
-          "@id" : "_:Word_192"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_194"
-        },
-        "destination" : {
-          "@id" : "_:Word_193"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_200"
-        },
-        "destination" : {
-          "@id" : "_:Word_205"
-        },
-        "relation" : "nmod_with"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_200"
-        },
-        "destination" : {
-          "@id" : "_:Word_196"
-        },
-        "relation" : "advmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_200"
-        },
-        "destination" : {
-          "@id" : "_:Word_197"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_200"
-        },
-        "destination" : {
-          "@id" : "_:Word_198"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_200"
-        },
-        "destination" : {
-          "@id" : "_:Word_199"
-        },
-        "relation" : "amod"
-      } ]
-    }, {
-      "@type" : "Sentence",
-      "@id" : "_:Sentence_9",
-      "text" : "Accurate data on crop area and production for South Sudan are scarce , and there is considerable uncertainty in estimates .",
-      "words" : [ {
-        "@type" : "Word",
-        "@id" : "_:Word_207",
-        "text" : "Accurate",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 1206,
-        "endOffset" : 1214,
-        "lemma" : "accurate",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_208",
-        "text" : "data",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 1215,
-        "endOffset" : 1219,
-        "lemma" : "datum",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_209",
-        "text" : "on",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 1220,
-        "endOffset" : 1222,
-        "lemma" : "on",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_210",
-        "text" : "crop",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1223,
-        "endOffset" : 1227,
-        "lemma" : "crop",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_211",
-        "text" : "area",
-        "tag" : "NN",
-        "entity" : "B-Property",
-        "startOffset" : 1228,
-        "endOffset" : 1232,
-        "lemma" : "area",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_212",
-        "text" : "and",
-        "tag" : "CC",
-        "entity" : "O",
-        "startOffset" : 1233,
-        "endOffset" : 1236,
-        "lemma" : "and",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_213",
-        "text" : "production",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1237,
-        "endOffset" : 1247,
-        "lemma" : "production",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_214",
-        "text" : "for",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 1248,
-        "endOffset" : 1251,
-        "lemma" : "for",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_215",
-        "text" : "South",
-        "tag" : "NNP",
-        "entity" : "LOCATION",
-        "startOffset" : 1252,
-        "endOffset" : 1257,
-        "lemma" : "South",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_216",
-        "text" : "Sudan",
-        "tag" : "NNP",
-        "entity" : "LOCATION",
-        "startOffset" : 1258,
-        "endOffset" : 1263,
-        "lemma" : "Sudan",
-        "chunk" : "I-NP",
-        "norm" : "LOC"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_217",
-        "text" : "are",
-        "tag" : "VBP",
-        "entity" : "O",
-        "startOffset" : 1264,
-        "endOffset" : 1267,
-        "lemma" : "be",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_218",
-        "text" : "scarce",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 1268,
-        "endOffset" : 1274,
-        "lemma" : "scarce",
-        "chunk" : "B-ADJP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_219",
-        "text" : ",",
-        "tag" : ",",
-        "entity" : "O",
-        "startOffset" : 1274,
-        "endOffset" : 1275,
-        "lemma" : ",",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_220",
-        "text" : "and",
-        "tag" : "CC",
-        "entity" : "O",
-        "startOffset" : 1276,
-        "endOffset" : 1279,
-        "lemma" : "and",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_221",
-        "text" : "there",
-        "tag" : "EX",
-        "entity" : "O",
-        "startOffset" : 1280,
-        "endOffset" : 1285,
-        "lemma" : "there",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_222",
-        "text" : "is",
-        "tag" : "VBZ",
-        "entity" : "O",
-        "startOffset" : 1286,
-        "endOffset" : 1288,
-        "lemma" : "be",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_223",
-        "text" : "considerable",
-        "tag" : "JJ",
-        "entity" : "B-Quantifier",
-        "startOffset" : 1289,
-        "endOffset" : 1301,
-        "lemma" : "considerable",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_224",
-        "text" : "uncertainty",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1302,
-        "endOffset" : 1313,
-        "lemma" : "uncertainty",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_225",
-        "text" : "in",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 1314,
-        "endOffset" : 1316,
-        "lemma" : "in",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_226",
-        "text" : "estimates",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 1317,
-        "endOffset" : 1326,
-        "lemma" : "estimate",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_227",
-        "text" : ".",
-        "tag" : ".",
-        "entity" : "O",
-        "startOffset" : 1326,
-        "endOffset" : 1327,
-        "lemma" : ".",
-        "chunk" : "O",
-        "norm" : "O"
-      } ],
-      "dependencies" : [ {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_208"
-        },
-        "destination" : {
-          "@id" : "_:Word_216"
-        },
-        "relation" : "nmod_for"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_208"
-        },
-        "destination" : {
-          "@id" : "_:Word_207"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_208"
-        },
-        "destination" : {
-          "@id" : "_:Word_211"
-        },
-        "relation" : "nmod_on"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_208"
-        },
-        "destination" : {
-          "@id" : "_:Word_213"
-        },
-        "relation" : "nmod_on"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_211"
-        },
-        "destination" : {
-          "@id" : "_:Word_209"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_211"
-        },
-        "destination" : {
-          "@id" : "_:Word_210"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_211"
-        },
-        "destination" : {
-          "@id" : "_:Word_212"
-        },
-        "relation" : "cc"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_211"
-        },
-        "destination" : {
-          "@id" : "_:Word_213"
-        },
-        "relation" : "conj_and"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_216"
-        },
-        "destination" : {
-          "@id" : "_:Word_214"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_216"
-        },
-        "destination" : {
-          "@id" : "_:Word_215"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_218"
-        },
-        "destination" : {
-          "@id" : "_:Word_217"
-        },
-        "relation" : "cop"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_218"
-        },
-        "destination" : {
-          "@id" : "_:Word_219"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_218"
-        },
-        "destination" : {
-          "@id" : "_:Word_220"
-        },
-        "relation" : "cc"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_218"
-        },
-        "destination" : {
-          "@id" : "_:Word_222"
-        },
-        "relation" : "conj_and"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_218"
-        },
-        "destination" : {
-          "@id" : "_:Word_208"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_218"
-        },
-        "destination" : {
-          "@id" : "_:Word_227"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_222"
-        },
-        "destination" : {
-          "@id" : "_:Word_221"
-        },
-        "relation" : "expl"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_222"
-        },
-        "destination" : {
-          "@id" : "_:Word_224"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_224"
-        },
-        "destination" : {
-          "@id" : "_:Word_223"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_224"
-        },
-        "destination" : {
-          "@id" : "_:Word_226"
-        },
-        "relation" : "nmod_in"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_226"
-        },
-        "destination" : {
-          "@id" : "_:Word_225"
-        },
-        "relation" : "case"
-      } ],
-      "geolocs" : [ {
-        "@type" : "GeoLocation",
-        "@id" : "_:GeoLocation_4",
-        "startOffset" : 1258,
-        "endOffset" : 1263,
-        "text" : "Sudan",
-        "geoID" : "8056717"
-      } ]
-    }, {
-      "@type" : "Sentence",
-      "@id" : "_:Sentence_10",
-      "text" : "Nearly 5 million people or more than 40 % of the population in South Sudan were in need of urgent food , agriculture and nutrition assistance , the Integrated Food Security Phase Classification ( IPC ) projected early this year .",
-      "words" : [ {
-        "@type" : "Word",
-        "@id" : "_:Word_228",
-        "text" : "Nearly",
-        "tag" : "RB",
-        "entity" : "O",
-        "startOffset" : 1329,
-        "endOffset" : 1335,
-        "lemma" : "nearly",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_229",
-        "text" : "5",
-        "tag" : "CD",
-        "entity" : "NUMBER",
-        "startOffset" : 1336,
-        "endOffset" : 1337,
-        "lemma" : "5",
-        "chunk" : "I-NP",
-        "norm" : "~5000000.0"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_230",
-        "text" : "million",
-        "tag" : "CD",
-        "entity" : "NUMBER",
-        "startOffset" : 1338,
-        "endOffset" : 1345,
-        "lemma" : "million",
-        "chunk" : "I-NP",
-        "norm" : "~5000000.0"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_231",
-        "text" : "people",
-        "tag" : "NNS",
-        "entity" : "O",
-        "startOffset" : 1346,
-        "endOffset" : 1352,
-        "lemma" : "people",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_232",
-        "text" : "or",
-        "tag" : "CC",
-        "entity" : "O",
-        "startOffset" : 1353,
-        "endOffset" : 1355,
-        "lemma" : "or",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_233",
-        "text" : "more",
-        "tag" : "JJR",
-        "entity" : "O",
-        "startOffset" : 1356,
-        "endOffset" : 1360,
-        "lemma" : "more",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_234",
-        "text" : "than",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 1361,
-        "endOffset" : 1365,
-        "lemma" : "than",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_235",
-        "text" : "40",
-        "tag" : "CD",
-        "entity" : "PERCENT",
-        "startOffset" : 1366,
-        "endOffset" : 1368,
-        "lemma" : "40",
-        "chunk" : "I-NP",
-        "norm" : ">%40.0"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_236",
-        "text" : "%",
-        "tag" : "NN",
-        "entity" : "PERCENT",
-        "startOffset" : 1368,
-        "endOffset" : 1369,
-        "lemma" : "%",
-        "chunk" : "I-NP",
-        "norm" : ">%40.0"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_237",
-        "text" : "of",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 1370,
-        "endOffset" : 1372,
-        "lemma" : "of",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_238",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 1373,
-        "endOffset" : 1376,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_239",
-        "text" : "population",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1377,
-        "endOffset" : 1387,
-        "lemma" : "population",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_240",
-        "text" : "in",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 1388,
-        "endOffset" : 1390,
-        "lemma" : "in",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_241",
-        "text" : "South",
-        "tag" : "NNP",
-        "entity" : "LOCATION",
-        "startOffset" : 1391,
-        "endOffset" : 1396,
-        "lemma" : "South",
-        "chunk" : "B-NP",
-        "norm" : "LOC"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_242",
-        "text" : "Sudan",
-        "tag" : "NNP",
-        "entity" : "LOCATION",
-        "startOffset" : 1397,
-        "endOffset" : 1402,
-        "lemma" : "Sudan",
-        "chunk" : "I-NP",
-        "norm" : "LOC"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_243",
-        "text" : "were",
-        "tag" : "VBD",
-        "entity" : "O",
-        "startOffset" : 1403,
-        "endOffset" : 1407,
-        "lemma" : "be",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_244",
-        "text" : "in",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 1408,
-        "endOffset" : 1410,
-        "lemma" : "in",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_245",
-        "text" : "need",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1411,
-        "endOffset" : 1415,
-        "lemma" : "need",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_246",
-        "text" : "of",
-        "tag" : "IN",
-        "entity" : "O",
-        "startOffset" : 1416,
-        "endOffset" : 1418,
-        "lemma" : "of",
-        "chunk" : "B-PP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_247",
-        "text" : "urgent",
-        "tag" : "JJ",
-        "entity" : "O",
-        "startOffset" : 1419,
-        "endOffset" : 1425,
-        "lemma" : "urgent",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_248",
-        "text" : "food",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1426,
-        "endOffset" : 1430,
-        "lemma" : "food",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_249",
-        "text" : ",",
-        "tag" : ",",
-        "entity" : "O",
-        "startOffset" : 1430,
-        "endOffset" : 1431,
-        "lemma" : ",",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_250",
-        "text" : "agriculture",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1432,
-        "endOffset" : 1443,
-        "lemma" : "agriculture",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_251",
-        "text" : "and",
-        "tag" : "CC",
-        "entity" : "O",
-        "startOffset" : 1444,
-        "endOffset" : 1447,
-        "lemma" : "and",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_252",
-        "text" : "nutrition",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1448,
-        "endOffset" : 1457,
-        "lemma" : "nutrition",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_253",
-        "text" : "assistance",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1458,
-        "endOffset" : 1468,
-        "lemma" : "assistance",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_254",
-        "text" : ",",
-        "tag" : ",",
-        "entity" : "O",
-        "startOffset" : 1468,
-        "endOffset" : 1469,
-        "lemma" : ",",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_255",
-        "text" : "the",
-        "tag" : "DT",
-        "entity" : "O",
-        "startOffset" : 1470,
-        "endOffset" : 1473,
-        "lemma" : "the",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_256",
-        "text" : "Integrated",
-        "tag" : "NNP",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 1474,
-        "endOffset" : 1484,
-        "lemma" : "Integrated",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_257",
-        "text" : "Food",
-        "tag" : "NNP",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 1485,
-        "endOffset" : 1489,
-        "lemma" : "Food",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_258",
-        "text" : "Security",
-        "tag" : "NNP",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 1490,
-        "endOffset" : 1498,
-        "lemma" : "Security",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_259",
-        "text" : "Phase",
-        "tag" : "NN",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 1499,
-        "endOffset" : 1504,
-        "lemma" : "phase",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_260",
-        "text" : "Classification",
-        "tag" : "NN",
-        "entity" : "ORGANIZATION",
-        "startOffset" : 1505,
-        "endOffset" : 1519,
-        "lemma" : "classification",
-        "chunk" : "I-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_261",
-        "text" : "(",
-        "tag" : "-LRB-",
-        "entity" : "O",
-        "startOffset" : 1520,
-        "endOffset" : 1521,
-        "lemma" : "-lrb-",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_262",
-        "text" : "IPC",
-        "tag" : "NN",
-        "entity" : "O",
-        "startOffset" : 1521,
-        "endOffset" : 1524,
-        "lemma" : "ipc",
-        "chunk" : "B-NP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_263",
-        "text" : ")",
-        "tag" : "-RRB-",
-        "entity" : "O",
-        "startOffset" : 1524,
-        "endOffset" : 1525,
-        "lemma" : "-rrb-",
-        "chunk" : "O",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_264",
-        "text" : "projected",
-        "tag" : "VBD",
-        "entity" : "O",
-        "startOffset" : 1526,
-        "endOffset" : 1535,
-        "lemma" : "project",
-        "chunk" : "B-VP",
-        "norm" : "O"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_265",
-        "text" : "early",
-        "tag" : "RB",
-        "entity" : "DATE",
-        "startOffset" : 1536,
-        "endOffset" : 1541,
-        "lemma" : "early",
-        "chunk" : "B-NP",
-        "norm" : "THIS P1Y"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_266",
-        "text" : "this",
-        "tag" : "DT",
-        "entity" : "DATE",
-        "startOffset" : 1542,
-        "endOffset" : 1546,
-        "lemma" : "this",
-        "chunk" : "I-NP",
-        "norm" : "THIS P1Y"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_267",
-        "text" : "year",
-        "tag" : "NN",
-        "entity" : "DATE",
-        "startOffset" : 1547,
-        "endOffset" : 1551,
-        "lemma" : "year",
-        "chunk" : "I-NP",
-        "norm" : "THIS P1Y"
-      }, {
-        "@type" : "Word",
-        "@id" : "_:Word_268",
-        "text" : ".",
-        "tag" : ".",
-        "entity" : "O",
-        "startOffset" : 1551,
-        "endOffset" : 1552,
-        "lemma" : ".",
-        "chunk" : "O",
-        "norm" : "O"
-      } ],
-      "dependencies" : [ {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_230"
-        },
-        "destination" : {
-          "@id" : "_:Word_228"
-        },
-        "relation" : "advmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_230"
-        },
-        "destination" : {
-          "@id" : "_:Word_229"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_231"
-        },
-        "destination" : {
-          "@id" : "_:Word_230"
-        },
-        "relation" : "nummod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_231"
-        },
-        "destination" : {
-          "@id" : "_:Word_232"
-        },
-        "relation" : "cc"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_231"
-        },
-        "destination" : {
-          "@id" : "_:Word_236"
-        },
-        "relation" : "conj_or"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_233"
-        },
-        "destination" : {
-          "@id" : "_:Word_234"
-        },
-        "relation" : "mwe"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_235"
-        },
-        "destination" : {
-          "@id" : "_:Word_233"
-        },
-        "relation" : "advmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_236"
-        },
-        "destination" : {
-          "@id" : "_:Word_239"
-        },
-        "relation" : "nmod_of"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_236"
-        },
-        "destination" : {
-          "@id" : "_:Word_235"
-        },
-        "relation" : "nummod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_239"
-        },
-        "destination" : {
-          "@id" : "_:Word_238"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_239"
-        },
-        "destination" : {
-          "@id" : "_:Word_242"
-        },
-        "relation" : "nmod_in"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_239"
-        },
-        "destination" : {
-          "@id" : "_:Word_237"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_242"
-        },
-        "destination" : {
-          "@id" : "_:Word_240"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_242"
-        },
-        "destination" : {
-          "@id" : "_:Word_241"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_245"
-        },
-        "destination" : {
-          "@id" : "_:Word_254"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_245"
-        },
-        "destination" : {
-          "@id" : "_:Word_243"
-        },
-        "relation" : "cop"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_245"
-        },
-        "destination" : {
-          "@id" : "_:Word_244"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_245"
-        },
-        "destination" : {
-          "@id" : "_:Word_231"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_245"
-        },
-        "destination" : {
-          "@id" : "_:Word_248"
-        },
-        "relation" : "nmod_of"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_245"
-        },
-        "destination" : {
-          "@id" : "_:Word_264"
-        },
-        "relation" : "acl:relcl"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_245"
-        },
-        "destination" : {
-          "@id" : "_:Word_250"
-        },
-        "relation" : "nmod_of"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_245"
-        },
-        "destination" : {
-          "@id" : "_:Word_236"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_245"
-        },
-        "destination" : {
-          "@id" : "_:Word_268"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_245"
-        },
-        "destination" : {
-          "@id" : "_:Word_253"
-        },
-        "relation" : "nmod_of"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_248"
-        },
-        "destination" : {
-          "@id" : "_:Word_246"
-        },
-        "relation" : "case"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_248"
-        },
-        "destination" : {
-          "@id" : "_:Word_247"
-        },
-        "relation" : "amod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_248"
-        },
-        "destination" : {
-          "@id" : "_:Word_249"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_248"
-        },
-        "destination" : {
-          "@id" : "_:Word_250"
-        },
-        "relation" : "conj_and"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_248"
-        },
-        "destination" : {
-          "@id" : "_:Word_251"
-        },
-        "relation" : "cc"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_248"
-        },
-        "destination" : {
-          "@id" : "_:Word_253"
-        },
-        "relation" : "conj_and"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_253"
-        },
-        "destination" : {
-          "@id" : "_:Word_252"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_260"
-        },
-        "destination" : {
-          "@id" : "_:Word_255"
-        },
-        "relation" : "det"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_260"
-        },
-        "destination" : {
-          "@id" : "_:Word_256"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_260"
-        },
-        "destination" : {
-          "@id" : "_:Word_257"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_260"
-        },
-        "destination" : {
-          "@id" : "_:Word_258"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_260"
-        },
-        "destination" : {
-          "@id" : "_:Word_259"
-        },
-        "relation" : "compound"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_260"
-        },
-        "destination" : {
-          "@id" : "_:Word_262"
-        },
-        "relation" : "appos"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_262"
-        },
-        "destination" : {
-          "@id" : "_:Word_261"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_262"
-        },
-        "destination" : {
-          "@id" : "_:Word_263"
-        },
-        "relation" : "punct"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_264"
-        },
-        "destination" : {
-          "@id" : "_:Word_260"
-        },
-        "relation" : "nsubj"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_264"
-        },
-        "destination" : {
-          "@id" : "_:Word_267"
-        },
-        "relation" : "nmod:tmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_267"
-        },
-        "destination" : {
-          "@id" : "_:Word_265"
-        },
-        "relation" : "advmod"
-      }, {
-        "@type" : "Dependency",
-        "source" : {
-          "@id" : "_:Word_267"
-        },
-        "destination" : {
-          "@id" : "_:Word_266"
-        },
-        "relation" : "det"
-      } ],
-      "geolocs" : [ {
-        "@type" : "GeoLocation",
-        "@id" : "_:GeoLocation_5",
-        "startOffset" : 1391,
-        "endOffset" : 1402,
-        "text" : "South Sudan",
-        "geoID" : "7909807"
-      } ]
-    } ]
-  } ],
-  "extractions" : [ {
-    "@type" : "Extraction",
-    "@id" : "_:Extraction_1",
-    "type" : "concept",
-    "subtype" : "entity",
-    "labels" : [ "Concept", "Entity" ],
-    "text" : "Floods",
-    "rule" : "simple-np",
-    "canonicalName" : "flood",
-    "provenance" : [ {
-      "@type" : "Provenance",
-      "document" : {
-        "@id" : "_:Document_1"
-      },
-      "documentCharInterval" : [ {
-        "@type" : "Interval",
-        "start" : 1,
-        "end" : 6
-      } ],
-      "sentence" : {
-        "@id" : "_:Sentence_1"
-      },
-      "positions" : [ {
-        "@type" : "Interval",
-        "start" : 1,
-        "end" : 1
-      } ]
-    } ]
-  }, {
-    "@type" : "Extraction",
-    "@id" : "_:Extraction_2",
-    "type" : "concept",
-    "subtype" : "entity",
-    "labels" : [ "Concept", "Entity" ],
-    "text" : "rain",
-    "rule" : "simple-np",
-    "canonicalName" : "rain",
-    "provenance" : [ {
-      "@type" : "Provenance",
-      "document" : {
-        "@id" : "_:Document_1"
-      },
-      "documentCharInterval" : [ {
-        "@type" : "Interval",
-        "start" : 18,
-        "end" : 21
-      } ],
-      "sentence" : {
-        "@id" : "_:Sentence_1"
-      },
-      "positions" : [ {
-        "@type" : "Interval",
-        "start" : 4,
-        "end" : 4
-      } ]
-    } ]
-  }, {
-    "@type" : "Extraction",
-    "@id" : "_:Extraction_6",
-    "type" : "concept",
-    "subtype" : "entity",
-    "labels" : [ "Concept", "Entity" ],
-    "text" : "fears about the devastating impact",
-    "rule" : "simple-np++Increase_ported_syntax_1_verb",
-    "canonicalName" : "fear",
-    "provenance" : [ {
-      "@type" : "Provenance",
-      "document" : {
-        "@id" : "_:Document_1"
-      },
-      "documentCharInterval" : [ {
-        "@type" : "Interval",
-        "start" : 105,
-        "end" : 138
-      } ],
-      "sentence" : {
-        "@id" : "_:Sentence_1"
-      },
-      "positions" : [ {
-        "@type" : "Interval",
-        "start" : 20,
-        "end" : 24
-      } ]
-    } ],
-    "states" : [ {
-      "@type" : "State",
-      "type" : "INC",
-      "text" : "raising",
-      "provenance" : {
-        "@type" : "Provenance",
-        "document" : {
-          "@id" : "_:Document_1"
-        },
-        "documentCharInterval" : [ {
-          "@type" : "Interval",
-          "start" : 97,
-          "end" : 103
-        } ],
-        "sentence" : {
-          "@id" : "_:Sentence_1"
-        },
-        "positions" : [ {
-          "@type" : "Interval",
-          "start" : 19,
-          "end" : 19
-        } ]
-      }
-    } ]
-  }, {
-    "@type" : "Extraction",
-    "@id" : "_:Extraction_7",
-    "type" : "concept",
-    "subtype" : "entity",
-    "labels" : [ "Concept", "Entity" ],
-    "text" : "Floods caused by rain have displaced more than 100,000 people in South Sudan",
-    "rule" : "simple-np++simple-vp",
-    "canonicalName" : "flood cause rain have displace",
-    "provenance" : [ {
-      "@type" : "Provenance",
-      "document" : {
-        "@id" : "_:Document_1"
-      },
-      "documentCharInterval" : [ {
-        "@type" : "Interval",
-        "start" : 1,
-        "end" : 76
-      } ],
-      "sentence" : {
-        "@id" : "_:Sentence_1"
-      },
-      "positions" : [ {
-        "@type" : "Interval",
-        "start" : 1,
-        "end" : 13
-      } ]
-    } ],
-    "states" : [ {
-      "@type" : "State",
-      "type" : "LocationExp",
-      "text" : "South Sudan",
-      "value" : {
-        "@id" : "_:GeoLocation_1"
-      }
-    } ]
-  }, {
-    "@type" : "Extraction",
-    "@id" : "_:Extraction_8",
-    "type" : "concept",
-    "subtype" : "entity",
-    "labels" : [ "Concept", "Entity" ],
-    "text" : "floods",
-    "rule" : "simple-np",
-    "canonicalName" : "flood",
-    "provenance" : [ {
-      "@type" : "Provenance",
-      "document" : {
-        "@id" : "_:Document_1"
-      },
-      "documentCharInterval" : [ {
-        "@type" : "Interval",
-        "start" : 632,
-        "end" : 637
-      } ],
-      "sentence" : {
-        "@id" : "_:Sentence_5"
-      },
-      "positions" : [ {
-        "@type" : "Interval",
-        "start" : 7,
-        "end" : 7
-      } ]
-    } ]
-  }, {
-    "@type" : "Extraction",
-    "@id" : "_:Extraction_9",
-    "type" : "concept",
-    "subtype" : "entity",
-    "labels" : [ "Concept", "Entity" ],
-    "text" : "already dire humanitarian situation across the country, including the spread of cholera",
-    "rule" : "simple-np++Decrease_ported_syntax_1_verb",
-    "canonicalName" : "include cholera",
-    "provenance" : [ {
-      "@type" : "Provenance",
-      "document" : {
-        "@id" : "_:Document_1"
-      },
-      "documentCharInterval" : [ {
-        "@type" : "Interval",
-        "start" : 656,
-        "end" : 742
-      } ],
-      "sentence" : {
-        "@id" : "_:Sentence_5"
-      },
-      "positions" : [ {
-        "@type" : "Interval",
-        "start" : 11,
-        "end" : 23
-      } ]
-    } ],
-    "states" : [ {
-      "@type" : "State",
-      "type" : "DEC",
-      "text" : "worsen",
-      "provenance" : {
-        "@type" : "Provenance",
-        "document" : {
-          "@id" : "_:Document_1"
-        },
-        "documentCharInterval" : [ {
-          "@type" : "Interval",
-          "start" : 645,
-          "end" : 650
-        } ],
-        "sentence" : {
-          "@id" : "_:Sentence_5"
-        },
-        "positions" : [ {
-          "@type" : "Interval",
-          "start" : 9,
-          "end" : 9
-        } ]
-      }
-    }, {
-      "@type" : "State",
-      "type" : "INC",
-      "text" : "spread",
-      "provenance" : {
-        "@type" : "Provenance",
-        "document" : {
-          "@id" : "_:Document_1"
-        },
-        "documentCharInterval" : [ {
-          "@type" : "Interval",
-          "start" : 726,
-          "end" : 731
-        } ],
-        "sentence" : {
-          "@id" : "_:Sentence_5"
-        },
-        "positions" : [ {
-          "@type" : "Interval",
-          "start" : 21,
-          "end" : 21
-        } ]
-      }
-    } ]
-  }, {
-    "@type" : "Extraction",
-    "@id" : "_:Extraction_3",
-    "type" : "relation",
-    "subtype" : "causation",
-    "labels" : [ "Causal", "DirectedRelation", "EntityLinker", "Event" ],
-    "text" : "floods could worsen the already dire humanitarian situation across the country, including the spread of cholera",
-    "rule" : "ported_syntax_1_verb-Causal",
-    "canonicalName" : "flood worsen include cholera",
-    "provenance" : [ {
-      "@type" : "Provenance",
-      "document" : {
-        "@id" : "_:Document_1"
-      },
-      "documentCharInterval" : [ {
-        "@type" : "Interval",
-        "start" : 632,
-        "end" : 742
-      } ],
-      "sentence" : {
-        "@id" : "_:Sentence_5"
-      },
-      "positions" : [ {
-        "@type" : "Interval",
-        "start" : 7,
-        "end" : 23
-      } ]
-    } ],
-    "states" : [ {
-      "@type" : "State",
-      "type" : "HEDGE",
-      "text" : "could"
-    } ],
-    "trigger" : {
-      "@type" : "Trigger",
-      "text" : "worsen",
-      "provenance" : [ {
-        "@type" : "Provenance",
-        "document" : {
-          "@id" : "_:Document_1"
-        },
-        "documentCharInterval" : [ {
-          "@type" : "Interval",
-          "start" : 645,
-          "end" : 650
-        } ],
-        "sentence" : {
-          "@id" : "_:Sentence_5"
-        },
-        "positions" : [ {
-          "@type" : "Interval",
-          "start" : 9,
-          "end" : 9
-        } ]
-      } ]
+  "@type": "Corpus",
+  "documents": [
+    {
+      "@type": "Document",
+      "@id": "_:Document_1",
+      "text": "Floods caused displacement of more than 100,000 people in South Sudan.",
+      "sentences": [
+        {
+          "text": "Floods caused displacement of more than 100,000 people in South Sudan .",
+          "words": [
+            {
+              "endOffset": 6,
+              "chunk": "B-NP",
+              "lemma": "flood",
+              "tag": "NNS",
+              "text": "Floods",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 0,
+              "@type": "Word",
+              "@id": "_:Word_1"
+            },
+            {
+              "endOffset": 13,
+              "chunk": "B-VP",
+              "lemma": "cause",
+              "tag": "VBD",
+              "text": "caused",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 7,
+              "@type": "Word",
+              "@id": "_:Word_2"
+            },
+            {
+              "endOffset": 26,
+              "chunk": "B-NP",
+              "lemma": "displacement",
+              "tag": "NN",
+              "text": "displacement",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 14,
+              "@type": "Word",
+              "@id": "_:Word_3"
+            },
+            {
+              "endOffset": 29,
+              "chunk": "B-PP",
+              "lemma": "of",
+              "tag": "IN",
+              "text": "of",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 27,
+              "@type": "Word",
+              "@id": "_:Word_4"
+            },
+            {
+              "endOffset": 34,
+              "chunk": "B-NP",
+              "lemma": "more",
+              "tag": "JJR",
+              "text": "more",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 30,
+              "@type": "Word",
+              "@id": "_:Word_5"
+            },
+            {
+              "endOffset": 39,
+              "chunk": "I-NP",
+              "lemma": "than",
+              "tag": "IN",
+              "text": "than",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 35,
+              "@type": "Word",
+              "@id": "_:Word_6"
+            },
+            {
+              "endOffset": 47,
+              "chunk": "I-NP",
+              "lemma": "100,000",
+              "tag": "CD",
+              "text": "100,000",
+              "norm": ">100000.0",
+              "entity": "NUMBER",
+              "startOffset": 40,
+              "@type": "Word",
+              "@id": "_:Word_7"
+            },
+            {
+              "endOffset": 54,
+              "chunk": "I-NP",
+              "lemma": "people",
+              "tag": "NNS",
+              "text": "people",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 48,
+              "@type": "Word",
+              "@id": "_:Word_8"
+            },
+            {
+              "endOffset": 57,
+              "chunk": "B-PP",
+              "lemma": "in",
+              "tag": "IN",
+              "text": "in",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 55,
+              "@type": "Word",
+              "@id": "_:Word_9"
+            },
+            {
+              "endOffset": 63,
+              "chunk": "B-NP",
+              "lemma": "South",
+              "tag": "NNP",
+              "text": "South",
+              "norm": "O",
+              "entity": "LOCATION",
+              "startOffset": 58,
+              "@type": "Word",
+              "@id": "_:Word_10"
+            },
+            {
+              "endOffset": 69,
+              "chunk": "I-NP",
+              "lemma": "Sudan",
+              "tag": "NNP",
+              "text": "Sudan",
+              "norm": "O",
+              "entity": "LOCATION",
+              "startOffset": 64,
+              "@type": "Word",
+              "@id": "_:Word_11"
+            },
+            {
+              "endOffset": 70,
+              "chunk": "O",
+              "lemma": ".",
+              "tag": ".",
+              "text": ".",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 69,
+              "@type": "Word",
+              "@id": "_:Word_12"
+            }
+          ],
+          "@type": "Sentence",
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_2"
+              },
+              "destination": {
+                "@id": "_:Word_1"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_2"
+              },
+              "destination": {
+                "@id": "_:Word_3"
+              },
+              "relation": "dobj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_2"
+              },
+              "destination": {
+                "@id": "_:Word_12"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_3"
+              },
+              "destination": {
+                "@id": "_:Word_8"
+              },
+              "relation": "nmod_of"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_3"
+              },
+              "destination": {
+                "@id": "_:Word_11"
+              },
+              "relation": "nmod_in"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_5"
+              },
+              "destination": {
+                "@id": "_:Word_6"
+              },
+              "relation": "mwe"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_7"
+              },
+              "destination": {
+                "@id": "_:Word_5"
+              },
+              "relation": "advmod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_4"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_7"
+              },
+              "relation": "nummod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_11"
+              },
+              "destination": {
+                "@id": "_:Word_9"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_11"
+              },
+              "destination": {
+                "@id": "_:Word_10"
+              },
+              "relation": "compound"
+            }
+          ],
+          "geolocs": [
+            {
+              "endOffset": 69,
+              "text": "South Sudan",
+              "geoID": "7909807",
+              "startOffset": 58,
+              "@type": "GeoLocation",
+              "@id": "_:GeoLocation_1"
+            }
+          ],
+          "@id": "_:Sentence_1"
+        }
+      ]
+    }
+  ],
+  "extractions": [
+    {
+      "subtype": "entity",
+      "rule": "simple-np",
+      "text": "Floods",
+      "canonicalName": "flood",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 0,
+              "end": 5
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 1
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_1"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "wm",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/crisis_and_disaster/crisis/natural_disaster/flooding",
+              "value": 0.919083297252655
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/weather/precipitation/flooding",
+              "value": 0.919083297252655
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/crisis_and_disaster/crisis/natural_disaster/storm",
+              "value": 0.667123556137085
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/weather/precipitation/storm",
+              "value": 0.667123556137085
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/environment/natural_resources/land",
+              "value": 0.5832121968269348
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/environment/natural_resources/water",
+              "value": 0.5717988014221191
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/access/infrastructure/water",
+              "value": 0.5717988014221191
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/crisis_and_disaster/crisis/crisis",
+              "value": 0.5500820279121399
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/crisis_and_disaster/crisis/natural_disaster/drought",
+              "value": 0.5444111227989197
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/weather/precipitation/drought",
+              "value": 0.5444111227989197
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "interventions"
+        },
+        {
+          "@type": "Groundings",
+          "name": "mitre12",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of cattle loss accounted for by flood",
+              "value": 0.5955563187599182
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of sheep loss accounted for by flood",
+              "value": 0.5873316526412964
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of poultry loss accounted for by flood",
+              "value": 0.5804500579833984
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of goat loss accounted for by flood",
+              "value": 0.5709419250488281
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock whose main water source is rivers",
+              "value": 0.5364589691162109
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock whose main water source is pans & dams",
+              "value": 0.524304211139679
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Rainfall",
+              "value": 0.51468825340271
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock whose main water source is traditional river wells",
+              "value": 0.5097010731697083
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock whose main water source is lakes",
+              "value": 0.49990659952163696
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock whose main water source is natural ponds",
+              "value": 0.49015548825263977
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "who",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Environmental risk factors/Air pollution level in cities",
+              "value": 0.41595879197120667
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Mortality rate from road traffic injuries",
+              "value": 0.4038918912410736
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health information/Death registration coverage",
+              "value": 0.38195914030075073
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Externally sourced funding (% of current expenditure on health)",
+              "value": 0.3670355975627899
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Nutrition/Children under 5 years who are wasted",
+              "value": 0.3599957525730133
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Noncommunicable diseases/Raised blood pressure among adults",
+              "value": 0.3594062626361847
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Environmental risk factors/Population using modern fuels for cooking\\/heating\\/lighting",
+              "value": 0.3401567339897156
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Current expenditure on health by general government and compulsory schemes (% of current expenditure on health)",
+              "value": 0.3365815281867981
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Malaria/Indoor residual spraying (IRS) coverage",
+              "value": 0.33507484197616577
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Total capital expenditure on health (% current + capital expenditure on health)",
+              "value": 0.3268316984176636
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/natural_disaster/flooding",
+              "value": 0.919083297252655
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/natural_disaster/storm",
+              "value": 0.6445512175559998
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/natural_resources/abiotic_resources/land",
+              "value": 0.5832121968269348
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/natural_resources/abiotic_resources/water",
+              "value": 0.5717988014221191
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/infrastructure/water_management",
+              "value": 0.5657997131347656
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/infrastructure/building",
+              "value": 0.554114580154419
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/crisis",
+              "value": 0.5500820279121399
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/natural_disaster/drought",
+              "value": 0.5444111227989197
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/weather/precipitation",
+              "value": 0.5295354127883911
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/irrigation",
+              "value": 0.5264186263084412
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "props"
+        }
+      ],
+      "@id": "_:Extraction_1"
     },
-    "arguments" : [ {
-      "@type" : "Argument",
-      "type" : "source",
-      "value" : {
-        "@id" : "_:Extraction_8"
-      }
-    }, {
-      "@type" : "Argument",
-      "type" : "destination",
-      "value" : {
-        "@id" : "_:Extraction_9"
-      }
-    } ]
-  }, {
-    "@type" : "Extraction",
-    "@id" : "_:Extraction_4",
-    "type" : "relation",
-    "subtype" : "causation",
-    "labels" : [ "Causal", "DirectedRelation", "EntityLinker", "Event" ],
-    "text" : "Floods caused by rain have displaced more than 100,000 people in South Sudan, an official said, raising fears about the devastating impact",
-    "rule" : "ported_syntax_5_verb-Causal",
-    "canonicalName" : "flood cause rain have displace raise fear",
-    "provenance" : [ {
-      "@type" : "Provenance",
-      "document" : {
-        "@id" : "_:Document_1"
-      },
-      "documentCharInterval" : [ {
-        "@type" : "Interval",
-        "start" : 1,
-        "end" : 138
-      } ],
-      "sentence" : {
-        "@id" : "_:Sentence_1"
-      },
-      "positions" : [ {
-        "@type" : "Interval",
-        "start" : 1,
-        "end" : 24
-      } ]
-    } ],
-    "states" : [ {
-      "@type" : "State",
-      "type" : "HEDGE",
-      "text" : "could"
-    } ],
-    "trigger" : {
-      "@type" : "Trigger",
-      "text" : "raising",
-      "provenance" : [ {
-        "@type" : "Provenance",
-        "document" : {
-          "@id" : "_:Document_1"
+    {
+      "subtype": "causation",
+      "rule": "ported_syntax_1_verb-Causal",
+      "text": "Floods caused displacement of more than 100,000 people in South Sudan",
+      "canonicalName": "flood cause displacement",
+      "labels": [
+        "Causal",
+        "DirectedRelation",
+        "EntityLinker",
+        "Event"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 0,
+              "end": 68
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 11
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_1"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "relation",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "wm"
         },
-        "documentCharInterval" : [ {
-          "@type" : "Interval",
-          "start" : 97,
-          "end" : 103
-        } ],
-        "sentence" : {
-          "@id" : "_:Sentence_1"
+        {
+          "@type": "Groundings",
+          "name": "interventions"
         },
-        "positions" : [ {
-          "@type" : "Interval",
-          "start" : 19,
-          "end" : 19
-        } ]
-      } ]
+        {
+          "@type": "Groundings",
+          "name": "mitre12"
+        },
+        {
+          "@type": "Groundings",
+          "name": "who"
+        },
+        {
+          "@type": "Groundings",
+          "name": "un"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props"
+        }
+      ],
+      "arguments": [
+        {
+          "@type": "Argument",
+          "type": "source",
+          "value": {
+            "@id": "_:Extraction_1"
+          }
+        },
+        {
+          "@type": "Argument",
+          "type": "destination",
+          "value": {
+            "@id": "_:Extraction_3"
+          }
+        }
+      ],
+      "@id": "_:Extraction_2",
+      "trigger": {
+        "@type": "Trigger",
+        "text": "caused",
+        "provenance": [
+          {
+            "documentCharPositions": [
+              {
+                "@type": "Interval",
+                "start": 7,
+                "end": 12
+              }
+            ],
+            "document": {
+              "@id": "_:Document_1"
+            },
+            "sentenceWordPositions": [
+              {
+                "@type": "Interval",
+                "start": 2,
+                "end": 2
+              }
+            ],
+            "@type": "Provenance",
+            "sentence": {
+              "@id": "_:Sentence_1"
+            }
+          }
+        ]
+      }
     },
-    "arguments" : [ {
-      "@type" : "Argument",
-      "type" : "source",
-      "value" : {
-        "@id" : "_:Extraction_7"
-      }
-    }, {
-      "@type" : "Argument",
-      "type" : "destination",
-      "value" : {
-        "@id" : "_:Extraction_6"
-      }
-    } ]
-  }, {
-    "@type" : "Extraction",
-    "@id" : "_:Extraction_5",
-    "type" : "relation",
-    "subtype" : "causation",
-    "labels" : [ "Causal", "DirectedRelation", "EntityLinker", "Event" ],
-    "text" : "Floods caused by rain",
-    "rule" : "ported_syntax_1c_verb-Causal",
-    "canonicalName" : "flood cause rain",
-    "provenance" : [ {
-      "@type" : "Provenance",
-      "document" : {
-        "@id" : "_:Document_1"
-      },
-      "documentCharInterval" : [ {
-        "@type" : "Interval",
-        "start" : 1,
-        "end" : 21
-      } ],
-      "sentence" : {
-        "@id" : "_:Sentence_1"
-      },
-      "positions" : [ {
-        "@type" : "Interval",
-        "start" : 1,
-        "end" : 4
-      } ]
-    } ],
-    "trigger" : {
-      "@type" : "Trigger",
-      "text" : "caused",
-      "provenance" : [ {
-        "@type" : "Provenance",
-        "document" : {
-          "@id" : "_:Document_1"
+    {
+      "subtype": "entity",
+      "rule": "simple-np++GeoNormFinder",
+      "text": "displacement of more than 100,000 people in South Sudan",
+      "canonicalName": "displacement",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 14,
+              "end": 68
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 3,
+              "end": 11
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_1"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "wm",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/movement/movement/human displacement",
+              "value": 1.0000001192092896
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/indicator_and_reported_property/conflict/population displacement",
+              "value": 0.819111168384552
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/migration/human_migration",
+              "value": 0.5647571682929993
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/political/political_instability",
+              "value": 0.4422326385974884
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/condition/tension",
+              "value": 0.41953250765800476
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/threat/physical_insecurity",
+              "value": 0.3953157067298889
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/provision of goods and services/health/vector control",
+              "value": 0.38901540637016296
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/environment/pollution/land_pollution",
+              "value": 0.3744608461856842
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/humanitarian assistance",
+              "value": 0.36816224455833435
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/economic_and_commerce/economic activity/market/fuel",
+              "value": 0.3625190556049347
+            }
+          ]
         },
-        "documentCharInterval" : [ {
-          "@type" : "Interval",
-          "start" : 8,
-          "end" : 13
-        } ],
-        "sentence" : {
-          "@id" : "_:Sentence_1"
+        {
+          "@type": "Groundings",
+          "name": "interventions"
         },
-        "positions" : [ {
-          "@type" : "Interval",
-          "start" : 2,
-          "end" : 2
-        } ]
-      } ]
-    },
-    "arguments" : [ {
-      "@type" : "Argument",
-      "type" : "source",
-      "value" : {
-        "@id" : "_:Extraction_2"
-      }
-    }, {
-      "@type" : "Argument",
-      "type" : "destination",
-      "value" : {
-        "@id" : "_:Extraction_1"
-      }
-    } ]
-  } ]
+        {
+          "@type": "Groundings",
+          "name": "mitre12",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Internally displaced persons, new displacement associated with disasters",
+              "value": 0.5550634860992432
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Internally displaced persons, new displacement associated with conflict and violence",
+              "value": 0.5340858101844788
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Surface area",
+              "value": 0.4392697215080261
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Ratio of female to male labor force participation rate",
+              "value": 0.42834725975990295
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Average precipitation in depth",
+              "value": 0.4242918789386749
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Pump price for diesel fuel",
+              "value": 0.40667924284935
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Electric power transmission and distribution losses",
+              "value": 0.4036661982536316
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock whose main water source is boreholes",
+              "value": 0.4035279154777527
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/CO2 emissions from electricity and heat production, total",
+              "value": 0.4020176827907562
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/PM2.5 air pollution, population exposed to levels exceeding WHO guideline value",
+              "value": 0.40165066719055176
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "who",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Maternal mortality ratio",
+              "value": 0.3827572166919708
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Quality and safety of care/Institutional maternal mortality ratio",
+              "value": 0.3827572166919708
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV/HIV viral load suppression",
+              "value": 0.3684025704860687
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health workforce/Health worker density and distribution",
+              "value": 0.34149494767189026
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Environmental risk factors/Population using modern fuels for cooking\\/heating\\/lighting",
+              "value": 0.33853116631507874
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Noncommunicable diseases/Raised blood pressure among adults",
+              "value": 0.33625900745391846
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV/Prevention of mother-to-child transmission",
+              "value": 0.28134217858314514
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Headcount ratio of impoverishing health expenditure",
+              "value": 0.2799398601055145
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Headcount ratio of catastrophic health expenditure",
+              "value": 0.2737150192260742
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Mortality rate from road traffic injuries",
+              "value": 0.2694666385650635
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/human_migration",
+              "value": 0.5647571682929993
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/political/political_instability",
+              "value": 0.4422326385974884
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/physical_insecurity",
+              "value": 0.3953157067298889
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/nature_impact/pollution/land_pollution",
+              "value": 0.3744608461856842
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/humanitarian assistance",
+              "value": 0.36816224455833435
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/financial/economic/fuel",
+              "value": 0.3625190556049347
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/famine",
+              "value": 0.3382830321788788
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/irrigation",
+              "value": 0.3344916105270386
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/weather/temperature",
+              "value": 0.33191415667533875
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_insecurity",
+              "value": 0.3229786455631256
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "props"
+        }
+      ],
+      "states": [
+        {
+          "@type": "State",
+          "type": "LocationExp",
+          "text": "South Sudan",
+          "value": {
+            "@id": "_:GeoLocation_1"
+          }
+        }
+      ],
+      "@id": "_:Extraction_3"
+    }
+  ]
 }

--- a/indra/tests/eidos_geoloc_obj.json
+++ b/indra/tests/eidos_geoloc_obj.json
@@ -1,0 +1,1893 @@
+{
+  "@context": {
+    "Argument": "https://w3id.org/wm/cag/argument",
+    "Grounding": "https://w3id.org/wm/cag/grounding",
+    "Interval": "https://w3id.org/wm/cag/interval",
+    "Extraction": "https://w3id.org/wm/cag/extraction",
+    "Provenance": "https://w3id.org/wm/cag/provenance",
+    "Groundings": "https://w3id.org/wm/cag/groundings",
+    "GeoLocation": "https://w3id.org/wm/cag/geolocation",
+    "State": "https://w3id.org/wm/cag/state",
+    "Dependency": "https://w3id.org/wm/cag/dependency",
+    "Corpus": "https://w3id.org/wm/cag/corpus",
+    "Trigger": "https://w3id.org/wm/cag/trigger",
+    "Sentence": "https://w3id.org/wm/cag/sentence",
+    "Word": "https://w3id.org/wm/cag/word",
+    "Document": "https://w3id.org/wm/cag/document"
+  },
+  "@type": "Corpus",
+  "documents": [
+    {
+      "@type": "Document",
+      "@id": "_:Document_1",
+      "text": "In some cases , these frozen conflicts lead to de facto states -- or to strategic outposts , as is the case with South Ossetia , Abkhazia and Transnistria .",
+      "sentences": [
+        {
+          "text": "In some cases , these frozen conflicts lead to de facto states - - or to strategic outposts , as is the case with South Ossetia , Abkhazia and Transnistria .",
+          "words": [
+            {
+              "endOffset": 2,
+              "chunk": "B-PP",
+              "lemma": "in",
+              "tag": "IN",
+              "text": "In",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 0,
+              "@type": "Word",
+              "@id": "_:Word_1"
+            },
+            {
+              "endOffset": 7,
+              "chunk": "B-NP",
+              "lemma": "some",
+              "tag": "DT",
+              "text": "some",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 3,
+              "@type": "Word",
+              "@id": "_:Word_2"
+            },
+            {
+              "endOffset": 13,
+              "chunk": "I-NP",
+              "lemma": "case",
+              "tag": "NNS",
+              "text": "cases",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 8,
+              "@type": "Word",
+              "@id": "_:Word_3"
+            },
+            {
+              "endOffset": 15,
+              "chunk": "O",
+              "lemma": ",",
+              "tag": ",",
+              "text": ",",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 14,
+              "@type": "Word",
+              "@id": "_:Word_4"
+            },
+            {
+              "endOffset": 21,
+              "chunk": "B-NP",
+              "lemma": "these",
+              "tag": "DT",
+              "text": "these",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 16,
+              "@type": "Word",
+              "@id": "_:Word_5"
+            },
+            {
+              "endOffset": 28,
+              "chunk": "I-NP",
+              "lemma": "frozen",
+              "tag": "JJ",
+              "text": "frozen",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 22,
+              "@type": "Word",
+              "@id": "_:Word_6"
+            },
+            {
+              "endOffset": 38,
+              "chunk": "I-NP",
+              "lemma": "conflict",
+              "tag": "NNS",
+              "text": "conflicts",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 29,
+              "@type": "Word",
+              "@id": "_:Word_7"
+            },
+            {
+              "endOffset": 43,
+              "chunk": "B-VP",
+              "lemma": "lead",
+              "tag": "VBP",
+              "text": "lead",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 39,
+              "@type": "Word",
+              "@id": "_:Word_8"
+            },
+            {
+              "endOffset": 46,
+              "chunk": "B-PP",
+              "lemma": "to",
+              "tag": "TO",
+              "text": "to",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 44,
+              "@type": "Word",
+              "@id": "_:Word_9"
+            },
+            {
+              "endOffset": 49,
+              "chunk": "B-NP",
+              "lemma": "de",
+              "tag": "FW",
+              "text": "de",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 47,
+              "@type": "Word",
+              "@id": "_:Word_10"
+            },
+            {
+              "endOffset": 55,
+              "chunk": "I-NP",
+              "lemma": "facto",
+              "tag": "FW",
+              "text": "facto",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 50,
+              "@type": "Word",
+              "@id": "_:Word_11"
+            },
+            {
+              "endOffset": 62,
+              "chunk": "I-NP",
+              "lemma": "state",
+              "tag": "NNS",
+              "text": "states",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 56,
+              "@type": "Word",
+              "@id": "_:Word_12"
+            },
+            {
+              "endOffset": 64,
+              "chunk": "O",
+              "lemma": "-",
+              "tag": ":",
+              "text": "-",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 63,
+              "@type": "Word",
+              "@id": "_:Word_13"
+            },
+            {
+              "endOffset": 65,
+              "chunk": "B-PP",
+              "lemma": "-",
+              "tag": ":",
+              "text": "-",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 64,
+              "@type": "Word",
+              "@id": "_:Word_14"
+            },
+            {
+              "endOffset": 68,
+              "chunk": "I-PP",
+              "lemma": "or",
+              "tag": "CC",
+              "text": "or",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 66,
+              "@type": "Word",
+              "@id": "_:Word_15"
+            },
+            {
+              "endOffset": 71,
+              "chunk": "B-PP",
+              "lemma": "to",
+              "tag": "TO",
+              "text": "to",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 69,
+              "@type": "Word",
+              "@id": "_:Word_16"
+            },
+            {
+              "endOffset": 81,
+              "chunk": "B-NP",
+              "lemma": "strategic",
+              "tag": "JJ",
+              "text": "strategic",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 72,
+              "@type": "Word",
+              "@id": "_:Word_17"
+            },
+            {
+              "endOffset": 90,
+              "chunk": "I-NP",
+              "lemma": "outpost",
+              "tag": "NNS",
+              "text": "outposts",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 82,
+              "@type": "Word",
+              "@id": "_:Word_18"
+            },
+            {
+              "endOffset": 92,
+              "chunk": "O",
+              "lemma": ",",
+              "tag": ",",
+              "text": ",",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 91,
+              "@type": "Word",
+              "@id": "_:Word_19"
+            },
+            {
+              "endOffset": 95,
+              "chunk": "O",
+              "lemma": "as",
+              "tag": "RB",
+              "text": "as",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 93,
+              "@type": "Word",
+              "@id": "_:Word_20"
+            },
+            {
+              "endOffset": 98,
+              "chunk": "B-VP",
+              "lemma": "be",
+              "tag": "VBZ",
+              "text": "is",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 96,
+              "@type": "Word",
+              "@id": "_:Word_21"
+            },
+            {
+              "endOffset": 102,
+              "chunk": "B-NP",
+              "lemma": "the",
+              "tag": "DT",
+              "text": "the",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 99,
+              "@type": "Word",
+              "@id": "_:Word_22"
+            },
+            {
+              "endOffset": 107,
+              "chunk": "I-NP",
+              "lemma": "case",
+              "tag": "NN",
+              "text": "case",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 103,
+              "@type": "Word",
+              "@id": "_:Word_23"
+            },
+            {
+              "endOffset": 112,
+              "chunk": "B-PP",
+              "lemma": "with",
+              "tag": "IN",
+              "text": "with",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 108,
+              "@type": "Word",
+              "@id": "_:Word_24"
+            },
+            {
+              "endOffset": 118,
+              "chunk": "B-NP",
+              "lemma": "South",
+              "tag": "NNP",
+              "text": "South",
+              "norm": "O",
+              "entity": "LOCATION",
+              "startOffset": 113,
+              "@type": "Word",
+              "@id": "_:Word_25"
+            },
+            {
+              "endOffset": 126,
+              "chunk": "I-NP",
+              "lemma": "Ossetia",
+              "tag": "NNP",
+              "text": "Ossetia",
+              "norm": "O",
+              "entity": "LOCATION",
+              "startOffset": 119,
+              "@type": "Word",
+              "@id": "_:Word_26"
+            },
+            {
+              "endOffset": 128,
+              "chunk": "O",
+              "lemma": ",",
+              "tag": ",",
+              "text": ",",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 127,
+              "@type": "Word",
+              "@id": "_:Word_27"
+            },
+            {
+              "endOffset": 137,
+              "chunk": "B-NP",
+              "lemma": "Abkhazia",
+              "tag": "NNP",
+              "text": "Abkhazia",
+              "norm": "O",
+              "entity": "LOCATION",
+              "startOffset": 129,
+              "@type": "Word",
+              "@id": "_:Word_28"
+            },
+            {
+              "endOffset": 141,
+              "chunk": "O",
+              "lemma": "and",
+              "tag": "CC",
+              "text": "and",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 138,
+              "@type": "Word",
+              "@id": "_:Word_29"
+            },
+            {
+              "endOffset": 154,
+              "chunk": "B-NP",
+              "lemma": "Transnistria",
+              "tag": "NNP",
+              "text": "Transnistria",
+              "norm": "O",
+              "entity": "LOCATION",
+              "startOffset": 142,
+              "@type": "Word",
+              "@id": "_:Word_30"
+            },
+            {
+              "endOffset": 156,
+              "chunk": "O",
+              "lemma": ".",
+              "tag": ".",
+              "text": ".",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 155,
+              "@type": "Word",
+              "@id": "_:Word_31"
+            }
+          ],
+          "@type": "Sentence",
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_3"
+              },
+              "destination": {
+                "@id": "_:Word_1"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_3"
+              },
+              "destination": {
+                "@id": "_:Word_2"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_7"
+              },
+              "destination": {
+                "@id": "_:Word_5"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_7"
+              },
+              "destination": {
+                "@id": "_:Word_6"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_3"
+              },
+              "relation": "nmod_in"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_19"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_4"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_7"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_23"
+              },
+              "relation": "ccomp"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_8"
+              },
+              "relation": "conj_or"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_12"
+              },
+              "relation": "nmod_to"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_15"
+              },
+              "relation": "cc"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_31"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_18"
+              },
+              "relation": "nmod_to"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_8"
+              },
+              "destination": {
+                "@id": "_:Word_7"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_12"
+              },
+              "destination": {
+                "@id": "_:Word_9"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_12"
+              },
+              "destination": {
+                "@id": "_:Word_10"
+              },
+              "relation": "compound"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_12"
+              },
+              "destination": {
+                "@id": "_:Word_11"
+              },
+              "relation": "compound"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_12"
+              },
+              "destination": {
+                "@id": "_:Word_13"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_12"
+              },
+              "destination": {
+                "@id": "_:Word_14"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_18"
+              },
+              "destination": {
+                "@id": "_:Word_16"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_18"
+              },
+              "destination": {
+                "@id": "_:Word_17"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_23"
+              },
+              "destination": {
+                "@id": "_:Word_20"
+              },
+              "relation": "advmod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_23"
+              },
+              "destination": {
+                "@id": "_:Word_21"
+              },
+              "relation": "cop"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_23"
+              },
+              "destination": {
+                "@id": "_:Word_22"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_23"
+              },
+              "destination": {
+                "@id": "_:Word_26"
+              },
+              "relation": "nmod_with"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_23"
+              },
+              "destination": {
+                "@id": "_:Word_28"
+              },
+              "relation": "nmod_with"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_23"
+              },
+              "destination": {
+                "@id": "_:Word_30"
+              },
+              "relation": "nmod_with"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_26"
+              },
+              "destination": {
+                "@id": "_:Word_24"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_26"
+              },
+              "destination": {
+                "@id": "_:Word_25"
+              },
+              "relation": "compound"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_26"
+              },
+              "destination": {
+                "@id": "_:Word_27"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_26"
+              },
+              "destination": {
+                "@id": "_:Word_28"
+              },
+              "relation": "conj_and"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_26"
+              },
+              "destination": {
+                "@id": "_:Word_29"
+              },
+              "relation": "cc"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_26"
+              },
+              "destination": {
+                "@id": "_:Word_30"
+              },
+              "relation": "conj_and"
+            }
+          ],
+          "geolocs": [
+            {
+              "endOffset": 126,
+              "text": "South Ossetia",
+              "geoID": "611834",
+              "startOffset": 113,
+              "@type": "GeoLocation",
+              "@id": "_:GeoLocation_1"
+            },
+            {
+              "endOffset": 137,
+              "text": "Abkhazia",
+              "geoID": "6643410",
+              "startOffset": 129,
+              "@type": "GeoLocation",
+              "@id": "_:GeoLocation_2"
+            },
+            {
+              "endOffset": 154,
+              "text": "Transnistria",
+              "geoID": "858911",
+              "startOffset": 142,
+              "@type": "GeoLocation",
+              "@id": "_:GeoLocation_3"
+            }
+          ],
+          "@id": "_:Sentence_1"
+        }
+      ]
+    }
+  ],
+  "extractions": [
+    {
+      "subtype": "entity",
+      "rule": "simple-np",
+      "text": "frozen conflicts",
+      "canonicalName": "conflict",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 22,
+              "end": 37
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 6,
+              "end": 7
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_1"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "wm",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/conflict/hostility",
+              "value": 0.8189831376075745
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/political/political_instability",
+              "value": 0.7131220102310181
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/conflict/war",
+              "value": 0.6863936185836792
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/conflict/attack",
+              "value": 0.6633585691452026
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/provision of goods and services/health/sexual violence management",
+              "value": 0.6568310260772705
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/conflict/strike",
+              "value": 0.6533344984054565
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/conflict/demostrate",
+              "value": 0.6487948894500732
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/economic_and_commerce/economic_crisis",
+              "value": 0.6055613160133362
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/threat/physical_insecurity",
+              "value": 0.5905641317367554
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/conflict/terrorism",
+              "value": 0.5719400644302368
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "interventions"
+        },
+        {
+          "@type": "Groundings",
+          "name": "mitre12",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Conflict incidences",
+              "value": 1.0000001192092896
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Internally displaced persons, total displaced by conflict and violence",
+              "value": 0.8361855149269104
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Internally displaced persons, new displacement associated with conflict and violence",
+              "value": 0.7816300988197327
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Conflict fatalities",
+              "value": 0.7732743620872498
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock migrating due to conflict \\/ insecurity",
+              "value": 0.6838940978050232
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Legislation exists on domestic violence",
+              "value": 0.6727832555770874
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Value, Political stability and absence of violence\\/terrorism (index)",
+              "value": 0.6165004968643188
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Internally displaced persons, new displacement associated with disasters",
+              "value": 0.5427613258361816
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Ratio of female to male labor force participation rate",
+              "value": 0.5416882634162903
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Labor force participation rate, female",
+              "value": 0.5242236852645874
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "who",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Injuries/Intimate partner violence prevalence",
+              "value": 0.6249979138374329
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Births attended by skilled health personnel",
+              "value": 0.4309103786945343
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Suicide rate",
+              "value": 0.41145288944244385
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Current expenditure on health by general government and compulsory schemes (% of current expenditure on health)",
+              "value": 0.4072905480861664
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Externally sourced funding (% of current expenditure on health)",
+              "value": 0.4059835374355316
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health workforce/Output training institutions",
+              "value": 0.393792062997818
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health information/Death registration coverage",
+              "value": 0.39145776629447937
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Total capital expenditure on health (% current + capital expenditure on health)",
+              "value": 0.38965216279029846
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Quality and safety of care/Service-specific availability and readiness",
+              "value": 0.38702598214149475
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV/People living with HIV who have been diagnosed",
+              "value": 0.37452661991119385
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/conflict",
+              "value": 0.8077279925346375
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/political/political_instability",
+              "value": 0.7131220102310181
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/economic_crisis",
+              "value": 0.6055613160133362
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/physical_insecurity",
+              "value": 0.5905641317367554
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/crisis",
+              "value": 0.5339371562004089
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/GPE",
+              "value": 0.5104845762252808
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/human_migration",
+              "value": 0.5093052387237549
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/humanitarian assistance",
+              "value": 0.4969711899757385
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/government/government_entity",
+              "value": 0.49459677934646606
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/political/independence",
+              "value": 0.493647038936615
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "props"
+        }
+      ],
+      "@id": "_:Extraction_1"
+    },
+    {
+      "subtype": "causation",
+      "rule": "leadToSyntax1-Causal",
+      "text": "frozen conflicts lead to de facto states -- or to strategic outposts",
+      "canonicalName": "conflict lead outpost",
+      "labels": [
+        "Causal",
+        "DirectedRelation",
+        "EntityLinker",
+        "Event"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 22,
+              "end": 89
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 6,
+              "end": 18
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_1"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "relation",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "wm"
+        },
+        {
+          "@type": "Groundings",
+          "name": "interventions"
+        },
+        {
+          "@type": "Groundings",
+          "name": "mitre12"
+        },
+        {
+          "@type": "Groundings",
+          "name": "who"
+        },
+        {
+          "@type": "Groundings",
+          "name": "un"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props"
+        }
+      ],
+      "arguments": [
+        {
+          "@type": "Argument",
+          "type": "source",
+          "value": {
+            "@id": "_:Extraction_1"
+          }
+        },
+        {
+          "@type": "Argument",
+          "type": "destination",
+          "value": {
+            "@id": "_:Extraction_4"
+          }
+        }
+      ],
+      "@id": "_:Extraction_2",
+      "trigger": {
+        "@type": "Trigger",
+        "text": "lead",
+        "provenance": [
+          {
+            "documentCharPositions": [
+              {
+                "@type": "Interval",
+                "start": 39,
+                "end": 42
+              }
+            ],
+            "document": {
+              "@id": "_:Document_1"
+            },
+            "sentenceWordPositions": [
+              {
+                "@type": "Interval",
+                "start": 8,
+                "end": 8
+              }
+            ],
+            "@type": "Provenance",
+            "sentence": {
+              "@id": "_:Sentence_1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "subtype": "causation",
+      "rule": "ported_syntax_1_verb-Causal",
+      "text": "frozen conflicts lead to de facto states -- or to strategic outposts , as is the case with South Ossetia , Abkhazia and Transnistria",
+      "canonicalName": "conflict lead be",
+      "labels": [
+        "Causal",
+        "DirectedRelation",
+        "EntityLinker",
+        "Event"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 22,
+              "end": 153
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 6,
+              "end": 30
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_1"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "relation",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "wm"
+        },
+        {
+          "@type": "Groundings",
+          "name": "interventions"
+        },
+        {
+          "@type": "Groundings",
+          "name": "mitre12"
+        },
+        {
+          "@type": "Groundings",
+          "name": "who"
+        },
+        {
+          "@type": "Groundings",
+          "name": "un"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props"
+        }
+      ],
+      "arguments": [
+        {
+          "@type": "Argument",
+          "type": "source",
+          "value": {
+            "@id": "_:Extraction_1"
+          }
+        },
+        {
+          "@type": "Argument",
+          "type": "destination",
+          "value": {
+            "@id": "_:Extraction_5"
+          }
+        }
+      ],
+      "@id": "_:Extraction_3",
+      "trigger": {
+        "@type": "Trigger",
+        "text": "lead",
+        "provenance": [
+          {
+            "documentCharPositions": [
+              {
+                "@type": "Interval",
+                "start": 39,
+                "end": 42
+              }
+            ],
+            "document": {
+              "@id": "_:Document_1"
+            },
+            "sentenceWordPositions": [
+              {
+                "@type": "Interval",
+                "start": 8,
+                "end": 8
+              }
+            ],
+            "@type": "Provenance",
+            "sentence": {
+              "@id": "_:Sentence_1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "subtype": "entity",
+      "rule": "simple-np",
+      "text": "strategic outposts",
+      "canonicalName": "outpost",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 72,
+              "end": 89
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 17,
+              "end": 18
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_1"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "wm",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/conflict/strike",
+              "value": 0.3796776533126831
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/conflict/attack",
+              "value": 0.3787648379802704
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/conflict/war",
+              "value": 0.3722304105758667
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/conflict/demostrate",
+              "value": 0.3670312464237213
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/movement/movement/evacuate humanitarian workers",
+              "value": 0.35165169835090637
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/entity/person_and_group/population",
+              "value": 0.346971333026886
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/conflict/hostility",
+              "value": 0.3339744508266449
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/environment/natural_resources/land",
+              "value": 0.3177349269390106
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/migration/human_migration",
+              "value": 0.3012760877609253
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/agriculture/crop_storage",
+              "value": 0.2840387523174286
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "interventions"
+        },
+        {
+          "@type": "Groundings",
+          "name": "mitre12",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Procedures to build a warehouse",
+              "value": 0.31907904148101807
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Distance to frontier score",
+              "value": 0.3053215742111206
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Armed forces personnel",
+              "value": 0.27793747186660767
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Presence of peace keepers",
+              "value": 0.2722097337245941
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Commercial bank branches",
+              "value": 0.2697545289993286
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Capture fisheries production",
+              "value": 0.2650641202926636
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Burned Area, Open shrubland",
+              "value": 0.24877013266086578
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Emissions (CO2eq) (Burning - savanna), Open shrubland",
+              "value": 0.2423926591873169
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Population living in slums",
+              "value": 0.23902389407157898
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/CPIA public sector management and institutions cluster average",
+              "value": 0.2361612617969513
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "who",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Environmental risk factors/Air pollution level in cities",
+              "value": 0.21432821452617645
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Quality and safety of care/Service-specific availability and readiness",
+              "value": 0.17930558323860168
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Suicide rate",
+              "value": 0.1721561849117279
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health information/Completeness of reporting by facilities",
+              "value": 0.16954576969146729
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health workforce/Output training institutions",
+              "value": 0.16348859667778015
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/Malaria parasite prevalence among children aged 6-59 months",
+              "value": 0.15520887076854706
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Total capital expenditure on health (% current + capital expenditure on health)",
+              "value": 0.1412363499403
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Injuries/Intimate partner violence prevalence",
+              "value": 0.13908377289772034
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Malaria/Treatment of confirmed malaria cases",
+              "value": 0.1381588578224182
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Births attended by skilled health personnel",
+              "value": 0.13762475550174713
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/GPE",
+              "value": 0.4723265767097473
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/infrastructure/shipping_facilities_water",
+              "value": 0.3954717814922333
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/infrastructure/building",
+              "value": 0.36194777488708496
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/population",
+              "value": 0.346971333026886
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/conflict",
+              "value": 0.33645692467689514
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/natural_resources/abiotic_resources/land",
+              "value": 0.3177349269390106
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/human_migration",
+              "value": 0.3012760877609253
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/crop_storage",
+              "value": 0.2840387523174286
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/farming",
+              "value": 0.27541181445121765
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/infrastructure/transportation/bridge",
+              "value": 0.2732465863227844
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "props"
+        }
+      ],
+      "@id": "_:Extraction_4"
+    },
+    {
+      "subtype": "entity",
+      "rule": "simple-np++GeoNormFinder",
+      "text": "as is the case with South Ossetia , Abkhazia and Transnistria",
+      "canonicalName": "be",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 93,
+              "end": 153
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 20,
+              "end": 30
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_1"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "wm",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/provision of goods and services/provide moving of houseHolds",
+              "value": 0.6442373991012573
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/provision of goods and services/provide cash",
+              "value": 0.5899249315261841
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/institutional support/protection/capacity building human right",
+              "value": 0.5674468874931335
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/provision of goods and services/provide food",
+              "value": 0.5465098023414612
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/provision of goods and services/provide stationary",
+              "value": 0.5410333871841431
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/provision of goods and services/provide seed",
+              "value": 0.5283223986625671
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/provision of goods and services/provide veterinary drugs vaccines",
+              "value": 0.518553614616394
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/provision of goods and services/provide veterinary service",
+              "value": 0.5105955600738525
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/provision of goods and services/provide fishing tool",
+              "value": 0.5051254034042358
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/provision of goods and services/provide delivery kit",
+              "value": 0.4894048571586609
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "interventions",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "interventions/provision of goods and services/protection/provision of legal aid for displaced persons",
+              "value": 0.5811194777488708
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "interventions/provision of goods and services/water sanitation hygiene/provision of point of use water treatment at household level",
+              "value": 0.5755839347839355
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "interventions/provision of goods and services/food security/provision of once-off cash transfer to facilitate return",
+              "value": 0.571442186832428
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "interventions/peacekeeping and security/water sanitation hygiene/creation of temporary water points",
+              "value": 0.5411654114723206
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "interventions/institutional support/protection/capacity building of national authorities on human rights",
+              "value": 0.5404301881790161
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "interventions/provision of goods and services/protection/provision of public information campaigns on explosive hazards",
+              "value": 0.5402031540870667
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "interventions/provision of goods and services/education/provision of child friendly learning spaces",
+              "value": 0.5271109938621521
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "interventions/provision of goods and services/early recovery/provision of credit and training for income generation",
+              "value": 0.5261446833610535
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "interventions/provision of goods and services/emergency shelter and nfi/provision of household relief non-food item package",
+              "value": 0.5197038054466248
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "interventions/provision of goods and services/education/provision of training of community sourced emergency\\/temporary teachers",
+              "value": 0.5193918347358704
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "mitre12",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Duration in months when the migrated animals are expected to be back after",
+              "value": 0.8643350601196289
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Number of days sheep have been watered in the last 7 days",
+              "value": 0.8200744390487671
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Number of days cattle have been watered in the last 7 days",
+              "value": 0.8149015307426453
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Number of days goat have been watered in the last 7 days",
+              "value": 0.8148970007896423
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Duration in months browse is projected to last",
+              "value": 0.7637183666229248
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Duration in months pasture is projected to last",
+              "value": 0.7552404403686523
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Mothers are guaranteed an equivalent position after maternity leave",
+              "value": 0.7543724179267883
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock whose main water source is shallow wells",
+              "value": 0.7531013488769531
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock whose main water source is traditional river wells",
+              "value": 0.7173205018043518
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock whose main water source is rock",
+              "value": 0.7019083499908447
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "who",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Noncommunicable diseases/Children aged under 5 years who are overweight",
+              "value": 0.8335347771644592
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Nutrition/Children under 5 years who are wasted",
+              "value": 0.8311865329742432
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Nutrition/Children under 5 years who are stunted",
+              "value": 0.7708276510238647
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV/People living with HIV who have been diagnosed",
+              "value": 0.7569241523742676
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Noncommunicable diseases/Tobacco use among persons aged 18+ years",
+              "value": 0.5383896231651306
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health information/Death registration coverage",
+              "value": 0.5224623084068298
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Births attended by skilled health personnel",
+              "value": 0.5174747109413147
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Noncommunicable diseases/Raised blood pressure among adults",
+              "value": 0.503089189529419
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Demand for family planning satis ed with modern methods",
+              "value": 0.4890013337135315
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health information/Birth registration coverage",
+              "value": 0.4842914044857025
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/government/government_actions/duty",
+              "value": 0.49878954887390137
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/financial/economic/revenue",
+              "value": 0.47830626368522644
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/government/government_entity",
+              "value": 0.47738102078437805
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_price",
+              "value": 0.47371527552604675
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/soil/soil_contents",
+              "value": 0.4573880434036255
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/government/government_actions/organization",
+              "value": 0.456327885389328
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/death",
+              "value": 0.44708719849586487
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/financial/economic/economy",
+              "value": 0.4467976689338684
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/product",
+              "value": 0.44232314825057983
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/financial/economic/assets",
+              "value": 0.4401074945926666
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "props"
+        }
+      ],
+      "states": [
+        {
+          "@type": "State",
+          "type": "LocationExp",
+          "text": "South Ossetia",
+          "value": {
+            "@id": "_:GeoLocation_1"
+          }
+        },
+        {
+          "@type": "State",
+          "type": "LocationExp",
+          "text": "Abkhazia",
+          "value": {
+            "@id": "_:GeoLocation_2"
+          }
+        },
+        {
+          "@type": "State",
+          "type": "LocationExp",
+          "text": "Transnistria",
+          "value": {
+            "@id": "_:GeoLocation_3"
+          }
+        }
+      ],
+      "@id": "_:Extraction_5"
+    }
+  ]
+}

--- a/indra/tests/eidos_timex.json
+++ b/indra/tests/eidos_timex.json
@@ -1,94 +1,110 @@
 {
   "@context": {
-    "Argument": "https://github.com/clulab/eidos/wiki/JSON-LD#Argument",
-    "Corpus": "https://github.com/clulab/eidos/wiki/JSON-LD#Corpus",
-    "Dependency": "https://github.com/clulab/eidos/wiki/JSON-LD#Dependency",
-    "Document": "https://github.com/clulab/eidos/wiki/JSON-LD#Document",
-    "Extraction": "https://github.com/clulab/eidos/wiki/JSON-LD#Extraction",
-    "Grounding": "https://github.com/clulab/eidos/wiki/JSON-LD#Grounding",
-    "Groundings": "https://github.com/clulab/eidos/wiki/JSON-LD#Groundings",
-    "Interval": "https://github.com/clulab/eidos/wiki/JSON-LD#Interval",
-    "Provenance": "https://github.com/clulab/eidos/wiki/JSON-LD#Provenance",
-    "Sentence": "https://github.com/clulab/eidos/wiki/JSON-LD#Sentence",
-    "TimeExpression": "https://github.com/clulab/eidos/wiki/JSON-LD#TimeExpression",
-    "TimeInterval": "https://github.com/clulab/eidos/wiki/JSON-LD#TimeInterval",
-    "Trigger": "https://github.com/clulab/eidos/wiki/JSON-LD#Trigger",
-    "Word": "https://github.com/clulab/eidos/wiki/JSON-LD#Word"
+    "Argument": "https://w3id.org/wm/cag/argument",
+    "Grounding": "https://w3id.org/wm/cag/grounding",
+    "TimeExpression": "https://w3id.org/wm/cag/timeexpression",
+    "Interval": "https://w3id.org/wm/cag/interval",
+    "Extraction": "https://w3id.org/wm/cag/extraction",
+    "Provenance": "https://w3id.org/wm/cag/provenance",
+    "TimeInterval": "https://w3id.org/wm/cag/timeinterval",
+    "Groundings": "https://w3id.org/wm/cag/groundings",
+    "State": "https://w3id.org/wm/cag/state",
+    "Dependency": "https://w3id.org/wm/cag/dependency",
+    "Corpus": "https://w3id.org/wm/cag/corpus",
+    "Trigger": "https://w3id.org/wm/cag/trigger",
+    "Sentence": "https://w3id.org/wm/cag/sentence",
+    "Word": "https://w3id.org/wm/cag/word",
+    "Document": "https://w3id.org/wm/cag/document"
   },
   "@type": "Corpus",
   "documents": [
     {
       "@type": "Document",
       "@id": "_:Document_1",
-      "title": "default_file_name",
       "text": "hunger caused displacement in 2018",
       "sentences": [
         {
-          "@type": "Sentence",
-          "@id": "_:Sentence_1",
           "text": "hunger caused displacement in 2018",
-          "words": [
+          "timexes": [
             {
-              "@type": "Word",
-              "@id": "_:Word_1",
-              "text": "hunger",
-              "tag": "NN",
-              "entity": "O",
-              "startOffset": 0,
-              "endOffset": 6,
-              "lemma": "hunger",
-              "chunk": "B-NP",
-              "norm": "O"
-            },
-            {
-              "@type": "Word",
-              "@id": "_:Word_2",
-              "text": "caused",
-              "tag": "VBD",
-              "entity": "O",
-              "startOffset": 7,
-              "endOffset": 13,
-              "lemma": "cause",
-              "chunk": "B-VP",
-              "norm": "O"
-            },
-            {
-              "@type": "Word",
-              "@id": "_:Word_3",
-              "text": "displacement",
-              "tag": "NN",
-              "entity": "O",
-              "startOffset": 14,
-              "endOffset": 26,
-              "lemma": "displacement",
-              "chunk": "B-NP",
-              "norm": "O"
-            },
-            {
-              "@type": "Word",
-              "@id": "_:Word_4",
-              "text": "in",
-              "tag": "IN",
-              "entity": "O",
-              "startOffset": 27,
-              "endOffset": 29,
-              "lemma": "in",
-              "chunk": "B-PP",
-              "norm": "O"
-            },
-            {
-              "@type": "Word",
-              "@id": "_:Word_5",
-              "text": "2018",
-              "tag": "CD",
-              "entity": "DATE",
-              "startOffset": 30,
               "endOffset": 34,
-              "lemma": "2018",
-              "chunk": "B-NP",
-              "norm": "B-Time"
+              "intervals": [
+                {
+                  "@type": "TimeInterval",
+                  "@id": "_:TimeInterval_1",
+                  "start": "2018-01-01T00:00",
+                  "end": "2019-01-01T00:00"
+                }
+              ],
+              "text": "2018",
+              "startOffset": 30,
+              "@type": "TimeExpression",
+              "@id": "_:TimeExpression_1"
             }
           ],
+          "words": [
+            {
+              "endOffset": 6,
+              "chunk": "B-NP",
+              "lemma": "hunger",
+              "tag": "NN",
+              "text": "hunger",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 0,
+              "@type": "Word",
+              "@id": "_:Word_1"
+            },
+            {
+              "endOffset": 13,
+              "chunk": "B-VP",
+              "lemma": "cause",
+              "tag": "VBD",
+              "text": "caused",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 7,
+              "@type": "Word",
+              "@id": "_:Word_2"
+            },
+            {
+              "endOffset": 26,
+              "chunk": "B-NP",
+              "lemma": "displacement",
+              "tag": "NN",
+              "text": "displacement",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 14,
+              "@type": "Word",
+              "@id": "_:Word_3"
+            },
+            {
+              "endOffset": 29,
+              "chunk": "B-PP",
+              "lemma": "in",
+              "tag": "IN",
+              "text": "in",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 27,
+              "@type": "Word",
+              "@id": "_:Word_4"
+            },
+            {
+              "endOffset": 34,
+              "chunk": "B-NP",
+              "lemma": "2018",
+              "tag": "CD",
+              "text": "2018",
+              "norm": "2018",
+              "entity": "DATE",
+              "startOffset": 30,
+              "@type": "Word",
+              "@id": "_:Word_5"
+            }
+          ],
+          "@type": "Sentence",
           "dependencies": [
             {
               "@type": "Dependency",
@@ -131,543 +147,676 @@
               "relation": "case"
             }
           ],
-          "timexes": [
-            {
-              "@type": "TimeExpression",
-              "@id": "_:TimeExpression_1",
-              "startOffset": 30,
-              "endOffset": 34,
-              "text": "2018",
-              "intervals": [
-                {
-                  "@type": "TimeInterval",
-                  "@id": "_:TimeInterval_1",
-                  "start": "2018-01-01T00:00",
-                  "end": "2019-01-01T00:00",
-                  "duration": 31536000
-                }
-              ]
-            }
-          ]
+          "@id": "_:Sentence_1"
         }
       ]
     }
   ],
   "extractions": [
     {
-      "@type": "Extraction",
-      "@id": "_:Extraction_2",
-      "type": "concept",
       "subtype": "entity",
-      "labels": [
-        "Concept",
-        "Entity"
-      ],
-      "text": "displacement",
       "rule": "simple-np",
-      "canonicalName": "displacement",
-      "groundings": [
-        {
-          "@type": "Groundings",
-          "name": "un",
-          "values": [
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/human/human_migration",
-              "value": 0.6546270763202365
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/human/physical_insecurity",
-              "value": 0.5671727886043954
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/human/famine",
-              "value": 0.5569336505634456
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/entities/human/financial/economic/poverty",
-              "value": 0.4764737470607766
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/entities/human/food/food_insecurity",
-              "value": 0.4283068640558835
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/natural_disaster/drought",
-              "value": 0.41650638042599636
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/nature_impact/pollution/climate_change",
-              "value": 0.40917020219348643
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/human/conflict",
-              "value": 0.38051240824949834
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/interventions/provision of goods and services/protection/provision of legal aid for displaced persons",
-              "value": 0.37166802229289825
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/human/intervention/intervention",
-              "value": 0.367468114798105
-            }
-          ]
-        },
-        {
-          "@type": "Groundings",
-          "name": "wdi",
-          "values": [
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Internally_displaced_persons,_total_displaced_by_conflict_and_violence_(number_of_people)",
-              "value": 0.5188317090209378
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Internally_displaced_persons,_new_displacement_associated_with_disasters_(number_of_cases)",
-              "value": 0.5022043752824866
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Internally_displaced_persons,_new_displacement_associated_with_conflict_and_violence_(number_of_cases)",
-              "value": 0.5022043752824866
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Droughts,_floods,_extreme_temperatures_(%_of_population,_average_1990-2009)",
-              "value": 0.46678378443611845
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Rural_poverty_gap_at_national_poverty_lines_(%)",
-              "value": 0.43441694024698546
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Urban_poverty_gap_at_national_poverty_lines_(%)",
-              "value": 0.43126518636252725
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Intentional_homicides_(per_100,000_people)",
-              "value": 0.41879478458419633
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Battle-related_deaths_(number_of_people)",
-              "value": 0.40916073966520444
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Rural_poverty_headcount_ratio_at_national_poverty_lines_(%_of_rural_population)",
-              "value": 0.40098559359431146
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Urban_poverty_headcount_ratio_at_national_poverty_lines_(%_of_urban_population)",
-              "value": 0.39733830102505346
-            }
-          ]
-        },
-        {
-          "@type": "Groundings",
-          "name": "fao",
-          "values": [
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Value/Prevalence of severe food insecurity in the total population",
-              "value": 0.5134661984857619
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Rural population/Population - Est. & Proj.",
-              "value": 0.4080055031379335
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Urban population/Population - Est. & Proj.",
-              "value": 0.4080055031379335
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Gross Production Value (constant 2004-2006 1000 I$)/Meat indigenous, total",
-              "value": 0.348034511855539
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Net Production Value (constant 2004-2006 1000 I$)/Meat indigenous, total",
-              "value": 0.348034511855539
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Value/Per capita food production variability (I$ per person constant 2004-06)",
-              "value": 0.3305800488856844
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Value/Political stability and absence of violence\\/terrorism (index)",
-              "value": 0.3286796004901052
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Value/Number of people undernourished (millions) (3-year average)",
-              "value": 0.3193548825158809
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Value/Prevalence of undernourishment (%) (3-year average)",
-              "value": 0.3134795705369154
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Production/Meat indigenous, total",
-              "value": 0.29557280987826856
-            }
-          ]
-        }
-      ],
-      "provenance": [
-        {
-          "@type": "Provenance",
-          "document": {
-            "@id": "_:Document_1"
-          },
-          "documentCharInterval": [
-            {
-              "@type": "Interval",
-              "start": 15,
-              "end": 26
-            }
-          ],
-          "sentence": {
-            "@id": "_:Sentence_1"
-          },
-          "positions": [
-            {
-              "@type": "Interval",
-              "start": 3,
-              "end": 3
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@type": "Extraction",
-      "@id": "_:Extraction_3",
-      "type": "concept",
-      "subtype": "entity",
-      "labels": [
-        "Concept",
-        "Entity"
-      ],
       "text": "hunger",
-      "rule": "simple-np",
       "canonicalName": "hunger",
-      "groundings": [
-        {
-          "@type": "Groundings",
-          "name": "un",
-          "values": [
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/human/famine",
-              "value": 0.8011714168505154
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/entities/human/food/food_insecurity",
-              "value": 0.5596131625888734
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/entities/human/financial/economic/poverty",
-              "value": 0.5062081980899468
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/human/physical_insecurity",
-              "value": 0.4304670951826235
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/human/death",
-              "value": 0.38668481882680444
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/human/human_migration",
-              "value": 0.3713260657502345
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/natural_disaster/drought",
-              "value": 0.3623545927522337
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/entities/human/health/disease",
-              "value": 0.35344156085814393
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/nature_impact/pollution/climate_change",
-              "value": 0.3471733895810956
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "UN/events/human/agriculture/farming",
-              "value": 0.30246466697106805
-            }
-          ]
-        },
-        {
-          "@type": "Groundings",
-          "name": "wdi",
-          "values": [
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Use_of_insecticide-treated_bed_nets_(%_of_under-5_population)",
-              "value": 0.3985446609661958
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Cause_of_death,_by_communicable_diseases_and_maternal,_prenatal_and_nutrition_conditions_(%_of_total)",
-              "value": 0.38745262200098546
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Number_of_neonatal_deaths",
-              "value": 0.3706471904538178
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Number_of_under-five_deaths",
-              "value": 0.3700837279733295
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Urban_poverty_gap_at_national_poverty_lines_(%)",
-              "value": 0.3694102774754288
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Maternal_mortality_ratio_(national_estimate,_per_100,000_live_births)",
-              "value": 0.36667250366734755
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Rural_poverty_gap_at_national_poverty_lines_(%)",
-              "value": 0.3651718088697936
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Maternal_mortality_ratio_(modeled_estimate,_per_100,000_live_births)",
-              "value": 0.3516352414998364
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Diarrhea_treatment_(%_of_children_under_5_receiving_oral_rehydration_and_continued_feeding)",
-              "value": 0.348151628947713
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "WDI/Mortality_from_CVD,_cancer,_diabetes_or_CRD_between_exact_ages_30_and_70_(%)",
-              "value": 0.34762964584721784
-            }
-          ]
-        },
-        {
-          "@type": "Groundings",
-          "name": "fao",
-          "values": [
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Value/Prevalence of severe food insecurity in the total population",
-              "value": 0.44798882711793603
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Value/Percentage of children under 5 years of age affected by wasting (%)",
-              "value": 0.4069674306950103
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Value/Prevalence of undernourishment (%) (3-year average)",
-              "value": 0.38209566928144445
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Value/Number of severely food insecure people",
-              "value": 0.32865839556272824
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Value/Number of people undernourished (millions) (3-year average)",
-              "value": 0.32761291896060324
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Value/Per capita food production variability (I$ per person constant 2004-06)",
-              "value": 0.3197076485847902
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Value/Prevalence of anemia among women of reproductive age (15-49 years)",
-              "value": 0.3183020692139657
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Value/Percentage of children under 5 years of age who are stunted (%)",
-              "value": 0.3151573823464965
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Emissions (CH4) (Enteric)/Cattle, non-dairy",
-              "value": 0.31188440808261686
-            },
-            {
-              "@type": "Grounding",
-              "ontologyConcept": "FAO/events/Emissions (CO2eq) (Enteric)/Cattle, non-dairy",
-              "value": 0.31188440808261686
-            }
-          ]
-        }
+      "labels": [
+        "Concept",
+        "Entity"
       ],
       "provenance": [
         {
-          "@type": "Provenance",
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 0,
+              "end": 5
+            }
+          ],
           "document": {
             "@id": "_:Document_1"
           },
-          "documentCharInterval": [
-            {
-              "@type": "Interval",
-              "start": 1,
-              "end": 6
-            }
-          ],
-          "sentence": {
-            "@id": "_:Sentence_1"
-          },
-          "positions": [
+          "sentenceWordPositions": [
             {
               "@type": "Interval",
               "start": 1,
               "end": 1
             }
-          ]
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_1"
+          }
         }
-      ]
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "wm",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/condition/famine",
+              "value": 0.8501380681991577
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/condition/food_insecurity",
+              "value": 0.6722718477249146
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/famine",
+              "value": 0.6007419228553772
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/crisis_and_disaster/crisis/economic_crisis/poverty",
+              "value": 0.5943692922592163
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/condition/poverty",
+              "value": 0.5943692922592163
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/economic_and_commerce/economic activity/market/demand/food demand",
+              "value": 0.5373021364212036
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/humanitarian assistance",
+              "value": 0.5066195726394653
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/political/political_instability",
+              "value": 0.5040405988693237
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/indicator_and_reported_property/health/Global Acute Malnutrition (GAM) rate",
+              "value": 0.5026841759681702
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/condition/food_security",
+              "value": 0.5022417902946472
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "interventions"
+        },
+        {
+          "@type": "Groundings",
+          "name": "mitre12",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Cause of death, by communicable diseases and maternal, prenatal and nutrition conditions",
+              "value": 0.5356301665306091
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of poultry loss accounted for by starvation",
+              "value": 0.510614275932312
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Value, Prevalence of severe food insecurity in the total population",
+              "value": 0.507411539554596
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Number of children aged 6 to 59 months with severe acute malnutrition admitted for treatment",
+              "value": 0.5052984952926636
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of cattle loss accounted for by starvation",
+              "value": 0.4961101710796356
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of goat loss accounted for by starvation",
+              "value": 0.49465835094451904
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock migrating due to conflict \\/ insecurity",
+              "value": 0.4872787296772003
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Average number of poultry died\\/slaughtered\\/lost per  household during last 4 weeks",
+              "value": 0.48391038179397583
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of sheep loss accounted for by starvation",
+              "value": 0.48316672444343567
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Cause of death, by non-communicable diseases",
+              "value": 0.4702593684196472
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "who",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Noncommunicable diseases/Overweight and obesity in adults (Also adolescents)",
+              "value": 0.4687536656856537
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Noncommunicable diseases/Raised blood glucose\\/diabetes among adults",
+              "value": 0.45551156997680664
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Noncommunicable diseases/Raised blood pressure among adults",
+              "value": 0.4292360842227936
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Injuries/Intimate partner violence prevalence",
+              "value": 0.42508387565612793
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Mortality between 30 and 70 years of age from cardiovascular diseases, cancer, diabetes or chronic respiratory diseases",
+              "value": 0.41273921728134155
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Externally sourced funding (% of current expenditure on health)",
+              "value": 0.3923349678516388
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Current expenditure on health by general government and compulsory schemes (% of current expenditure on health)",
+              "value": 0.38288599252700806
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Malaria mortality rate",
+              "value": 0.38089656829833984
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Total capital expenditure on health (% current + capital expenditure on health)",
+              "value": 0.3787592947483063
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Out-of-pocket payment for health (% of current expenditure on health)",
+              "value": 0.3622094690799713
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/famine",
+              "value": 0.8501380681991577
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_insecurity",
+              "value": 0.6722718477249146
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/financial/economic/poverty",
+              "value": 0.5943692922592163
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/humanitarian assistance",
+              "value": 0.5066195726394653
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/political/political_instability",
+              "value": 0.5040405988693237
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_security",
+              "value": 0.5022417902946472
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/physical_insecurity",
+              "value": 0.49259862303733826
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/food_availability",
+              "value": 0.4735701084136963
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/death",
+              "value": 0.47233593463897705
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/conflict",
+              "value": 0.4583386778831482
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "props"
+        }
+      ],
+      "states": [
+        {
+          "@type": "State",
+          "type": "TIMEX",
+          "text": "2018",
+          "value": {
+            "@id": "_:TimeExpression_1"
+          }
+        }
+      ],
+      "@id": "_:Extraction_1"
     },
     {
-      "@type": "Extraction",
-      "@id": "_:Extraction_1",
-      "type": "relation",
       "subtype": "causation",
+      "rule": "ported_syntax_1_verb-Causal",
+      "text": "hunger caused displacement",
+      "canonicalName": "hunger cause displacement",
       "labels": [
         "Causal",
         "DirectedRelation",
         "EntityLinker",
         "Event"
       ],
-      "text": "hunger caused displacement",
-      "rule": "ported_syntax_1_verb-Causal",
-      "canonicalName": "hunger cause displacement",
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 0,
+              "end": 25
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 3
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_1"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "relation",
       "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "wm"
+        },
+        {
+          "@type": "Groundings",
+          "name": "interventions"
+        },
+        {
+          "@type": "Groundings",
+          "name": "mitre12"
+        },
+        {
+          "@type": "Groundings",
+          "name": "who"
+        },
         {
           "@type": "Groundings",
           "name": "un"
         },
         {
           "@type": "Groundings",
-          "name": "wdi"
-        },
-        {
-          "@type": "Groundings",
-          "name": "fao"
+          "name": "props"
         }
       ],
-      "provenance": [
-        {
-          "@type": "Provenance",
-          "document": {
-            "@id": "_:Document_1"
-          },
-          "documentCharInterval": [
-            {
-              "@type": "Interval",
-              "start": 1,
-              "end": 26
-            }
-          ],
-          "sentence": {
-            "@id": "_:Sentence_1"
-          },
-          "positions": [
-            {
-              "@type": "Interval",
-              "start": 1,
-              "end": 3
-            }
-          ]
-        }
-      ],
-      "trigger": {
-        "@type": "Trigger",
-        "text": "caused",
-        "provenance": [
-          {
-            "@type": "Provenance",
-            "document": {
-              "@id": "_:Document_1"
-            },
-            "documentCharInterval": [
-              {
-                "@type": "Interval",
-                "start": 8,
-                "end": 13
-              }
-            ],
-            "sentence": {
-              "@id": "_:Sentence_1"
-            },
-            "positions": [
-              {
-                "@type": "Interval",
-                "start": 2,
-                "end": 2
-              }
-            ]
-          }
-        ]
-      },
       "arguments": [
         {
           "@type": "Argument",
           "type": "source",
           "value": {
-            "@id": "_:Extraction_3"
+            "@id": "_:Extraction_1"
           }
         },
         {
           "@type": "Argument",
           "type": "destination",
           "value": {
-            "@id": "_:Extraction_2"
+            "@id": "_:Extraction_3"
           }
         }
-      ]
+      ],
+      "@id": "_:Extraction_2",
+      "trigger": {
+        "@type": "Trigger",
+        "text": "caused",
+        "provenance": [
+          {
+            "documentCharPositions": [
+              {
+                "@type": "Interval",
+                "start": 7,
+                "end": 12
+              }
+            ],
+            "document": {
+              "@id": "_:Document_1"
+            },
+            "sentenceWordPositions": [
+              {
+                "@type": "Interval",
+                "start": 2,
+                "end": 2
+              }
+            ],
+            "@type": "Provenance",
+            "sentence": {
+              "@id": "_:Sentence_1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "subtype": "entity",
+      "rule": "simple-np",
+      "text": "displacement",
+      "canonicalName": "displacement",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 14,
+              "end": 25
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 3,
+              "end": 3
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_1"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "wm",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/movement/movement/human displacement",
+              "value": 1.0000001192092896
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/indicator_and_reported_property/conflict/population displacement",
+              "value": 0.819111168384552
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/migration/human_migration",
+              "value": 0.5647571682929993
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/political/political_instability",
+              "value": 0.4422326385974884
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/condition/tension",
+              "value": 0.41953250765800476
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/threat/physical_insecurity",
+              "value": 0.3953157067298889
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/provision of goods and services/health/vector control",
+              "value": 0.38901540637016296
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/environment/pollution/land_pollution",
+              "value": 0.3744608461856842
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/intervention/humanitarian assistance",
+              "value": 0.36816224455833435
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/economic_and_commerce/economic activity/market/fuel",
+              "value": 0.3625190556049347
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "interventions"
+        },
+        {
+          "@type": "Groundings",
+          "name": "mitre12",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Internally displaced persons, new displacement associated with disasters",
+              "value": 0.5550634860992432
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Internally displaced persons, new displacement associated with conflict and violence",
+              "value": 0.5340858101844788
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Surface area",
+              "value": 0.4392697215080261
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Ratio of female to male labor force participation rate",
+              "value": 0.42834725975990295
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Average precipitation in depth",
+              "value": 0.4242918789386749
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Pump price for diesel fuel",
+              "value": 0.40667924284935
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Electric power transmission and distribution losses",
+              "value": 0.4036661982536316
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock whose main water source is boreholes",
+              "value": 0.4035279154777527
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/CO2 emissions from electricity and heat production, total",
+              "value": 0.4020176827907562
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/PM2.5 air pollution, population exposed to levels exceeding WHO guideline value",
+              "value": 0.40165066719055176
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "who",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Maternal mortality ratio",
+              "value": 0.3827572166919708
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Quality and safety of care/Institutional maternal mortality ratio",
+              "value": 0.3827572166919708
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV/HIV viral load suppression",
+              "value": 0.3684025704860687
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health workforce/Health worker density and distribution",
+              "value": 0.34149494767189026
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Environmental risk factors/Population using modern fuels for cooking\\/heating\\/lighting",
+              "value": 0.33853116631507874
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Noncommunicable diseases/Raised blood pressure among adults",
+              "value": 0.33625900745391846
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV/Prevention of mother-to-child transmission",
+              "value": 0.28134217858314514
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Headcount ratio of impoverishing health expenditure",
+              "value": 0.2799398601055145
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Headcount ratio of catastrophic health expenditure",
+              "value": 0.2737150192260742
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Mortality rate from road traffic injuries",
+              "value": 0.2694666385650635
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/human_migration",
+              "value": 0.5647571682929993
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/political/political_instability",
+              "value": 0.4422326385974884
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/physical_insecurity",
+              "value": 0.3953157067298889
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/nature_impact/pollution/land_pollution",
+              "value": 0.3744608461856842
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/humanitarian assistance",
+              "value": 0.36816224455833435
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/financial/economic/fuel",
+              "value": 0.3625190556049347
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/famine",
+              "value": 0.3382830321788788
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/irrigation",
+              "value": 0.3344916105270386
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/weather/temperature",
+              "value": 0.33191415667533875
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_insecurity",
+              "value": 0.3229786455631256
+            }
+          ]
+        },
+        {
+          "@type": "Groundings",
+          "name": "props"
+        }
+      ],
+      "@id": "_:Extraction_3"
     }
   ]
 }

--- a/indra/tests/test_eidos.py
+++ b/indra/tests/test_eidos.py
@@ -76,8 +76,13 @@ def test_sanitize():
 def test_process_json_ld_file():
     ep = eidos.process_json_file(test_jsonld)
     assert len(ep.statements) == 1
-    assert 'UN' in ep.statements[0].subj.concept.db_refs
-    assert 'UN' in ep.statements[0].obj.concept.db_refs
+    st = ep.statements[0]
+    assert 'UN' in st.subj.concept.db_refs
+    assert 'UN' in st.obj.concept.db_refs
+
+    ep = eidos.process_json_file(test_jsonld, grounding_ns=['UN'])
+    st = ep.statements[0]
+    assert set(st.subj.concept.db_refs.keys()) == {'TEXT', 'UN'}
 
 
 def test_process_corefs():

--- a/indra/tests/test_eidos.py
+++ b/indra/tests/test_eidos.py
@@ -138,15 +138,16 @@ def test_process_geoids():
     ep = eidos.process_json_file(geo_jsonld)
     # Make sure we collect all geoids up front
     ss_loc = {'name': 'South Sudan', 'db_refs': {'GEOID': '7909807'}}
-    assert len(ep.doc.geolocs) == 5, len(ep.geoids)
+    assert len(ep.doc.geolocs) == 1, len(ep.doc.geolocs)
     assert ep.doc.geolocs['_:GeoLocation_1'].to_json() == ss_loc
     # Make sure this event has the right geoid
     assert isinstance(ep.statements[0], Influence)
-    ev = ep.statements[1].evidence[0]
-    assert ev.context.geo_location.to_json() == ss_loc
+    ev = ep.statements[0].evidence[0]
+    assert not ev.context
+    assert ep.statements[0].obj.context.geo_location.to_json() == ss_loc
     # And that the subject context is captured in annotations
-    assert 'subj_context' in ev.annotations, ev.annotations
-    assert ev.annotations['subj_context']['geo_location'] == ss_loc
+    assert 'obj_context' in ev.annotations, ev.annotations
+    assert ev.annotations['obj_context']['geo_location'] == ss_loc
 
 
 def test_eidos_to_cag():

--- a/indra/tests/test_eidos.py
+++ b/indra/tests/test_eidos.py
@@ -98,15 +98,16 @@ def test_process_timex():
     ep = eidos.process_json_file(timex_jsonld)
     assert len(ep.statements) == 1
     ev = ep.statements[0].evidence[0]
-    assert ev.context is not None
-    assert ev.context.__repr__() == ev.context.__str__()
-    assert ev.context.time.duration == 365 * 86400, ev.context.time.duration
-    assert ev.context.time.start == \
+    assert ev.context is None
+    subjc = ep.statements[0].subj.context
+    assert subjc.__repr__() == subjc.__str__()
+    assert subjc.time.duration == 365 * 86400, subjc.time.duration
+    assert subjc.time.start == \
         datetime.datetime(year=2018, month=1, day=1, hour=0, minute=0), \
-        ev.context.time.start
-    assert ev.context.time.end == \
+        subjc.time.start
+    assert subjc.time.end == \
         datetime.datetime(year=2019, month=1, day=1, hour=0, minute=0), \
-        ev.context.time.end
+        subjc.time.end
 
 
 def test_process_correlations():
@@ -213,3 +214,12 @@ def test_standalone_event():
     from indra.statements import stmts_to_json
     js2 = stmts_to_json([st])[0]
     assert 'evidence' in js2
+
+
+def test_geoloc_obj():
+    se_jsonld = os.path.join(path_this, 'eidos_geoloc_obj.json')
+    ep = eidos.process_json_file(se_jsonld)
+    st = ep.statements[1]
+    ev = st.evidence[0]
+    assert not ev.context, ev.context
+    assert st.obj.context

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -220,11 +220,13 @@ def eidos_process_text():
     body = json.loads(req)
     text = body.get('text')
     webservice = body.get('webservice')
+    grounding_ns = body.get('grounding_ns')
     if not webservice:
         response.status = 400
         response.content_type = 'application/json'
         return json.dumps({'error': 'No web service address provided.'})
-    ep = eidos.process_text(text, webservice=webservice)
+    ep = eidos.process_text(text, webservice=webservice,
+                            grounding_ns=grounding_ns)
     return _stmts_from_proc(ep)
 
 
@@ -237,7 +239,8 @@ def eidos_process_jsonld():
     response = request.body.read().decode('utf-8')
     body = json.loads(response)
     eidos_json = body.get('jsonld')
-    ep = eidos.process_json_str(eidos_json)
+    grounding_ns = body.get('grounding_ns')
+    ep = eidos.process_json_str(eidos_json, grounding_ns=grounding_ns)
     return _stmts_from_proc(ep)
 
 


### PR DESCRIPTION
This PR improves the Eidos input processor in the following ways:
- It doesn't look for `duration`s (they were recently removed from Eidos) when extracting timexes and rather calculates durations when both a `start` and and `end` time are available
- It doesn't assume that a time intervals list is always provided in timexes because in the latest Eidos output, these are missing in case a `start` and `end` are not available.
- It no longer extracts evidence-level context from the `sentences` portion of the JSON-LD because these contexts are now always available at the `entity` level as `state`s and can therefore be directly extracted as Event context
- It adds an optional `grounding_ns` argument to all API calls that allows controlling which grounding name spaces to propagate in `Concept` `db_refs`.

Fixes #934 