### PR TITLE
Test reporting

### DIFF
--- a/indra/explanation/reporting.py
+++ b/indra/explanation/reporting.py
@@ -120,12 +120,12 @@ def stmts_from_pybel_path(path, model, from_db=True, stmts=None):
             # edges with non-regular indices
             except KeyError:
                 continue
-            if from_db:
-                statements = get_statements_by_hash(list(hashes))
-            else:
-                statements = [
-                    stmt for stmt in stmts if stmt.get_hash() in hashes]
-            steps.append(statements)
+        if from_db:
+            statements = get_statements_by_hash(list(hashes))
+        else:
+            statements = [
+                stmt for stmt in stmts if stmt.get_hash() in hashes]
+        steps.append(statements)
     return steps
 
 

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -203,6 +203,7 @@ def test_pysb_assembler_phospho_policies():
     assert results[0][0] == st
     pr = results[0][1]
     assert pr.paths == [(('A_phosphorylation_B_T185', 0), ('B_T185_p_obs', 0))]
+    assert stmts_from_pysb_path(pr.paths[0], pa.model, [st]) == [st]
     # Try one step
     pa.make_model(policies='one_step')
     mc = PysbModelChecker(pa.model, [st])
@@ -213,6 +214,7 @@ def test_pysb_assembler_phospho_policies():
     pr = results[0][1]
     assert pr.path_found
     assert pr.paths == [(('A_phosphorylation_B_T185', 0), ('B_T185_p_obs', 0))]
+    assert stmts_from_pysb_path(pr.paths[0], pa.model, [st]) == [st]
     # Try interactions_only
     pa.make_model(policies='interactions_only')
     mc = PysbModelChecker(pa.model, [st])
@@ -548,6 +550,8 @@ def test_check_increase_grounded_with_state():
     assert len(results) == 1
     path_result = results[0][1]
     assert path_result.path_found is True
+    assert stmts_from_pysb_path(
+        path_result.paths[0], pa.model, [stmt2]) == [stmt2]
 
 
 def test_check_activation_grounded():
@@ -777,6 +781,8 @@ def test_grounded_modified_enzyme():
     assert results[0][1].paths == \
         [(('MEK1_phosphoS202_phosphorylation_ERK2_phospho', 0),
           ('ERK2_phospho_p_obs', 0))]
+    assert stmts_from_pysb_path(
+        results[0][1].paths[0], pa.model, [stmt_to_model]) == [stmt_to_model]
 
 
 def test_check_ubiquitination():
@@ -793,6 +799,8 @@ def test_check_ubiquitination():
     assert checks[0][0] == stmt
     assert checks[0][1].paths == [(('XIAP_ubiquitination_CASP3_ub', 0),
                                    ('CASP3_ub_y_obs', 0))]
+    assert stmts_from_pysb_path(
+        checks[0][1].paths[0], pysba.model, [stmt]) == [stmt]
 
 
 def test_check_rule_subject1():
@@ -826,6 +834,8 @@ def test_gef_activation():
     assert checks[0][0] == act_stmt
     assert checks[0][1].paths == [(('SOS1_activates_KRAS', 0),
                                    ('KRAS_gtpbound_active_obs', 0))]
