### PR TITLE
Influence signs

### DIFF
--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -179,6 +179,16 @@ class IndraNetAssembler():
                 agA_ns, agA_id = get_ag_ns_id(agA)
                 agB_ns, agB_id = get_ag_ns_id(agB)
                 stmt_type = type(stmt).__name__
+                if stmt_type == 'Influence' or stmt_type == 'Association':
+                    stmt_pol = stmt.overall_polarity()
+                    if stmt_pol == 1:
+                        sign = 0
+                    elif stmt_pol == -1:
+                        sign = 1
+                    else:
+                        sign = None
+                else:
+                    sign = None
                 row = OrderedDict([
                     ('agA_name', agA.name),
                     ('agB_name', agB.name),
@@ -190,9 +200,11 @@ class IndraNetAssembler():
                     ('evidence_count', len(stmt.evidence)),
                     ('stmt_hash', stmt.get_hash(refresh=True)),
                     ('belief', stmt.belief),
-                    ('source_counts', _get_source_counts(stmt))])
+                    ('source_counts', _get_source_counts(stmt)),
+                    ('initial_sign', sign)])
                 rows.append(row)
         df = pd.DataFrame.from_dict(rows)
+        df = df.where((pd.notnull(df)), None)
         return df
 
 

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -205,9 +205,12 @@ class IndraNet(nx.MultiDiGraph):
 
         SG = nx.MultiDiGraph()
         for u, v, data in self.edges(data=True):
-            if data['stmt_type'] not in sign_dict:
+            if data['initial_sign'] is not None:
+                sign = data['initial_sign']
+            elif data['stmt_type'] not in sign_dict:
                 continue
-            sign = sign_dict[data['stmt_type']]
+            else:
+                sign = sign_dict[data['stmt_type']]
             if SG.has_edge(u, v, sign):
                 SG[u][v][sign]['statements'].append(data)
             else:

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -14,8 +14,7 @@ from indra.statements import Statement
 
 logger = logging.getLogger(__name__)
 simple_scorer = SimpleScorer()
-np.seterr(all='raise')
-NP_PRECISION = 10 ** -np.finfo(np.longfloat).precision  # Numpy precision
+
 
 default_sign_dict = {'Activation': 0,
                      'Inhibition': 1,
@@ -276,6 +275,8 @@ def _simple_scorer_update(G, edge):
 
 def _complementary_belief(G, edge):
     # Aggregate belief score: 1-prod(1-belief_i)
+    np.seterr(all='raise')
+    NP_PRECISION = 10 ** -np.finfo(np.longfloat).precision  # Numpy precision
     belief_list = [s['belief'] for s in G.edges[edge]['statements']]
     try:
         ag_belief = np.longfloat(1.0) - np.prod(np.fromiter(

--- a/indra/tests/test_indranet_assembler.py
+++ b/indra/tests/test_indranet_assembler.py
@@ -67,7 +67,8 @@ def test_make_df():
     assert len(df) == 9
     assert set(df.columns) == {
         'agA_name', 'agB_name', 'agA_ns', 'agA_id', 'agB_ns', 'agB_id',
-        'stmt_type', 'evidence_count', 'stmt_hash', 'belief', 'source_counts'}
+        'stmt_type', 'evidence_count', 'stmt_hash', 'belief', 'source_counts',
+        'initial_sign'}
 
 
 # Test assembly from IndraNet directly
@@ -167,3 +168,25 @@ def _weight_mapping(G):
     for edge in G.edges:
         G.edges[edge]['weight'] = 1 - G.edges[edge]['belief']
     return G
+
+
+def test_initial_signs():
+    a = Event(Concept('a'), QualitativeDelta(polarity=1))
+    b = Event(Concept('b'), QualitativeDelta(polarity=1))
+    c = Event(Concept('c'), QualitativeDelta(polarity=-1))
+    d = Event(Concept('d'), QualitativeDelta(polarity=-1))
+    st1 = Influence(a, b)
+    st2 = Influence(b, c)
+    st3 = Influence(c, d)
+    st4 = Influence(b, d)
+    ia = IndraNetAssembler([st1, st2, st3, st4])
+    sg = ia.make_model(graph_type='signed')
+    assert len(sg.nodes) == 4
+    assert len(sg.edges) == 4
+    assert ('a', 'b', 0) in sg.edges
+    assert ('b', 'c', 0) not in sg.edges
+    assert ('b', 'c', 1) in sg.edges
+    assert ('c', 'd', 0) in sg.edges
+    assert ('c', 'd', 1) not in sg.edges
+    assert ('b', 'd', 0) not in sg.edges
+    assert ('b', 'd', 1) in sg.edges


### PR DESCRIPTION
This PR enables assembly of signed networks from Influence and Association statements. These statements can have different polarities, that's why we cannot just use a dictionary mapping statement types to signs. For these statements the signs can be retrieved at the stage of creating a dataframe using `stmt.overall_polarity()` method. However, if we still want to give a user a flexibility to decide which other statement types to add with which signs to a network, the sign mapping can be used later at flattening stage (i.e. the dataframe will only have signs for Influences and Associations with defined polarities, while other statements will get the signs only if their types are in provided sign_dict). It's possible to shift to using sign_dict earlier in the process when creating a df if that is more clear, but in that case we'll have to make a new data frame every time we want to change sign assignment. 