### PR TITLE
Make Conversion PySB assembly compatible with Kappa

### DIFF
--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -2107,14 +2107,19 @@ def conversion_assemble_one_step(stmt, model, agent_set, parameters):
     obj_to_pattern = ReactionPattern(obj_to_patterns)
     rule_obj_to_str = '_'.join([get_agent_rule_str(o) for o in stmt.obj_to])
 
+    # We now need to take care of padding both sides of the rule for
+    # compatibility with Kappa
+    lhs_pattern = ReactionPattern([obj_from_pattern] +
+                                  [None] * len(obj_to_patterns))
+    rhs_pattern = ReactionPattern([None] + obj_to_patterns)
+
     if stmt.subj is None:
         rule_name = '%s_converted_to_%s' % (rule_obj_from_str, rule_obj_to_str)
         param_name = 'kf_%s%s_convert' % (obj_from.name[0].lower(),
                                           obj_to_monomers[0].name[0].lower())
         kfp = parameters.get('kf', Param(param_name, 2, True))
         kf_one_step_convert = get_create_parameter(model, kfp)
-        r = Rule(rule_name, obj_from_pattern >> obj_to_pattern,
-                 kf_one_step_convert)
+        r = Rule(rule_name, lhs_pattern >> rhs_pattern, kf_one_step_convert)
     else:
         subj_pattern = ComplexPattern(
             [get_monomer_pattern(model, stmt.subj)], None)

--- a/indra/assemblers/pysb/assembler.py
+++ b/indra/assemblers/pysb/assembler.py
@@ -2107,24 +2107,28 @@ def conversion_assemble_one_step(stmt, model, agent_set, parameters):
     obj_to_pattern = ReactionPattern(obj_to_patterns)
     rule_obj_to_str = '_'.join([get_agent_rule_str(o) for o in stmt.obj_to])
 
-    # We now need to take care of padding both sides of the rule for
-    # compatibility with Kappa
-    lhs_pattern = ReactionPattern([obj_from_pattern] +
-                                  [None] * len(obj_to_patterns))
-    rhs_pattern = ReactionPattern([None] + obj_to_patterns)
-
     if stmt.subj is None:
         rule_name = '%s_converted_to_%s' % (rule_obj_from_str, rule_obj_to_str)
         param_name = 'kf_%s%s_convert' % (obj_from.name[0].lower(),
                                           obj_to_monomers[0].name[0].lower())
         kfp = parameters.get('kf', Param(param_name, 2, True))
         kf_one_step_convert = get_create_parameter(model, kfp)
+        # We now need to take care of padding both sides of the rule for
+        # compatibility with Kappa
+        lhs_pattern = ReactionPattern([obj_from_pattern] +
+                                      [None] * len(obj_to_patterns))
+        rhs_pattern = ReactionPattern([None] + obj_to_patterns)
+
         r = Rule(rule_name, lhs_pattern >> rhs_pattern, kf_one_step_convert)
     else:
         subj_pattern = ComplexPattern(
             [get_monomer_pattern(model, stmt.subj)], None)
-        result_pattern = obj_to_pattern
-        result_pattern.complex_patterns.insert(0, subj_pattern)
+        # We now need to take care of padding both sides of the rule for
+        # compatibility with Kappa
+        lhs_pattern = ReactionPattern([subj_pattern, obj_from_pattern] +
+                                      [None] * len(obj_to_patterns))
+        rhs_pattern = ReactionPattern([subj_pattern, None] + obj_to_patterns)
+
         rule_subj_str = get_agent_rule_str(stmt.subj)
         rule_name = '%s_catalyzes_%s_converted_to_%s' % \
             (rule_subj_str, rule_obj_from_str, rule_obj_to_str)
@@ -2136,8 +2140,7 @@ def conversion_assemble_one_step(stmt, model, agent_set, parameters):
         kfp = parameters.get('kf', Param(param_name, 2e-4, True))
         kf_one_step_convert = get_create_parameter(model, kfp)
 
-        r = Rule(rule_name, subj_pattern + obj_from_pattern >>
-                            result_pattern,
+        r = Rule(rule_name, lhs_pattern >> rhs_pattern,
                  kf_one_step_convert)
     anns = [Annotation(rule_name, stmt.uuid, 'from_indra_statement')]
     add_rule_to_model(model, r, anns)

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str
 import xml.etree.ElementTree as ET
 from indra.assemblers.pysb import PysbAssembler
 import indra.assemblers.pysb.assembler as pa
@@ -9,6 +7,7 @@ from indra.statements import *
 from pysb import bng, WILD, Monomer, Annotation
 from pysb.testing import with_model
 from nose.tools import raises
+
 
 def test_pysb_assembler_complex1():
     member1 = Agent('BRAF')
@@ -1154,6 +1153,12 @@ def test_convert_nosubj():
     assert len(pa.model.parameters) == 3
     assert len(pa.model.rules) == 1
     assert len(pa.model.monomers) == 2
+    # We need to make sure that these are Kappa-compatible, and the easiest
+    # way to do that is by making a ModelChecker and getting the IM without
+    # error
+    from indra.explanation.model_checker import PysbModelChecker
+    pmc = PysbModelChecker(pa.model)
+    pmc.get_im()
 
 
 def test_convert_subj():
@@ -1163,6 +1168,12 @@ def test_convert_subj():
     assert len(pa.model.parameters) == 4
     assert len(pa.model.rules) == 1
     assert len(pa.model.monomers) == 3
+    # We need to make sure that these are Kappa-compatible, and the easiest
+    # way to do that is by making a ModelChecker and getting the IM without
+    # error
+    from indra.explanation.model_checker import PysbModelChecker
+    pmc = PysbModelChecker(pa.model)
+    pmc.get_im()
 
 
 def test_activity_agent_rule_name():


### PR DESCRIPTION
This PR extends the reaction patterns on both sides of PySB Rules assembled from Conversion statements with Nones as placeholders for created or destroyed complex patterns.