### PR TITLE
Fix handling of the persist option, allowing for waiting.

### DIFF
--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -470,7 +470,8 @@ class IndraDBRestSearchProcessor(IndraDBRestProcessor):
         return
 
     def _run(self, subject=None, object=None, agents=None, stmt_type=None,
-             use_exact_type=False, persist=True, **api_params):
+             use_exact_type=False, persist=True, strict_stop=False,
+             **api_params):
         self.__started = False
         self.__done_dict = defaultdict(lambda: False)
         self.__page_dict = defaultdict(lambda: 0)
@@ -484,7 +485,7 @@ class IndraDBRestSearchProcessor(IndraDBRestProcessor):
                              "the scope will be too large.")
 
         # Make timeouts apply differently in this case
-        if not persist:
+        if not strict_stop:
             timeout = api_params.pop('timeout', None)
         else:
             timeout = api_params.get('timeout', None)


### PR DESCRIPTION
The meaning of "persist" had come to have something of a dual meaning, and in the previous PR morphed someone from the original intent, causing a test to fail in certain cases (depending on how long the query took). The behavior should now be consistent with the original intent.