### PR TITLE
IndraNet flatten

### DIFF
--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -47,7 +47,8 @@ class IndraNetAssembler():
         """
         self.statements += stmts
 
-    def make_model(self, exclude_stmts=None, complex_members=3):
+    def make_model(self, exclude_stmts=None, complex_members=3,
+                   graph_type='multi_graph', sign_dict=None):
         """Assemble an IndraNet graph object.
 
         Parameters
@@ -59,6 +60,13 @@ class IndraNetAssembler():
             All complexes larger than complex_members will be rejected. For
             accepted complexes, all permutations of their members will be added
             as edges.
+        graph_type : str
+            Specify the type of graph to assemble. Chose from 'multi_graph'
+            (default), 'digraph', 'signed'.
+        sign_dict : dict
+            A dictionary mapping a Statement type to a sign to be used for
+            the edge. This parameter is only used with the 'signed' option.
+            See IndraNet.to_signed_graph for more info.
 
         Returns
         -------
@@ -66,7 +74,19 @@ class IndraNetAssembler():
             IndraNet graph object.
         """
         df = self.make_df(exclude_stmts, complex_members)
-        model = IndraNet.from_df(df)
+        if graph_type == 'multi_graph':
+            model = IndraNet.from_df(df)
+        elif graph_type == 'digraph':
+            model = IndraNet.digraph_from_df(df)
+        elif graph_type == 'signed':
+            if not sign_dict:
+                model = IndraNet.signed_from_df(df)
+            else:
+                model = IndraNet.signed_from_df(df, sign_dict=sign_dict)
+        else:
+            raise TypeError('Have to specify one of \'multi_graph\', '
+                            '\'digraph\' or \'signed\' when providing graph '
+                            'type.')
         return model
 
     def make_df(self, exclude_stmts=None, complex_members=3):

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -32,6 +32,11 @@ class IndraNetAssembler():
     model : IndraNet
         An IndraNet graph object assembled by this class.
     """
+    default_sign_dict = {'Activation': 0,
+                         'Inhibition': 1,
+                         'IncreaseAmount': 0,
+                         'DecreaseAmount': 1}
+
     def __init__(self, statements=None):
         self.statements = statements if statements else []
         self.model = None
@@ -79,10 +84,8 @@ class IndraNetAssembler():
         elif graph_type == 'digraph':
             model = IndraNet.digraph_from_df(df)
         elif graph_type == 'signed':
-            if not sign_dict:
-                model = IndraNet.signed_from_df(df)
-            else:
-                model = IndraNet.signed_from_df(df, sign_dict=sign_dict)
+            sign_dict = self.default_sign_dict if not sign_dict else sign_dict
+            model = IndraNet.signed_from_df(df, sign_dict=sign_dict)
         else:
             raise TypeError('Have to specify one of \'multi_graph\', '
                             '\'digraph\' or \'signed\' when providing graph '

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -3,7 +3,7 @@ import pandas as pd
 from .net import IndraNet
 from indra.statements import *
 from itertools import permutations
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 
 logger = logging.getLogger(__name__)
@@ -132,7 +132,15 @@ class IndraNetAssembler():
                     ('stmt_type', stmt_type),
                     ('evidence_count', len(stmt.evidence)),
                     ('stmt_hash', stmt.get_hash(refresh=True)),
-                    ('belief', stmt.belief)])
+                    ('belief', stmt.belief),
+                    ('source_counts', _get_source_counts(stmt))])
                 rows.append(row)
         df = pd.DataFrame.from_dict(rows)
         return df
+
+
+def _get_source_counts(stmt):
+    source_counts = defaultdict
+    for ev in stmt.evidence:
+        source_counts[ev.source_api] += 1
+    return source_counts

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -140,7 +140,7 @@ class IndraNetAssembler():
 
 
 def _get_source_counts(stmt):
-    source_counts = defaultdict
+    source_counts = defaultdict(int)
     for ev in stmt.evidence:
         source_counts[ev.source_api] += 1
     return source_counts

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -113,7 +113,7 @@ class IndraNet(nx.MultiDiGraph):
                 G[u][v]['statements'].append(data)
             else:
                 G.add_edge(u, v, statements=[data])
-        return G
+        return self._update_edge_belief(G)
 
     def to_signed_graph(self, sign_dict=default_sign_dict):
         """Flatten the IndraNet to a signed graph.
@@ -135,7 +135,7 @@ class IndraNet(nx.MultiDiGraph):
                 SG[u][v][sign]['statements'].append(data)
             else:
                 SG.add_edge(u, v, sign, statements=[data], sign=sign)
-        return SG
+        return self._update_edge_belief(SG)
 
     @classmethod
     def digraph_from_df(cls, df):

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -8,10 +8,6 @@ from indra.statements import Evidence
 from indra.statements import Statement
 
 logger = logging.getLogger(__name__)
-default_sign_dict = {'Activation': 0,
-                     'Inhibition': 1,
-                     'IncreaseAmount': 0,
-                     'DecreaseAmount': 1}
 scorer = SimpleScorer()
 
 
@@ -121,7 +117,7 @@ class IndraNet(nx.MultiDiGraph):
                 G.add_edge(u, v, statements=[data])
         return self._update_edge_belief(G)
 
-    def to_signed_graph(self, sign_dict=default_sign_dict):
+    def to_signed_graph(self, sign_dict):
         """Flatten the IndraNet to a signed graph.
         
         Parameters
