### PR TITLE
Move source_mapping.json from indra_db

### DIFF
--- a/indra/resources/source_mapping.json
+++ b/indra/resources/source_mapping.json
@@ -1,0 +1,5 @@
+{
+    "cbn": "bel",
+    "bel_lc": "bel",
+    "pc11": "biopax"
+}


### PR DESCRIPTION
This PR moves a resource file from `indra_db` to avoid dependency issues.