+    assert stmts_from_pysb_path(
+        checks[0][1].paths[0], pysba.model, [gef_stmt]) == [gef_stmt]
     # TODO TODO TODO
     """
     # Check that the Gef is satisfied by the Activation
@@ -862,7 +872,8 @@ def test_gef_rasgtp():
                                    ('KRAS_gtp_activates_BRAF_kinase', 0),
                                    ('BRAF_kinase_active_obs', 0))], \
         checks[0][1].paths
-
+    assert stmts_from_pysb_path(checks[0][1].paths[0], pysba.model, [
+        gef_stmt, rasgtp_stmt]) == [gef_stmt, rasgtp_stmt]
 
 
 def test_gef_rasgtp_phos():
@@ -891,6 +902,8 @@ def test_gef_rasgtp_phos():
                                    ('BRAF_kin_phosphorylation_MEK_phospho', 0),
                                    ('MEK_phospho_p_obs', 0))], \
         checks[0][1].paths
+    assert stmts_from_pysb_path(checks[0][1].paths[0], pysba.model, [
+        gef_stmt, rasgtp_stmt, phos]) == [gef_stmt, rasgtp_stmt, phos]
 
 
 def test_gap_activation():
@@ -908,6 +921,8 @@ def test_gap_activation():
     assert checks[0][0] == act_stmt
     assert checks[0][1].paths == [(('NF1_deactivates_KRAS', 0),
                                    ('KRAS_gtpbound_active_obs', 1))]
+    assert stmts_from_pysb_path(
+        checks[0][1].paths[0], pysba.model, [gap_stmt]) == [gap_stmt]
     # TODO TODO TODO
     """
     # Check that the Gap is satisfied by the Activation
@@ -945,6 +960,8 @@ def test_gap_rasgtp():
                                    ('KRAS_gtp_activates_BRAF_kinase', 1),
                                    ('BRAF_kinase_active_obs', 1))], \
         checks[0][1].paths
+    assert stmts_from_pysb_path(checks[0][1].paths[0], pysba.model, [
+        gap_stmt, rasgtp_stmt]) == [gap_stmt, rasgtp_stmt]
 
 
 def test_gap_rasgtp_phos():
@@ -973,6 +990,8 @@ def test_gap_rasgtp_phos():
           ('KRAS_gtp_activates_BRAF_kinase', 1),
           ('BRAF_kin_phosphorylation_MEK_phospho', 1),
           ('MEK_phospho_p_obs', 1))], checks[0][1].paths
+    assert stmts_from_pysb_path(checks[0][1].paths[0], pysba.model, [
+        gap_stmt, rasgtp_stmt, phos]) == [gap_stmt, rasgtp_stmt, phos]
 
 
 def test_increase_amount():
@@ -991,6 +1010,8 @@ def test_increase_amount():
     assert checks[0][1].paths == [(('TP53_produces_X', 0),
                                    ('X_produces_MDM2', 0),
                                    ('MDM2__obs', 0))]
+    assert stmts_from_pysb_path(
+        checks[0][1].paths[0], pysba.model, stmts) == stmts
 
 
 def test_decrease_amount():
@@ -1012,6 +1033,8 @@ def test_decrease_amount():
                                    ('MDM2_ubiquitination_TP53_ub', 0),
                                    ('TP53_ub_degraded', 0),
                                    ('TP53__obs', 1))]
+    assert stmts_from_pysb_path(
+        checks[0][1].paths[0], pysba.model, stmts) == stmts
 
 
 def test_stmt_from_rule():
@@ -1538,9 +1561,9 @@ def test_pybel_path():
     d = _get_agent_node(Agent('D', db_refs={'HGNC': 4}))[0]
     e = _get_agent_node(Agent('E', db_refs={'HGNC': 5}))[0]
     assert results[0][1].result_code == 'PATHS_FOUND'
-    assert results[0][1].paths[0] == ((a, 0), (b, 1), (d, 0), (e, 0)), results[0][1].paths[0]
+    assert results[0][1].paths[0] == ((a, 0), (b, 1), (d, 0), (e, 0))
     assert results[1][1].result_code == 'PATHS_FOUND'
-    assert results[1][1].paths[0] == ((a, 0), (b, 0), (d, 1), (e, 1)), results[1][1].paths[0]
+    assert results[1][1].paths[0] == ((a, 0), (b, 0), (d, 1), (e, 1))
     assert results[2][1].result_code == 'NO_PATHS_FOUND'
     assert results[3][1].result_code == 'SUBJECT_NOT_FOUND'
     assert results[4][1].result_code == 'OBJECT_NOT_FOUND'


### PR DESCRIPTION
This PR expands ModelChecker tests to test reporting functions (returning statements from path) and fixes a bug in Pybel reporting function. This should fix the issue of duplicated stmts in Pybel path.