### PR TITLE
Use new UP/HGNC ID mapping in processors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - sudo apt-get install libstdc++6 graphviz
 install:
   # Install test/Travis-specific dependencies not covered elsewhere
-  - pip install pydot jsonschema coverage python-coveralls
+  - pip install pydot jsonschema coverage
         nose-timer doctest-ignore-unicode awscli pycodestyle
   - mkdir -p $HOME/.pybel/data
   - aws s3 cp s3://bigmech/travis/pybel_cache.db $HOME/.pybel/data/ --no-sign-request  --source-region us-east-1
@@ -125,5 +125,3 @@ script:
   - git remote set-branches --add origin master
   - git fetch
   - git diff origin/master | pycodestyle --diff > pep8.txt; cat pep8.txt;
-after_success:
-  - coveralls

--- a/indra/preassembler/grounding_mapper/mapper.py
+++ b/indra/preassembler/grounding_mapper/mapper.py
@@ -283,12 +283,10 @@ class GroundingMapper(object):
         hgnc_id = db_refs.get('HGNC')
         # If we have a UP ID and no HGNC ID, we try to get a gene name,
         # and if possible, a HGNC ID from that
-        if up_id and not hgnc_id and uniprot_client.is_human(up_id):
-            gene_name = uniprot_client.get_gene_name(up_id, False)
-            if gene_name:
-                hgnc_id = hgnc_client.get_hgnc_id(gene_name)
-                if hgnc_id:
-                    db_refs['HGNC'] = hgnc_id
+        if up_id and not hgnc_id:
+            hgnc_id = uniprot_client.get_hgnc_id(up_id)
+            if hgnc_id:
+                db_refs['HGNC'] = hgnc_id
         # Otherwise, if we don't have a UP ID but have an HGNC ID, we try to
         # get the UP ID
         elif hgnc_id:
@@ -400,28 +398,27 @@ class GroundingMapper(object):
 
         # If there's a FamPlex ID, prefer that for the name
         if db_ns == 'FPLX':
-            agent.name = agent.db_refs['FPLX']
+            agent.name = db_id
         # Importantly, HGNC here will be a symbol because that is what
         # get_grounding returns
         elif db_ns == 'HGNC':
             agent.name = hgnc_client.get_hgnc_name(db_id)
         elif db_ns == 'UP':
             # Try for the gene name
-            gene_name = uniprot_client.get_gene_name(agent.db_refs['UP'],
-                                                     web_fallback=False)
+            gene_name = uniprot_client.get_gene_name(db_id, web_fallback=False)
             if gene_name:
                 agent.name = gene_name
         elif db_ns == 'CHEBI':
             chebi_name = \
-                chebi_client.get_chebi_name_from_id(agent.db_refs['CHEBI'])
+                chebi_client.get_chebi_name_from_id(db_id)
             if chebi_name:
                 agent.name = chebi_name
         elif db_ns == 'MESH':
-            mesh_name = mesh_client.get_mesh_name(agent.db_refs['MESH'], False)
+            mesh_name = mesh_client.get_mesh_name(db_id, False)
             if mesh_name:
                 agent.name = mesh_name
         elif db_ns == 'GO':
-            go_name = go_client.get_go_label(agent.db_refs['GO'])
+            go_name = go_client.get_go_label(db_id)
             if go_name:
                 agent.name = go_name
         return

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -962,12 +962,8 @@ class BiopaxProcessor(object):
                 uniprot_id = hgnc_client.get_uniprot_id(hgnc_id)
             elif uniprot_id and not hgnc_id:
                 uniprot_id_lookup = uniprot_id.split('-')[0]
-                if uniprot_client.is_human(uniprot_id_lookup):
-                    hgnc_name = uniprot_client.get_gene_name(uniprot_id_lookup,
-                                                             False)
-                    if hgnc_name:
-                        hgnc_id = hgnc_client.get_hgnc_id(hgnc_name)
-            # If we have both an HGNC ID and a Uniprot ID, override the 
+                hgnc_id = uniprot_client.get_hgnc_id(uniprot_id_lookup)
+            # If we have both an HGNC ID and a Uniprot ID, override the
             # Uniprot ID with the one associated with the HGNC ID
             elif uniprot_id and hgnc_id:
                 hgnc_up_id = hgnc_client.get_uniprot_id(hgnc_id)

--- a/indra/sources/lincs_drug/processor.py
+++ b/indra/sources/lincs_drug/processor.py
@@ -66,12 +66,14 @@ class LincsProcessor(object):
             # try to get that and standardize the name to the gene name
             up_id = db_refs.get('UP')
             if up_id:
