### PR TITLE
Custom flattened belief and weight

### DIFF
--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -73,6 +73,38 @@ class IndraNetAssembler():
             A dictionary mapping a Statement type to a sign to be used for
             the edge. This parameter is only used with the 'signed' option.
             See IndraNet.to_signed_graph for more info.
+        belief_flattening : str|function(G, edge)
+            The method to use when updating the belief for the flattened edge.
+
+            If a string is provided, it must be one of the predefined options
+            'simple_scorer' or 'complementary_belief'.
+
+            If a function is provided, it must take the flattened graph 'G'
+            and an edge 'edge' to perform the belief flattening on and return
+            a number:
+
+            >>> def belief_flattening(G, edge):
+            ...     # Return the average belief score of the constituent edges
+            ...     all_beliefs = [s['belief']
+            ...         for s in G.edges[edge]['statements']]
+            ...     return sum(all_beliefs)/len(all_beliefs)
+
+        weight_flattening : function(G)
+            A function taking at least the graph G as an argument and
+            returning G after adding edge weights as an edge attribute to the
+            flattened edges using the reserved keyword 'weight'.
+
+            Example:
+
+            >>> def weight_flattening(G):
+            ...     # Sets the flattened weight to the average of the
+            ...     # inverse source count
+            ...     for edge in G.edges:
+            ...         w = [1/s['evidence_count']
+            ...             for s in G.edges[edge]['statements']]
+            ...         G.edges[edge]['weight'] = sum(w)/len(w)
+            ...     return G
+
 
         Returns
         -------

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -10,6 +10,11 @@ logger = logging.getLogger(__name__)
 NS_PRIORITY_LIST = (
     'FPLX', 'HGNC', 'UP', 'CHEBI', 'GO', 'MESH', 'HMDB', 'PUBCHEM')
 
+default_sign_dict = {'Activation': 0,
+                     'Inhibition': 1,
+                     'IncreaseAmount': 0,
+                     'DecreaseAmount': 1}
+
 
 def get_ag_ns_id(ag):
     """Return a tuple of name space, id from an Agent's db_refs."""
@@ -32,10 +37,6 @@ class IndraNetAssembler():
     model : IndraNet
         An IndraNet graph object assembled by this class.
     """
-    default_sign_dict = {'Activation': 0,
-                         'Inhibition': 1,
-                         'IncreaseAmount': 0,
-                         'DecreaseAmount': 1}
 
     def __init__(self, statements=None):
         self.statements = statements if statements else []
@@ -121,7 +122,7 @@ class IndraNetAssembler():
                 weight_mapping=weight_flattening
             )
         elif graph_type == 'signed':
-            sign_dict = self.default_sign_dict if not sign_dict else sign_dict
+            sign_dict = default_sign_dict if not sign_dict else sign_dict
             model = IndraNet.signed_from_df(df, sign_dict=sign_dict,
                                             flattening_method=belief_flattening,
                                             weight_mapping=weight_flattening)

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -10,11 +10,6 @@ logger = logging.getLogger(__name__)
 NS_PRIORITY_LIST = (
     'FPLX', 'HGNC', 'UP', 'CHEBI', 'GO', 'MESH', 'HMDB', 'PUBCHEM')
 
-default_sign_dict = {'Activation': 0,
-                     'Inhibition': 1,
-                     'IncreaseAmount': 0,
-                     'DecreaseAmount': 1}
-
 
 def get_ag_ns_id(ag):
     """Return a tuple of name space, id from an Agent's db_refs."""
@@ -122,7 +117,6 @@ class IndraNetAssembler():
                 weight_mapping=weight_flattening
             )
         elif graph_type == 'signed':