@@ -156,7 +152,7 @@ class IndraNet(nx.MultiDiGraph):
         return net.to_digraph()
 
     @classmethod
-    def signed_from_df(cls, df, sign_dict=default_sign_dict):
+    def signed_from_df(cls, df, sign_dict):
         """Create a signed graph from a pandas DataFrame."""
         net = cls.from_df(df)
         return net.to_signed_graph(sign_dict=sign_dict)

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -1,11 +1,15 @@
-from networkx import MultiDiGraph
+import networkx as nx
 import pandas as pd
 import logging
 
 logger = logging.getLogger(__name__)
+default_sign_dict = {'Activation': 0,
+                     'Inhibition': 1,
+                     'IncreaseAmount': 0,
+                     'DecreaseAmount': 1}
 
 
-class IndraNet(MultiDiGraph):
+class IndraNet(nx.MultiDiGraph):
     """A Networkx representation of INDRA Statements."""
     def __init__(self, incoming_graph_data=None, **attr):
         super().__init__(incoming_graph_data, **attr)
@@ -92,3 +96,47 @@ class IndraNet(MultiDiGraph):
         if skipped:
             logger.warning('Skipped %d edges with None as node' % skipped)
         return graph
+
+    def to_digraph(self):
+        """Flatten the IndraNet to a DiGraph."""
+        G = nx.DiGraph()
+        for u, v, data in self.edges(data=True):
+            if G.has_edge(u, v):
+                G[u][v]['statements'].append(data)
+            else:
+                G.add_edge(u, v, statements=[data])
+        return G
+
+    def to_signed_graph(self, sign_dict=default_sign_dict):
+        """Flatten the IndraNet to a signed graph.
+        
+        Parameters
+        ----------
+        sign_dict : dict
+            A dictionary mapping a Statement type to a sign to be used for
+            the edge. By default only Activation and IncreaseAmount are added
+            as positive edges and Inhibition and DecreaseAmount are added as
+            negative edges, but a user can pass any other Statement types in
+            a dictionary."""
+        SG = nx.MultiDiGraph()
+        for u, v, data in self.edges(data=True):
+            if data['stmt_type'] not in sign_dict:
+                continue
+            sign = sign_dict[data['stmt_type']]
+            if SG.has_edge(u, v, sign):
+                SG[u][v][sign]['statements'].append(data)
+            else:
+                SG.add_edge(u, v, sign, statements=[data], sign=sign)
+        return SG
+
+    @classmethod
+    def digraph_from_df(cls, df):
+        """Create a digraph from a pandas DataFrame."""
+        net = cls.from_df(df)
+        return net.to_digraph()
+
+    @classmethod
+    def signed_from_df(cls, df, sign_dict=default_sign_dict):
+        """Create a signed graph from a pandas DataFrame."""
+        net = cls.from_df(df)
+        return net.to_signed_graph(sign_dict=sign_dict)

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -106,7 +106,13 @@ class IndraNet(nx.MultiDiGraph):
         return graph
 
     def to_digraph(self):
-        """Flatten the IndraNet to a DiGraph."""
+        """Flatten the IndraNet to a DiGraph
+
+        Returns
+        -------
+        G : IndraNet(nx.DiGraph)
+            An IndraNet graph flattened to a DiGraph
+        """
         G = nx.DiGraph()
         for u, v, data in self.edges(data=True):
             if G.has_edge(u, v):
@@ -125,7 +131,13 @@ class IndraNet(nx.MultiDiGraph):
             the edge. By default only Activation and IncreaseAmount are added
             as positive edges and Inhibition and DecreaseAmount are added as
             negative edges, but a user can pass any other Statement types in
-            a dictionary."""
+            a dictionary.
+
+        Returns
+        -------
+        SG : IndraNet(nx.MultiDiGraph)
+            An IndraNet graph flattened to a signed graph
+        """
         SG = nx.MultiDiGraph()
         for u, v, data in self.edges(data=True):
             if data['stmt_type'] not in sign_dict:

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -16,7 +16,8 @@ class IndraNet(nx.MultiDiGraph):
         self._is_multi = True
         self.mandatory_columns = ['agA_name', 'agB_name', 'agA_ns', 'agA_id',
                                   'agB_ns', 'agB_id', 'stmt_type',
-                                  'evidence_count', 'stmt_hash', 'belief']
+                                  'evidence_count', 'stmt_hash', 'belief',
+                                  'source_counts']
 
     @classmethod
     def from_df(cls, df):
