### PR TITLE
ModelChecker fixes

### DIFF
--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -204,7 +204,7 @@ class IndraNet(nx.MultiDiGraph):
 
         SG = nx.MultiDiGraph()
         for u, v, data in self.edges(data=True):
-            if data['initial_sign'] is not None:
+            if data.get('initial_sign'):
                 sign = data['initial_sign']
             elif data['stmt_type'] not in sign_dict:
                 continue

--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -204,7 +204,8 @@ class IndraNet(nx.MultiDiGraph):
 
         SG = nx.MultiDiGraph()
         for u, v, data in self.edges(data=True):
-            if data.get('initial_sign'):
+            # Explicit 'is not None' needed to accept 0
+            if data.get('initial_sign') is not None:
                 sign = data['initial_sign']
             elif data['stmt_type'] not in sign_dict:
                 continue

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -291,7 +291,8 @@ class PybelAssembler(object):
         activates = stmt.is_active
         relation = get_causal_edge(stmt, activates)
         stmt_hash = stmt.get_hash(refresh=True)
-        if not stmt.agent.mods and not stmt.agent.bound_conditions:
+        if not stmt.agent.mods and not stmt.agent.bound_conditions and \
+                not stmt.agent.mutations:
             self._add_nodes_edges(stmt.agent, act_agent, relation,
                                   stmt_hash, stmt.evidence)
         else:
@@ -305,6 +306,12 @@ class PybelAssembler(object):
                     stmt.agent.name, db_refs=stmt.agent.db_refs,
                     bound_conditions=[bc])
                 self._add_nodes_edges(bound_agent, act_agent, relation,
+                                      stmt_hash, stmt.evidence)
+            for mut in stmt.agent.mutations:
+                mut_agent = Agent(
+                    stmt.agent.name, db_refs=stmt.agent.db_refs,
+                    mutations=[mut])
+                self._add_nodes_edges(mut_agent, act_agent, relation,
                                       stmt_hash, stmt.evidence)
 
     def _assemble_complex(self, stmt):

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -291,7 +291,7 @@ class PybelAssembler(object):
         activates = stmt.is_active
         relation = get_causal_edge(stmt, activates)
         stmt_hash = stmt.get_hash(refresh=True)
-        if not stmt.agent.mods:
+        if not stmt.agent.mods and not stmt.agent.bound_conditions:
             self._add_nodes_edges(stmt.agent, act_agent, relation,
                                   stmt_hash, stmt.evidence)
         else:
@@ -299,6 +299,12 @@ class PybelAssembler(object):
                 mod_agent = Agent(
                     stmt.agent.name, db_refs=stmt.agent.db_refs, mods=[mod])
                 self._add_nodes_edges(mod_agent, act_agent, relation,
+                                      stmt_hash, stmt.evidence)
+            for bc in stmt.agent.bound_conditions:
+                bound_agent = Agent(
+                    stmt.agent.name, db_refs=stmt.agent.db_refs,
+                    bound_conditions=[bc])
+                self._add_nodes_edges(bound_agent, act_agent, relation,
                                       stmt_hash, stmt.evidence)
 
     def _assemble_complex(self, stmt):

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -290,8 +290,16 @@ class PybelAssembler(object):
         act_agent.activity = ActivityCondition(stmt.activity, True)
         activates = stmt.is_active
         relation = get_causal_edge(stmt, activates)
-        self._add_nodes_edges(stmt.agent, act_agent, relation,
-                              stmt.get_hash(refresh=True), stmt.evidence)
+        stmt_hash = stmt.get_hash(refresh=True)
+        if not stmt.agent.mods:
+            self._add_nodes_edges(stmt.agent, act_agent, relation,
+                                  stmt_hash, stmt.evidence)
+        else:
+            for mod in stmt.agent.mods:
+                mod_agent = Agent(
+                    stmt.agent.name, db_refs=stmt.agent.db_refs, mods=[mod])
+                self._add_nodes_edges(mod_agent, act_agent, relation,
+                                      stmt_hash, stmt.evidence)
 
     def _assemble_complex(self, stmt):
         """Example: complex(p(HGNC:MAPK14), p(HGNC:TAB1))"""

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -507,15 +507,15 @@ def _get_agent_grounding(agent):
             logger.warning('Agent %s with HGNC ID %s has no HGNC name.',
                            agent, hgnc_id)
             return
-        return protein('HGNC', hgnc_name)
+        return protein('HGNC', name=hgnc_name, identifier=hgnc_id)
 
     uniprot_id = _get_id(agent, 'UP')
     if uniprot_id:
-        return protein('UP', uniprot_id)
+        return protein('UP', name=uniprot_id, identifier=uniprot_id)
 
     fplx_id = _get_id(agent, 'FPLX')
     if fplx_id:
-        return protein('FPLX', fplx_id)
+        return protein('FPLX', name=fplx_id, identifier=fplx_id)
 
     pfam_id = _get_id(agent, 'PF')
     if pfam_id:
@@ -533,19 +533,19 @@ def _get_agent_grounding(agent):
     if chebi_id:
         if chebi_id.startswith('CHEBI:'):
             chebi_id = chebi_id[len('CHEBI:'):]
-        return abundance('CHEBI', chebi_id)
+        return abundance('CHEBI', name=agent.name, identifier=chebi_id)
 
     pubchem_id = _get_id(agent, 'PUBCHEM')
     if pubchem_id:
-        return abundance('PUBCHEM', pubchem_id)
+        return abundance('PUBCHEM', name=pubchem_id, identifier=pubchem_id)
 
     go_id = _get_id(agent, 'GO')
     if go_id:
-        return bioprocess('GO', go_id)
+        return bioprocess('GO', name=agent.name, identifier=go_id)
 
     mesh_id = _get_id(agent, 'MESH')
     if mesh_id:
-        return bioprocess('MESH', mesh_id)
+        return bioprocess('MESH', name=agent.name, identifier=mesh_id)
 
     return
 

--- a/indra/explanation/model_checker/__init__.py
+++ b/indra/explanation/model_checker/__init__.py
@@ -1,4 +1,4 @@
-from .model_checker import ModelChecker, PathResult, PathMetric
+from .model_checker import ModelChecker, PathResult, PathMetric, get_path_iter
 from .pysb import PysbModelChecker
 from .signed_graph import SignedGraphModelChecker
 from .unsigned_graph import UnsignedGraphModelChecker

--- a/indra/explanation/model_checker/__init__.py
+++ b/indra/explanation/model_checker/__init__.py
@@ -3,3 +3,4 @@ from .pysb import PysbModelChecker
 from .signed_graph import SignedGraphModelChecker
 from .unsigned_graph import UnsignedGraphModelChecker
 from .pybel import PybelModelChecker
+from .model_checker import signed_edges_to_signed_nodes, prune_signed_nodes

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -384,68 +384,6 @@ class ModelChecker(object):
         # There was no path; this will produce an empty generator
         return
 
-    def signed_edges_to_signed_nodes(self, graph, prune_nodes=True,
-                                     edge_signs={'pos': 0, 'neg': 1}):
-        """Convert a graph with signed edges to a graph with signed nodes.
-
-        Each pair of nodes linked by an edge in an input graph are represented
-        as four nodes and two edges in the new graph. For example, an edge (a,
-        b, 0), where a and b are nodes and 0 is a sign of an edge (positive),
-        will be represented as edges ((a, 0), (b, 0)) and ((a, 1), (b, 1)),
-        where (a, 0), (a, 1), (b, 0), (b, 1) are signed nodes. An edge (a, b,
-        1) with sign 1 (negative) will be represented as edges ((a, 0), (b,
-        1)) and ((a, 1), (b, 0)).
-
-        Parameters
-        ----------
-        graph : networkx.MultiDiGraph
-            Graph with signed edges to convert. Can have multiple edges between
-            a pair of nodes.
-        prune_nodes : Optional[bool]
-            If True, iteratively prunes negative (with sign 1) nodes without
-            predecessors.
-        edge_signs : dict
-            A dictionary representing the signing policy of incoming graph. The
-            dictionary should have strings 'pos' and 'neg' as keys and integers
-            as values.
-
-        Returns
-        -------
-        signed_nodes_graph : networkx.DiGraph
-        """
-        signed_nodes_graph = nx.DiGraph()
-        nodes = []
-        for node, node_data in graph.nodes(data=True):
-            nodes.append(((node, 0), node_data))
-            nodes.append(((node, 1), node_data))
-        signed_nodes_graph.add_nodes_from(nodes)
-        edges = set()
-        for u, v, edge_data in graph.edges(data=True):
-            edge_sign = edge_data.get('sign')
-            if edge_sign == edge_signs['pos']:
-                edges.add(((u, 0), (v, 0)))
-                edges.add(((u, 1), (v, 1)))
-            elif edge_sign == edge_signs['neg']:
-                edges.add(((u, 0), (v, 1)))
-                edges.add(((u, 1), (v, 0)))
-        signed_nodes_graph.add_edges_from(edges)
-        if prune_nodes:
-            signed_nodes_graph = self.prune_nodes(signed_nodes_graph)
-        return signed_nodes_graph
-
-    def prune_nodes(self, graph):
-        """Prune nodes with sign (1) if they do not have predecessors."""
-        nodes_to_prune = [node for node, in_deg
-                          in graph.in_degree()
-                          if in_deg == 0 and node[1] == 1]
-        while nodes_to_prune:
-            graph.remove_nodes_from(nodes_to_prune)
-            # Make a list of nodes whose in degree is now 0
-            nodes_to_prune = [node for node, in_deg
-                              in graph.in_degree()
-                              if in_deg == 0 and node[1] == 1]
-        return graph
-
     def make_false_result(self, result_code, max_paths, max_path_length):
         return PathResult(False, result_code, max_paths, max_path_length)
 