-            sign_dict = default_sign_dict if not sign_dict else sign_dict
             model = IndraNet.signed_from_df(df, sign_dict=sign_dict,
                                             flattening_method=belief_flattening,
                                             weight_mapping=weight_flattening)

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -53,7 +53,8 @@ class IndraNetAssembler():
         self.statements += stmts
 
     def make_model(self, exclude_stmts=None, complex_members=3,
-                   graph_type='multi_graph', sign_dict=None):
+                   graph_type='multi_graph', sign_dict=None,
+                   belief_flattening=None, weight_flattening=None):
         """Assemble an IndraNet graph object.
 
         Parameters
@@ -82,10 +83,16 @@ class IndraNetAssembler():
         if graph_type == 'multi_graph':
             model = IndraNet.from_df(df)
         elif graph_type == 'digraph':
-            model = IndraNet.digraph_from_df(df)
+            model = IndraNet.digraph_from_df(
+                df=df,
+                flattening_method=belief_flattening,
+                weight_mapping=weight_flattening
+            )
         elif graph_type == 'signed':
             sign_dict = self.default_sign_dict if not sign_dict else sign_dict
-            model = IndraNet.signed_from_df(df, sign_dict=sign_dict)
+            model = IndraNet.signed_from_df(df, sign_dict=sign_dict,
+                                            flattening_method=belief_flattening,
+                                            weight_mapping=weight_flattening)
         else:
             raise TypeError('Have to specify one of \'multi_graph\', '
                             '\'digraph\' or \'signed\' when providing graph '

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -132,6 +132,12 @@ class IndraNet(nx.MultiDiGraph):
         """
         G = nx.DiGraph()
         for u, v, data in self.edges(data=True):
+            # Add nodes and their attributes
+            if u not in G.nodes:
+                G.add_node(u, **self.nodes[u])
+            if v not in G.nodes:
+                G.add_node(v, **self.nodes[v])
+            # Add edges and their attributes
             if G.has_edge(u, v):
                 G[u][v]['statements'].append(data)
             else:

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -170,9 +170,9 @@ class IndraNet(nx.MultiDiGraph):
 
     @staticmethod
     def _update_edge_belief(G, flattening_method):
-        """G must be or be a child of an nx.Graph object. If provided,
-        flattening_method must be a function taking at least a graph G and
-        return a number (the new belief for the flattened edge).
+        """G must be or be a child of an nx.Graph object. If provided as
+        function, 'flattening_method' must be a function taking at least a
+        graph G and return a number (the new belief for the flattened edge).
 
         We assume that G is the flattened graph, and that there is an edge
         attribute called 'statements' containing a list of dictionaries, each
@@ -185,6 +185,9 @@ class IndraNet(nx.MultiDiGraph):
         elif flattening_method == 'complementary_belief':
             for e in G.edges:
                 G.edges[e]['belief'] = _complementary_belief(G, edge=e)
+        else:
+            for e in G.edges:
+                G.edges[e]['belief'] = flattening_method(G, edge=e)
         return G
 
 

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -107,6 +107,11 @@ class IndraNet(nx.MultiDiGraph):
     def to_digraph(self, flattening_method=None):
         """Flatten the IndraNet to a DiGraph
 
+        Parameters
+        ----------
+        flattening_method : str
+            The method to use when updating the belief for the flattened edge
+
         Returns
         -------
         G : IndraNet(nx.DiGraph)
@@ -131,6 +136,8 @@ class IndraNet(nx.MultiDiGraph):
             as positive edges and Inhibition and DecreaseAmount are added as
             negative edges, but a user can pass any other Statement types in
             a dictionary.
+        flattening_method : str
+            The method to use when updating the belief for the flattened edge
 
         Returns
         -------

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -7,7 +7,7 @@ import pandas as pd
 import networkx as nx
 from decimal import Decimal
 
-import indra_db.resources as res
+import indra
 from indra.belief import SimpleScorer
 from indra.statements import Evidence
 from indra.statements import Statement
@@ -22,9 +22,9 @@ default_sign_dict = {'Activation': 0,
                      'IncreaseAmount': 0,
                      'DecreaseAmount': 1}
 
-
-with open(path.join(path.dirname(res.__file__),
-                    'source_mapping.json'), 'r') as f:
+INDRA_ROOT = path.abspath(path.dirname(path.abspath(indra.__file__)))
+INDRA_RESOURCES = path.join(INDRA_ROOT, 'resources')
+with open(path.join(INDRA_RESOURCES, 'source_mapping.json'), 'r') as f:
     db_source_mapping = json.load(f)
 
 

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -11,6 +11,7 @@ import indra_db.resources as res
 from indra.belief import SimpleScorer
 from indra.statements import Evidence
 from indra.statements import Statement
+from indra.assemblers.indranet.assembler import default_sign_dict
 
 logger = logging.getLogger(__name__)
 simple_scorer = SimpleScorer()
@@ -147,8 +148,8 @@ class IndraNet(nx.MultiDiGraph):
             G = weight_mapping(G)
         return G
 
-    def to_signed_graph(self, sign_dict, flattening_method=None,
-                        weight_mapping=None):
+    def to_signed_graph(self, sign_dict=default_sign_dict,
+                        flattening_method=None, weight_mapping=None):
         """Flatten the IndraNet to a signed graph.
         
         Parameters

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -145,12 +145,38 @@ class IndraNet(nx.MultiDiGraph):
             as positive edges and Inhibition and DecreaseAmount are added as
             negative edges, but a user can pass any other Statement types in
             a dictionary.