-                gene_name = uniprot_client.get_gene_name(up_id)
-                if gene_name:
-                    prot_name = gene_name
-                    hgnc_id = hgnc_client.get_hgnc_id(gene_name)
-                    if hgnc_id:
-                        db_refs['HGNC'] = hgnc_id
+                hgnc_id = uniprot_client.get_hgnc_id(up_id)
+                if hgnc_id:
+                    db_refs['HGNC'] = hgnc_id
+                    prot_name = hgnc_client.get_hgnc_name(hgnc_id)
+                else:
+                    gene_name = uniprot_client.get_gene_name(up_id)
+                    if gene_name:
+                        prot_name = gene_name
         # In some cases lines are missing protein information in which
         # case we return None
         else:

--- a/indra/sources/ndex_cx/processor.py
+++ b/indra/sources/ndex_cx/processor.py
@@ -84,9 +84,13 @@ class NdexCxProcessor(object):
             cx_db_refs = self.get_aliases(node)
             up_id = cx_db_refs.get('UP')
             if up_id:
-                gene_name = uniprot_client.get_gene_name(up_id)
-                hgnc_id = hgnc_client.get_hgnc_id(gene_name)
-                db_refs = {'UP': up_id, 'HGNC': hgnc_id, 'TEXT': gene_name}
+                db_refs = {'UP': up_id, 'TEXT': gene_name}
+                hgnc_id = uniprot_client.get_hgnc_id(up_id)
+                if hgnc_id:
+                    db_refs['HGNC'] = hgnc_id
+                    gene_name = hgnc_client.get_hgnc_name(hgnc_id)
+                else:
+                    gene_name = uniprot_client.get_gene_name(up_id)
                 agent = Agent(gene_name, db_refs=db_refs)
                 self._node_names[id] = gene_name
                 self._node_agents[id] = agent

--- a/indra/sources/ndex_cx/processor.py
+++ b/indra/sources/ndex_cx/processor.py
@@ -83,8 +83,10 @@ class NdexCxProcessor(object):
             id = node['@id']
             cx_db_refs = self.get_aliases(node)
             up_id = cx_db_refs.get('UP')
+            up_id = uniprot_client.get_primary_id(up_id)
+            node_name = node['n']
             if up_id:
-                db_refs = {'UP': up_id, 'TEXT': gene_name}
+                db_refs = {'UP': up_id, 'TEXT': node_name}
                 hgnc_id = uniprot_client.get_hgnc_id(up_id)
                 if hgnc_id:
                     db_refs['HGNC'] = hgnc_id
@@ -96,7 +98,6 @@ class NdexCxProcessor(object):
                 self._node_agents[id] = agent
                 continue
             else:
-                node_name = node['n']
                 self._node_names[id] = node_name
                 hgnc_id = hgnc_client.get_hgnc_id(node_name)
                 db_refs = {'TEXT': node_name}

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -387,16 +387,17 @@ class ReachProcessor(object):
             if ns == 'uniprot':
                 up_id = xr['id']
                 db_refs['UP'] = up_id
-                # Look up official names in UniProt
-                gene_name = up_client.get_gene_name(up_id)
-                if gene_name is not None:
-                    agent_name = gene_name
-                    # If the gene name corresponds to an HGNC ID, add it to the
-                    # db_refs
-                    if up_client.is_human(up_id):
-                        hgnc_id = hgnc_client.get_hgnc_id(gene_name)
-                        if hgnc_id:
-                            db_refs['HGNC'] = hgnc_id
+                hgnc_id = up_client.get_hgnc_id(up_id)
+                if hgnc_id:
+                    db_refs['HGNC'] = hgnc_id
+                    gene_name = hgnc_client.get_hgnc_name(hgnc_id)
+                    if gene_name:
+                        agent_name = gene_name
+                else:
+                    # Look up official names in UniProt
+                    gene_name = up_client.get_gene_name(up_id)
+                    if gene_name is not None:
+                        agent_name = gene_name
             elif ns == 'hgnc':
                 hgnc_id = xr['id']
                 db_refs['HGNC'] = hgnc_id

--- a/indra/sources/rlimsp/processor.py
+++ b/indra/sources/rlimsp/processor.py
@@ -217,21 +217,23 @@ def get_agent_from_entity_info(entity_info):
                     refs['HGNC'] = hgnc_id
         elif id_dict['source'] == 'UniProt':
             refs['UP'] = id_dict['idString']
