### PR TITLE
Add MeSH isa functionality

### DIFF
--- a/indra/tests/test_mesh.py
+++ b/indra/tests/test_mesh.py
@@ -81,3 +81,8 @@ def test_mesh_term_lookups():
         mesh_id, mesh_name = mesh_client.get_mesh_id_name(query_term)
         assert mesh_id == correct_id
         assert mesh_name == correct_name
+
+
+def test_mesh_isa():
+    assert mesh_client.mesh_isa('D011506', 'D000602')
+    assert not mesh_client.mesh_isa('D000602', 'D011506')


### PR DESCRIPTION
This PR adds a function to check if there is a hierarchical relationship between two MeSH terms, which can be used to determine the category of a given MeSH term. It also refactors querying the SPARQL endpoint to use a generic query call.