### PR TITLE
Make statement API returns more uniform

### DIFF
--- a/indra/explanation/reporting.py
+++ b/indra/explanation/reporting.py
@@ -73,7 +73,7 @@ def stmts_from_indranet_path(path, model, signed, from_db=True, stmts=None):
             stmt_data = model[source[0]][target[0]]['statements']
         hashes = [stmt['stmt_hash'] for stmt in stmt_data]
         if from_db:
-            statements = get_statements_by_hash(hashes)
+            statements = get_statements_by_hash(hashes, simple_response=True)
         else:
             statements = [
                 stmt for stmt in stmts if stmt.get_hash() in hashes]
@@ -121,7 +121,8 @@ def stmts_from_pybel_path(path, model, from_db=True, stmts=None):
             except KeyError:
                 continue
         if from_db:
-            statements = get_statements_by_hash(list(hashes))
+            statements = get_statements_by_hash(list(hashes),
+                                                simple_response=True)
         else:
             statements = [
                 stmt for stmt in stmts if stmt.get_hash() in hashes]

--- a/indra/sources/indra_db_rest/api.py
+++ b/indra/sources/indra_db_rest/api.py
@@ -2,7 +2,7 @@ from indra.util import clockit
 from indra.statements import stmts_from_json, Complex, SelfModification, \
     ActiveForm, Translocation, Conversion
 
-from indra.sources.indra_db_rest.processor import IndraDBRestProcessor
+from indra.sources.indra_db_rest.processor import IndraDBRestPagingProcessor
 from indra.sources.indra_db_rest.util import submit_statement_request, \
     make_db_rest_request, get_url_base
 from indra.util.statement_presentation import get_simplified_stmts