-        flattening_method : str|function
-            The method to use when updating the belief for the flattened edge
-        weight_mapping : function
+        flattening_method : str|function(G, edge)
+            The method to use when updating the belief for the flattened edge.
+
+            If a string is provided, it must be one of the predefined options
+            'simple_scorer' or 'complementary_belief'.
+
+            If a function is provided, it must take the flattened graph 'G'
+            and an edge 'edge' to perform the belief flattening on and return
+            a number:
+
+            >>> def flattening_function(G, edge):
+            ...     # Return the average belief score of the constituent edges
+            ...     l = len(G.edges[edge]['statements'])
+            ...     all_beliefs = [s['belief']/l
+            ...         for s in G.edges[edge]['statements']]
+            ...     return sum(all_beliefs)
+
+        weight_mapping : function(G)
             A function taking at least the graph G as an argument and
             returning G after adding edge weights as an edge attribute to the
             flattened edges using the reserved keyword 'weight'.
+
+            Example:
+
+            >>> def weight_mapping(G):
+            ...     # Sets the flattened weight to the inverse of the average
+            ...     # source count
+            ...     for edge in G.edges:
+            ...         w = [s['evidence_count']
+            ...             for s in G.edges[edge]['statements']]
+            ...         G.edges[edge]['weight'] = w
+            ...     return G
 
         Returns
         -------

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -171,10 +171,9 @@ class IndraNet(nx.MultiDiGraph):
 
             >>> def flattening_function(G, edge):
             ...     # Return the average belief score of the constituent edges