-            gene_name = uniprot_client.get_gene_name(id_dict['idString'])
-            if gene_name is not None:
-                name = gene_name
-                hgnc_id = hgnc_client.get_hgnc_id(gene_name)
-                if hgnc_id is not None:
-                    # Check to see if we have a conflict with an HGNC id
-                    # found from the Entrez id. If so, overwrite with this
-                    # one, in which we have greater faith.
-                    if 'HGNC' in refs.keys() and refs['HGNC'] != hgnc_id:
-                        msg = ('Inferred HGNC:%s from UP:%s does not'
-                               ' match HGNC:%s from EGID:%s') % \
-                               (refs['HGNC'], refs['UP'], hgnc_id,
-                                refs['EGID'])
-                        logger.info(msg)
-                    refs['HGNC'] = hgnc_id
+            hgnc_id = uniprot_client.get_hgnc_id(id_dict['idString'])
+            if hgnc_id:
+                # Check to see if we have a conflict with an HGNC id
+                # found from the Entrez id. If so, overwrite with this
+                # one, in which we have greater faith.
+                if 'HGNC' in refs.keys() and refs['HGNC'] != hgnc_id:
+                    msg = ('Inferred HGNC:%s from UP:%s does not'
+                           ' match HGNC:%s from EGID:%s') % \
+                          (refs['HGNC'], refs['UP'], hgnc_id,
+                           refs['EGID'])
+                    logger.info(msg)
+                refs['HGNC'] = hgnc_id
+                name = hgnc_client.get_hgnc_name(hgnc_id)
+            else:
+                gene_name = uniprot_client.get_gene_name(id_dict['idString'])
+                if gene_name is not None:
+                    name = gene_name
         elif id_dict['source'] in ('Tax', 'NCBI'):
             refs['TAX'] = id_dict['idString']
         elif id_dict['source'] == 'CHEBI':

--- a/indra/sources/signor/processor.py
+++ b/indra/sources/signor/processor.py
@@ -186,10 +186,12 @@ class SignorProcessor(object):
             if gnd_type == 'UP':
                 up_id = id
                 db_refs = {'UP': up_id}
-                name = uniprot_client.get_gene_name(up_id)
-                hgnc_id = hgnc_client.get_hgnc_id(name)
+                hgnc_id = uniprot_client.get_hgnc_id(up_id)
                 if hgnc_id:
                     db_refs['HGNC'] = hgnc_id
+                    name = hgnc_client.get_hgnc_name(hgnc_id)
+                else:
+                    name = uniprot_client.get_gene_name(up_id)
             # Map SIGNOR protein families to FamPlex families
             elif ent_type == 'proteinfamily':
                 db_refs = {database: id} # Keep the SIGNOR family ID in db_refs
@@ -256,8 +258,9 @@ class SignorProcessor(object):
                 db_refs['SIGNOR'] = c
             else:
                 db_refs['UP'] = c
-                hgnc_id = hgnc_client.get_hgnc_id(name)
+                hgnc_id = uniprot_client.get_hgnc_id(c)
                 if hgnc_id:
+                    name = hgnc_client.get_hgnc_name(hgnc_id)
                     db_refs['HGNC'] = hgnc_id
 
             famplex_key = ('SIGNOR', c)

--- a/indra/sources/sparser/processor.py
+++ b/indra/sources/sparser/processor.py
@@ -432,6 +432,9 @@ class SparserXMLProcessor(object):
                 db_refs['FPLX'] = be_id
                 agent_name = be_id
             elif db_ns in ['UP', 'Uniprot']:
+                id_from_mnemonic = uniprot_client.get_id_from_mnemonic(db_id)
+                if id_from_mnemonic:
+                    db_id = id_from_mnemonic
                 db_refs['UP'] = db_id
                 hgnc_id = uniprot_client.get_hgnc_id(db_id)
                 if hgnc_id:

--- a/indra/sources/sparser/processor.py
+++ b/indra/sources/sparser/processor.py
@@ -238,18 +238,20 @@ def _fix_agent(agent):
             if up_id:
                 agent.db_refs['UP'] = up_id
     elif up_id:
-        gene_name = uniprot_client.get_gene_name(up_id)
-        if gene_name:
-            agent.name = gene_name
-            hgnc_id = hgnc_client.get_hgnc_id(gene_name)
-            if hgnc_id:
-                agent.db_refs['HGNC'] = hgnc_id
-        # If it doesn't have a gene name, it's better to just
-        # use the raw string name otherwise Sparser sets
-        # has Uniprot IDs or mnemonics as the name
+        hgnc_id = uniprot_client.get_hgnc_id(up_id)
+        if hgnc_id:
+            agent.db_refs['HGNC'] = hgnc_id
+            agent.name = hgnc_client.get_hgnc_name(hgnc_id)
         else:
-            name = agent.db_refs.get('TEXT', agent.name)
-            agent.name = name
+            gene_name = uniprot_client.get_gene_name(up_id)
+            if gene_name:
+                agent.name = gene_name
+            # If it doesn't have a gene name, it's better to just
+            # use the raw string name otherwise Sparser sets
+            # has Uniprot IDs or mnemonics as the name
+            else:
+                name = agent.db_refs.get('TEXT', agent.name)
+                agent.name = name
 
 
 class SparserXMLProcessor(object):
@@ -431,12 +433,14 @@ class SparserXMLProcessor(object):
                 agent_name = be_id
             elif db_ns in ['UP', 'Uniprot']:
                 db_refs['UP'] = db_id
-                gene_name = uniprot_client.get_gene_name(db_id)
-                if gene_name:
-                    agent_name = gene_name
-                    hgnc_id = hgnc_client.get_hgnc_id(gene_name)
-                    if hgnc_id:
-                        db_refs['HGNC'] = hgnc_id
+                hgnc_id = uniprot_client.get_hgnc_id(db_id)
+                if hgnc_id:
+                    db_refs['HGNC'] = hgnc_id
+                    agent_name = hgnc_client.get_hgnc_name(hgnc_id)
+                else:
+                    gene_name = uniprot_client.get_gene_name(db_id)
+                    if gene_name:
+                        agent_name = gene_name
             elif db_ns == 'NCIT':
                 db_refs['NCIT'] = db_id
                 target = ncit_map.get(db_id)

--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -2065,11 +2065,9 @@ def _get_db_mappings(dbname, dbid):
         if target is not None:
             db_mappings.append((target[0], target[1]))
             if target[0] == 'UP':
-                gene_name = up_client.get_gene_name(target[1])
-                if gene_name:
-                    hgnc_id = hgnc_client.get_hgnc_id(gene_name)
-                    if hgnc_id:
-                        db_mappings.append(('HGNC', hgnc_id))
+                hgnc_id = up_client.get_hgnc_id(target[1])
+                if hgnc_id:
+                    db_mappings.append(('HGNC', hgnc_id))
             elif target[0] == 'HGNC':
                 standard_up_id = hgnc_client.get_uniprot_id(target[1])
                 if standard_up_id:
@@ -2087,12 +2085,9 @@ def _get_db_mappings(dbname, dbid):
                 goid = up_client.uniprot_subcell_loc.get(dbid)
                 if goid:
                     db_mappings.append(('GO', goid))
-            elif up_client.is_human(dbid):
-                gene_name = up_client.get_gene_name(dbid)
-                if gene_name:
-                    hgnc_id = hgnc_client.get_hgnc_id(gene_name)
-                    if hgnc_id:
-                        db_mappings.append(('HGNC', hgnc_id))
+            hgnc_id = up_client.get_hgnc_id(dbid)
+            if hgnc_id:
+                db_mappings.append(('HGNC', hgnc_id))
 
     # TODO: we could do some chemical mappings here i.e. CHEBI/PUBCHEM/CHEMBL
     return db_mappings

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def main():
     install_list = ['pysb>=1.3.0', 'objectpath', 'rdflib==4.2.1',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
                     'networkx>=2', 'pandas', 'ndex2==2.0.1', 'jinja2',
-                    'protmapper>=0.0.12']
+                    'protmapper>=0.0.13']
 
     extras_require = {
                       # Inputs and outputs

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def main():
     install_list = ['pysb>=1.3.0', 'objectpath', 'rdflib==4.2.1',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
                     'networkx>=2', 'pandas', 'ndex2==2.0.1', 'jinja2',
-                    'protmapper>=0.0.6']
+                    'protmapper>=0.0.12']
 
     extras_require = {
                       # Inputs and outputs


### PR DESCRIPTION
This PR integrates the new `uniprot_client.get_hgnc_id` function into various processors as an alternative to mapping via gene names. The rationale is that when HGNC symbols change, UniProt is often temporarily out of sync with HGNC (e.g., right now), and provides gene names that don't match the latest official HGNC symbols. By mapping via IDs, and looking up the name afterwards, this corner case is eliminated.