@@ -516,3 +454,67 @@ def get_path_iter(graph, source, target):
                 yield path
         except nx.NetworkXNoPath:
             pass
+
+
+def signed_edges_to_signed_nodes(graph, prune_nodes=True,
+                                 edge_signs={'pos': 0, 'neg': 1}):
+    """Convert a graph with signed edges to a graph with signed nodes.
+
+    Each pair of nodes linked by an edge in an input graph are represented
+    as four nodes and two edges in the new graph. For example, an edge (a,
+    b, 0), where a and b are nodes and 0 is a sign of an edge (positive),
+    will be represented as edges ((a, 0), (b, 0)) and ((a, 1), (b, 1)),
+    where (a, 0), (a, 1), (b, 0), (b, 1) are signed nodes. An edge (a, b,
+    1) with sign 1 (negative) will be represented as edges ((a, 0), (b,
+    1)) and ((a, 1), (b, 0)).
+
+    Parameters
+    ----------
+    graph : networkx.MultiDiGraph
+        Graph with signed edges to convert. Can have multiple edges between
+        a pair of nodes.
+    prune_nodes : Optional[bool]
+        If True, iteratively prunes negative (with sign 1) nodes without
+        predecessors.
+    edge_signs : dict
+        A dictionary representing the signing policy of incoming graph. The
+        dictionary should have strings 'pos' and 'neg' as keys and integers
+        as values.
+
+    Returns
+    -------
+    signed_nodes_graph : networkx.DiGraph
+    """
+    signed_nodes_graph = nx.DiGraph()
+    nodes = []
+    for node, node_data in graph.nodes(data=True):
+        nodes.append(((node, 0), node_data))
+        nodes.append(((node, 1), node_data))
+    signed_nodes_graph.add_nodes_from(nodes)
+    edges = set()
+    for u, v, edge_data in graph.edges(data=True):
+        edge_sign = edge_data.get('sign')
+        if edge_sign == edge_signs['pos']:
+            edges.add(((u, 0), (v, 0)))
+            edges.add(((u, 1), (v, 1)))
+        elif edge_sign == edge_signs['neg']:
+            edges.add(((u, 0), (v, 1)))
+            edges.add(((u, 1), (v, 0)))
+    signed_nodes_graph.add_edges_from(edges)
+    if prune_nodes:
+        signed_nodes_graph = prune_signed_nodes(signed_nodes_graph)
+    return signed_nodes_graph
+
+
+def prune_signed_nodes(graph):
+    """Prune nodes with sign (1) if they do not have predecessors."""
+    nodes_to_prune = [node for node, in_deg
+                      in graph.in_degree()
+                      if in_deg == 0 and node[1] == 1]
+    while nodes_to_prune:
+        graph.remove_nodes_from(nodes_to_prune)
+        # Make a list of nodes whose in degree is now 0
+        nodes_to_prune = [node for node, in_deg
+                          in graph.in_degree()
+                          if in_deg == 0 and node[1] == 1]
+    return graph

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -233,10 +233,6 @@ class ModelChecker(object):
         return self.make_false_result('NO_PATHS_FOUND',
                                       max_paths, max_path_length)
 
