### PR TITLE
Extend and optimize URL generation for DB lookups

### DIFF
--- a/indra/sources/indra_db_rest/api.py
+++ b/indra/sources/indra_db_rest/api.py
@@ -271,14 +271,17 @@ def get_statement_queries(stmts, **params):
     """
 
     def pick_ns(ag):
+        # If the Agent has grounding, in order of preference, in any of these
+        # name spaces then we look it up based on grounding.
         for ns in ['HGNC', 'FPLX', 'CHEMBL', 'CHEBI', 'GO', 'MESH']:
             if ns in ag.db_refs.keys():
                 dbid = ag.db_refs[ns]
-                break
-        else:
-            ns = 'TEXT'
-            dbid = ag.name
-        return '%s@%s' % (dbid, ns)
+                return '%s@%s' % (dbid, ns)
+        # Otherwise, we search by Agent name - if the name is standardized,
+        # this will still yield good results. If it isn't standardized, then
+        # the name will match the raw entity text so again this lookup will
+        # work.
+        return ag.name
 
     queries = []
     url_base = get_url_base('statements/from_agents')

--- a/indra/sources/indra_db_rest/api.py
+++ b/indra/sources/indra_db_rest/api.py
@@ -273,8 +273,8 @@ def get_statement_queries(stmts, **params):
     def pick_ns(ag):
         # If the Agent has grounding, in order of preference, in any of these
         # name spaces then we look it up based on grounding.
-        for ns in ['HGNC', 'FPLX', 'CHEMBL', 'CHEBI', 'GO', 'MESH']:
-            if ns in ag.db_refs.keys():
+        for ns in ['HGNC', 'UP', 'FPLX', 'CHEBI', 'GO', 'MESH']:
+            if ns in ag.db_refs:
                 dbid = ag.db_refs[ns]
                 return '%s@%s' % (dbid, ns)
         # Otherwise, we search by Agent name - if the name is standardized,

--- a/indra/sources/indra_db_rest/api.py
+++ b/indra/sources/indra_db_rest/api.py
@@ -272,7 +272,7 @@ def get_statement_queries(stmts, **params):
         The name space to search by when an Agent in a Statement is not
         grounded to one of the standardized name spaces. Typically,
         searching by 'NAME' (i.e., the Agent's name) is a good option if
-        (1) An Agent's grounding is missing but the agent's name is
+        (1) An Agent's grounding is missing but its name is
         known to be standard in one of the name spaces. In this case the
         name-based lookup will yield the same result as looking up by
         grounding. Example: MAP2K1(db_refs={})
@@ -280,7 +280,7 @@ def get_statement_queries(stmts, **params):
         is never standardized, so looking up by name yields the same result
         as looking up by TEXT. Example: xyz(db_refs={'TEXT': 'xyz'})
         Searching by TEXT is better in other cases e.g., when the given
-        specific Agent is not grounded but we have other Agent's with the
+        specific Agent is not grounded but we have other Agents with the
         same TEXT that are grounded and then standardized to a different name.
         Example: Erk(db_refs={'TEXT': 'Erk'}).
         Default: 'NAME'

--- a/indra/sources/indra_db_rest/api.py
+++ b/indra/sources/indra_db_rest/api.py
@@ -258,7 +258,8 @@ def submit_curation(hash_val, tag, curator, text=None,
     return make_db_rest_request('post', url, qstr, data=data)
 
 
-def get_statement_queries(stmts, **params):
+def get_statement_queries(stmts, fallback_ns='NAME', pick_ns_fun=None,
+                          **params):
     """Get queries used to search based on a statement.
 
     In addition to the stmts, you can enter any parameters standard to the
@@ -304,8 +305,7 @@ def get_statement_queries(stmts, **params):
         # usefully looked up in that name space).
         return '%s@%s' % (ag.name, fallback_ns)
 
-    fallback_ns = params.pop('fallback_ns', 'NAME')
-    pick_ns_fun = params.pop('pick_ns_fun', pick_ns)
+    pick_ns_fun = pick_ns if not pick_ns_fun else pick_ns_fun
 
     queries = []
     url_base = get_url_base('statements/from_agents')

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -5,6 +5,8 @@ from unittest import SkipTest
 
 from nose.plugins.attrib import attr
 from indra.sources import indra_db_rest as dbr
+from indra.sources.indra_db_rest.api import get_statement_queries
+from indra.statements import Agent, Phosphorylation
 
 
 EXPECTED_BATCH_SIZE = 500
@@ -198,3 +200,25 @@ def test_curation_submission():
     raise SkipTest("Curation currently not working.")
     dbr.submit_curation(32760831642168299, 'TEST', 'This is a test.',
                         'tester', is_test=True)
+
+
+def test_get_statement_queries():
+    ag = Agent('MAP2K1', db_refs={})
+    stmt = Phosphorylation(None, ag)
+    urls = get_statement_queries([stmt])
+    assert 'MAP2K1@NAME' in urls[0]
+    urls = get_statement_queries([stmt], fallback_ns='TEXT')
+    assert 'MAP2K1@TEXT' in urls[0]
+    urls = get_statement_queries([stmt],
+                                 pick_ns_fun=lambda x: '%s@%s' %
+                                                       (x.name, 'XXX'))
+    assert 'MAP2K1@XXX' in urls[0], urls[0]
+    ag = Agent('MEK', db_refs={'FPLX': 'MEK'})
+    stmt = Phosphorylation(None, ag)
+    urls = get_statement_queries([stmt])
+    assert 'MEK@FPLX' in urls[0]
+    urls = get_statement_queries([stmt], fallback_ns='TEXT')
+    assert 'MEK@FPLX' in urls[0]
+    urls = get_statement_queries([stmt],
+                                 pick_ns_fun=lambda x: '%s@%s' %
+                                                       (x.name, 'XXX'))

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -202,6 +202,7 @@ def test_curation_submission():
                         'tester', is_test=True)
 
 
+@attr('nonpublic')
 def test_get_statement_queries():
     ag = Agent('MAP2K1', db_refs={})
     stmt = Phosphorylation(None, ag)


### PR DESCRIPTION
This PR makes lookups of Agents with no standard grounding be done by name by default, and adds two options to make how Agents are looked up configurable. One lets the user switch between name-based and text-based lookup as fallback, the other allows passing in a user-defined function to customize the lookup procedure fully. It also fixes the default order of grounded name spaces to correspond to the actual standardization order.