-            ...     l = len(G.edges[edge]['statements'])
-            ...     all_beliefs = [s['belief']/l
+            ...     all_beliefs = [s['belief']
             ...         for s in G.edges[edge]['statements']]
-            ...     return sum(all_beliefs)
+            ...     return sum(all_beliefs)/len(all_beliefs)
 
         weight_mapping : function(G)
             A function taking at least the graph G as an argument and
@@ -184,12 +183,12 @@ class IndraNet(nx.MultiDiGraph):
             Example:
 
             >>> def weight_mapping(G):
-            ...     # Sets the flattened weight to the inverse of the average
-            ...     # source count
+            ...     # Sets the flattened weight to the average of the
+            ...     # inverse source count
             ...     for edge in G.edges:
-            ...         w = [s['evidence_count']
+            ...         w = [1/s['evidence_count']
             ...             for s in G.edges[edge]['statements']]
-            ...         G.edges[edge]['weight'] = w
+            ...         G.edges[edge]['weight'] = sum(w)/len(w)
             ...     return G
 
         Returns

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -110,8 +110,12 @@ class IndraNet(nx.MultiDiGraph):
 
         Parameters
         ----------
-        flattening_method : str
+        flattening_method : str|function
             The method to use when updating the belief for the flattened edge
+        weight_mapping : function
+            A function taking at least the graph G as an argument and
+            returning G after adding edge weights as an edge attribute to the
+            flattened edges using the reserved keyword 'weight'.
 
         Returns
         -------
@@ -141,8 +145,12 @@ class IndraNet(nx.MultiDiGraph):
             as positive edges and Inhibition and DecreaseAmount are added as
             negative edges, but a user can pass any other Statement types in
             a dictionary.
-        flattening_method : str
+        flattening_method : str|function
             The method to use when updating the belief for the flattened edge
+        weight_mapping : function
+            A function taking at least the graph G as an argument and
+            returning G after adding edge weights as an edge attribute to the
+            flattened edges using the reserved keyword 'weight'.
 
         Returns
         -------

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -14,6 +14,7 @@ simple_scorer = SimpleScorer()
 np.seterr(all='raise')
 NP_PRECISION = 10 ** -np.finfo(np.longfloat).precision  # Numpy precision
 
+
 class IndraNet(nx.MultiDiGraph):
     """A Networkx representation of INDRA Statements."""
     def __init__(self, incoming_graph_data=None, **attr):
@@ -189,7 +190,7 @@ class IndraNet(nx.MultiDiGraph):
         contaning the edge data from the edges included on the flattened edge.
         """
 
-        if not flattening_method:
+        if not flattening_method or flattening_method == 'simple_scorer':
             for e in G.edges:
                 G.edges[e]['belief'] = _simple_scorer_update(G, edge=e)
         elif flattening_method == 'complementary_belief':

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -190,12 +190,14 @@ class IndraNet(nx.MultiDiGraph):
     @staticmethod
     def _update_edge_belief(G, flattening_method):
         """G must be or be a child of an nx.Graph object. If
-        'flattening_method' is a function, it must take at least a graph G
-        and return a number (the new belief for the flattened edge).
+        'flattening_method' is a function, it must take at least the graph G
+        and an edge and return a number (the new belief for the flattened
+        edge).
 
-        We assume that G is the flattened graph, and that there is an edge
-        attribute called 'statements' containing a list of dictionaries, each
-        contaning the edge data from the edges included on the flattened edge.
+        We assume that G is the flattened graph and that all its edges have an
+        edge attribute called 'statements' containing a list of dictionaries
+        representing the edge data of all the edges in the un-flattened graph
+        that were mapped to the corresponding flattened edge in G.
         """
 
         if not flattening_method or flattening_method == 'simple_scorer':

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -170,9 +170,9 @@ class IndraNet(nx.MultiDiGraph):
 
     @staticmethod
     def _update_edge_belief(G, flattening_method):
-        """G must be or be a child of an nx.Graph object. If provided as
-        function, 'flattening_method' must be a function taking at least a
-        graph G and return a number (the new belief for the flattened edge).
+        """G must be or be a child of an nx.Graph object. If
+        'flattening_method' is a function, it must take at least a graph G
+        and return a number (the new belief for the flattened edge).
 
         We assume that G is the flattened graph, and that there is an edge
         attribute called 'statements' containing a list of dictionaries, each

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -104,7 +104,7 @@ class IndraNet(nx.MultiDiGraph):
             logger.warning('Skipped %d edges with None as node' % skipped)
         return graph
 
-    def to_digraph(self):
+    def to_digraph(self, flattening_method=None):
         """Flatten the IndraNet to a DiGraph
 
         Returns
@@ -118,9 +118,9 @@ class IndraNet(nx.MultiDiGraph):
                 G[u][v]['statements'].append(data)
             else:
                 G.add_edge(u, v, statements=[data])
-        return self._update_edge_belief(G)
+        return self._update_edge_belief(G, flattening_method)
 
-    def to_signed_graph(self, sign_dict):
+    def to_signed_graph(self, sign_dict, flattening_method=None):
         """Flatten the IndraNet to a signed graph.
         
         Parameters
@@ -146,22 +146,23 @@ class IndraNet(nx.MultiDiGraph):
                 SG[u][v][sign]['statements'].append(data)
             else:
                 SG.add_edge(u, v, sign, statements=[data], sign=sign)
-        return self._update_edge_belief(SG)
+        return self._update_edge_belief(SG, flattening_method)
 
     @classmethod
-    def digraph_from_df(cls, df):
+    def digraph_from_df(cls, df, flattening_method=None):
         """Create a digraph from a pandas DataFrame."""
         net = cls.from_df(df)
-        return net.to_digraph()
+        return net.to_digraph(flattening_method=flattening_method)
 
     @classmethod
-    def signed_from_df(cls, df, sign_dict):
+    def signed_from_df(cls, df, sign_dict, flattening_method=None):
         """Create a signed graph from a pandas DataFrame."""
         net = cls.from_df(df)
-        return net.to_signed_graph(sign_dict=sign_dict)
+        return net.to_signed_graph(sign_dict=sign_dict,
+                                   flattening_method=flattening_method)
 
     @staticmethod
-    def _update_edge_belief(G, flattening_method=None):
+    def _update_edge_belief(G, flattening_method):
         """G must be or be a child of an nx.Graph object. If provided,
         flattening_method must be a function taking at least a graph G and
         return a number (the new belief for the flattened edge).

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -104,7 +104,7 @@ class IndraNet(nx.MultiDiGraph):
             logger.warning('Skipped %d edges with None as node' % skipped)
         return graph
 
-    def to_digraph(self, flattening_method=None):
+    def to_digraph(self, flattening_method=None, weight_mapping=None):
         """Flatten the IndraNet to a DiGraph
 
         Parameters
@@ -123,9 +123,13 @@ class IndraNet(nx.MultiDiGraph):
                 G[u][v]['statements'].append(data)
             else:
                 G.add_edge(u, v, statements=[data])
-        return self._update_edge_belief(G, flattening_method)
+        G = self._update_edge_belief(G, flattening_method)
+        if weight_mapping:
+            G = weight_mapping(G)
+        return G
 
-    def to_signed_graph(self, sign_dict, flattening_method=None):
+    def to_signed_graph(self, sign_dict, flattening_method=None,
+                        weight_mapping=None):
         """Flatten the IndraNet to a signed graph.
         
         Parameters
@@ -153,20 +157,26 @@ class IndraNet(nx.MultiDiGraph):
                 SG[u][v][sign]['statements'].append(data)
             else:
                 SG.add_edge(u, v, sign, statements=[data], sign=sign)
-        return self._update_edge_belief(SG, flattening_method)
+        SG = self._update_edge_belief(SG, flattening_method)
+        if weight_mapping:
+            SG = weight_mapping(SG)
+        return SG
 
     @classmethod
-    def digraph_from_df(cls, df, flattening_method=None):
+    def digraph_from_df(cls, df, flattening_method=None, weight_mapping=None):
         """Create a digraph from a pandas DataFrame."""
         net = cls.from_df(df)
-        return net.to_digraph(flattening_method=flattening_method)
+        return net.to_digraph(flattening_method=flattening_method,
+                              weight_mapping=weight_mapping)
 
     @classmethod
-    def signed_from_df(cls, df, sign_dict, flattening_method=None):
+    def signed_from_df(cls, df, sign_dict, flattening_method=None,
+                       weight_mapping=None):
         """Create a signed graph from a pandas DataFrame."""
         net = cls.from_df(df)
         return net.to_signed_graph(sign_dict=sign_dict,
-                                   flattening_method=flattening_method)
+                                   flattening_method=flattening_method,
+                                   weight_mapping=weight_mapping)
 
     @staticmethod
     def _update_edge_belief(G, flattening_method):

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -11,12 +11,16 @@ import indra_db.resources as res
 from indra.belief import SimpleScorer
 from indra.statements import Evidence
 from indra.statements import Statement
-from indra.assemblers.indranet.assembler import default_sign_dict
 
 logger = logging.getLogger(__name__)
 simple_scorer = SimpleScorer()
 np.seterr(all='raise')
 NP_PRECISION = 10 ** -np.finfo(np.longfloat).precision  # Numpy precision
+
+default_sign_dict = {'Activation': 0,
+                     'Inhibition': 1,
+                     'IncreaseAmount': 0,
+                     'DecreaseAmount': 1}
 
 
 with open(path.join(path.dirname(res.__file__),
@@ -148,7 +152,7 @@ class IndraNet(nx.MultiDiGraph):
             G = weight_mapping(G)
         return G
 
-    def to_signed_graph(self, sign_dict=default_sign_dict,
+    def to_signed_graph(self, sign_dict=None,
                         flattening_method=None, weight_mapping=None):
         """Flatten the IndraNet to a signed graph.
         
@@ -197,6 +201,8 @@ class IndraNet(nx.MultiDiGraph):
         SG : IndraNet(nx.MultiDiGraph)
             An IndraNet graph flattened to a signed graph
         """
+        sign_dict = default_sign_dict if not sign_dict else sign_dict
+
         SG = nx.MultiDiGraph()
         for u, v, data in self.edges(data=True):
             if data['stmt_type'] not in sign_dict:
@@ -219,7 +225,7 @@ class IndraNet(nx.MultiDiGraph):
                               weight_mapping=weight_mapping)
 
     @classmethod
-    def signed_from_df(cls, df, sign_dict, flattening_method=None,
+    def signed_from_df(cls, df, sign_dict=None, flattening_method=None,
                        weight_mapping=None):
         """Create a signed graph from a pandas DataFrame."""
         net = cls.from_df(df)

--- a/indra/resources/default_belief_probs.json
+++ b/indra/resources/default_belief_probs.json
@@ -22,8 +22,8 @@
     "hprd": 0.01,
     "trrust": 0.01,
     "medscan": 0.05,
-    "geneways": 0.3,
-    "tees": 0.3
+    "geneways": 0.05,
+    "tees": 0.05
   },
   "rand": {
     "eidos": 0.3,
@@ -48,7 +48,7 @@
     "hprd": 0.1,
     "trrust": 0.1,
     "medscan": 0.3,
-    "geneways": 0.05,
-    "tees": 0.05
+    "geneways": 0.3,
+    "tees": 0.3
   }
 }

--- a/indra/resources/default_belief_probs.json
+++ b/indra/resources/default_belief_probs.json
@@ -21,7 +21,9 @@
     "rlimsp": 0.05,
     "hprd": 0.01,
     "trrust": 0.01,
-    "medscan": 0.05
+    "medscan": 0.05,
+    "geneways": 0.3,
+    "tees": 0.3
   },
   "rand": {
     "eidos": 0.3,
@@ -45,6 +47,8 @@
     "rlimsp": 0.3,
     "hprd": 0.1,
     "trrust": 0.1,
-    "medscan": 0.3
+    "medscan": 0.3,
+    "geneways": 0.05,
+    "tees": 0.05
   }
 }