-    def path_iter(self, subj, obj):
-        """Returns a path generator of the graph from subject to obejct"""
-        return get_path_iter(self.graph, subj, obj)
-
     def find_paths(self, subj, obj, max_paths=1, max_path_length=5):
         """Check for a source/target path in the model.
 
@@ -302,7 +298,7 @@ class ModelChecker(object):
                 # Get the first path
                 # Try to find paths using sources found above
                 for source in sources:
-                    path_iter = self.path_iter(source, obj)
+                    path_iter = get_path_iter(source, obj)
                     for path in path_iter:
                         pr.add_path(tuple(path))
                         # Do not get next path if reached max_paths

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -501,7 +501,7 @@ def get_path_iter(graph, source, target):
                     path.append(source)
                     yield path
             except nx.NetworkXNoPath:
-                continue
+                pass
     else:
         # Regular path search
         path_iter = nx.shortest_simple_paths(graph, source, target)
@@ -509,4 +509,4 @@ def get_path_iter(graph, source, target):
             for path in path_iter:
                 yield path
         except nx.NetworkXNoPath:
-            continue
+            pass

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -501,12 +501,12 @@ def get_path_iter(graph, source, target):
                     path.append(source)
                     yield path
             except nx.NetworkXNoPath:
-                    continue
+                continue
     else:
         # Regular path search
         path_iter = nx.shortest_simple_paths(graph, source, target)
         try:
             for path in path_iter:
                 yield path
-            except nx.NetworkXNoPath:
-                continue
+        except nx.NetworkXNoPath:
+            continue

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -275,12 +275,14 @@ class ModelChecker(object):
         # Generate the predecessors to our observable and count the paths
         path_lengths = []
         path_metrics = []
-        sources = set()
+        sources = []
         for source, path_length in self._find_sources(obj, input_set):
             pm = PathMetric(source, obj, path_length)
             path_metrics.append(pm)
             path_lengths.append(path_length)
-            sources.add(source)
+            # Keep unique sources but use a list (not set) to preserve order
+            if source not in sources:
+                sources.append(source)
         logger.info('Finding paths between %s and %s' % (subj, obj))
         # Now, look for paths
         if path_metrics and max_paths == 0:

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -274,12 +274,12 @@ class ModelChecker(object):
         # Generate the predecessors to our observable and count the paths
         path_lengths = []
         path_metrics = []
-        sources = []
+        sources = set()
         for source, path_length in self._find_sources(obj, input_set):
             pm = PathMetric(source, obj, path_length)
             path_metrics.append(pm)
             path_lengths.append(path_length)
-            sources.append(source)
+            sources.add(source)
         logger.info('Finding paths between %s and %s' % (subj, obj))
         # Now, look for paths
         if path_metrics and max_paths == 0:

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -233,6 +233,10 @@ class ModelChecker(object):
         return self.make_false_result('NO_PATHS_FOUND',
                                       max_paths, max_path_length)
 
+    def path_iter(self, subj, obj):
+        """Returns a path generator of the graph from subject to obejct"""
+        return get_path_iter(self.graph, subj, obj)
+
     def find_paths(self, subj, obj, max_paths=1, max_path_length=5):
         """Check for a source/target path in the model.
 
@@ -298,7 +302,7 @@ class ModelChecker(object):
                 # Get the first path
                 # Try to find paths using sources found above
                 for source in sources:
-                    path_iter = get_path_iter(self.graph, source, obj)
+                    path_iter = self.path_iter(source, obj)
                     for path in path_iter:
                         pr.add_path(tuple(path))
                         # Do not get next path if reached max_paths

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -486,30 +486,20 @@ class ModelChecker(object):
 
 
 def get_path_iter(graph, source, target):
-    """Return a generator of simple paths or cycles from source to target
-    depending on whether source and target are the same node.
-    """
+    """Return a generator of paths from source to target."""
+    # If source and target are the same node we need to find paths from source
+    # to its predecessors
     if source == target:
-        # NOTE # TODO This method only returns one cycle. It's currently only
-        # possible to get either one cycle with a specified source or
-        # a generator of all cycles in a graph (not specifying the source).
-        # There's no functionality in networkx to return a generator of
-        # cycles from a given source. Looping through all returned cycles to
-        # get ones from a desired source is very inefficient. This needs to be
-        # implemented if we want to find multiple paths (cycles) from a given
-        # source.
-        cycle_edges = nx.find_cycle(graph, source=source)
-        # reformat list of edges to a list of nodes (a path) for consistency
-        path = [source]
-        for i, edge in enumerate(cycle_edges):
-            if i == 0:
-                path.append(edge[0])
-                path.append(edge[1])
-            else:
-                path.append(edge[1])
-        path.append(source)
-        yield path
+        new_targets = graph.predecessors(source)
+        for nt in new_targets:
+            path_iter = nx.shortest_simple_paths(graph, source, nt)
+            for p in path_iter:
+                path = deepcopy(p)
+                # Append source to close the loop
+                path.append(source)
+                yield path
     else:
+        # Regular path search
         path_iter = nx.shortest_simple_paths(graph, source, target)
         for path in path_iter:
             yield path

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -298,7 +298,7 @@ class ModelChecker(object):
                 # Get the first path
                 # Try to find paths using sources found above
                 for source in sources:
-                    path_iter = get_path_iter(source, obj)
+                    path_iter = get_path_iter(self.graph, source, obj)
                     for path in path_iter:
                         pr.add_path(tuple(path))
                         # Do not get next path if reached max_paths

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -4,6 +4,7 @@ import itertools
 import numpy as np
 import networkx as nx
 from collections import deque
+from copy import deepcopy
 
 try:
     import paths_graph as pg
@@ -493,13 +494,19 @@ def get_path_iter(graph, source, target):
         new_targets = graph.predecessors(source)
         for nt in new_targets:
             path_iter = nx.shortest_simple_paths(graph, source, nt)