@@ -97,16 +97,16 @@ def get_statements(subject=None, object=None, agents=None, stmt_type=None,
 
     Returns
     -------
-    processor : :py:class:`IndraDBRestProcessor`
+    processor : :py:class:`IndraDBRestPagingProcessor`
         An instance of the IndraDBRestProcessor, which has an attribute
         `statements` which will be populated when the query/queries are done.
         This is the default behavior, and is encouraged in all future cases,
         however a simple list of statements may be returned using the
         `simple_response` option described above.
     """
-    processor = IndraDBRestProcessor(subject, object, agents, stmt_type,
-                                     use_exact_type, persist, timeout,
-                                     ev_limit, best_first, tries, max_stmts)
+    processor = IndraDBRestPagingProcessor(subject, object, agents, stmt_type,
+                                           use_exact_type, persist, timeout,
+                                           ev_limit, best_first, tries, max_stmts)
 
     # Format the result appropriately.
     if simple_response:

--- a/indra/sources/indra_db_rest/api.py
+++ b/indra/sources/indra_db_rest/api.py
@@ -1,3 +1,6 @@
+__all__ = ['get_statements', 'get_statements_for_paper',
+           'get_statements_by_hash', 'submit_curation']
+
 from indra.util import clockit
 from indra.statements import stmts_from_json, Complex, SelfModification, \
     ActiveForm, Translocation, Conversion
@@ -6,10 +9,6 @@ from indra.sources.indra_db_rest.processor import IndraDBRestSearchProcessor, \
     IndraDBRestHashProcessor
 from indra.sources.indra_db_rest.util import submit_statement_request, \
     make_db_rest_request, get_url_base
-from indra.util.statement_presentation import get_simplified_stmts
-
-__all__ = ['get_statements', 'get_statements_for_paper',
-           'get_statements_by_hash', 'submit_curation']
 
 
 @clockit

--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -125,8 +125,8 @@ class IndraDBRestProcessor(object):
         # Where there is overlap, there _should_ be agreement.
         self.__evidence_counts.update(ev_counts)
         # We turn source counts into an int-keyed dict and update it that way
-        self.__source_counts.update({int(k): v for k,
-                                                   v in source_counts.items()})
+        self.__source_counts.update({int(k): v
+                                     for k, v in source_counts.items()})
 
         for k, sj in stmt_json.items():
             if k not in self.__statement_jsons:

--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -236,8 +236,10 @@ class IndraDBRestPaperProcessor(IndraDBRestProcessor):
 
     Parameters
     ----------
-    hash_list : list[int or str]
-        A list of the matches-key hashes for the statements you want to get.
+    ids : list[(<id type>, <id value>)]
+        A list of tuples with ids and their type. The type can be any one of
+        'pmid', 'pmcid', 'doi', 'pii', 'manuscript id', or 'trid', which is the
+        primary key id of the text references in the database.
 
     Keyword Parameters
     ------------------

--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -481,6 +481,9 @@ class IndraDBRestSearchProcessor(IndraDBRestProcessor):
             raise ValueError("At least one agent must be specified, or else "
                              "the scope will be too large.")
 
+        # Make timeouts apply differently in this case
+        timeout = api_params.pop('timeout', None)
+
         # Formulate inputs for the agents..
         key_val_list = [('subject', subject), ('object', object)]
         params = {param_key: param_val for param_key, param_val in key_val_list
@@ -504,11 +507,11 @@ class IndraDBRestSearchProcessor(IndraDBRestProcessor):
         self.__th = Thread(target=self._run_queries, args=args)
         self.__th.start()
 
-        if api_params['timeout'] is None:
+        if timeout is None:
             logger.debug("Waiting for thread to complete...")
             self.__th.join()
-        elif api_params['timeout']:  # is not 0
+        elif timeout:  # is not 0
             logger.debug("Waiting at most %d seconds for thread to complete..."
-                         % api_params['timeout'])
-            self.__th.join(api_params['timeout'])
+                         % timeout)
+            self.__th.join(timeout)
         return

--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 from builtins import dict, str
 
-__all__ = ['IndraDBRestProcessor']
+__all__ = ['IndraDBRestPagingProcessor']
 
 import logging
 from copy import deepcopy
@@ -19,39 +19,10 @@ logger = logging.getLogger(__name__)
 
 
 class IndraDBRestProcessor(object):
-    """The packaging for query responses.
+    """The generalized packaging for query responses.
 
-    Parameters
-    ----------
-    subject/object : str
-        Optionally specify the subject and/or object of the statements in
-        you wish to get from the database. By default, the namespace is assumed
-        to be HGNC gene names, however you may specify another namespace by
-        including `@<namespace>` at the end of the name string. For example, if
-        you want to specify an agent by chebi, you could use `CHEBI:6801@CHEBI`,
-        or if you wanted to use the HGNC id, you could use `6871@HGNC`.
-    agents : list[str]
-        A list of agents, specified in the same manner as subject and object,
-        but without specifying their grammatical position.
-    stmt_type : str
-        Specify the types of interactions you are interested in, as indicated
-        by the sub-classes of INDRA's Statements. This argument is *not* case
-        sensitive. If the statement class given has sub-classes
-        (e.g. RegulateAmount has IncreaseAmount and DecreaseAmount), then both
-        the class itself, and its subclasses, will be queried, by default. If
-        you do not want this behavior, set use_exact_type=True. Note that if
-        max_stmts is set, it is possible only the exact statement type will
-        be returned, as this is the first searched. The processor then cycles
-        through the types, getting a page of results for each type and adding it
-        to the quota, until the max number of statements is reached.
-    use_exact_type : bool
-        If stmt_type is given, and you only want to search for that specific
-        statement type, set this to True. Default is False.
-    persist : bool
-        Default is True. When False, if a query comes back limited (not all
-        results returned), just give up and pass along what was returned.
-        Otherwise, make further queries to get the rest of the data (which may
-        take some time).
+    General Parameters
+    ------------------
     timeout : positive int or None
         If an int, block until the work is done and statements are retrieved, or
         until the timeout has expired, in which case the results so far will be
@@ -87,64 +58,20 @@ class IndraDBRestProcessor(object):
         general these will be the "best" (currently this means they have the
         most evidence) Statements available.
     """
-    def __init__(self, subject=None, object=None, agents=None, stmt_type=None,
-                 use_exact_type=False, persist=True, timeout=None, ev_limit=10,
-                 best_first=True, tries=2, max_stmts=None):
+    def __init__(self, *args, **kwargs):
         self.statements = []
         self.statements_sample = None
         self.__statement_jsons = {}
-        self.__done_dict = defaultdict(lambda: False)
         self.__evidence_counts = {}
         self.__source_counts = {}
-        self.__started = False
-        self.__page_dict = defaultdict(lambda: 0)
-        self.__th = None
-        self.__quota = max_stmts
 
-        # Make sure we got at least SOME agents (the remote API will error if
-        # we proceed with no arguments).
-        if subject is None and object is None and not agents:
-            raise ValueError("At least one agent must be specified, or else "
-                             "the scope will be too large.")
+        defaults_api_params = dict(timeout=None, ev_limit=10, best_first=True,
+                                   tries=2, max_stmts=None)
+        kwargs.update((k, kwargs.get(k, defaults_api_params[k]))
+                      for k in defaults_api_params.keys())
 
-        # Formulate inputs for the agents..
-        agent_strs = [] if agents is None else ['agent%d=%s' % (i, ag)
-                                                for i, ag in enumerate(agents)]
-        key_val_list = [('subject', subject), ('object', object)]
-        params = {param_key: param_val for param_key, param_val in key_val_list
-                  if param_val is not None}
-        params['best_first'] = best_first
-        params['ev_limit'] = ev_limit
-        params['tries'] = tries
-
-        # Handle the type(s).
-        stmt_types = [stmt_type] if stmt_type else []
-        if stmt_type is not None and not use_exact_type:
-            stmt_class = get_statement_by_name(stmt_type)
-            descendant_classes = get_all_descendants(stmt_class)
-            stmt_types += [cls.__name__ for cls in descendant_classes]
-
-        # Handle the content if we were limited.
-        args = [agent_strs, stmt_types, params, persist]
-        logger.debug("The remainder of the query will be performed in a "
-                     "thread...")
-        self.__th = Thread(target=self._run_queries, args=args)
-        self.__th.start()
-
-        if timeout is None:
-            logger.debug("Waiting for thread to complete...")
-            self.__th.join()
-        elif timeout:  # is not 0
-            logger.debug("Waiting at most %d seconds for thread to complete..."
-                         % timeout)
-            self.__th.join(timeout)
+        self._run(*args, **kwargs)
         return
-
-    def is_working(self):
-        """Check if the thread is running."""
-        if not self.__th:
-            return False
-        return self.__th.is_alive()
 
     def get_ev_count(self, stmt):
         """Get the total evidence count for a statement."""
@@ -193,32 +120,13 @@ class IndraDBRestProcessor(object):
                          other_processor.__source_counts)
         return
 
