### PR TITLE
Upper limit on networkx version and BeliefEngine debug messages

### DIFF
--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -350,6 +350,7 @@ class BeliefEngine(object):
         """
         def build_hierarchy_graph(stmts):
             """Return a DiGraph based on matches keys and Statement supports"""
+            logger.debug('Building hierarchy graph')
             g = networkx.DiGraph()
             for st1 in stmts:
                 g.add_node(self.matches_fun(st1), stmt=st1)
@@ -357,11 +358,13 @@ class BeliefEngine(object):
                     g.add_node(self.matches_fun(st2), stmt=st2)
                     g.add_edge(self.matches_fun(st2),
                                self.matches_fun(st1))
+            logger.debug('Finished building hierarchy graph')
             return g
 
         def get_ranked_stmts(g):
             """Return a topological sort of statement matches keys from a graph.
             """
+            logger.debug('Getting ranked statements')
             node_ranks = networkx.algorithms.dag.topological_sort(g)
             node_ranks = reversed(list(node_ranks))
             stmts = [g.node[n]['stmt'] for n in node_ranks]
@@ -369,6 +372,7 @@ class BeliefEngine(object):
 
         def assert_no_cycle(g):
             """If the graph has cycles, throws AssertionError."""
+            logger.debug('Looking for cycles in belief graph')
             try:
                 cyc = networkx.algorithms.cycles.find_cycle(g)
             except networkx.exception.NetworkXNoCycle:
@@ -379,6 +383,7 @@ class BeliefEngine(object):
         g = build_hierarchy_graph(statements)
         assert_no_cycle(g)
         ranked_stmts = get_ranked_stmts(g)
+        logger.debug('Start belief propagation over ranked statements')
         for st in ranked_stmts:
             bps = _get_belief_package(st, self.matches_fun)
             supporting_evidences = []
@@ -393,6 +398,7 @@ class BeliefEngine(object):
             # Now score all the evidences
             belief = self.scorer.score_statement(st, supporting_evidences)
             st.belief = belief
+        logger.debug('Finished belief propagation over ranked statements')
 
     def set_linked_probs(self, linked_statements):
         """Sets the belief probabilities for a list of linked INDRA Statements.

--- a/rest_api/test_api.py
+++ b/rest_api/test_api.py
@@ -2,7 +2,7 @@ import json
 import requests
 from indra.statements import *
 
-base_url = 'http://localhost:8080'
+base_url = 'http://api.indra.bio:8000'
 
 
 def test_filter_by_type():

--- a/rest_api/test_api.py
+++ b/rest_api/test_api.py
@@ -2,7 +2,7 @@ import json
 import requests
 from indra.statements import *
 
-base_url = 'http://api.indra.bio:8000'
+base_url = 'http://localhost:8080'
 
 
 def test_filter_by_type():

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(readme_path, 'r', encoding='utf-8') as fh:
 def main():
     install_list = ['pysb>=1.3.0', 'objectpath', 'rdflib',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
-                    'networkx>=2', 'pandas', 'ndex2==2.0.1', 'jinja2',
+                    'networkx>=2,<=2.3', 'pandas', 'ndex2==2.0.1', 'jinja2',
                     'protmapper>=0.0.14']
 
     extras_require = {


### PR DESCRIPTION
This PR adds an upper limit on the version of networkx (2.3) since the just-released version 2.4 breaks compatibility with INDRA, in e.g., the BeliefEngine's graph algorithms. The PR also adds some useful debug messages to the BeliefEngine which were missing previously.