-            for p in path_iter:
-                path = deepcopy(p)
-                # Append source to close the loop
-                path.append(source)
-                yield path
+            try:
+                for p in path_iter:
+                    path = deepcopy(p)
+                    # Append source to close the loop
+                    path.append(source)
+                    yield path
+            except nx.NetworkXNoPath:
+                    continue
     else:
         # Regular path search
         path_iter = nx.shortest_simple_paths(graph, source, target)
-        for path in path_iter:
-            yield path
+        try:
+            for path in path_iter:
+                yield path
+            except nx.NetworkXNoPath:
+                continue

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -295,8 +295,7 @@ class ModelChecker(object):
                 # Get the first path
                 # Try to find paths using sources found above
                 for source in sources:
-                    path_iter = nx.shortest_simple_paths(
-                        self.graph, source, obj)
+                    path_iter = get_path_iter(self.graph, source, obj)
                     for path in path_iter:
                         pr.add_path(tuple(path))
                         # Do not get next path if reached max_paths
@@ -485,3 +484,32 @@ class ModelChecker(object):
                       max_paths=1, max_path_length=5):
         raise NotImplementedError("Method must be implemented in child class.")
 
+
+def get_path_iter(graph, source, target):
+    """Return a generator of simple paths or cycles from source to target
+    depending on whether source and target are the same node.
+    """
+    if source == target:
+        # NOTE # TODO This method only returns one cycle. It's currently only
+        # possible to get either one cycle with a specified source or
+        # a generator of all cycles in a graph (not specifying the source).
+        # There's no functionality in networkx to return a generator of
+        # cycles from a given source. Looping through all returned cycles to
+        # get ones from a desired source is very inefficient. This needs to be
+        # implemented if we want to find multiple paths (cycles) from a given
+        # source.
+        cycle_edges = nx.find_cycle(graph, source=source)
+        # reformat list of edges to a list of nodes (a path) for consistency
+        path = [source]
+        for i, edge in enumerate(cycle_edges):
+            if i == 0:
+                path.append(edge[0])
+                path.append(edge[1])
+            else:
+                path.append(edge[1])
+        path.append(source)
+        yield path
+    else:
+        path_iter = nx.shortest_simple_paths(graph, source, target)
+        for path in path_iter:
+            yield path

--- a/indra/explanation/model_checker/pybel.py
+++ b/indra/explanation/model_checker/pybel.py
@@ -74,3 +74,9 @@ class PybelModelChecker(ModelChecker):
 
     def process_subject(self, subj):
         return [subj], None
+
+    def _get_model_agents(self):
+        # This import is done here rather than at the top level to avoid
+        # making pybel an implicit dependency of the model checker
+        from indra.sources.bel.processor import get_agent
+        return [get_agent(node) for node in self.model.nodes]

--- a/indra/explanation/model_checker/pybel.py
+++ b/indra/explanation/model_checker/pybel.py
@@ -75,6 +75,25 @@ class PybelModelChecker(ModelChecker):
     def process_subject(self, subj):
         return [subj], None
 
+    def get_node(self, agent, graph, target_polarity):
+        # This import is done here rather than at the top level to avoid
+        # making pybel an implicit dependency of the model checker
+        from indra.assemblers.pybel.assembler import _get_agent_node
+        if agent is None:
+            return None
+        node = (_get_agent_node(agent)[0], target_polarity)
+        if node not in graph.nodes:
+            # Try find more refined agents in the graph
+            specific_agent = None
+            for ag in self.model_agents:
+                if ag.refinement_of(agent, hierarchies):
+                    specific_agent = ag
+            if specific_agent:
+                node = (_get_agent_node(specific_agent)[0], target_polarity)
+                if node not in graph.nodes:
+                    return None
+        return node
+
     def _get_model_agents(self):
         # This import is done here rather than at the top level to avoid
         # making pybel an implicit dependency of the model checker

--- a/indra/explanation/model_checker/pybel.py
+++ b/indra/explanation/model_checker/pybel.py
@@ -87,8 +87,8 @@ class PybelModelChecker(ModelChecker):
                     specific_agent = ag
             if specific_agent:
                 node = (_get_agent_node(specific_agent)[0], target_polarity)
-                if node not in graph.nodes:
-                    return None
+            if node not in graph.nodes:
+                return None
         return node
 
     def _get_model_agents(self):

--- a/indra/explanation/model_checker/pybel.py
+++ b/indra/explanation/model_checker/pybel.py
@@ -1,8 +1,9 @@
 import logging
+from copy import deepcopy
 from . import ModelChecker
 from indra.statements import *
 from indra.preassembler.hierarchy_manager import hierarchies
