### PR TITLE
Matches by Ontology node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ models/fallahi_eval/output
 
 .pytest_cache
 .DS_Store
+.noseids

--- a/indra/statements/concept.py
+++ b/indra/statements/concept.py
@@ -39,6 +39,8 @@ class Concept(object):
         # If there's no grounding, just use the name as key
         if not db_ns and not db_id:
             return self.name
+        if '/' in db_id:
+            return str((db_ns, db_id.split('/')[-1]))
         return str((db_ns, db_id))
 
     def equals(self, other):

--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -236,6 +236,19 @@ def test_run_preassembly_all_stmts():
     assert len(st_out) == 4
 
 
+def test_run_preassembly_concepts():
+    rainfall = Event(Concept('rain', db_refs={
+        'WM': 'wm/concept/indicator_and_reported_property/weather/rainfall'}))
+    flooding_1 = Event(Concept('flood', db_refs={
+        'WM': 'wm/concept/causal_factor/crisis_and_disaster/crisis/'
+              'natural_disaster/flooding'}))
+    flooding_2 = Event(Concept('flooding', db_refs={
+        'WM': 'wm/concept/causal_factor/weather/precipitation/flooding'}))
+    st_out = ac.run_preassembly([
+        Influence(rainfall, flooding_1), Influence(rainfall, flooding_2)])
+    assert len(st_out) == 1
+
+
 def test_expand_families():
     st_out = ac.expand_families([st10])
     assert len(st_out) == 2

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -687,9 +687,9 @@ def test_influence_duplicate():
     pa = Preassembler(hierarchies, [stmt1, stmt2, stmt3])
     unique_stmts = pa.combine_duplicates()
     assert len(unique_stmts) == 2
-    assert len(unique_stmts[0].evidence) == 2
-    assert len(unique_stmts[1].evidence) == 1
-    sources = [e.source_api for e in unique_stmts[0].evidence]
+    assert len(unique_stmts[1].evidence) == 2
+    assert len(unique_stmts[0].evidence) == 1
+    sources = [e.source_api for e in unique_stmts[1].evidence]
     assert set(sources) == set(['eidos1', 'eidos3'])
 
 

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -481,6 +481,20 @@ def test_agent_entity_match_ungrounded():
     assert not ag3.entity_matches(ag4)
 
 
+def test_concept_entity_match_wm():
+    flooding_1 = Concept('flood', db_refs={
+        'WM': 'wm/concept/causal_factor/crisis_and_disaster/crisis/'
+              'natural_disaster/flooding'})
+    flooding_2 = Concept('flooding', db_refs={
+        'WM': 'wm/concept/causal_factor/weather/precipitation/flooding'})
+    storm = Concept('flood', db_refs={
+        'WM': 'wm/concept/causal_factor/weather/precipitation/storm'})
+    # If the last node in ontology is the same, they should match
+    assert flooding_1.entity_matches(flooding_2)
+    assert not flooding_1.entity_matches(storm)
+    assert not flooding_2.entity_matches(storm)
+
+
 def test_entities_match_mod():
     """Test matching of entities only, entities match on name and grounding."""
     src = Agent('SRC', db_refs={'HGNC': '11283'})


### PR DESCRIPTION
This PR changes `entity_matches_key` method of Concepts to only include the last suffix (node) of the db_id (ontology entry) instead of entire db_id. This will only affect WM related concepts (because db_id in biological agents have different structure). This will allow concepts with groundings like 'wm/concept/causal_factor/crisis_and_disaster/crisis/natural_disaster/**flooding**' and 'wm/concept/causal_factor/weather/precipitation/**flooding**' (different categories but same concept) to be considered identical. PR also adds and updates relevant tests.