--- a/indra/tests/test_indranet_assembler.py
+++ b/indra/tests/test_indranet_assembler.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pandas as pd
 import networkx as nx
-from indra.assemblers.indranet import IndraNetAssembler, IndraNet
 from indra.statements import *
+from indra.assemblers.indranet.net import default_sign_dict
+from indra.assemblers.indranet import IndraNetAssembler, IndraNet
 
 
 ev1 = Evidence(pmid='1')
@@ -137,7 +138,7 @@ def test_to_signed_graph():
     df = ia.make_df()
     net = IndraNet.from_df(df)
     signed_graph = net.to_signed_graph(
-        sign_dict=IndraNetAssembler.default_sign_dict,
+        sign_dict=default_sign_dict,
         weight_mapping=_weight_mapping)
     assert len(signed_graph.nodes) == 3
     assert len(signed_graph.edges) == 4


### PR DESCRIPTION
This PR adds options allowing for custom mapping functions for the belief and weight of the flattened edges in a flattened IndraNet graph given just the graph and the edge attributes (including the list of statements making up the flattened edge) of the flattened graph.

_Note that for flattened weight, the default behavior is that no weight is calculated._

In addition to allowing for custom belief calculation, two pre-defined functions for mapping belief to the flattened edge are provided:
- Simple scorer: This uses the belief score of a mock Statement created with all the sources in the flattened edge as evidence. _This is currently the default behavior for flattened belief._
- Complementary belief: This mapping calculates a complementary belief score using the belief scores of the individual statements making up the flattened edge according to <a href="https://www.codecogs.com/eqnedit.php?latex=\inline&space;\text{flattened&space;belief}&space;=&space;1&space;-&space;\prod_i&space;\left(1&space;-&space;\text{belief}_i&space;\right)" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\inline&space;\text{flattened&space;belief}&space;=&space;1&space;-&space;\prod_i&space;\left(1&space;-&space;\text{belief}_i&space;\right)" title="\text{flattened belief} = 1 - \prod_i \left(1 - \text{belief}_i \right)" /></a>
 