-    def wait_until_done(self, timeout=None):
-        """Wait for the background load to complete."""
-        start = datetime.now()
-        if not self.__th:
-            raise IndraDBRestResponseError("There is no thread waiting to "
-                                           "complete.")
-        self.__th.join(timeout)
-        now = datetime.now()
-        dt = now - start
-        if self.__th.is_alive():
-            logger.warning("Timed out after %0.3f seconds waiting for "
-                           "statement load to complete." % dt.total_seconds())
-            ret = False
-        else:
-            logger.info("Waited %0.3f seconds for statements to finish"
-                        "loading." % dt.total_seconds())
-            ret = True
-        return ret
-
     def _merge_json(self, stmt_json, ev_counts, source_counts):
         """Merge these statement jsons with new jsons."""
         # Where there is overlap, there _should_ be agreement.
         self.__evidence_counts.update(ev_counts)
         # We turn source counts into an int-keyed dict and update it that way
         self.__source_counts.update({int(k): v for k,
-                                     v in source_counts.items()})
+                                                   v in source_counts.items()})
 
         for k, sj in stmt_json.items():
             if k not in self.__statement_jsons:
@@ -238,6 +146,120 @@ class IndraDBRestProcessor(object):
         """Generate statements from the jsons."""
         self.statements = stmts_from_json(self.__statement_jsons.values())
 