-from copy import deepcopy
+from .model_checker import signed_edges_to_signed_nodes
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ class PybelModelChecker(ModelChecker):
         if self.graph:
             return self.graph
         signed_edges = belgraph_to_signed_graph(self.model)
-        self.graph = self.signed_edges_to_signed_nodes(signed_edges)
+        self.graph = signed_edges_to_signed_nodes(signed_edges)
         return self.graph
 
     def process_statement(self, stmt):

--- a/indra/explanation/model_checker/pybel.py
+++ b/indra/explanation/model_checker/pybel.py
@@ -88,7 +88,7 @@ class PybelModelChecker(ModelChecker):
                 nodes.add(node)
         # Try get refined versions
         for ag in self.model_agents:
-            if ag.refinement_of(agent, hierarchies):
+            if ag is not None and ag.refinement_of(agent, hierarchies):
                 agent_node = _get_agent_node(ag)[0]
                 if agent_node:
                     node = (agent_node, target_polarity)

--- a/indra/explanation/model_checker/pysb.py
+++ b/indra/explanation/model_checker/pysb.py
@@ -1,22 +1,32 @@
 import numbers
-import scipy.stats
-import kappy
 import logging
-import itertools
-import networkx as nx
 from copy import deepcopy
 from collections import Counter
+
+import scipy.stats
+import kappy
+import itertools
+import numpy as np
+import networkx as nx
 from pysb import WILD, export, Observable, ComponentSet
 from pysb.core import as_complex_pattern, ComponentDuplicateNameError
-from . import ModelChecker, PathResult
 from indra.explanation.reporting import stmt_from_rule
 from indra.statements import *
 from indra.assemblers.pysb import assembler as pa
 from indra.assemblers.pysb.kappa_util import im_json_to_graph
+
+from . import ModelChecker, PathResult
 from .model_checker import signed_edges_to_signed_nodes
 
-
 logger = logging.getLogger(__name__)
+
+try:
+    import paths_graph as pg
+    has_pg = True
+except ImportError:
+    pg = None
+    has_pg = False
+    logger.warning('PathsGraph is not available')
 
 
 class PysbModelChecker(ModelChecker):
@@ -285,6 +295,8 @@ class PysbModelChecker(ModelChecker):
                       max_paths=1, max_path_length=5):
         if max_paths == 0:
             raise ValueError("max_paths cannot be 0 for path sampling.")
+        if not has_pg:
+            raise ImportError("Paths Graph is not imported")
         # Convert path polarity representation from 0/1 to 1/-1
 
         def convert_polarities(path_list):

--- a/indra/explanation/model_checker/pysb.py
+++ b/indra/explanation/model_checker/pysb.py
@@ -13,6 +13,7 @@ from indra.explanation.reporting import stmt_from_rule
 from indra.statements import *
 from indra.assemblers.pysb import assembler as pa
 from indra.assemblers.pysb.kappa_util import im_json_to_graph
+from .model_checker import signed_edges_to_signed_nodes
 
 
 logger = logging.getLogger(__name__)
@@ -199,7 +200,7 @@ class PysbModelChecker(ModelChecker):
             self.prune_influence_map_degrade_bind_positive(self.model_stmts)
         if prune_im_subj_obj:
             self.prune_influence_map_subj_obj()