@@ -91,6 +92,7 @@ class IndraNet(nx.MultiDiGraph):
                   'stmt_type': row['stmt_type'],
                   'evidence_count': row['evidence_count'],
                   'belief': row['belief'],
+                  'source_counts': row['source_counts'],
                   **edge_attr}
             graph.add_edge(**ed)
         if skipped:

--- a/indra/tests/test_indranet_assembler.py
+++ b/indra/tests/test_indranet_assembler.py
@@ -113,6 +113,7 @@ def test_to_digraph():
     assert set([
         stmt['stmt_type'] for stmt in digraph['a']['b']['statements']]) == {
             'Activation', 'Phosphorylation', 'Inhibition', 'IncreaseAmount'}
+    assert all(digraph.edges[e].get('belief', False) for e in digraph.edges)
     digraph_from_df = IndraNet.digraph_from_df(df)
     assert nx.is_isomorphic(digraph, digraph_from_df)
 
@@ -136,3 +137,5 @@ def test_to_signed_graph():
     assert set([stmt['stmt_type'] for stmt in
                 signed_graph['b']['c'][1]['statements']]) == {
                     'Inhibition', 'DecreaseAmount'}
+    assert all(signed_graph.edges[e].get('belief', False) for e in
+               signed_graph.edges)

--- a/indra/tests/test_indranet_assembler.py
+++ b/indra/tests/test_indranet_assembler.py
@@ -121,7 +121,8 @@ def test_to_signed_graph():
     ia = IndraNetAssembler([ab1, ab2, ab3, ab4, bc1, bc2, bc3, bc4])
     df = ia.make_df()
     net = IndraNet.from_df(df)
-    signed_graph = net.to_signed_graph()
+    signed_graph = net.to_signed_graph(
+        sign_dict=IndraNetAssembler.default_sign_dict)
     assert len(signed_graph.nodes) == 3
     assert len(signed_graph.edges) == 4
     assert set([stmt['stmt_type'] for stmt in

--- a/indra/tests/test_indranet_assembler.py
+++ b/indra/tests/test_indranet_assembler.py
@@ -65,7 +65,7 @@ def test_make_df():
     assert len(df) == 9
     assert set(df.columns) == {
         'agA_name', 'agB_name', 'agA_ns', 'agA_id', 'agB_ns', 'agB_id',
-        'stmt_type', 'evidence_count', 'stmt_hash', 'belief'}
+        'stmt_type', 'evidence_count', 'stmt_hash', 'belief', 'source_counts'}
 
 
 # Test assembly from IndraNet directly

--- a/indra/tests/test_indranet_assembler.py
+++ b/indra/tests/test_indranet_assembler.py
@@ -91,14 +91,22 @@ def test_from_df():
     assert net['b']['d'][0]['evidence_count'] == 0
 
 
-ab1 = Activation(Agent('a'), Agent('b'))
-ab2 = Phosphorylation(Agent('a'), Agent('b'))
-ab3 = Inhibition(Agent('a'), Agent('b'))
-ab4 = IncreaseAmount(Agent('a'), Agent('b'))
-bc1 = Activation(Agent('b'), Agent('c'))
-bc2 = Inhibition(Agent('b'), Agent('c'))
-bc3 = IncreaseAmount(Agent('b'), Agent('c'))
-bc4 = DecreaseAmount(Agent('b'), Agent('c'))
+ab1 = Activation(Agent('a'), Agent('b'), evidence=[
+    Evidence(source_api='sparser')])
+ab2 = Phosphorylation(Agent('a'), Agent('b'),evidence=[
+    Evidence(source_api='sparser'), Evidence(source_api='reach')])
+ab3 = Inhibition(Agent('a'), Agent('b'), evidence=[
+    Evidence(source_api='sparser'), Evidence(source_api='reach')])
+ab4 = IncreaseAmount(Agent('a'), Agent('b'), evidence=[
+    Evidence(source_api='trips')])
+bc1 = Activation(Agent('b'), Agent('c'), evidence=[
+    Evidence(source_api='trips')])
+bc2 = Inhibition(Agent('b'), Agent('c'), evidence=[
+    Evidence(source_api='trips'), Evidence(source_api='reach')])
+bc3 = IncreaseAmount(Agent('b'), Agent('c'), evidence=[
+    Evidence(source_api='sparser'), Evidence(source_api='reach')])
+bc4 = DecreaseAmount(Agent('b'), Agent('c'), evidence=[
+    Evidence(source_api='reach'), Evidence(source_api='trips')])
 
 
 def test_to_digraph():


### PR DESCRIPTION
This PR adds methods to IndraNet class to flatten it to a digraph and to a signed graph. Each edge both cases will represent multiple statements and the edge data will have a list of statement data. At this point there's no belief aggregation, but we can add it later when modifying this method for weighted search.