+    def _unload_and_merge_resp(self, resp):
+        resp_dict = resp.json(object_pairs_hook=OrderedDict)
+        stmts_json = resp_dict['statements']
+        ev_totals = resp_dict['evidence_totals']
+        source_counts = resp_dict['source_counts']
+        limit = resp_dict['statement_limit']
+        num_returned = len(stmts_json)
+
+        # Update the result
+        self._merge_json(stmts_json, ev_totals, source_counts)
+
+        return limit, num_returned
+
+    def _run(self, *args, **kwargs):
+        raise NotImplementedError("_run must be defined in subclass.")
+
+
+class IndraDBRestPagingProcessor(IndraDBRestProcessor):
+    """The packaging for query responses.
+
+    Parameters
+    ----------
+    subject/object : str
+        Optionally specify the subject and/or object of the statements in
+        you wish to get from the database. By default, the namespace is assumed
+        to be HGNC gene names, however you may specify another namespace by
+        including `@<namespace>` at the end of the name string. For example, if
+        you want to specify an agent by chebi, you could use `CHEBI:6801@CHEBI`,
+        or if you wanted to use the HGNC id, you could use `6871@HGNC`.
+    agents : list[str]
+        A list of agents, specified in the same manner as subject and object,
+        but without specifying their grammatical position.
+    stmt_type : str
+        Specify the types of interactions you are interested in, as indicated
+        by the sub-classes of INDRA's Statements. This argument is *not* case
+        sensitive. If the statement class given has sub-classes
+        (e.g. RegulateAmount has IncreaseAmount and DecreaseAmount), then both
+        the class itself, and its subclasses, will be queried, by default. If
+        you do not want this behavior, set use_exact_type=True. Note that if
+        max_stmts is set, it is possible only the exact statement type will
+        be returned, as this is the first searched. The processor then cycles
+        through the types, getting a page of results for each type and adding it
+        to the quota, until the max number of statements is reached.
+    use_exact_type : bool
+        If stmt_type is given, and you only want to search for that specific
+        statement type, set this to True. Default is False.
+    persist : bool
+        Default is True. When False, if a query comes back limited (not all
+        results returned), just give up and pass along what was returned.
+        Otherwise, make further queries to get the rest of the data (which may
+        take some time).
+
+    Keyword Parameters
+    ------------------
+    timeout : positive int or None
+        If an int, block until the work is done and statements are retrieved, or
+        until the timeout has expired, in which case the results so far will be
+        returned in the response object, and further results will be added in
+        a separate thread as they become available. If simple_response is True,
+        all statements available will be returned. Otherwise (if None), block
+        indefinitely until all statements are retrieved. Default is None.
+    ev_limit : int or None
+        Limit the amount of evidence returned per Statement. Default is 10.
+    best_first : bool
+        If True, the preassembled statements will be sorted by the amount of
+        evidence they have, and those with the most evidence will be
+        prioritized. When using `max_stmts`, this means you will get the "best"
+        statements. If False, statements will be queried in arbitrary order.
+    tries : int > 0
+        Set the number of times to try the query. The database often caches
+        results, so if a query times out the first time, trying again after a
+        timeout will often succeed fast enough to avoid a timeout. This can also
+        help gracefully handle an unreliable connection, if you're willing to
+        wait. Default is 2.
+    max_stmts : int or None
+        Select the maximum number of statements to return. When set less than
+        1000 the effect is much the same as setting persist to false, and will
+        guarantee a faster response. Default is None.
+
+    Attributes
+    ----------
+    statements : list[:py:class:`indra.statements.Statement`]
+        A list of INDRA Statements that will be filled once all queries have
+        been completed.
+    statements_sample : list[:py:class:`indra.statements.Statement`]
+        A list of the INDRA Statements received from the first query. In
+        general these will be the "best" (currently this means they have the
+        most evidence) Statements available.
+    """
+    def is_working(self):
+        """Check if the thread is running."""
+        if not self.__th:
+            return False
+        return self.__th.is_alive()
+
+    def wait_until_done(self, timeout=None):
+        """Wait for the background load to complete."""
+        start = datetime.now()
+        if not self.__th:
+            raise IndraDBRestResponseError("There is no thread waiting to "
+                                           "complete.")
+        self.__th.join(timeout)
+        now = datetime.now()
+        dt = now - start
+        if self.__th.is_alive():
+            logger.warning("Timed out after %0.3f seconds waiting for "
+                           "statement load to complete." % dt.total_seconds())
+            ret = False
+        else:
+            logger.info("Waited %0.3f seconds for statements to finish"
+                        "loading." % dt.total_seconds())
+            ret = True
+        return ret
+
     def _all_done(self):
         every_type_done = (len(self.__done_dict) > 0
                            and all(self.__done_dict.values()))