-        self.graph = self.signed_edges_to_signed_nodes(
+        self.graph = signed_edges_to_signed_nodes(
             im, prune_nodes=False, edge_signs={'pos': 1, 'neg': -1})
         return self.graph
 

--- a/indra/explanation/model_checker/signed_graph.py
+++ b/indra/explanation/model_checker/signed_graph.py
@@ -1,6 +1,7 @@
 import logging
 from . import ModelChecker
 from indra.statements import *
+from .model_checker import signed_edges_to_signed_nodes
 
 
 logger = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ class SignedGraphModelChecker(ModelChecker):
     def get_graph(self):
         if self.graph:
             return self.graph
-        self.graph = self.signed_edges_to_signed_nodes(self.model)
+        self.graph = signed_edges_to_signed_nodes(self.model)
         return self.graph
 
     def process_statement(self, stmt):

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -480,10 +480,11 @@ def get_db_refs_by_name(ns, name, node_data):
             return name, None
         db_refs = {'GO': go_id}
     elif ns in ('MESHPP', 'MESHD', 'MESH'):
-        mesh_id = mesh_client.get_mesh_id_name(name)[0]
+        mesh_id, mesh_name = mesh_client.get_mesh_id_name(name)
         if not mesh_id:
-            logger.info('Could not find MESH ID fro %s' % name)
+            logger.info('Could not find MESH ID from %s' % name)
             return name, None
+        name = mesh_name
         db_refs = {'MESH': mesh_id}
     # For now, handle MGI/RGD but putting the name into the db_refs so
     # it's clear what namespace the name belongs to

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -480,7 +480,7 @@ def get_db_refs_by_name(ns, name, node_data):
             return name, None
         db_refs = {'GO': go_id}
     elif ns in ('MESHPP', 'MESHD', 'MESH'):
-        mesh_id = mesh_client.get_mesh_id_name(name)
+        mesh_id = mesh_client.get_mesh_id_name(name)[0]
         if not mesh_id:
             logger.info('Could not find MESH ID fro %s' % name)
             return name, None

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -16,7 +16,7 @@ from pysb.tools import render_reactions
 from indra.databases import hgnc_client
 from indra.explanation.model_checker import ModelChecker, PysbModelChecker, \
     UnsignedGraphModelChecker, SignedGraphModelChecker, PybelModelChecker, \
-    PathResult
+    PathResult, signed_edges_to_signed_nodes
 from indra.explanation.model_checker.pysb import _mp_embeds_into, \
     _cp_embeds_into, _match_lhs, remove_im_params
 from indra.explanation.reporting import stmt_from_rule, stmts_from_pysb_path, \
@@ -1676,9 +1676,8 @@ def test_signed_edges_to_nodes():
     g.add_edge('E', 'B', sign=1)
     assert len(g.edges) == 5
     assert len(g.nodes) == 5
-    mc = ModelChecker(g)
     # Create a signed nodes graph without pruning
-    sng = mc.signed_edges_to_signed_nodes(g, prune_nodes=False)
+    sng = signed_edges_to_signed_nodes(g, prune_nodes=False)
     assert len(sng.nodes) == 10
     assert len(sng.edges) == 10
     assert set(sng.nodes) == {('A', 0), ('A', 1), ('B', 0), ('B', 1), ('C', 0),
@@ -1688,7 +1687,7 @@ def test_signed_edges_to_nodes():
     assert (('B', 0), ('D', 1)) in sng.edges
     assert (('B', 1), ('D', 0)) in sng.edges
     # Create a signed nodes graph with pruning
-    psng = mc.signed_edges_to_signed_nodes(g, prune_nodes=True)
+    psng = signed_edges_to_signed_nodes(g, prune_nodes=True)
     assert len(psng.nodes) == 7
     assert ('A', 1) not in psng.nodes
     assert ('C', 1) not in psng.nodes

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -1640,6 +1640,32 @@ def test_pybel_active_form_path():
     assert stmts_from_path == [[stmt] for stmt in stmts]
 
 
+def test_pybel_refinements():
+    prkcb = Agent('PRKCB', db_refs={'TEXT': 'PRKCB', 'HGNC': '9395'})
+    gsk3b = Agent('GSK3B', db_refs={'TEXT': 'GSK3B', 'HGNC': '4617'})
+    map2k1 = Agent('MAP2K1', db_refs={'TEXT': 'MAP2K1', 'HGNC': '6840'})
+    mapk1 = Agent('MAPK1', db_refs={'TEXT': 'MAPK1', 'HGNC': '6871'})
+    mek = Agent('MEK', db_refs={'TEXT': 'MEK', 'FPLX': 'MEK'})
+    erk = Agent('ERK', db_refs={'TEXT': 'ERK', 'FPLX': 'ERK'})
+    # Model statements are refined versions of test statements
+    model_stmts = [Phosphorylation(prkcb, gsk3b, 'S', '9'),
+                   Phosphorylation(map2k1, mapk1)]
+    test_stmts = [Phosphorylation(prkcb, gsk3b, 'S'),
+                  Phosphorylation(mek, erk)]
+    pba = PybelAssembler(model_stmts)
+    pybel_model = pba.make_model()
+    pbmc = PybelModelChecker(pybel_model, test_stmts)
+    results = pbmc.check_model()
+    assert results[0][1].path_found
+    assert results[1][1].path_found
+    path0 = results[0][1].paths[0]
+    path1 = results[1][1].paths[0]
+    assert stmts_from_pybel_path(
+        path0, pybel_model, False, model_stmts) == [[model_stmts[0]]]
+    assert stmts_from_pybel_path(
+        path1, pybel_model, False, model_stmts) == [[model_stmts[1]]]
+
+
 # Test graph conversion
 def test_signed_edges_to_nodes():
     g = nx.MultiDiGraph()

--- a/indra/tests/test_pybel_api.py
+++ b/indra/tests/test_pybel_api.py
@@ -1,5 +1,6 @@
 import os
 from urllib import request
+
 from nose.plugins.attrib import attr
 from pybel import BELGraph
 from pybel.dsl import *
@@ -209,7 +210,7 @@ def test_get_agent_mirna():
     m = MicroRna(namespace='MIRBASE', name='hsa-let-7a-1')
     agent = pb.get_agent(m, {})
     assert isinstance(agent, Agent)
-    assert agent.name == 'hsa-let-7a-1'
+    assert agent.name == 'MIRLET7A1'
     assert agent.db_refs.get('MIRBASE') == 'MI0000060'
     assert agent.db_refs.get('HGNC') == '31476'
 

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -21,8 +21,10 @@ tp53_dsl = protein(namespace='HGNC', name='TP53')
 mdm2_dsl = protein(namespace='HGNC', name='MDM2')
 egfr_dsl = protein(namespace='HGNC', name='EGFR')
 
-chebi_17534 = abundance(namespace='CHEBI', name='17634')
-chebi_4170 = abundance(namespace='CHEBI', name='4170')
+chebi_17534 = abundance(namespace='CHEBI', name='D-glucose',
+                        identifier='17634')
+chebi_4170 = abundance(namespace='CHEBI', name='D-glucopyranose 6-phosphate',
+                       identifier='4170')
 chebi_17534_to_4170 = reaction(chebi_17534, chebi_4170)
 
 grb2_dsl = protein(namespace='HGNC', name='GRB2')
@@ -347,8 +349,8 @@ def test_complex():
 
 
 def test_rxn_no_controller():
-    glu = Agent('D-GLUCOSE', db_refs={'CHEBI': 'CHEBI:17634'})
-    g6p = Agent('GLUCOSE-6-PHOSPHATE', db_refs={'CHEBI': 'CHEBI:4170'})
+    glu = Agent('D-glucose', db_refs={'CHEBI': 'CHEBI:17634'})
+    g6p = Agent('D-glucopyranose 6-phosphate', db_refs={'CHEBI': 'CHEBI:4170'})
     stmt = Conversion(None, [glu], [g6p])
     pba = pa.PybelAssembler([stmt])
     belgraph = pba.make_model()
@@ -369,8 +371,8 @@ def test_rxn_no_controller():
 
 def test_rxn_with_controller():
     hk1 = Agent('HK1', db_refs={'HGNC': id('HK1')})
-    glu = Agent('D-GLUCOSE', db_refs={'CHEBI': 'CHEBI:17634'})
-    g6p = Agent('GLUCOSE-6-PHOSPHATE', db_refs={'CHEBI': 'CHEBI:4170'})
+    glu = Agent('D-glucose', db_refs={'CHEBI': 'CHEBI:17634'})
+    g6p = Agent('D-glucopyranose 6-phosphate', db_refs={'CHEBI': 'CHEBI:4170'})
     stmt = Conversion(hk1, [glu], [g6p])
     pba = pa.PybelAssembler([stmt])
     belgraph = pba.make_model()
@@ -540,7 +542,8 @@ def test_no_activity_on_bioprocess():
     assert belgraph.number_of_edges() == 1
 
     yfg_pybel = protein('HGNC', 'PPP1R13L')
-    apoptosis_pybel = bioprocess('GO', 'GO:0006915')
+    apoptosis_pybel = bioprocess('GO', name='apoptotic process',
+                                 identifier='GO:0006915')
     assert yfg_pybel in belgraph
     assert apoptosis_pybel in belgraph
 

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -322,10 +322,13 @@ def test_active_form():
     stmt1 = ActiveForm(ras, 'gtpbound', True)
     stmt2 = ActiveForm(mapk1_p, 'kinase', True)
     stmt3 = ActiveForm(mapk1_pp, 'kinase', True)
-    for stmt in (stmt1, stmt2, stmt3):
+    for i, stmt in enumerate((stmt1, stmt2, stmt3)):
         pba = pa.PybelAssembler([stmt])
         belgraph = pba.make_model()
-        assert len(belgraph) == 3, len(belgraph)
+        if i == 2:
+            assert len(belgraph) == 3, len(belgraph)
+        else:
+            assert len(belgraph) == 2, len(belgraph)
 
 
 def test_complex():

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -325,7 +325,7 @@ def test_active_form():
     for stmt in (stmt1, stmt2, stmt3):
         pba = pa.PybelAssembler([stmt])
         belgraph = pba.make_model()
-        assert len(belgraph) == 2
+        assert len(belgraph) == 3, len(belgraph)
 
 
 def test_complex():


### PR DESCRIPTION
This PR makes some improvements to model checking process. One change is handling cases where a path should be a cycle - when subject and object are the same in test statement.
Another change is in assembling ActiveForm statements by PybelAssembler. In case an agent has multiple mod conditions, bound conditions or mutations, separate nodes are created for each one. Finally, this PR adds preprocessing of test statement agents before turning them into Pybel nodes in PybelModelChecker (to ensure consistency between assembled model and test statements). 