@@ -251,15 +273,7 @@ class IndraDBRestProcessor(object):
         if stmt_type is not None:
             params['type'] = stmt_type
         resp = submit_query_request('from_agents', *agent_strs, **params)
-        resp_dict = resp.json(object_pairs_hook=OrderedDict)
-        stmts_json = resp_dict['statements']
-        ev_totals = resp_dict['evidence_totals']
-        source_counts = resp_dict['source_counts']
-        page_step = resp_dict['statement_limit']
-        num_returned = len(stmts_json)
-
-        # Update the result
-        self._merge_json(stmts_json, ev_totals, source_counts)
+        page_step, num_returned = self._unload_and_merge_resp(resp)
 
         # NOTE: this is technically not a direct conclusion, and could be
         # wrong, resulting in a single unnecessary extra query, but that
@@ -295,7 +309,7 @@ class IndraDBRestProcessor(object):
         self._query_over_statement_types(agent_strs, stmt_types, params)
 
         assert len(self.__done_dict) == len(stmt_types) \
-            or None in self.__done_dict.keys(), \
+               or None in self.__done_dict.keys(), \
             "Done dict was not initiated for all stmt_type's."
 
         # Check if we want to keep going.
@@ -309,4 +323,50 @@ class IndraDBRestProcessor(object):
 
         # Create the actual statements.
         self._compile_statements()
+        return
+
+    def _run(self, subject=None, object=None, agents=None, stmt_type=None,
+             use_exact_type=False, persist=True, **api_params):
+        self.__started = False
+        self.__done_dict = defaultdict(lambda: False)
+        self.__page_dict = defaultdict(lambda: 0)
+        self.__th = None
+        self.__quota = api_params['max_stmts']
+
+        # Make sure we got at least SOME agents (the remote API will error if
+        # we proceed with no arguments).
+        if subject is None and object is None and not agents:
+            raise ValueError("At least one agent must be specified, or else "
+                             "the scope will be too large.")
+
+        # Formulate inputs for the agents..
+        key_val_list = [('subject', subject), ('object', object)]
+        params = {param_key: param_val for param_key, param_val in key_val_list
+                  if param_val is not None}
+        params.update(api_params)
+
+        agent_strs = [] if agents is None else ['agent%d=%s' % (i, ag)
+                                                for i, ag in enumerate(agents)]
+
+        # Handle the type(s).
+        stmt_types = [stmt_type] if stmt_type else []
+        if stmt_type is not None and not use_exact_type:
+            stmt_class = get_statement_by_name(stmt_type)
+            descendant_classes = get_all_descendants(stmt_class)
+            stmt_types += [cls.__name__ for cls in descendant_classes]
+
+        # Handle the content if we were limited.
+        args = [agent_strs, stmt_types, params, persist]
+        logger.debug("The remainder of the query will be performed in a "
+                     "thread...")
+        self.__th = Thread(target=self._run_queries, args=args)
+        self.__th.start()
+
+        if api_params['timeout'] is None:
+            logger.debug("Waiting for thread to complete...")
+            self.__th.join()
+        elif api_params['timeout']:  # is not 0
+            logger.debug("Waiting at most %d seconds for thread to complete..."
+                         % api_params['timeout'])
+            self.__th.join(api_params['timeout'])
         return

--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -463,7 +463,7 @@ class IndraDBRestSearchProcessor(IndraDBRestProcessor):
                                                 source_counts)
 
         if not self.__started:
-            self.statements_sample = stmts_from_json(stmt_json)
+            self.statements_sample = stmts_from_json(stmt_json.values())
             self.__started = True
         return
 

--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -482,7 +482,10 @@ class IndraDBRestSearchProcessor(IndraDBRestProcessor):
                              "the scope will be too large.")
 
         # Make timeouts apply differently in this case
-        timeout = api_params.pop('timeout', None)
+        if not persist:
+            timeout = api_params.pop('timeout', None)
+        else:
+            timeout = api_params.get('timeout', None)
 
         # Formulate inputs for the agents..
         key_val_list = [('subject', subject), ('object', object)]

--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -1,7 +1,4 @@
-from __future__ import absolute_import, unicode_literals
-from builtins import dict, str
-
-__all__ = ['IndraDBRestSearchProcessor']
+__all__ = ['IndraDBRestSearchProcessor', 'IndraDBRestHashProcessor']
 
 import logging
 from copy import deepcopy

--- a/indra/sources/indra_db_rest/util.py
+++ b/indra/sources/indra_db_rest/util.py
@@ -64,7 +64,6 @@ def make_db_rest_request(meth, end_point, query_str, data=None, params=None,
     method_func = getattr(requests, meth.lower())
     while tries > 0:
         tries -= 1
-        timeout = timeout if timeout else None
         resp = method_func(url_path, headers=headers, data=json_data,
                            params=params, timeout=timeout)
         if resp.status_code == 200:

--- a/indra/sources/indra_db_rest/util.py
+++ b/indra/sources/indra_db_rest/util.py
@@ -13,6 +13,7 @@ def submit_query_request(end_point, *args, **kwargs):
     ev_limit = kwargs.pop('ev_limit', 10)
     best_first = kwargs.pop('best_first', True)
     tries = kwargs.pop('tries', 2)
+    timeout = kwargs.pop('timeout', None)
     # This isn't handled by requests because of the multiple identical agent
     # keys, e.g. {'agent': 'MEK', 'agent': 'ERK'} which is not supported in
     # python, but is allowed and necessary in these query strings.
@@ -23,19 +24,19 @@ def submit_query_request(end_point, *args, **kwargs):
                                + list(args))
     return submit_statement_request('get', end_point, query_str,
                                     ev_limit=ev_limit, best_first=best_first,
-                                    tries=tries)
+                                    tries=tries, timeout=timeout)
 
 
 def submit_statement_request(meth, end_point, query_str='', data=None,
-                             tries=2, **params):
+                             tries=2, timeout=None, **params):
     """Even lower level function to make the request."""
     full_end_point = 'statements/' + end_point.lstrip('/')
     return make_db_rest_request(meth, full_end_point, query_str, data,
-                                params, tries)
+                                params, tries, timeout)
 
 
 def make_db_rest_request(meth, end_point, query_str, data=None, params=None,
-                         tries=2):
+                         tries=2, timeout=None):
     if params is None:
         params = {}
 
@@ -64,7 +65,7 @@ def make_db_rest_request(meth, end_point, query_str, data=None, params=None,
     while tries > 0:
         tries -= 1
         resp = method_func(url_path, headers=headers, data=json_data,
-                           params=params)
+                           params=params, timeout=timeout)
         if resp.status_code == 200:
             return resp
         elif resp.status_code == 504 and tries > 0:

--- a/indra/sources/indra_db_rest/util.py
+++ b/indra/sources/indra_db_rest/util.py
@@ -64,6 +64,7 @@ def make_db_rest_request(meth, end_point, query_str, data=None, params=None,
     method_func = getattr(requests, meth.lower())
     while tries > 0:
         tries -= 1
+        timeout = timeout if timeout else None
         resp = method_func(url_path, headers=headers, data=json_data,
                            params=params, timeout=timeout)
         if resp.status_code == 200:

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -117,8 +117,10 @@ def test_too_big_request_persist_no_block():
         ("Counts dict was improperly handled before completing: %d counts "
          "for %d statements." % (num_counts, num_stmts))
     assert resp_all2.is_working(), "Background complete resolved too fast."
-    assert len(resp_all2.statements_sample) == len(resp_some.statements)
-    resp_all2.wait_until_done(120)
+    assert len(resp_all2.statements_sample) == len(resp_some.statements), \
+        "Sample size: %s, Small resp size: %s" \
+        % (len(resp_all2.statements_sample), len(resp_some.statements))
+    resp_all2.wait_until_done(500)
     assert not resp_all2.is_working(), \
         "Response is still working. Took too long."
     assert resp_all2.statements

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -153,6 +153,12 @@ def test_paper_query():
                                            simple_response=True)
     assert len(stmts_1)
 
+    p = dbr.get_statements_for_paper([('pmcid', 'PMC5770457'),
+                                      ('pmid', '27014235')])
+    assert len(p.statements)
+    assert len(p.get_source_counts())
+    assert len(p.get_ev_counts())
+
 
 @attr('nonpublic')
 def test_regulate_amount():
@@ -174,6 +180,11 @@ def test_get_statements_by_hash():
     print({s.get_hash(shallow=True): s for s in stmts})
     assert len(stmts) >= 2, \
         "Wrong number of statements: %s vs. %s" % (len(stmts), len(hash_list))
+
+    p = dbr.get_statements_by_hash(hash_list)
+    assert len(p.statements)
+    assert len(p.get_source_counts())
+    assert len(p.get_ev_counts())
     return
 
 

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -1,7 +1,4 @@
-from __future__ import absolute_import, print_function, unicode_literals
-
 import random
-from builtins import dict, str
 
 from datetime import datetime
 from unittest import SkipTest

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -150,7 +150,8 @@ def test_famplex_namespace():
 def test_paper_query():
     raise SkipTest("Paper query currently not supported.")
     stmts_1 = dbr.get_statements_for_paper([('pmcid', 'PMC5770457'),
-                                            ('pmid', '27014235')])
+                                            ('pmid', '27014235')],
+                                           simple_response=True)
     assert len(stmts_1)
 
 

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -170,7 +170,7 @@ def test_regulate_amount():
 @attr('nonpublic')
 def test_get_statements_by_hash():
     hash_list = [30674674032092136, -22289282229858243, -25056605420392180]
-    stmts = dbr.get_statements_by_hash(hash_list)
+    stmts = dbr.get_statements_by_hash(hash_list, simple_response=True)
     print({s.get_hash(shallow=True): s for s in stmts})
     assert len(stmts) >= 2, \
         "Wrong number of statements: %s vs. %s" % (len(stmts), len(hash_list))
@@ -179,7 +179,7 @@ def test_get_statements_by_hash():
 
 @attr('nonpublic')
 def test_get_statements_by_hash_no_hash():
-    stmts = dbr.get_statements_by_hash([])
+    stmts = dbr.get_statements_by_hash([], simple_response=True)
     assert not stmts, "Got statements without giving a hash."
 
 


### PR DESCRIPTION
This PR makes it so that the API for retrieving statements is more consistent regardless of the search method, specifically allowing a user to get a processor with the expected metadata in all cases.