### PR TITLE
Update PyBEL to v0.14

### DIFF
--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -3,7 +3,7 @@ from builtins import dict, str
 import uuid
 import logging
 import networkx as nx
-from copy import copy, deepcopy
+from copy import deepcopy, copy
 import pybel
 import pybel.constants as pc
 from pybel.dsl import *
@@ -110,7 +110,7 @@ class PybelAssembler(object):
                     'namespace/mesh-processes/mesh-processes-20170725.belns'
         }
         self.model.namespace_url.update(ns_dict)
-        self.model.namespace_pattern['PUBCHEM'] = r'\d+'
+        self.model.namespace_pattern['PUBCHEM'] = '\d+'
 
     def add_statements(self, stmts_to_add):
         self.statements += stmts_to_add
@@ -119,7 +119,7 @@ class PybelAssembler(object):
         for stmt in self.statements:
             # Skip statements with no subject
             if stmt.agent_list()[0] is None and \
-                not isinstance(stmt, Conversion):
+                    not isinstance(stmt, Conversion):
                 continue
             # Assemble statements
             if isinstance(stmt, Modification):

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -231,12 +231,12 @@ class PybelAssembler(object):
         # If we failed to create nodes for subject or object, skip it
         if subj_data is None or obj_data is None:
             return
-        subj_node = self.model.add_node_from_data(subj_data)
-        obj_node = self.model.add_node_from_data(obj_data)
+        self.model.add_node_from_data(subj_data)
+        self.model.add_node_from_data(obj_data)
         edge_data_list = _combine_edge_data(
             relation, subj_edge, obj_edge, stmt_hash, evidences)
         for edge_data in edge_data_list:
-            self.model.add_edge(subj_node, obj_node, **edge_data)
+            self.model.add_edge(subj_data, obj_data, **edge_data)
 
     def _assemble_regulate_activity(self, stmt):
         """Example: p(HGNC:MAP2K1) => act(p(HGNC:MAPK1))"""
@@ -337,17 +337,17 @@ class PybelAssembler(object):
             reactants=pybel_lists[0],
             products=pybel_lists[1],
         )
-        obj_node = self.model.add_node_from_data(rxn_node_data)
+        self.model.add_node_from_data(rxn_node_data)
         obj_edge = None  # TODO: Any edge information possible here?
         # Add node for controller, if there is one
         if stmt.subj is not None:
             subj_attr, subj_edge = _get_agent_node(stmt.subj)
-            subj_node = self.model.add_node_from_data(subj_attr)
+            self.model.add_node_from_data(subj_attr)
             edge_data_list = _combine_edge_data(
                 pc.DIRECTLY_INCREASES, subj_edge, obj_edge,
                 stmt.get_hash(refresh=True), stmt.evidence)
             for edge_data in edge_data_list:
-                self.model.add_edge(subj_node, obj_node, **edge_data)
+                self.model.add_edge(subj_attr, rxn_node_data, **edge_data)
 
     def _assemble_autophosphorylation(self, stmt):
         """Example: complex(p(HGNC:MAPK14), p(HGNC:TAB1)) =>

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -586,20 +586,16 @@ def _get_evidence(evidence):
     pybel_ev = {pc.EVIDENCE: text}
     # If there is a PMID, use it as the citation
     if evidence.pmid:
-        citation = {
-            pc.CITATION_DB: pc.CITATION_TYPE_PUBMED,
-            pc.CITATION_IDENTIFIER: evidence.pmid,
-        }
+        citation = {pc.CITATION_DB: pc.CITATION_TYPE_PUBMED,
+                    pc.CITATION_IDENTIFIER: evidence.pmid}
     # If no PMID, include the interface and source_api for now--
     # in general this should probably be in the annotations for all evidence
     else:
         cit_source = evidence.source_api if evidence.source_api else 'Unknown'
         cit_id = evidence.source_id if evidence.source_id else 'Unknown'
         cit_ref_str = '%s:%s' % (cit_source, cit_id)
-        citation = {
-            pc.CITATION_DB: pc.CITATION_TYPE_OTHER,
-            pc.CITATION_IDENTIFIER: cit_ref_str,
-        }
+        citation = {pc.CITATION_DB: pc.CITATION_TYPE_OTHER,
+                    pc.CITATION_IDENTIFIER: cit_ref_str}
     pybel_ev[pc.CITATION] = citation
 
     annotations = {}

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -396,7 +396,7 @@ def belgraph_to_signed_graph(
             edge_set.add((u, v, 0))
             if symmetric_variant_links:
                 edge_set.add((v, u, 0))
-        elif rel in pc.HAS_COMPONENT and include_components:
+        elif rel in pc.PART_OF and include_components:
             edge_set.add((u, v, 0))
             if symmetric_component_links:
                 edge_set.add((v, u, 0))

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -1,20 +1,18 @@
 from __future__ import absolute_import, print_function, unicode_literals
-
-import logging
-import uuid
 from builtins import dict, str
-from copy import copy, deepcopy
-
+import uuid
+import logging
 import networkx as nx
+from copy import copy, deepcopy
 import pybel
 import pybel.constants as pc
 from pybel.dsl import *
 from pybel.language import pmod_namespace
-
-from indra.databases import hgnc_client
 from indra.statements import *
+from indra.databases import hgnc_client
 
 logger = logging.getLogger(__name__)
+
 
 _indra_pybel_act_map = {
     'kinase': 'kin',
@@ -71,7 +69,6 @@ class PybelAssembler(object):
     >>> belgraph.number_of_edges()
     2
     """
-
     def __init__(self, stmts=None, name=None, description=None, version=None,
                  authors=None, contact=None, license=None, copyright=None,
                  disclaimer=None):
@@ -96,17 +93,15 @@ class PybelAssembler(object):
         )
         ns_dict = {
             'HGNC': 'https://arty.scai.fraunhofer.de/artifactory/bel/'
-                    'namespace/hgnc-human-genes/'
-                    'hgnc-human-genes-20170725.belns',
+                    'namespace/hgnc-human-genes/hgnc-human-genes-20170725.belns',
             'UP': 'https://arty.scai.fraunhofer.de/artifactory/bel/'
                   'namespace/swissprot/swissprot-20170725.belns',
             'IP': 'https://arty.scai.fraunhofer.de/artifactory/bel/'
                   'namespace/interpro/interpro-20170731.belns',
             'FPLX': 'https://raw.githubusercontent.com/sorgerlab/famplex/'
-                    '5f5b573fe26d7405dbccb711ae8e5697b6a3ec7e/export/'
-                    'famplex.belns',
-            # 'PFAM':
-            # 'NXPFA':
+                    '5f5b573fe26d7405dbccb711ae8e5697b6a3ec7e/export/famplex.belns',
+            #'PFAM':
+            #'NXPFA':
             'CHEBI': 'https://arty.scai.fraunhofer.de/artifactory/bel/'
                      'namespace/chebi-ids/chebi-ids-20170725.belns',
             'GO': 'https://arty.scai.fraunhofer.de/artifactory/bel/'
@@ -123,10 +118,8 @@ class PybelAssembler(object):
     def make_model(self):
         for stmt in self.statements:
             # Skip statements with no subject
-            if (
-                stmt.agent_list()[0] is None
-                and not isinstance(stmt, Conversion)
-            ):
+            if stmt.agent_list()[0] is None and \
+                not isinstance(stmt, Conversion):
                 continue
             # Assemble statements
             if isinstance(stmt, Modification):
@@ -217,8 +210,7 @@ class PybelAssembler(object):
         path : str
             The path to output to
         output_format : Optional[str]
-            Output format as ``cx``, ``pickle``, ``json`` or defaults to
-            ``bel``
+            Output format as ``cx``, ``pickle``, ``json`` or defaults to ``bel``
         """
         if output_format == 'pickle':
             pybel.to_pickle(self.model, path)
@@ -228,7 +220,7 @@ class PybelAssembler(object):
                     pybel.to_json_file(self.model, fh)
                 elif output_format == 'cx':
                     pybel.to_cx_file(self.model, fh)
-                else:  # output_format == 'bel':
+                else: # output_format == 'bel':
                     pybel.to_bel(self.model, fh)
 
     def _add_nodes_edges(self, subj_agent, obj_agent, relation, stmt_hash,
@@ -300,7 +292,7 @@ class PybelAssembler(object):
         relation = get_causal_edge(stmt, activates)
         stmt_hash = stmt.get_hash(refresh=True)
         if not stmt.agent.mods and not stmt.agent.bound_conditions and \
-            not stmt.agent.mutations:
+                not stmt.agent.mutations:
             self._add_nodes_edges(stmt.agent, act_agent, relation,
                                   stmt_hash, stmt.evidence)
         else:
@@ -335,7 +327,7 @@ class PybelAssembler(object):
                                        products(a(CHEBI:"CHEBI:4170")))"""
         pybel_lists = ([], [])
         for pybel_list, agent_list in \
-            zip(pybel_lists, (stmt.obj_from, stmt.obj_to)):
+                            zip(pybel_lists, (stmt.obj_from, stmt.obj_to)):
             for agent in agent_list:
                 node = _get_agent_grounding(agent)
                 # TODO check for missing grounding?
@@ -385,10 +377,10 @@ class PybelAssembler(object):
                               stmt.get_hash(refresh=True), stmt.evidence)
 
     def _assemble_translocation(self, stmt):
-        # cc = hierarchies['cellular_component']
-        # nuc_uri = cc.find_entity('nucleus')
-        # cyto_uri = cc.find_entity('cytoplasm')
-        # cyto_go = cyto_uri.rsplit('/')[-1]
+        #cc = hierarchies['cellular_component']
+        #nuc_uri = cc.find_entity('nucleus')
+        #cyto_uri = cc.find_entity('cytoplasm')
+        #cyto_go = cyto_uri.rsplit('/')[-1]
         pass
 
 
@@ -510,7 +502,6 @@ def _get_agent_node_no_bcs(agent):
 
 def _get_agent_grounding(agent):
     """Convert an agent to the corresponding PyBEL DSL object (to be filled with variants later)."""
-
     def _get_id(_agent, key):
         _id = _agent.db_refs.get(key)
         if isinstance(_id, list):

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -2,17 +2,17 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import uuid
+from builtins import dict, str
 from copy import copy, deepcopy
 
 import networkx as nx
-from builtins import dict, str
-
 import pybel
 import pybel.constants as pc
-from indra.databases import hgnc_client
-from indra.statements import *
 from pybel.dsl import *
 from pybel.language import pmod_namespace
+
+from indra.databases import hgnc_client
+from indra.statements import *
 
 logger = logging.getLogger(__name__)
 

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -577,16 +577,16 @@ def _get_evidence(evidence):
     pybel_ev = {pc.EVIDENCE: text}
     # If there is a PMID, use it as the citation
     if evidence.pmid:
-        citation = {pc.CITATION_TYPE: pc.CITATION_TYPE_PUBMED,
-                    pc.CITATION_REFERENCE: evidence.pmid}
+        citation = {pc.CITATION_DB: pc.CITATION_TYPE_PUBMED,
+                    pc.CITATION_IDENTIFIER: evidence.pmid}
     # If no PMID, include the interface and source_api for now--
     # in general this should probably be in the annotations for all evidence
     else:
         cit_source = evidence.source_api if evidence.source_api else 'Unknown'
         cit_id = evidence.source_id if evidence.source_id else 'Unknown'
         cit_ref_str = '%s:%s' % (cit_source, cit_id)
-        citation = {pc.CITATION_TYPE: pc.CITATION_TYPE_OTHER,
-                    pc.CITATION_REFERENCE: cit_ref_str}
+        citation = {pc.CITATION_DB: pc.CITATION_TYPE_OTHER,
+                    pc.CITATION_IDENTIFIER: cit_ref_str}
     pybel_ev[pc.CITATION] = citation
 
     annotations = {}

--- a/indra/explanation/reporting.py
+++ b/indra/explanation/reporting.py
@@ -93,11 +93,11 @@ PybelEdge = namedtuple(
 def pybel_edge_to_english(pybel_edge):
     source_str = _assemble_agent_str(pybel_edge.source)
     target_str = _assemble_agent_str(pybel_edge.target)
-    if pybel_edge.relation == 'hasComponent':
+    if pybel_edge.relation == 'partOf':
         if pybel_edge.reverse:
-            rel_str = ' is a part of '
-        else:
             rel_str = ' has a component '
+        else:
+            rel_str = ' is a part of '
     elif pybel_edge.relation == 'hasVariant':
         if pybel_edge.reverse:
             rel_str = ' is a variant of '
@@ -149,11 +149,11 @@ def stmts_from_pybel_path(path, model, from_db=True, stmts=None):
         for j in range(len(edges)):
             try:
                 hashes.add(edges[j]['stmt_hash'])
-            # hasComponent and hasVariant edges don't have hashes
+            #  and hasVariant edges don't have hashes
             except KeyError:
                 continue
         # If we didn't get any hashes, we can get PybelEdge object from
-        # hasComponent and hasVariant edges
+        # partOf and hasVariant edges
         if not hashes:
             statements = []
             # Can't get statements without hash from db

--- a/indra/explanation/reporting.py
+++ b/indra/explanation/reporting.py
@@ -149,7 +149,7 @@ def stmts_from_pybel_path(path, model, from_db=True, stmts=None):
         for j in range(len(edges)):
             try:
                 hashes.add(edges[j]['stmt_hash'])
-            #  and hasVariant edges don't have hashes
+            # partOf and hasVariant edges don't have hashes
             except KeyError:
                 continue
         # If we didn't get any hashes, we can get PybelEdge object from

--- a/indra/sources/bel/__init__.py
+++ b/indra/sources/bel/__init__.py
@@ -1,3 +1,3 @@
 from .api import process_large_corpus, process_small_corpus, process_belrdf, \
-    process_belscript, process_pybel_graph, process_json_file, \
+    process_belscript, process_pybel_graph, process_nodelink_json_file, \
     process_pybel_neighborhood, process_cbn_jgif_file

--- a/indra/sources/bel/__init__.py
+++ b/indra/sources/bel/__init__.py
@@ -1,3 +1,3 @@
 from .api import process_large_corpus, process_small_corpus, process_belrdf, \
-    process_belscript, process_pybel_graph, process_nodelink_json_file, \
+    process_belscript, process_pybel_graph, process_json_file, \
     process_pybel_neighborhood, process_cbn_jgif_file

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -6,7 +6,6 @@ import requests
 from functools import lru_cache
 from .processor import PybelProcessor
 
-
 logger = logging.getLogger(__name__)
 
 branch = (
@@ -274,5 +273,3 @@ def process_belrdf(rdf_str, print_output=True):
         bp.print_statement_coverage()
         bp.print_statements()
     return bp
-
-

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -1,14 +1,11 @@
-# -*- coding: utf-8 -*-
-
-import json
-import logging
 import zlib
-from functools import lru_cache
-
+import json
 import pybel
+import logging
 import requests
-
+from functools import lru_cache
 from .processor import PybelProcessor
+
 
 logger = logging.getLogger(__name__)
 

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -1,9 +1,13 @@
-import zlib
+# -*- coding: utf-8 -*-
+
 import json
-import pybel
 import logging
-import requests
+import zlib
 from functools import lru_cache
+
+import pybel
+import requests
+
 from .processor import PybelProcessor
 
 logger = logging.getLogger(__name__)

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -9,11 +9,12 @@ from .processor import PybelProcessor
 
 logger = logging.getLogger(__name__)
 
-large_corpus_url = ('https://github.com/cthoyt/selventa-knowledge/raw/master/'
-                    'selventa_knowledge/large_corpus-20170611.bel.json.gz')
-small_corpus_url = ('https://github.com/cthoyt/selventa-knowledge/raw/master/'
-                    'selventa_knowledge/'
-                    'selventa-small-corpus-20150611.bel.json.gz')
+branch = (
+    'https://github.com/cthoyt/selventa-knowledge/raw/'
+    'prepare-pybel-14/selventa_knowledge'
+)
+large_corpus_url = branch + 'large_corpus.bel.nodelink.json.gz'
+small_corpus_url = branch + 'small_corpus.bel.nodelink.json.gz'
 
 
 def process_small_corpus():

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -2,14 +2,12 @@
 
 """High level API functions for the PyBEL processor."""
 
-import json
-import logging
 import zlib
-from functools import lru_cache
-
+import json
 import pybel
+import logging
 import requests
-
+from functools import lru_cache
 from .processor import PybelProcessor
 
 logger = logging.getLogger(__name__)
@@ -31,10 +29,8 @@ def process_small_corpus():
         its statements attribute.
 
     """
-    return process_pybel_network(
-        network_type='graph_jsongz_url',
-        network_file=small_corpus_url,
-    )
+    return process_pybel_network(network_type='graph_jsongz_url',
+                                 network_file=small_corpus_url)
 
 
 def process_large_corpus():
@@ -47,10 +43,8 @@ def process_large_corpus():
         its statements attribute.
 
     """
-    return process_pybel_network(
-        network_type='graph_jsongz_url',
-        network_file=large_corpus_url,
-    )
+    return process_pybel_network(network_type='graph_jsongz_url',
+                                 network_file=large_corpus_url)
 
 
 def process_pybel_network(network_type, network_file, **kwargs):
@@ -74,8 +68,8 @@ def process_pybel_network(network_type, network_file, **kwargs):
     """
     if network_type == 'belscript':
         return process_belscript(network_file, **kwargs)
-    elif network_type == 'nodelink':
-        return process_nodelink_json_file(network_file)
+    elif network_type == 'json':
+        return process_json_file(network_file)
     elif network_type == 'cbn_jgif':
         return process_cbn_jgif_file(network_file)
     elif network_type == 'graph_jsongz_url':
@@ -188,13 +182,15 @@ def process_belscript(file_name, **kwargs):
         bp.statements.
 
     """
-    kwargs.setdefault('citation_clearing', False)
-    kwargs.setdefault('no_identifier_validation', True)
+    if 'citation_clearing' not in kwargs:
+        kwargs['citation_clearing'] = False
+    if 'no_identifier_validation' not in kwargs:
+        kwargs['no_identifier_validation'] = True
     pybel_graph = pybel.from_bel_script(file_name, **kwargs)
     return process_pybel_graph(pybel_graph)
 
 
-def process_nodelink_json_file(file_name):
+def process_json_file(file_name):
     """Return a PybelProcessor by processing a Node-Link JSON file.
 
     For more information on this format, see:

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""High level API functions for the PyBEL processor."""
+
 import json
 import logging
 import zlib
@@ -13,7 +15,8 @@ from .processor import PybelProcessor
 logger = logging.getLogger(__name__)
 
 version = 'v1.0.0'
-branch = 'https://github.com/cthoyt/selventa-knowledge/raw/{}/selventa_knowledge/{}'
+branch = 'https://github.com/cthoyt/selventa-knowledge/raw/' \
+         '{}/selventa_knowledge/{}'
 large_corpus_url = branch.format(version, 'large_corpus.bel.nodelink.json.gz')
 small_corpus_url = branch.format(version, 'small_corpus.bel.nodelink.json.gz')
 
@@ -26,6 +29,7 @@ def process_small_corpus():
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         its statements attribute.
+
     """
     return process_pybel_network(
         network_type='graph_jsongz_url',
@@ -41,6 +45,7 @@ def process_large_corpus():
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         its statements attribute.
+
     """
     return process_pybel_network(
         network_type='graph_jsongz_url',
@@ -65,6 +70,7 @@ def process_pybel_network(network_type, network_file, **kwargs):
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         bp.statements.
+
     """
     if network_type == 'belscript':
         return process_belscript(network_file, **kwargs)
@@ -116,6 +122,7 @@ def process_pybel_neighborhood(entity_names, network_type='graph_jsongz_url',
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         bp.statements.
+
     """
     bp = process_pybel_network(network_type, network_file, **kwargs)
     filtered_stmts = []
@@ -148,6 +155,7 @@ def process_pybel_graph(graph):
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         bp.statements.
+
     """
     bp = PybelProcessor(graph)
     bp.get_statements()
@@ -178,6 +186,7 @@ def process_belscript(file_name, **kwargs):
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         bp.statements.
+
     """
     kwargs.setdefault('citation_clearing', False)
     kwargs.setdefault('no_identifier_validation', True)
@@ -201,6 +210,7 @@ def process_nodelink_json_file(file_name):
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         bp.statements.
+
     """
     pybel_graph = pybel.from_nodelink_file(file_name, check_version=False)
     return process_pybel_graph(pybel_graph)
@@ -219,6 +229,7 @@ def process_cbn_jgif_file(file_name):
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         bp.statements.
+
     """
     with open(file_name, 'r') as jgf:
         return process_pybel_graph(pybel.from_cbn_jgif(json.load(jgf)))
@@ -247,6 +258,7 @@ def process_belrdf(rdf_str, print_output=True):
     This function calls all the specific get_type_of_mechanism()
     functions of the newly constructed BelRdfProcessor to extract
     INDRA Statements.
+
     """
     import rdflib
     from rdflib.plugins.parsers.ntriples import ParseError

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 branch = (
     'https://github.com/cthoyt/selventa-knowledge/raw/'
-    'prepare-pybel-14/selventa_knowledge'
+    'prepare-pybel-14/selventa_knowledge/'
 )
 large_corpus_url = branch + 'large_corpus.bel.nodelink.json.gz'
 small_corpus_url = branch + 'small_corpus.bel.nodelink.json.gz'

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -6,7 +6,6 @@ import requests
 from functools import lru_cache
 from .processor import PybelProcessor
 
-
 logger = logging.getLogger(__name__)
 
 version = 'v1.0.0'

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -8,12 +8,10 @@ from .processor import PybelProcessor
 
 logger = logging.getLogger(__name__)
 
-branch = (
-    'https://github.com/cthoyt/selventa-knowledge/raw/'
-    'prepare-pybel-14/selventa_knowledge/'
-)
-large_corpus_url = branch + 'large_corpus.bel.nodelink.json.gz'
-small_corpus_url = branch + 'small_corpus.bel.nodelink.json.gz'
+version = 'v1.0.0'
+branch = 'https://github.com/cthoyt/selventa-knowledge/raw/{}/selventa_knowledge/{}'
+large_corpus_url = branch.format(version, 'large_corpus.bel.nodelink.json.gz')
+small_corpus_url = branch.format(version, 'small_corpus.bel.nodelink.json.gz')
 
 
 def process_small_corpus():

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -10,6 +10,7 @@ import requests
 from functools import lru_cache
 from .processor import PybelProcessor
 
+
 logger = logging.getLogger(__name__)
 
 version = 'v1.0.0'
@@ -27,7 +28,6 @@ def process_small_corpus():
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         its statements attribute.
-
     """
     return process_pybel_network(network_type='graph_jsongz_url',
                                  network_file=small_corpus_url)
@@ -41,7 +41,6 @@ def process_large_corpus():
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         its statements attribute.
-
     """
     return process_pybel_network(network_type='graph_jsongz_url',
                                  network_file=large_corpus_url)
@@ -64,7 +63,6 @@ def process_pybel_network(network_type, network_file, **kwargs):
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         bp.statements.
-
     """
     if network_type == 'belscript':
         return process_belscript(network_file, **kwargs)
@@ -116,7 +114,6 @@ def process_pybel_neighborhood(entity_names, network_type='graph_jsongz_url',
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         bp.statements.
-
     """
     bp = process_pybel_network(network_type, network_file, **kwargs)
     filtered_stmts = []
@@ -149,7 +146,6 @@ def process_pybel_graph(graph):
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         bp.statements.
-
     """
     bp = PybelProcessor(graph)
     bp.get_statements()
@@ -180,7 +176,6 @@ def process_belscript(file_name, **kwargs):
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         bp.statements.
-
     """
     if 'citation_clearing' not in kwargs:
         kwargs['citation_clearing'] = False
@@ -206,7 +201,6 @@ def process_json_file(file_name):
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         bp.statements.
-
     """
     pybel_graph = pybel.from_nodelink_file(file_name, check_version=False)
     return process_pybel_graph(pybel_graph)
@@ -225,7 +219,6 @@ def process_cbn_jgif_file(file_name):
     bp : PybelProcessor
         A PybelProcessor object which contains INDRA Statements in
         bp.statements.
-
     """
     with open(file_name, 'r') as jgf:
         return process_pybel_graph(pybel.from_cbn_jgif(json.load(jgf)))
@@ -254,7 +247,6 @@ def process_belrdf(rdf_str, print_output=True):
     This function calls all the specific get_type_of_mechanism()
     functions of the newly constructed BelRdfProcessor to extract
     INDRA Statements.
-
     """
     import rdflib
     from rdflib.plugins.parsers.ntriples import ParseError

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -1,7 +1,6 @@
 import zlib
 import json
 import pybel
-import pickle
 import logging
 import requests
 from functools import lru_cache
@@ -74,12 +73,11 @@ def process_pybel_network(network_type, network_file, **kwargs):
         res = requests.get(network_file)
         res.raise_for_status()
         content = zlib.decompress(res.content, zlib.MAX_WBITS | 32)
-        graph = pybel.from_jsons(content)
+        graph = pybel.from_nodelink(json.loads(content))
         return process_pybel_graph(graph)
     elif network_type == 'graph_pickle':
-        with open(network_file, 'rb') as fh:
-            graph = pickle.load(fh)
-            return process_pybel_graph(graph)
+        graph = pybel.from_pickle(network_file)
+        return process_pybel_graph(graph)
     else:
         raise ValueError('Unknown network type: %s' % network_type)
 
@@ -179,7 +177,7 @@ def process_belscript(file_name, **kwargs):
         kwargs['citation_clearing'] = False
     if 'no_identifier_validation' not in kwargs:
         kwargs['no_identifier_validation'] = True
-    pybel_graph = pybel.from_path(file_name, **kwargs)
+    pybel_graph = pybel.from_bel_script(file_name, **kwargs)
     return process_pybel_graph(pybel_graph)
 
 
@@ -201,7 +199,7 @@ def process_json_file(file_name):
         bp.statements.
     """
     with open(file_name, 'rt') as fh:
-        pybel_graph = pybel.from_json_file(fh, False)
+        pybel_graph = pybel.from_nodelink_file(fh, check_version=False)
     return process_pybel_graph(pybel_graph)
 
 

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -829,8 +829,8 @@ def _get_translocation_target(node_modifier_data):
     to_loc_info = transloc_data.get(pc.TO_LOC)
     if not to_loc_info:
         return None
-    to_loc_ns = to_loc_info.namespace
-    to_loc_name = to_loc_info.name
+    to_loc_ns = to_loc_info.get('namespace')
+    to_loc_name = to_loc_info.get('name')
     # Only use GO Cellular Component location names
     if to_loc_ns not in ('GO', 'GOCC', 'GOCCID') or not to_loc_name:
         return None

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -828,8 +828,8 @@ def _get_translocation_target(node_modifier_data):
     to_loc_info = transloc_data.get(pc.TO_LOC)
     if not to_loc_info:
         return None
-    to_loc_ns = to_loc_info.namespace
-    to_loc_name = to_loc_info.name
+    to_loc_ns = to_loc_info.get(pc.NAMESPACE)
+    to_loc_name = to_loc_info.get(pc.NAME)
     # Only use GO Cellular Component location names
     if to_loc_ns not in ('GO', 'GOCC', 'GOCCID') or not to_loc_name:
         return None
@@ -851,7 +851,7 @@ def _has_unhandled_modifiers(node_modifier_data):
     if mod is None:
         return False
     if mod in (pc.CELL_SECRETION, pc.CELL_SURFACE_EXPRESSION):
-        logger.info("Unhandled node modifier data: %s" % node_modifier_data)
+        logger.info("Unhandled node modifier data: %s", node_modifier_data)
         return True
 
 

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -37,7 +37,8 @@ _pybel_indra_pmod_map = {
 
 #: A mapping from the BEL text location annotation to the INDRA ones at
 # :py:data:`indra.reach.processor._section_list`
-#: see https://arty.scai.fraunhofer.de/artifactory/bel/annotation/text-location/text-location-1.0.0.belanno
+#: see https://arty.scai.fraunhofer.de/artifactory/bel/annotation/
+#       text-location/text-location-1.0.0.belanno
 _pybel_text_location_map = {
     "Abstract": 'abstract',
     "Results": 'results',
@@ -46,7 +47,7 @@ _pybel_text_location_map = {
     'Introduction': 'introduction',
     'Methods': 'methods',
     'Discussion': 'discussion',
-    'Conclusion': 'conclusion'
+    'Conclusion': 'conclusion',
 }
 
 
@@ -167,7 +168,7 @@ class PybelProcessor(object):
             # rxn(reactants(r1,...,rn), products(p1,...pn))
             # Complex(a,b)
             # p(A, pmod('ph')) -> Complex(A, B)
-            # Complex(A-Ph, B) 
+            # Complex(A-Ph, B)
             # Complexes
             #   complex(x(Foo), x(Bar), ...)
             else:
@@ -379,7 +380,7 @@ def get_agent(node_data, node_modifier_data=None):
 
     # Skip gene/protein fusions
     if isinstance(node_data, dsl.FusionBase):
-        logger.info("Gene and protein fusions not handled: %s" % str(node_data))
+        logger.info("Gene and protein fusions not handled: %s", node_data)
         return None
     # COMPLEXES ------------
     # First, handle complexes, which will consist recursively of other agents

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -213,7 +213,7 @@ class PybelProcessor(object):
 
     def _get_modification(self, u_data, v_data, k, edge_data):
         subj_agent = get_agent(u_data, edge_data.get(pc.SUBJECT))
-        mods, muts = _get_all_pmods(v_data)
+        mods, muts = _get_mods_and_muts(v_data)
         v_data_no_mods = v_data.get_parent()
         obj_agent = get_agent(v_data_no_mods, edge_data.get(pc.OBJECT))
         if subj_agent is None or obj_agent is None:
@@ -230,12 +230,10 @@ class PybelProcessor(object):
         # Subject info
         subj_agent = get_agent(u_data, edge_data.get(pc.SUBJECT))
         subj_activity = _get_activity_condition(edge_data.get(pc.SUBJECT))
-        subj_function = u_data.function
         # Object info
         # Note: Don't pass the object modifier data because we don't want to
         # put an activity on the agent
         obj_agent = get_agent(v_data, None)
-        obj_function = v_data.function
         # If it's a bioprocess object, we won't have an activity in the edge
         if isinstance(v_data, (dsl.BiologicalProcess, dsl.Pathology)):
             activity_type = 'activity'
@@ -425,7 +423,7 @@ def get_agent(node_data, node_modifier_data=None):
         return None
 
     # Get modification conditions
-    mods, muts = _get_all_pmods(node_data)
+    mods, muts = _get_mods_and_muts(node_data)
     # Get activity condition
     ac = _get_activity_condition(node_modifier_data)
     to_loc = _get_translocation_target(node_modifier_data)
@@ -733,7 +731,21 @@ class AnnotationManager(object):
         self.failures[key].add(value)
 
 
-def _get_all_pmods(node_data):
+def _get_mods_and_muts(node_data):
+    """Get all modifications and mutations on the PyBEL node.
+
+    Parameters
+    ----------
+    node_data : pybel.dsl.CentralDogma
+        A PyBEL node
+
+    Returns
+    -------
+    mods : List[ModCondition]
+        A list of modifications to the given abundance
+    muts : List[MutCondition]
+        A list of mutations to the given abundance
+    """
     mods = []
     muts = []
     variants = node_data.get(pc.VARIANTS)
@@ -792,7 +804,7 @@ def _get_activity_condition(node_modifier_data):
     if activity_ns == pc.BEL_DEFAULT_NAMESPACE:
         activity_name = effect[pc.NAME]
         activity_type = _pybel_indra_act_map.get(activity_name)
-        # If an activity type in Bel/PyBel that is not implemented in INDRA,
+        # If an activity type in Bel/PyBEL that is not implemented in INDRA,
         # return generic activity
         if activity_type is None:
             return ActivityCondition('activity', True)

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""Processor for PyBEL."""
+
 import logging
 import re
 from collections import defaultdict
@@ -71,6 +73,7 @@ class PybelProcessor(object):
     ----------
     statements : list[indra.statements.Statement]
         A list of extracted INDRA Statements representing BEL Statements.
+
     """
 
     def __init__(self, graph):
@@ -209,11 +212,17 @@ class PybelProcessor(object):
             # stmt_class = RegulateAmount
             return
         elif has_deg:
-            stmt_class = (DecreaseAmount if rel in
-                                            pc.CAUSAL_INCREASE_RELATIONS else IncreaseAmount)
+            stmt_class = (
+                DecreaseAmount
+                if rel in pc.CAUSAL_INCREASE_RELATIONS else
+                IncreaseAmount
+            )
         else:
-            stmt_class = (IncreaseAmount if rel in
-                                            pc.CAUSAL_INCREASE_RELATIONS else DecreaseAmount)
+            stmt_class = (
+                IncreaseAmount
+                if rel in pc.CAUSAL_INCREASE_RELATIONS else
+                DecreaseAmount
+            )
         ev = self._get_evidence(u_data, v_data, k, edge_data)
         stmt = stmt_class(subj_agent, obj_agent, evidence=[ev])
         self.statements.append(stmt)
@@ -315,13 +324,15 @@ class PybelProcessor(object):
         product_agents = [get_agent(p) for p in v_data[pc.PRODUCTS]]
         # We are not handling the following degenerate cases:
         # If there is no subject agent
-        if (subj_agent is None or
+        if (
+            subj_agent is None or
             # If get_agent returned None for any of the reactants or
             # products
             any(r is None for r in reactant_agents) or
             any(p is None for p in product_agents) or
             # If there are no reactants and or no products
-            (not reactant_agents and not product_agents)):
+            (not reactant_agents and not product_agents)
+        ):
             self.unhandled.append((u_data, v_data, k, edge_data))
             return
         ev = self._get_evidence(u_data, v_data, k, edge_data)
@@ -369,6 +380,7 @@ class PybelProcessor(object):
 
 
 def get_agent(node_data, node_modifier_data=None):
+    """Get an INDRA agent from a PyBEL node."""
     # Check the node type/function
     if not isinstance(node_data, dsl.BaseEntity):
         raise TypeError('Non-pybel dict given: ({}) {}'.format(
@@ -463,6 +475,7 @@ def get_db_refs_by_name(ns, name, node_data):
         The standardized name for the given entity.
     db_refs : dict
         The grounding for the given entity.
+
     """
     db_refs = None
     if ns == 'HGNC':
@@ -601,6 +614,7 @@ def get_db_refs_by_ident(ns, ident, node_data):
         The standardized name for the given entity.
     db_refs : dict
         The grounding for the given entity.
+
     """
     name = node_data.name
     db_refs = None
@@ -661,6 +675,7 @@ def extract_context(annotations, annot_manager):
     -------
     bc : BioContext
         An INDRA BioContext object
+
     """
 
     def get_annot(annotations, key):
@@ -753,6 +768,7 @@ def _get_mods_and_muts(node_data):
         A list of modifications to the given abundance
     muts : List[MutCondition]
         A list of mutations to the given abundance
+
     """
     mods = []
     muts = []

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -3,14 +3,11 @@
 import logging
 import re
 from collections import defaultdict
-from pybel.struct import has_protein_modification
-from pybel.canonicalize import edge_to_bel
-import pybel.dsl as dsl
+
 from bel_resources import get_bel_resource
-from indra.statements import *
-from indra.sources.bel.rdf_processor import bel_to_indra, chebi_name_id
-from indra.databases import hgnc_client, uniprot_client, chebi_client, \
-    go_client, mesh_client, mirbase_client
+
+import pybel.constants as pc
+import pybel.dsl as dsl
 from indra.assemblers.pybel.assembler import _pybel_indra_act_map
 from indra.databases import (
     chebi_client, go_client, hgnc_client, mesh_client,

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -328,9 +328,9 @@ class PybelProcessor(object):
         ev_citation = edge_data.get(pc.CITATION)
         ev_pmid = None
         if ev_citation:
-            cit_type = ev_citation[pc.CITATION_TYPE]
-            cit_ref = ev_citation[pc.CITATION_REFERENCE]
-            if cit_type == pc.CITATION_TYPE_PUBMED:
+            cit_type = ev_citation[pc.CITATION_DB]
+            cit_ref = ev_citation[pc.CITATION_IDENTIFIER]
+            if cit_type == pc.CITATION_TYPES[pc.CITATION_TYPE_PUBMED]:
                 ev_pmid = cit_ref
                 ev_ref = None
             else:

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -4,10 +4,12 @@ import logging
 import re
 from collections import defaultdict
 
-from bel_resources import get_bel_resource
-
 import pybel.constants as pc
 import pybel.dsl as dsl
+from bel_resources import get_bel_resource
+from pybel.canonicalize import edge_to_bel
+from pybel.struct import has_protein_modification
+
 from indra.assemblers.pybel.assembler import _pybel_indra_act_map
 from indra.databases import (
     chebi_client, go_client, hgnc_client, mesh_client,
@@ -15,8 +17,6 @@ from indra.databases import (
 )
 from indra.sources.bel.rdf_processor import bel_to_indra, chebi_name_id
 from indra.statements import *
-from pybel.canonicalize import edge_to_bel
-from pybel.struct import has_protein_modification
 
 __all__ = [
     'PybelProcessor',

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -3,11 +3,14 @@
 import logging
 import re
 from collections import defaultdict
-
-from bel_resources import get_bel_resource
-
-import pybel.constants as pc
+from pybel.struct import has_protein_modification
+from pybel.canonicalize import edge_to_bel
 import pybel.dsl as dsl
+from bel_resources import get_bel_resource
+from indra.statements import *
+from indra.sources.bel.rdf_processor import bel_to_indra, chebi_name_id
+from indra.databases import hgnc_client, uniprot_client, chebi_client, \
+    go_client, mesh_client, mirbase_client
 from indra.assemblers.pybel.assembler import _pybel_indra_act_map
 from indra.databases import (
     chebi_client, go_client, hgnc_client, mesh_client,
@@ -106,7 +109,7 @@ class PybelProcessor(object):
             #   x(Foo) -> p(Bar, pmod(Ph))
             #   act(x(Foo)) -> p(Bar, pmod(Ph))
             if isinstance(v_data, dsl.Protein) and \
-                has_protein_modification(v_data):
+                    has_protein_modification(v_data):
                 if obj_activity:
                     logger.info("Ignoring object activity modifier in "
                                 "modification statement: %s, %s, %s, %s",
@@ -835,8 +838,8 @@ def _get_translocation_target(node_modifier_data):
     to_loc_info = transloc_data.get(pc.TO_LOC)
     if not to_loc_info:
         return None
-    to_loc_ns = to_loc_info.get(pc.NAMESPACE)
-    to_loc_name = to_loc_info.get(pc.NAME)
+    to_loc_ns = to_loc_info.namespace
+    to_loc_name = to_loc_info.name
     # Only use GO Cellular Component location names
     if to_loc_ns not in ('GO', 'GOCC', 'GOCCID') or not to_loc_name:
         return None

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -2,16 +2,14 @@
 
 """Processor for PyBEL."""
 
-import logging
 import re
-from collections import defaultdict
-
-import pybel.constants as pc
+import logging
 import pybel.dsl as dsl
-from bel_resources import get_bel_resource
+import pybel.constants as pc
+from collections import defaultdict
 from pybel.canonicalize import edge_to_bel
+from bel_resources import get_bel_resource
 from pybel.struct import has_protein_modification
-
 from indra.assemblers.pybel.assembler import _pybel_indra_act_map
 from indra.databases import (
     chebi_client, go_client, hgnc_client, mesh_client,
@@ -26,6 +24,7 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
+
 
 _pybel_indra_pmod_map = {
     'Ph': 'phosphorylation',
@@ -43,9 +42,8 @@ _pybel_indra_pmod_map = {
 }
 
 #: A mapping from the BEL text location annotation to the INDRA ones at
-# :py:data:`indra.reach.processor._section_list`
-#: see https://arty.scai.fraunhofer.de/artifactory/bel/annotation/
-#       text-location/text-location-1.0.0.belanno
+#: :py:data:`indra.reach.processor._section_list`
+#: see https://arty.scai.fraunhofer.de/artifactory/bel/annotation/text-location/text-location-1.0.0.belanno
 _pybel_text_location_map = {
     "Abstract": 'abstract',
     "Results": 'results',
@@ -54,7 +52,7 @@ _pybel_text_location_map = {
     'Introduction': 'introduction',
     'Methods': 'methods',
     'Discussion': 'discussion',
-    'Conclusion': 'conclusion',
+    'Conclusion': 'conclusion'
 }
 
 
@@ -75,7 +73,6 @@ class PybelProcessor(object):
         A list of extracted INDRA Statements representing BEL Statements.
 
     """
-
     def __init__(self, graph):
         self.graph = graph
         self.statements = []
@@ -212,17 +209,11 @@ class PybelProcessor(object):
             # stmt_class = RegulateAmount
             return
         elif has_deg:
-            stmt_class = (
-                DecreaseAmount
-                if rel in pc.CAUSAL_INCREASE_RELATIONS else
-                IncreaseAmount
-            )
+            stmt_class = (DecreaseAmount
+                          if rel in pc.CAUSAL_INCREASE_RELATIONS else IncreaseAmount)
         else:
-            stmt_class = (
-                IncreaseAmount
-                if rel in pc.CAUSAL_INCREASE_RELATIONS else
-                DecreaseAmount
-            )
+            stmt_class = (IncreaseAmount
+                          if rel in pc.CAUSAL_INCREASE_RELATIONS else DecreaseAmount)
         ev = self._get_evidence(u_data, v_data, k, edge_data)
         stmt = stmt_class(subj_agent, obj_agent, evidence=[ev])
         self.statements.append(stmt)
@@ -264,13 +255,9 @@ class PybelProcessor(object):
             return
         # Check which kind of statement we need to make
         # GtpActivation
-        if (
-            subj_activity
-            and subj_activity.activity_type == 'gtpbound'
-            and isinstance(u_data, dsl.Protein)
-            and isinstance(v_data, dsl.Protein)
-            and edge_data[pc.RELATION] == pc.DIRECTLY_INCREASES
-        ):
+        if subj_activity and subj_activity.activity_type == 'gtpbound' and \
+            isinstance(u_data, dsl.Protein) and isinstance(v_data, dsl.Protein) and \
+            edge_data[pc.RELATION] == pc.DIRECTLY_INCREASES:
             stmt_class = GtpActivation
         elif edge_data[pc.RELATION] in pc.CAUSAL_INCREASE_RELATIONS:
             stmt_class = Activation
@@ -294,7 +281,7 @@ class PybelProcessor(object):
             self.unhandled.append((u_data, v_data, edge_data))
             return
         obj_activity_condition = \
-            _get_activity_condition(edge_data.get(pc.OBJECT))
+                        _get_activity_condition(edge_data.get(pc.OBJECT))
         activity_type = obj_activity_condition.activity_type
         # If the relation is DECREASES, this means that this agent state
         # is inactivating
@@ -324,15 +311,13 @@ class PybelProcessor(object):
         product_agents = [get_agent(p) for p in v_data[pc.PRODUCTS]]
         # We are not handling the following degenerate cases:
         # If there is no subject agent
-        if (
-            subj_agent is None or
-            # If get_agent returned None for any of the reactants or
-            # products
-            any(r is None for r in reactant_agents) or
-            any(p is None for p in product_agents) or
-            # If there are no reactants and or no products
-            (not reactant_agents and not product_agents)
-        ):
+        if (subj_agent is None or
+                # If get_agent returned None for any of the reactants or
+                # products
+                any(r is None for r in reactant_agents) or
+                any(p is None for p in product_agents) or
+                # If there are no reactants and or no products
+                (not reactant_agents and not product_agents)):
             self.unhandled.append((u_data, v_data, k, edge_data))
             return
         ev = self._get_evidence(u_data, v_data, k, edge_data)
@@ -417,7 +402,7 @@ def get_agent(node_data, node_modifier_data=None):
         bound_conditions = [BoundCondition(get_agent(m), True)
                             for m in members[1:]]
         # Check the bound_conditions for any None agents
-        if any(bc.agent is None for bc in bound_conditions):
+        if any([bc.agent is None for bc in bound_conditions]):
             return None
         main_agent.bound_conditions = bound_conditions
         # Get activity of main agent
@@ -858,7 +843,7 @@ def _get_translocation_target(node_modifier_data):
         return None
     try:
         if re.match(r'\d+', to_loc_name) and \
-            not to_loc_name.startswith('GO'):
+                not to_loc_name.startswith('GO'):
             to_loc_name = 'GO:' + to_loc_name
         valid_loc = get_valid_location(to_loc_name)
     except InvalidLocationError:

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -1,16 +1,22 @@
-import re
+# -*- coding: utf-8 -*-
+
 import logging
-import pybel.constants as pc
+import re
 from collections import defaultdict
-from pybel.struct import has_protein_modification
-from pybel.canonicalize import edge_to_bel
-import pybel.dsl as dsl
+
 from bel_resources import get_bel_resource
-from indra.statements import *
-from indra.sources.bel.rdf_processor import bel_to_indra, chebi_name_id
-from indra.databases import hgnc_client, uniprot_client, chebi_client, \
-    go_client, mesh_client, mirbase_client
+
+import pybel.constants as pc
+import pybel.dsl as dsl
 from indra.assemblers.pybel.assembler import _pybel_indra_act_map
+from indra.databases import (
+    chebi_client, go_client, hgnc_client, mesh_client,
+    mirbase_client, uniprot_client,
+)
+from indra.sources.bel.rdf_processor import bel_to_indra, chebi_name_id
+from indra.statements import *
+from pybel.canonicalize import edge_to_bel
+from pybel.struct import has_protein_modification
 
 __all__ = [
     'PybelProcessor',
@@ -18,7 +24,6 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
-
 
 _pybel_indra_pmod_map = {
     'Ph': 'phosphorylation',
@@ -67,6 +72,7 @@ class PybelProcessor(object):
     statements : list[indra.statements.Statement]
         A list of extracted INDRA Statements representing BEL Statements.
     """
+
     def __init__(self, graph):
         self.graph = graph
         self.statements = []
@@ -100,7 +106,7 @@ class PybelProcessor(object):
             #   x(Foo) -> p(Bar, pmod(Ph))
             #   act(x(Foo)) -> p(Bar, pmod(Ph))
             if isinstance(v_data, dsl.Protein) and \
-               has_protein_modification(v_data):
+                has_protein_modification(v_data):
                 if obj_activity:
                     logger.info("Ignoring object activity modifier in "
                                 "modification statement: %s, %s, %s, %s",
@@ -204,10 +210,10 @@ class PybelProcessor(object):
             return
         elif has_deg:
             stmt_class = (DecreaseAmount if rel in
-                          pc.CAUSAL_INCREASE_RELATIONS else IncreaseAmount)
+                                            pc.CAUSAL_INCREASE_RELATIONS else IncreaseAmount)
         else:
             stmt_class = (IncreaseAmount if rel in
-                          pc.CAUSAL_INCREASE_RELATIONS else DecreaseAmount)
+                                            pc.CAUSAL_INCREASE_RELATIONS else DecreaseAmount)
         ev = self._get_evidence(u_data, v_data, k, edge_data)
         stmt = stmt_class(subj_agent, obj_agent, evidence=[ev])
         self.statements.append(stmt)
@@ -240,7 +246,7 @@ class PybelProcessor(object):
             activity_type = 'activity'
         else:
             obj_activity_condition = \
-                            _get_activity_condition(edge_data.get(pc.OBJECT))
+                _get_activity_condition(edge_data.get(pc.OBJECT))
             activity_type = obj_activity_condition.activity_type
             assert obj_activity_condition.is_active is True
         # Check for valid subject/object
@@ -310,12 +316,12 @@ class PybelProcessor(object):
         # We are not handling the following degenerate cases:
         # If there is no subject agent
         if (subj_agent is None or
-                # If get_agent returned None for any of the reactants or
-                # products
-                any(r is None for r in reactant_agents) or
-                any(p is None for p in product_agents) or
-                # If there are no reactants and or no products
-                (not reactant_agents and not product_agents)):
+            # If get_agent returned None for any of the reactants or
+            # products
+            any(r is None for r in reactant_agents) or
+            any(p is None for p in product_agents) or
+            # If there are no reactants and or no products
+            (not reactant_agents and not product_agents)):
             self.unhandled.append((u_data, v_data, k, edge_data))
             return
         ev = self._get_evidence(u_data, v_data, k, edge_data)
@@ -656,6 +662,7 @@ def extract_context(annotations, annot_manager):
     bc : BioContext
         An INDRA BioContext object
     """
+
     def get_annot(annotations, key):
         """Return a specific annotation given a key."""
         val = annotations.pop(key, None)
@@ -835,7 +842,7 @@ def _get_translocation_target(node_modifier_data):
         return None
     try:
         if re.match(r'\d+', to_loc_name) and \
-                not to_loc_name.startswith('GO'):
+            not to_loc_name.startswith('GO'):
             to_loc_name = 'GO:' + to_loc_name
         valid_loc = get_valid_location(to_loc_name)
     except InvalidLocationError:

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -1464,37 +1464,37 @@ def test_amount_vs_activation():
 
 
 # Test other ModelChecker types
-st1 = Activation(Agent('A', db_refs={'HGNC': 1}),
-                 Agent('B', db_refs={'HGNC': 2}))
-st2 = Inhibition(Agent('B', db_refs={'HGNC': 2}),
-                 Agent('D', db_refs={'HGNC': 4}))
-st3 = IncreaseAmount(Agent('C', db_refs={'HGNC': 3}),
-                     Agent('B', db_refs={'HGNC': 2}))
-st4 = DecreaseAmount(Agent('C', db_refs={'HGNC': 3}),
-                     Agent('D', db_refs={'HGNC': 4}))
-st5 = IncreaseAmount(Agent('D', db_refs={'HGNC': 4}),
-                     Agent('E', db_refs={'HGNC': 5}))
-st6 = Inhibition(Agent('A', db_refs={'HGNC': 1}),
-                 Agent('B', db_refs={'HGNC': 2}))
-st7 = DecreaseAmount(Agent('B', db_refs={'HGNC': 2}),
-                     Agent('D', db_refs={'HGNC': 4}))
-st8 = IncreaseAmount(Agent('E', db_refs={'HGNC': 5}),
-                     Agent('B', db_refs={'HGNC': 2}))
+st1 = Activation(Agent('A', db_refs={'HGNC': '1'}),
+                 Agent('B', db_refs={'HGNC': '2'}))
+st2 = Inhibition(Agent('B', db_refs={'HGNC': '2'}),
+                 Agent('D', db_refs={'HGNC': '4'}))
+st3 = IncreaseAmount(Agent('C', db_refs={'HGNC': '3'}),
+                     Agent('B', db_refs={'HGNC': '2'}))
+st4 = DecreaseAmount(Agent('C', db_refs={'HGNC': '3'}),
+                     Agent('D', db_refs={'HGNC': '4'}))
+st5 = IncreaseAmount(Agent('D', db_refs={'HGNC': '4'}),
+                     Agent('E', db_refs={'HGNC': '5'}))
+st6 = Inhibition(Agent('A', db_refs={'HGNC': '1'}),
+                 Agent('B', db_refs={'HGNC': '2'}))
+st7 = DecreaseAmount(Agent('B', db_refs={'HGNC': '2'}),
+                     Agent('D', db_refs={'HGNC': '4'}))
+st8 = IncreaseAmount(Agent('E', db_refs={'HGNC': '5'}),
+                     Agent('B', db_refs={'HGNC': '2'}))
 statements = [st1, st2, st3, st4, st5, st6, st7, st8]
 
-test_st1 = Activation(Agent('A', db_refs={'HGNC': 1}),
-                      Agent('E', db_refs={'HGNC': 5}))
-test_st2 = Inhibition(Agent('A', db_refs={'HGNC': 1}),
-                      Agent('E', db_refs={'HGNC': 5}))
-test_st3 = Activation(Agent('A', db_refs={'HGNC': 1}),
-                      Agent('C', db_refs={'HGNC': 3}))
-test_st4 = Activation(Agent('F', db_refs={'HGNC': 6}),
-                      Agent('B', db_refs={'HGNC': 2}))
-test_st5 = DecreaseAmount(Agent('B', db_refs={'HGNC': 2}),
-                          Agent('F', db_refs={'HGNC': 6}))
-test_st6 = ActiveForm(Agent('A', db_refs={'HGNC': 1}), None, True)
-test_st7 = DecreaseAmount(Agent('B', db_refs={'HGNC': 2}),
-                          Agent('B', db_refs={'HGNC': 2}))
+test_st1 = Activation(Agent('A', db_refs={'HGNC': '1'}),
+                      Agent('E', db_refs={'HGNC': '5'}))
+test_st2 = Inhibition(Agent('A', db_refs={'HGNC': '1'}),
+                      Agent('E', db_refs={'HGNC': '5'}))
+test_st3 = Activation(Agent('A', db_refs={'HGNC': '1'}),
+                      Agent('C', db_refs={'HGNC': '3'}))
+test_st4 = Activation(Agent('F', db_refs={'HGNC': '6'}),
+                      Agent('B', db_refs={'HGNC': '2'}))
+test_st5 = DecreaseAmount(Agent('B', db_refs={'HGNC': '2'}),
+                          Agent('F', db_refs={'HGNC': '6'}))
+test_st6 = ActiveForm(Agent('A', db_refs={'HGNC': '1'}), None, True)
+test_st7 = DecreaseAmount(Agent('B', db_refs={'HGNC': '2'}),
+                          Agent('B', db_refs={'HGNC': '2'}))
 test_statements = [
     test_st1, test_st2, test_st3, test_st4, test_st5, test_st6, test_st7]
 
@@ -1572,10 +1572,10 @@ def test_pybel_path():
     pbmc = PybelModelChecker(pybel_model)
     pbmc.add_statements(test_statements)
     results = pbmc.check_model()
-    a = _get_agent_node(Agent('A', db_refs={'HGNC': 1}))[0]
-    b = _get_agent_node(Agent('B', db_refs={'HGNC': 2}))[0]
-    d = _get_agent_node(Agent('D', db_refs={'HGNC': 4}))[0]
-    e = _get_agent_node(Agent('E', db_refs={'HGNC': 5}))[0]
+    a = _get_agent_node(Agent('A', db_refs={'HGNC': '1'}))[0]
+    b = _get_agent_node(Agent('B', db_refs={'HGNC': '2'}))[0]
+    d = _get_agent_node(Agent('D', db_refs={'HGNC': '4'}))[0]
+    e = _get_agent_node(Agent('E', db_refs={'HGNC': '5'}))[0]
     # Paths found
     assert results[0][1].result_code == 'PATHS_FOUND'
     assert results[0][1].paths[0] == ((a, 0), (b, 1), (d, 0), (e, 0))

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -1660,23 +1660,23 @@ def test_pybel_refinements():
 
 
 def test_pybel_edge_types():
-    a = Agent('A', db_refs={'HGNC': 1})
-    b = Agent('B', db_refs={'HGNC': 2})
-    c = Agent('C', db_refs={'HGNC': 3})
-    a_b = Agent('A', db_refs={'HGNC': 1}, bound_conditions=[BoundCondition(b)])
-    c_phos = Agent('C', db_refs={'HGNC': 3},
+    a = Agent('A', db_refs={'HGNC': '1'})
+    b = Agent('B', db_refs={'HGNC': '2'})
+    c = Agent('C', db_refs={'HGNC': '3'})
+    a_b = Agent('A', db_refs={'HGNC': '1'}, bound_conditions=[BoundCondition(b)])
+    c_phos = Agent('C', db_refs={'HGNC': '3'},
                    mods=[ModCondition('phosphorylation', 'S', '218')])
     model_stmts = [Complex([a, b]),
                    Phosphorylation(b, c, 'S', '218')]
     test_stmts = [Activation(a, c),
                   Activation(b, c),
                   Activation(b, a),
-                  Activation(a_b, b),
+                  Activation(b, a_b),
                   Activation(c, c_phos)]
     pba = PybelAssembler(model_stmts)
     pybel_model = pba.make_model()
     pbmc = PybelModelChecker(pybel_model, test_stmts)
-    # Do not include hasVariant and hasComponent edges at all
+    # Do not include hasVariant and partOf edges at all
     pbmc.graph = None
     pbmc.get_graph(include_variants=False, symmetric_variant_links=False,
                    include_components=False, symmetric_component_links=False)
@@ -1686,7 +1686,7 @@ def test_pybel_edge_types():
     assert not results[2][1].path_found
     assert not results[3][1].path_found, results[3][1]
     assert not results[4][1].path_found
-    # Include hasVariant and hasComponent edges without symmetric links
+    # Include hasVariant and partOf edges without symmetric links
     pbmc.graph = None
     pbmc.get_graph(include_variants=True, symmetric_variant_links=False,
                    include_components=True, symmetric_component_links=False)
@@ -1703,7 +1703,7 @@ def test_pybel_edge_types():
     path_stmt_4 = stmts_from_pybel_path(
         path4, pybel_model, False, model_stmts)[0][0]
     assert isinstance(path_stmt_3, PybelEdge)
-    assert path_stmt_3.relation == 'hasComponent'
+    assert path_stmt_3.relation == 'partOf'
     assert isinstance(path_stmt_4, PybelEdge)
     assert path_stmt_4.relation == 'hasVariant'
     # Include symmetric links
@@ -1721,13 +1721,13 @@ def test_pybel_edge_types():
 def test_pybel_edge_to_english():
     pe = PybelEdge(
         Agent('EGF', bound_conditions=[BoundCondition(Agent('EGFR'))]),
-        Agent('EGF'), 'hasComponent', False)
+        Agent('EGF'), 'partOf', True)
     s = pybel_edge_to_english(pe)
     assert s == 'EGF bound to EGFR has a component EGF.'
     pe = PybelEdge(
         Agent('EGF'),
         Agent('EGF', bound_conditions=[BoundCondition(Agent('EGFR'))]),
-        'hasComponent', True)
+        'partOf', False)
     s = pybel_edge_to_english(pe)
     assert s == 'EGF is a part of EGF bound to EGFR.'
     pe = PybelEdge(

--- a/indra/tests/test_pybel_api.py
+++ b/indra/tests/test_pybel_api.py
@@ -31,37 +31,27 @@ def test_pybel_neighborhood_query():
         network_file=small_corpus_url,
     )
     assert bp.statements
-    assert all(s.evidence[0].context.cell_line.name == 'MCF 10A'
-                for s in bp.statements)
+    assert all(
+        s.evidence[0].context.cell_line.name == 'MCF 10A'
+        for s in bp.statements
+    )
     # Locate statement about epidermis development
     stmt = [st for st in bp.statements if st.agent_list()[1].name ==
             'epidermis development'][0]
     assert repr(stmt.evidence[0].context) == str(stmt.evidence[0].context)
     assert stmt.evidence[0].context == BioContext(
-        location=RefContext(
-            name="Cytoplasm",
-            db_refs={'MESH': 'D003593'},
-        ),
-        cell_line=RefContext(
-            name="MCF 10A",
-            db_refs={'EFO': '0001200'},
-        ),
-        cell_type=RefContext(
-            name="keratinocyte",
-            db_refs={'CL': '0000312'},
-        ),
-        organ=RefContext(
-            name="colon",
-            db_refs={'UBERON': '0001155'},
-        ),
-        disease=RefContext(
-            name="cancer",
-            db_refs={'DOID': '162'},
-        ),
-        species=RefContext(
-            name="Rattus norvegicus",
-            db_refs={'TAXONOMY': '10116'},
-        ))
+        location=RefContext(name="Cytoplasm",
+                            db_refs={'MESH': 'D003593'}),
+        cell_line=RefContext(name="MCF 10A",
+                             db_refs={'EFO': '0001200'}),
+        cell_type=RefContext(name="keratinocyte",
+                             db_refs={'CL': '0000312'}),
+        organ=RefContext(name="colon",
+                         db_refs={'UBERON': '0001155'}),
+        disease=RefContext(name="cancer",
+                           db_refs={'DOID': '162'}),
+        species=RefContext(name="Rattus norvegicus",
+                           db_refs={'TAXONOMY': '10116'}))
     # Test annotation manager
     assert bp.annot_manager.get_mapping('Species', '9606') == 'Homo sapiens'
 
@@ -659,7 +649,8 @@ def test_gtpactivation():
 
 def test_conversion():
     enz = Protein(name='PLCG1', namespace='HGNC')
-    react_1 = abundance('SCHEM', '1-Phosphatidyl-D-myo-inositol 4,5-bisphosphate')
+    react_1 = abundance('SCHEM',
+                        '1-Phosphatidyl-D-myo-inositol 4,5-bisphosphate')
     p1 = abundance('SCHEM', 'Diacylglycerol')
     p2 = abundance('SCHEM', 'Inositol 1,4,5-trisphosphate')
 
@@ -697,8 +688,10 @@ def test_controlled_transloc_loc_cond():
     subj = Protein(name='MAP2K1', namespace='HGNC')
     obj = Protein(name='MAPK1', namespace='HGNC')
     g = BELGraph()
-    transloc = translocation(from_loc=Entity(namespace='GOCC', name='intracellular'),
-                             to_loc=Entity(namespace='GOCC', name='extracellular space'))
+    transloc = translocation(
+        from_loc=Entity(namespace='GOCC', name='intracellular'),
+        to_loc=Entity(namespace='GOCC', name='extracellular space'),
+    )
     g.add_increases(subj, obj, object_modifier=transloc,
                     evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)

--- a/indra/tests/test_pybel_api.py
+++ b/indra/tests/test_pybel_api.py
@@ -19,23 +19,18 @@ from indra.sources.bel.api import process_cbn_jgif_file, process_pybel_graph, \
     small_corpus_url
 from indra.databases import hgnc_client
 
-
 mek_hgnc_id = hgnc_client.get_hgnc_id('MAP2K1')
 mek_up_id = hgnc_client.get_uniprot_id(mek_hgnc_id)
 
 
 @attr('slow')
 def test_pybel_neighborhood_query():
-    bp = bel.process_pybel_neighborhood(
-        ['TP63'],
-        network_type='graph_jsongz_url',
-        network_file=small_corpus_url,
-    )
+    bp = bel.process_pybel_neighborhood(['TP63'],
+                                        network_type='graph_jsongz_url',
+                                        network_file=small_corpus_url)
     assert bp.statements
-    assert all(
-        s.evidence[0].context.cell_line.name == 'MCF 10A'
-        for s in bp.statements
-    )
+    assert all([s.evidence[0].context.cell_line.name == 'MCF 10A'
+               for s in bp.statements])
     # Locate statement about epidermis development
     stmt = [st for st in bp.statements if st.agent_list()[1].name ==
             'epidermis development'][0]
@@ -54,7 +49,8 @@ def test_pybel_neighborhood_query():
         species=RefContext(name="Rattus norvegicus",
                            db_refs={'TAXONOMY': '10116'}))
     # Test annotation manager
-    assert bp.annot_manager.get_mapping('Species', '9606') == 'Homo sapiens'
+    assert bp.annot_manager.get_mapping('Species', '9606') == \
+           'Homo sapiens'
 
 
 def test_process_pybel():

--- a/indra/tests/test_pybel_api.py
+++ b/indra/tests/test_pybel_api.py
@@ -6,20 +6,18 @@ import os
 from urllib import request
 
 from nose.plugins.attrib import attr
-
-from indra.databases import hgnc_client
+from pybel import BELGraph, constants as pc
+from pybel.dsl import *
+from pybel.language import Entity
+from pybel.io import from_nodelink_file
+from pybel.examples import egf_graph
+from indra.statements import *
 from indra.sources import bel
 from indra.sources.bel import processor as pb
-from indra.sources.bel.api import (
-    process_cbn_jgif_file, process_pybel_graph, small_corpus_url,
-)
-from indra.statements import *
-from pybel import BELGraph
-from pybel.dsl import *
-import pybel.constants as pc
-from pybel.examples import egf_graph
-from pybel.io import from_nodelink_file
-from pybel.language import Entity
+from indra.sources.bel.api import process_cbn_jgif_file, process_pybel_graph, \
+    small_corpus_url
+from indra.databases import hgnc_client
+
 
 mek_hgnc_id = hgnc_client.get_hgnc_id('MAP2K1')
 mek_up_id = hgnc_client.get_uniprot_id(mek_hgnc_id)
@@ -33,10 +31,8 @@ def test_pybel_neighborhood_query():
         network_file=small_corpus_url,
     )
     assert bp.statements
-    assert all(
-        s.evidence[0].context.cell_line.name == 'MCF 10A'
-        for s in bp.statements
-    )
+    assert all(s.evidence[0].context.cell_line.name == 'MCF 10A'
+                for s in bp.statements)
     # Locate statement about epidermis development
     stmt = [st for st in bp.statements if st.agent_list()[1].name ==
             'epidermis development'][0]
@@ -663,8 +659,7 @@ def test_gtpactivation():
 
 def test_conversion():
     enz = Protein(name='PLCG1', namespace='HGNC')
-    react_1 = abundance('SCHEM',
-                        '1-Phosphatidyl-D-myo-inositol 4,5-bisphosphate')
+    react_1 = abundance('SCHEM', '1-Phosphatidyl-D-myo-inositol 4,5-bisphosphate')
     p1 = abundance('SCHEM', 'Diacylglycerol')
     p2 = abundance('SCHEM', 'Inositol 1,4,5-trisphosphate')
 
@@ -702,10 +697,8 @@ def test_controlled_transloc_loc_cond():
     subj = Protein(name='MAP2K1', namespace='HGNC')
     obj = Protein(name='MAPK1', namespace='HGNC')
     g = BELGraph()
-    transloc = translocation(
-        from_loc=Entity(namespace='GOCC', name='intracellular'),
-        to_loc=Entity(namespace='GOCC', name='extracellular space'),
-    )
+    transloc = translocation(from_loc=Entity(namespace='GOCC', name='intracellular'),
+                             to_loc=Entity(namespace='GOCC', name='extracellular space'))
     g.add_increases(subj, obj, object_modifier=transloc,
                     evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
@@ -763,7 +756,7 @@ def test_complex_stmt_with_activation():
     raf = Protein(name='BRAF', namespace='HGNC')
     mek = Protein(name='MAP2K1', namespace='HGNC')
     erk = Protein(name='MAPK1', namespace='HGNC')
-    cplx = ComplexAbundance([raf, mek])
+    cplx = complex_abundance([raf, mek])
     g = BELGraph()
     g.add_directly_increases(cplx, erk,
                              object_modifier=activity(name='kin'),

--- a/indra/tests/test_pybel_api.py
+++ b/indra/tests/test_pybel_api.py
@@ -5,6 +5,7 @@
 import os
 from urllib import request
 
+import pybel.constants as pc
 from nose.plugins.attrib import attr
 from pybel import BELGraph, constants as pc
 from pybel.dsl import *
@@ -370,12 +371,9 @@ def test_phosphorylation_one_site_with_evidence():
     ev_text = 'Some evidence.'
     ev_pmid = '123456'
     edge_hash = g.add_directly_increases(
-        mek, erk,
-        evidence=ev_text,
-        citation={
-            pc.CITATION_DB: pc.CITATION_TYPE_PUBMED,
-            pc.CITATION_IDENTIFIER: ev_pmid,
-        },
+        mek, erk, evidence=ev_text,
+        citation={pc.CITATION_DB: pc.CITATION_TYPES[pc.CITATION_TYPE_PUBMED],
+                  pc.CITATION_IDENTIFIER: ev_pmid},
         annotations={"TextLocation": 'Abstract'},
     )
     pbp = bel.process_pybel_graph(g)

--- a/indra/tests/test_pybel_api.py
+++ b/indra/tests/test_pybel_api.py
@@ -24,29 +24,29 @@ def test_pybel_neighborhood_query():
                                         network_type='graph_jsongz_url',
                                         network_file=small_corpus_url)
     assert bp.statements
-    assert all(s.evidence[0].context.cell_line.name == 'MCF 10A'
-                for s in bp.statements)
+    assert all(
+        s.evidence[0].context.cell_line.name == 'MCF 10A'
+        for s in bp.statements
+    )
     # Locate statement about epidermis development
     stmt = [st for st in bp.statements if st.agent_list()[1].name ==
             'epidermis development'][0]
-    assert stmt.evidence[0].context.__repr__() == \
-           stmt.evidence[0].context.__str__()
-    assert stmt.evidence[0].context == \
-           BioContext(location=RefContext(name="Cytoplasm",
-                                          db_refs={'MESH': 'D003593'}),
-                      cell_line=RefContext(name="MCF 10A",
-                                           db_refs={'EFO': '0001200'}),
-                      cell_type=RefContext(name="keratinocyte",
-                                           db_refs={'CL': '0000312'}),
-                      organ=RefContext(name="colon",
-                                       db_refs={'UBERON': '0001155'}),
-                      disease=RefContext(name="cancer",
-                                         db_refs={'DOID': '162'}),
-                      species=RefContext(name="Rattus norvegicus",
-                                         db_refs={'TAXONOMY': '10116'}))
+    assert repr(stmt.evidence[0].context) == str(stmt.evidence[0].context)
+    assert stmt.evidence[0].context == BioContext(
+        location=RefContext(name="Cytoplasm",
+                            db_refs={'MESH': 'D003593'}),
+        cell_line=RefContext(name="MCF 10A",
+                             db_refs={'EFO': '0001200'}),
+        cell_type=RefContext(name="keratinocyte",
+                             db_refs={'CL': '0000312'}),
+        organ=RefContext(name="colon",
+                         db_refs={'UBERON': '0001155'}),
+        disease=RefContext(name="cancer",
+                           db_refs={'DOID': '162'}),
+        species=RefContext(name="Rattus norvegicus",
+                           db_refs={'TAXONOMY': '10116'}))
     # Test annotation manager
-    assert bp.annot_manager.get_mapping('Species', '9606') == \
-           'Homo sapiens'
+    assert bp.annot_manager.get_mapping('Species', '9606') == 'Homo sapiens'
 
 
 def test_process_pybel():
@@ -199,6 +199,7 @@ def test_get_agent_mirna():
     assert agent.name == 'MIRLET7A1'
     assert agent.db_refs.get('MIRBASE') == 'MI0000060'
     assert agent.db_refs.get('HGNC') == '31476'
+
 
 def test_get_agent_fusion():
     node_data = ProteinFusion(
@@ -361,8 +362,11 @@ def test_phosphorylation_one_site_with_evidence():
     g = BELGraph()
     ev_text = 'Some evidence.'
     ev_pmid = '123456'
-    edge_hash = g.add_directly_increases(mek, erk, evidence=ev_text, citation=ev_pmid,
-                                         annotations={"TextLocation": 'Abstract'})
+    edge_hash = g.add_directly_increases(
+        mek, erk, evidence=ev_text,
+        citation=ev_pmid,
+        annotations={"TextLocation": 'Abstract'},
+    )
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements
     assert len(pbp.statements) == 1
@@ -508,7 +512,8 @@ def test_active_form():
                        variants=[pmod('Ph', position=33, code='Ser')])
     p53_obj = Protein(name='TP53', namespace='HGNC')
     g = BELGraph()
-    g.add_increases(p53_pmod, p53_obj, object_modifier=activity(name='tscript'),
+    g.add_increases(p53_pmod, p53_obj,
+                    object_modifier=activity(name='tscript'),
                     evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements
@@ -631,7 +636,8 @@ def test_gtpactivation():
 
 def test_conversion():
     enz = Protein(name='PLCG1', namespace='HGNC')
-    react_1 = abundance('SCHEM', '1-Phosphatidyl-D-myo-inositol 4,5-bisphosphate')
+    react_1 = abundance('SCHEM',
+                        '1-Phosphatidyl-D-myo-inositol 4,5-bisphosphate')
     p1 = abundance('SCHEM', 'Diacylglycerol')
     p2 = abundance('SCHEM', 'Inositol 1,4,5-trisphosphate')
 
@@ -669,8 +675,10 @@ def test_controlled_transloc_loc_cond():
     subj = Protein(name='MAP2K1', namespace='HGNC')
     obj = Protein(name='MAPK1', namespace='HGNC')
     g = BELGraph()
-    transloc = translocation(from_loc=Entity(namespace='GOCC', name='intracellular'),
-                             to_loc=Entity(namespace='GOCC', name='extracellular space'))
+    transloc = translocation(
+        from_loc=Entity(namespace='GOCC', name='intracellular'),
+        to_loc=Entity(namespace='GOCC', name='extracellular space'),
+    )
     g.add_increases(subj, obj, object_modifier=transloc,
                     evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)

--- a/indra/tests/test_pybel_api.py
+++ b/indra/tests/test_pybel_api.py
@@ -1,6 +1,7 @@
 import os
 from urllib import request
 
+import pybel.constants as pc
 from nose.plugins.attrib import attr
 from pybel import BELGraph
 from pybel.dsl import *
@@ -364,7 +365,8 @@ def test_phosphorylation_one_site_with_evidence():
     ev_pmid = '123456'
     edge_hash = g.add_directly_increases(
         mek, erk, evidence=ev_text,
-        citation=ev_pmid,
+        citation={pc.CITATION_DB: pc.CITATION_TYPES[pc.CITATION_TYPE_PUBMED],
+                  pc.CITATION_IDENTIFIER: ev_pmid},
         annotations={"TextLocation": 'Abstract'},
     )
     pbp = bel.process_pybel_graph(g)
@@ -384,7 +386,7 @@ def test_phosphorylation_one_site_with_evidence():
     ev = pbp.statements[0].evidence[0]
     assert ev.source_api == 'bel'
     assert ev.source_id == edge_hash
-    assert ev.pmid == ev_pmid
+    assert ev.pmid == ev_pmid, (ev.pmid, ev_pmid)
     assert ev.text == ev_text
     assert ev.annotations == {'bel': 'p(HGNC:MAP2K1) directlyIncreases '
                                      'p(HGNC:MAPK1, pmod(Ph, Thr, 185))'}

--- a/indra/tests/test_pybel_api.py
+++ b/indra/tests/test_pybel_api.py
@@ -5,7 +5,7 @@ from nose.plugins.attrib import attr
 from pybel import BELGraph
 from pybel.dsl import *
 from pybel.language import Entity
-from pybel.io import from_json_file
+from pybel.io import from_nodelink_file
 from pybel.examples import egf_graph
 from indra.statements import *
 from indra.sources import bel
@@ -24,8 +24,8 @@ def test_pybel_neighborhood_query():
                                         network_type='graph_jsongz_url',
                                         network_file=small_corpus_url)
     assert bp.statements
-    assert all([s.evidence[0].context.cell_line.name == 'MCF 10A'
-                for s in bp.statements])
+    assert all(s.evidence[0].context.cell_line.name == 'MCF 10A'
+                for s in bp.statements)
     # Locate statement about epidermis development
     stmt = [st for st in bp.statements if st.agent_list()[1].name ==
             'epidermis development'][0]
@@ -73,8 +73,7 @@ def test_nodelink_json():
         'https://s3.amazonaws.com/bigmech/travis/Hox-2.0-Hs_nljson.json'
     test_file = 'Hox-2.0-Hs_nljson.json'
     request.urlretrieve(url=test_file_url, filename=test_file)
-    with open(test_file) as jr:
-        pbp = process_pybel_graph(from_json_file(file=jr))
+    pbp = process_pybel_graph(from_nodelink_file(test_file))
 
     # Clean up
     os.remove(test_file)
@@ -85,7 +84,7 @@ def test_nodelink_json():
 
 
 def test_get_agent_hgnc():
-    mek = protein(name='MAP2K1', namespace='HGNC')
+    mek = Protein(name='MAP2K1', namespace='HGNC')
     agent = pb.get_agent(mek, {})
     assert isinstance(agent, Agent)
     assert agent.name == 'MAP2K1', agent
@@ -93,7 +92,7 @@ def test_get_agent_hgnc():
     assert agent.db_refs.get('UP') == mek_up_id
 
     # Now create an agent with an identifier
-    mek = protein(name='Foo', namespace='HGNC', identifier='6840')
+    mek = Protein(name='Foo', namespace='HGNC', identifier='6840')
     agent = pb.get_agent(mek, {})
     assert isinstance(agent, Agent)
     assert agent.name == 'MAP2K1', agent
@@ -102,7 +101,7 @@ def test_get_agent_hgnc():
 
 
 def test_get_agent_up():
-    mek = protein(namespace='UP', identifier='Q02750')
+    mek = Protein(namespace='UP', identifier='Q02750')
     agent = pb.get_agent(mek, {})
     assert isinstance(agent, Agent)
     assert agent.name == 'MAP2K1'
@@ -111,7 +110,7 @@ def test_get_agent_up():
 
 
 def test_get_agent_egid():
-    node_data = {'function': 'Protein', 'name': '5008', 'namespace': 'EGID'}
+    node_data = Protein(name='5008', namespace='EGID')
     agent = pb.get_agent(node_data)
     assert isinstance(agent, Agent)
     assert agent.name == 'OSM'
@@ -122,7 +121,7 @@ def test_get_agent_egid():
 
 
 def test_get_agent_mgi():
-    node = protein(namespace='MGI', name='Nr1h3')
+    node = Protein(namespace='MGI', name='Nr1h3')
     agent = pb.get_agent(node, {})
     assert isinstance(agent, Agent)
     assert agent.name == 'Nr1h3'
@@ -131,7 +130,7 @@ def test_get_agent_mgi():
 
 
 def test_get_agent_rgd():
-    node = protein(namespace='RGD', name='Tp53')
+    node = Protein(namespace='RGD', name='Tp53')
     agent = pb.get_agent(node, {})
     assert isinstance(agent, Agent)
     assert agent.name == 'Tp53'
@@ -140,11 +139,10 @@ def test_get_agent_rgd():
 
 
 def test_get_agent_sfam():
-    node_data = {
-            'cname': 'PRKC Family',
-            'function': 'Protein',
-            'name': 'PRKC Family',
-            'namespace': 'SFAM'}
+    node_data = Protein(
+        namespace='SFAM',
+        name='PRKC Family',
+    )
     agent = pb.get_agent(node_data)
     assert isinstance(agent, Agent)
     assert len(agent.db_refs) == 2
@@ -154,11 +152,7 @@ def test_get_agent_sfam():
 
 
 def test_get_agent_sdis():
-    node_data = {
-            'cname': 'metastasis',
-            'function': 'Pathology',
-            'name': 'metastasis',
-            'namespace': 'SDIS'}
+    node_data = Pathology(namespace='SDIS', name='metastasis')
     agent = pb.get_agent(node_data)
     assert isinstance(agent, Agent)
     assert agent.name == 'metastasis'
@@ -167,11 +161,7 @@ def test_get_agent_sdis():
 
 
 def test_get_agent_chebi():
-    node_data = {
-            'cname': 'nitric oxide',
-            'function': 'Abundance',
-            'name': 'nitric oxide',
-            'namespace': 'CHEBI'}
+    node_data = Abundance(namespace='CHEBI', name='nitric oxide')
     agent = pb.get_agent(node_data)
     assert isinstance(agent, Agent)
     assert agent.name == 'nitric oxide'
@@ -180,11 +170,7 @@ def test_get_agent_chebi():
 
 
 def test_get_agent_schem():
-    node_data = {
-            'cname': 'Promegestone',
-            'function': 'Abundance',
-            'name': 'Promegestone',
-            'namespace': 'SCHEM'}
+    node_data = Abundance(namespace='SCHEM', name='Promegestone')
     agent = pb.get_agent(node_data)
     assert isinstance(agent, Agent)
     assert agent.name == 'Promegestone'
@@ -215,18 +201,16 @@ def test_get_agent_mirna():
     assert agent.db_refs.get('HGNC') == '31476'
 
 def test_get_agent_fusion():
-    node_data = {'function': 'Protein',
-                 'fusion': {
-                     'partner_5p': {'namespace': 'HGNC', 'name': 'BCR'},
-                     'range_5p': {'missing': '?'},
-                     'range_3p': {'missing': '?'},
-                     'partner_3p': {'namespace': 'HGNC', 'name': 'ABL1'}}}
+    node_data = ProteinFusion(
+        partner_5p=Protein(namespace='HGNC', name='BCR'),
+        partner_3p=Protein(namespace='HGNC', name='ABL1'),
+    )
     agent = pb.get_agent(node_data)
     assert agent is None
 
 
 def test_get_agent_up_no_id():
-    mek = protein(name='MAP2K1', namespace='UP')
+    mek = Protein(name='MAP2K1', namespace='UP')
     agent = pb.get_agent(mek, {})
     assert agent is None
 
@@ -248,7 +232,7 @@ def test_get_agent_meshd():
 
 
 def test_get_agent_with_mods():
-    mek = protein(name='MAP2K1', namespace='HGNC',
+    mek = Protein(name='MAP2K1', namespace='HGNC',
                   variants=[pmod('Ph')])
     agent = pb.get_agent(mek, {})
     assert isinstance(agent, Agent)
@@ -258,7 +242,7 @@ def test_get_agent_with_mods():
     assert not mod.residue
     assert not mod.position
 
-    mek = protein(name='MAP2K1', namespace='HGNC',
+    mek = Protein(name='MAP2K1', namespace='HGNC',
                   variants=[pmod('Ph', code='Ser')])
     agent = pb.get_agent(mek, {})
     assert isinstance(agent, Agent)
@@ -268,7 +252,7 @@ def test_get_agent_with_mods():
     assert mod.residue == 'S'
     assert not mod.position
 
-    mek = protein(name='MAP2K1', namespace='HGNC',
+    mek = Protein(name='MAP2K1', namespace='HGNC',
                   variants=[pmod('Ph', position=218)])
     agent = pb.get_agent(mek, {})
     assert isinstance(agent, Agent)
@@ -278,7 +262,7 @@ def test_get_agent_with_mods():
     assert not mod.residue
     assert mod.position == '218'
 
-    mek = protein(name='MAP2K1', namespace='HGNC',
+    mek = Protein(name='MAP2K1', namespace='HGNC',
                   variants=[pmod('Ph', position=218, code='Ser')])
     agent = pb.get_agent(mek, {})
     assert isinstance(agent, Agent)
@@ -290,7 +274,7 @@ def test_get_agent_with_mods():
 
 
 def test_get_agent_with_muts():
-    mek = protein(name='MAP2K1', namespace='HGNC',
+    mek = Protein(name='MAP2K1', namespace='HGNC',
                   variants=[hgvs('p.Val600Glu')])
     agent = pb.get_agent(mek, {})
     assert isinstance(agent, Agent)
@@ -302,7 +286,7 @@ def test_get_agent_with_muts():
 
 
 def test_get_agent_with_activity():
-    mek = protein(name='MAP2K1', namespace='HGNC')
+    mek = Protein(name='MAP2K1', namespace='HGNC')
     agent = pb.get_agent(mek, activity('act'))
     assert isinstance(agent, Agent)
     assert isinstance(agent.activity, ActivityCondition)
@@ -311,8 +295,8 @@ def test_get_agent_with_activity():
 
 
 def test_get_agent_complex():
-    mek = protein(name='MAP2K1', namespace='HGNC')
-    erk = protein(name='MAPK1', namespace='HGNC',
+    mek = Protein(name='MAP2K1', namespace='HGNC')
+    erk = Protein(name='MAPK1', namespace='HGNC',
                   variants=[pmod('Ph', position=185, code='Thr')])
     cplx = complex_abundance([mek, erk])
     agent = pb.get_agent(cplx)
@@ -334,16 +318,16 @@ def test_get_agent_complex_none_agent():
     """If one of the agents in the complex can't be obtained (e.g., an
     unhandled namespace), then the complex itself should be None."""
     # Prime agent is None
-    mek = protein(name='MAP2K1', namespace='FOO')
-    erk = protein(name='MAPK1', namespace='HGNC',
+    mek = Protein(name='MAP2K1', namespace='FOO')
+    erk = Protein(name='MAPK1', namespace='HGNC',
                   variants=[pmod('Ph', position=185, code='Thr')])
     cplx = complex_abundance([mek, erk])
     agent = pb.get_agent(cplx)
     assert agent is None
 
     # Bound agent is None
-    mek = protein(name='MAP2K1', namespace='HGNC')
-    erk = protein(name='MAPK1', namespace='FOO',
+    mek = Protein(name='MAP2K1', namespace='HGNC')
+    erk = Protein(name='MAPK1', namespace='FOO',
                   variants=[pmod('Ph', position=185, code='Thr')])
     cplx = complex_abundance([mek, erk])
     agent = pb.get_agent(cplx)
@@ -352,20 +336,18 @@ def test_get_agent_complex_none_agent():
 
 def test_get_agent_named_complex_go():
     # TODO: Handle named complexes and map to FamPlex where possible
-    node_data = {
-            'cname': '0043509',
-            'function': 'Complex',
-            'name': '0043509',
-            'namespace': 'GOCCID'}
+    node_data = NamedComplexAbundance(namespace='GOCCID', name='0043509')
     agent = pb.get_agent(node_data)
     assert agent is None
 
 
 def test_get_agent_with_translocation():
-    node_data = protein(name='MAPK1', namespace='HGNC')
+    node_data = Protein(name='MAPK1', namespace='HGNC')
     # Some example edge data
-    edge_data = translocation(from_loc=Entity('GOCC', 'intracellular'),
-                              to_loc=Entity('GOCC', 'extracellular space'))
+    edge_data = translocation(
+        from_loc=Entity(namespace='GOCC', name='intracellular'),
+        to_loc=Entity(namespace='GOCC', name='extracellular space'),
+    )
     agent = pb.get_agent(node_data, edge_data)
     assert isinstance(agent, Agent)
     assert agent.name == 'MAPK1'
@@ -373,8 +355,8 @@ def test_get_agent_with_translocation():
 
 
 def test_phosphorylation_one_site_with_evidence():
-    mek = protein(name='MAP2K1', namespace='HGNC')
-    erk = protein(name='MAPK1', namespace='HGNC',
+    mek = Protein(name='MAP2K1', namespace='HGNC')
+    erk = Protein(name='MAPK1', namespace='HGNC',
                   variants=[pmod('Ph', position=185, code='Thr')])
     g = BELGraph()
     ev_text = 'Some evidence.'
@@ -406,8 +388,8 @@ def test_phosphorylation_one_site_with_evidence():
 
 
 def test_phosphorylation_two_sites():
-    mek = protein(name='MAP2K1', namespace='HGNC')
-    erk = protein(name='MAPK1', namespace='HGNC',
+    mek = Protein(name='MAP2K1', namespace='HGNC')
+    erk = Protein(name='MAPK1', namespace='HGNC',
                   variants=[pmod('Ph', position=185, code='Thr'),
                             pmod('Ph', position=187, code='Tyr')])
     g = BELGraph()
@@ -428,8 +410,8 @@ def test_phosphorylation_two_sites():
 
 
 def test_regulate_amount1_prot_obj():
-    mek = protein(name='MAP2K1', namespace='HGNC')
-    erk = protein(name='MAPK1', namespace='HGNC')
+    mek = Protein(name='MAP2K1', namespace='HGNC')
+    erk = Protein(name='MAPK1', namespace='HGNC')
     g = BELGraph()
     g.add_increases(mek, erk, evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
@@ -441,7 +423,7 @@ def test_regulate_amount1_prot_obj():
 
 def test_regulate_amount2_rna_obj():
     # FIXME: Create a transcription-specific statement for p->rna
-    mek = protein(name='MAP2K1', namespace='HGNC')
+    mek = Protein(name='MAP2K1', namespace='HGNC')
     erk = rna(name='MAPK1', namespace='HGNC')
     g = BELGraph()
     g.add_increases(mek, erk, evidence="Some evidence.", citation='123456')
@@ -454,8 +436,8 @@ def test_regulate_amount2_rna_obj():
 
 def test_regulate_amount3_deg():
     # FIXME: Create a stability-specific statement for p->deg(p(Foo))
-    mek = protein(name='MAP2K1', namespace='HGNC')
-    erk = protein(name='MAPK1', namespace='HGNC')
+    mek = Protein(name='MAP2K1', namespace='HGNC')
+    erk = Protein(name='MAPK1', namespace='HGNC')
     g = BELGraph()
     g.add_increases(mek, erk, object_modifier=degradation(),
                     evidence="Some evidence.", citation='123456')
@@ -467,8 +449,8 @@ def test_regulate_amount3_deg():
 
 
 def test_regulate_amount4_subj_act():
-    mek = protein(name='MAP2K1', namespace='HGNC')
-    erk = protein(name='MAPK1', namespace='HGNC')
+    mek = Protein(name='MAP2K1', namespace='HGNC')
+    erk = Protein(name='MAPK1', namespace='HGNC')
     g = BELGraph()
     g.add_increases(mek, erk, subject_modifier=activity(name='tscript'),
                     evidence="Some evidence.", citation='123456')
@@ -499,8 +481,8 @@ def test_regulate_amount4_subj_act():
 
 
 def test_regulate_activity():
-    mek = protein(name='MAP2K1', namespace='HGNC')
-    erk = protein(name='MAPK1', namespace='HGNC')
+    mek = Protein(name='MAP2K1', namespace='HGNC')
+    erk = Protein(name='MAPK1', namespace='HGNC')
     g = BELGraph()
     g.add_increases(mek, erk, subject_modifier=activity(name='kin'),
                     object_modifier=activity(name='kin'),
@@ -522,9 +504,9 @@ def test_regulate_activity():
 
 
 def test_active_form():
-    p53_pmod = protein(name='TP53', namespace='HGNC',
+    p53_pmod = Protein(name='TP53', namespace='HGNC',
                        variants=[pmod('Ph', position=33, code='Ser')])
-    p53_obj = protein(name='TP53', namespace='HGNC')
+    p53_obj = Protein(name='TP53', namespace='HGNC')
     g = BELGraph()
     g.add_increases(p53_pmod, p53_obj, object_modifier=activity(name='tscript'),
                     evidence="Some evidence.", citation='123456')
@@ -546,8 +528,8 @@ def test_active_form():
 
 
 def test_gef():
-    sos = protein(name='SOS1', namespace='HGNC')
-    kras = protein(name='KRAS', namespace='HGNC')
+    sos = Protein(name='SOS1', namespace='HGNC')
+    kras = Protein(name='KRAS', namespace='HGNC')
     g = BELGraph()
     g.add_directly_increases(sos, kras,
                              subject_modifier=activity(name='activity'),
@@ -567,8 +549,8 @@ def test_gef():
 
 
 def test_indirect_gef_is_activation():
-    sos = protein(name='SOS1', namespace='HGNC')
-    kras = protein(name='KRAS', namespace='HGNC')
+    sos = Protein(name='SOS1', namespace='HGNC')
+    kras = Protein(name='KRAS', namespace='HGNC')
     g = BELGraph()
     g.add_increases(sos, kras, subject_modifier=activity(name='activity'),
                     object_modifier=activity(name='gtp'),
@@ -588,8 +570,8 @@ def test_indirect_gef_is_activation():
 
 
 def test_gap():
-    sos = protein(name='RASA1', namespace='HGNC')
-    kras = protein(name='KRAS', namespace='HGNC')
+    sos = Protein(name='RASA1', namespace='HGNC')
+    kras = Protein(name='KRAS', namespace='HGNC')
     g = BELGraph()
     g.add_directly_decreases(sos, kras,
                              subject_modifier=activity(name='activity'),
@@ -609,7 +591,7 @@ def test_gap():
 
 
 def test_activation_bioprocess():
-    bax = protein(name='BAX', namespace='HGNC')
+    bax = Protein(name='BAX', namespace='HGNC')
     apoptosis = bioprocess(name='apoptotic process', namespace='GOBP')
     g = BELGraph()
     g.add_increases(bax, apoptosis, evidence="Some evidence.",
@@ -626,8 +608,8 @@ def test_activation_bioprocess():
 
 
 def test_gtpactivation():
-    kras = protein(name='KRAS', namespace='HGNC')
-    braf = protein(name='BRAF', namespace='HGNC')
+    kras = Protein(name='KRAS', namespace='HGNC')
+    braf = Protein(name='BRAF', namespace='HGNC')
     g = BELGraph()
     g.add_directly_increases(kras, braf,
                              subject_modifier=activity(name='gtp'),
@@ -648,7 +630,7 @@ def test_gtpactivation():
 
 
 def test_conversion():
-    enz = protein(name='PLCG1', namespace='HGNC')
+    enz = Protein(name='PLCG1', namespace='HGNC')
     react_1 = abundance('SCHEM', '1-Phosphatidyl-D-myo-inositol 4,5-bisphosphate')
     p1 = abundance('SCHEM', 'Diacylglycerol')
     p2 = abundance('SCHEM', 'Inositol 1,4,5-trisphosphate')
@@ -684,11 +666,11 @@ def test_conversion():
 
 def test_controlled_transloc_loc_cond():
     """Controlled translocations are currently not handled."""
-    subj = protein(name='MAP2K1', namespace='HGNC')
-    obj = protein(name='MAPK1', namespace='HGNC')
+    subj = Protein(name='MAP2K1', namespace='HGNC')
+    obj = Protein(name='MAPK1', namespace='HGNC')
     g = BELGraph()
-    transloc = translocation(from_loc=Entity('GOCC', 'intracellular'),
-                             to_loc=Entity('GOCC', 'extracellular space'))
+    transloc = translocation(from_loc=Entity(namespace='GOCC', name='intracellular'),
+                             to_loc=Entity(namespace='GOCC', name='extracellular space'))
     g.add_increases(subj, obj, object_modifier=transloc,
                     evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
@@ -698,10 +680,12 @@ def test_controlled_transloc_loc_cond():
 def test_subject_transloc_loc_cond():
     """Translocations of the subject are treated as location conditions on the
     subject (using the to_loc location as the condition)"""
-    subj = protein(name='MAP2K1', namespace='HGNC')
-    obj = protein(name='MAPK1', namespace='HGNC')
-    transloc = translocation(from_loc=Entity('GOCC', 'intracellular'),
-                             to_loc=Entity('GOCC', 'extracellular space'))
+    subj = Protein(name='MAP2K1', namespace='HGNC')
+    obj = Protein(name='MAPK1', namespace='HGNC')
+    transloc = translocation(
+        from_loc=Entity(namespace='GOCC', name='intracellular'),
+        to_loc=Entity(namespace='GOCC', name='extracellular space'),
+    )
     g = BELGraph()
     g.add_increases(subj, obj, subject_modifier=transloc,
                     evidence="Some evidence.", citation='123456')
@@ -718,10 +702,12 @@ def test_subject_transloc_loc_cond():
 def test_subject_transloc_active_form():
     """ActiveForms where the subject is a translocation--should draw on the
     to-location of the subject."""
-    subj = protein(name='MAP2K1', namespace='HGNC')
-    obj = protein(name='MAP2K1', namespace='HGNC')
-    transloc = translocation(from_loc=Entity('GOCC', 'intracellular'),
-                             to_loc=Entity('GOCC', 'extracellular space'))
+    subj = Protein(name='MAP2K1', namespace='HGNC')
+    obj = Protein(name='MAP2K1', namespace='HGNC')
+    transloc = translocation(
+        from_loc=Entity(namespace='GOCC', name='intracellular'),
+        to_loc=Entity(namespace='GOCC', name='extracellular space'),
+    )
     g = BELGraph()
     g.add_increases(subj, obj, subject_modifier=transloc,
                     object_modifier=activity(name='kin'),
@@ -739,9 +725,9 @@ def test_subject_transloc_active_form():
 
 
 def test_complex_stmt_with_activation():
-    raf = protein(name='BRAF', namespace='HGNC')
-    mek = protein(name='MAP2K1', namespace='HGNC')
-    erk = protein(name='MAPK1', namespace='HGNC')
+    raf = Protein(name='BRAF', namespace='HGNC')
+    mek = Protein(name='MAP2K1', namespace='HGNC')
+    erk = Protein(name='MAPK1', namespace='HGNC')
     cplx = complex_abundance([raf, mek])
     g = BELGraph()
     g.add_directly_increases(cplx, erk,
@@ -762,7 +748,3 @@ def test_complex_stmt_with_activation():
     assert stmt2.obj.name == 'MAPK1'
     assert stmt2.obj.activity is None
     assert stmt2.obj_activity == 'kinase'
-
-
-if __name__ == '__main__':
-    test_get_agent_fusion()

--- a/indra/tests/test_pybel_api.py
+++ b/indra/tests/test_pybel_api.py
@@ -1,19 +1,25 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for the PyBEL processor."""
+
 import os
 from urllib import request
 
-import pybel.constants as pc
 from nose.plugins.attrib import attr
-from pybel import BELGraph
-from pybel.dsl import *
-from pybel.language import Entity
-from pybel.io import from_nodelink_file
-from pybel.examples import egf_graph
-from indra.statements import *
+
+from indra.databases import hgnc_client
 from indra.sources import bel
 from indra.sources.bel import processor as pb
-from indra.sources.bel.api import process_cbn_jgif_file, process_pybel_graph, \
-    small_corpus_url
-from indra.databases import hgnc_client
+from indra.sources.bel.api import (
+    process_cbn_jgif_file, process_pybel_graph, small_corpus_url,
+)
+from indra.statements import *
+from pybel import BELGraph
+from pybel.dsl import *
+import pybel.constants as pc
+from pybel.examples import egf_graph
+from pybel.io import from_nodelink_file
+from pybel.language import Entity
 
 mek_hgnc_id = hgnc_client.get_hgnc_id('MAP2K1')
 mek_up_id = hgnc_client.get_uniprot_id(mek_hgnc_id)
@@ -21,9 +27,11 @@ mek_up_id = hgnc_client.get_uniprot_id(mek_hgnc_id)
 
 @attr('slow')
 def test_pybel_neighborhood_query():
-    bp = bel.process_pybel_neighborhood(['TP63'],
-                                        network_type='graph_jsongz_url',
-                                        network_file=small_corpus_url)
+    bp = bel.process_pybel_neighborhood(
+        ['TP63'],
+        network_type='graph_jsongz_url',
+        network_file=small_corpus_url,
+    )
     assert bp.statements
     assert all(
         s.evidence[0].context.cell_line.name == 'MCF 10A'
@@ -34,18 +42,30 @@ def test_pybel_neighborhood_query():
             'epidermis development'][0]
     assert repr(stmt.evidence[0].context) == str(stmt.evidence[0].context)
     assert stmt.evidence[0].context == BioContext(
-        location=RefContext(name="Cytoplasm",
-                            db_refs={'MESH': 'D003593'}),
-        cell_line=RefContext(name="MCF 10A",
-                             db_refs={'EFO': '0001200'}),
-        cell_type=RefContext(name="keratinocyte",
-                             db_refs={'CL': '0000312'}),
-        organ=RefContext(name="colon",
-                         db_refs={'UBERON': '0001155'}),
-        disease=RefContext(name="cancer",
-                           db_refs={'DOID': '162'}),
-        species=RefContext(name="Rattus norvegicus",
-                           db_refs={'TAXONOMY': '10116'}))
+        location=RefContext(
+            name="Cytoplasm",
+            db_refs={'MESH': 'D003593'},
+        ),
+        cell_line=RefContext(
+            name="MCF 10A",
+            db_refs={'EFO': '0001200'},
+        ),
+        cell_type=RefContext(
+            name="keratinocyte",
+            db_refs={'CL': '0000312'},
+        ),
+        organ=RefContext(
+            name="colon",
+            db_refs={'UBERON': '0001155'},
+        ),
+        disease=RefContext(
+            name="cancer",
+            db_refs={'DOID': '162'},
+        ),
+        species=RefContext(
+            name="Rattus norvegicus",
+            db_refs={'TAXONOMY': '10116'},
+        ))
     # Test annotation manager
     assert bp.annot_manager.get_mapping('Species', '9606') == 'Homo sapiens'
 
@@ -364,9 +384,12 @@ def test_phosphorylation_one_site_with_evidence():
     ev_text = 'Some evidence.'
     ev_pmid = '123456'
     edge_hash = g.add_directly_increases(
-        mek, erk, evidence=ev_text,
-        citation={pc.CITATION_DB: pc.CITATION_TYPES[pc.CITATION_TYPE_PUBMED],
-                  pc.CITATION_IDENTIFIER: ev_pmid},
+        mek, erk,
+        evidence=ev_text,
+        citation={
+            pc.CITATION_DB: pc.CITATION_TYPE_PUBMED,
+            pc.CITATION_IDENTIFIER: ev_pmid,
+        },
         annotations={"TextLocation": 'Abstract'},
     )
     pbp = bel.process_pybel_graph(g)
@@ -388,8 +411,10 @@ def test_phosphorylation_one_site_with_evidence():
     assert ev.source_id == edge_hash
     assert ev.pmid == ev_pmid, (ev.pmid, ev_pmid)
     assert ev.text == ev_text
-    assert ev.annotations == {'bel': 'p(HGNC:MAP2K1) directlyIncreases '
-                                     'p(HGNC:MAPK1, pmod(Ph, Thr, 185))'}
+    assert ev.annotations == {
+        'bel': 'p(HGNC:MAP2K1) directlyIncreases '
+               'p(HGNC:MAPK1, pmod(Ph, Thr, 185))'
+    }
     assert ev.epistemics == {'direct': True, 'section_type': 'abstract'}
 
 
@@ -738,7 +763,7 @@ def test_complex_stmt_with_activation():
     raf = Protein(name='BRAF', namespace='HGNC')
     mek = Protein(name='MAP2K1', namespace='HGNC')
     erk = Protein(name='MAPK1', namespace='HGNC')
-    cplx = complex_abundance([raf, mek])
+    cplx = ComplexAbundance([raf, mek])
     g = BELGraph()
     g.add_directly_increases(cplx, erk,
                              object_modifier=activity(name='kin'),

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -417,10 +417,8 @@ def test_autophosphorylation():
     # There will be two edges between these nodes
     edge_dicts = list(belgraph.get_edge_data(egfr_dsl,
                                              egfr_phos_node).values())
-    assert {
-               pc.RELATION: pc.DIRECTLY_INCREASES,
-               'stmt_hash': stmt_hash
-           } in edge_dicts
+    assert {pc.RELATION: pc.DIRECTLY_INCREASES, 'stmt_hash': stmt_hash} \
+        in edge_dicts
 
     # Test an autophosphorylation with a bound condition
     tab1 = Agent('TAB1', db_refs={'HGNC': id('TAB1')})
@@ -479,8 +477,7 @@ def test_transphosphorylation():
     egfr_phos_node = egfr_dsl.with_variants(pmod('Ph', 'Tyr', 1173))
     edge_data = get_edge_data(belgraph, egfr_dimer_node, egfr_phos_node)
     assert edge_data == {
-        pc.RELATION: pc.DIRECTLY_INCREASES, 'stmt_hash': stmt_hash
-    }
+        pc.RELATION: pc.DIRECTLY_INCREASES, 'stmt_hash': stmt_hash}
 
 
 """

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -4,7 +4,8 @@ import pybel.constants as pc
 from indra.assemblers.pybel import assembler as pa
 from indra.databases import hgnc_client
 from indra.statements import *
-from pybel.dsl import abundance, activity, bioprocess, complex_abundance, hgvs, pmod, protein, reaction
+from pybel.dsl import abundance, activity, bioprocess, \
+    complex_abundance, hgvs, pmod, protein, reaction
 
 
 def id(gene_name):
@@ -423,9 +424,11 @@ def test_bound_condition():
     egfr = Agent('EGFR', db_refs={'HGNC': id('EGFR')})
     grb2 = Agent('GRB2', db_refs={'HGNC': id('GRB2')})
     ras = Agent('KRAS', db_refs={'HGNC': '6407'})
-    sos1_bound = Agent('SOS1', mods=[ModCondition('phosphorylation')],
-                       bound_conditions=[BoundCondition(egfr), BoundCondition(grb2)],
-                       db_refs={'HGNC': id('SOS1')})
+    sos1_bound = Agent(
+        'SOS1', mods=[ModCondition('phosphorylation')],
+        bound_conditions=[BoundCondition(egfr), BoundCondition(grb2)],
+        db_refs={'HGNC': id('SOS1')}
+    )
     stmt = Gef(sos1_bound, ras)
     stmt_hash = stmt.get_hash(refresh=True)
     pba = pa.PybelAssembler([stmt])

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -3,13 +3,16 @@
 """Tests for the PyBEL assembler."""
 
 import networkx as nx
-
 import pybel.constants as pc
 from indra.assemblers.pybel import assembler as pa
 from indra.databases import hgnc_client
 from indra.statements import *
 from pybel.dsl import abundance, activity, bioprocess, \
     complex_abundance, hgvs, pmod, protein, reaction
+
+from indra.assemblers.pybel import assembler as pa
+from indra.databases import hgnc_client
+from indra.statements import *
 
 
 def id(gene_name):

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -106,8 +106,8 @@ def test_modification_with_evidences():
     assert edge_data[pc.RELATION] == pc.INCREASES
     assert edge_data[pc.EVIDENCE] == 'evidence text'
     assert edge_data[pc.CITATION] == {
-        pc.CITATION_TYPE: pc.CITATION_TYPE_PUBMED,
-        pc.CITATION_REFERENCE: '1234',
+        pc.CITATION_DB: pc.CITATION_TYPE_PUBMED,
+        pc.CITATION_IDENTIFIER: '1234',
     }
     assert 'source_api' in edge_data[pc.ANNOTATIONS]
     assert edge_data[pc.ANNOTATIONS]['source_api'] == 'test'
@@ -176,8 +176,8 @@ def test_direct_activation():
         pc.OBJECT: {pc.MODIFIER: pc.ACTIVITY},
         pc.EVIDENCE: 'No evidence text.',
         pc.CITATION: {
-            pc.CITATION_TYPE: pc.CITATION_TYPE_PUBMED,
-            pc.CITATION_REFERENCE: '1234',
+            pc.CITATION_DB: pc.CITATION_TYPE_PUBMED,
+            pc.CITATION_IDENTIFIER: '1234',
         },
         'stmt_hash': hash1
     }
@@ -187,8 +187,8 @@ def test_direct_activation():
         pc.OBJECT: activity('kin'),
         pc.EVIDENCE: 'No evidence text.',
         pc.CITATION: {
-            pc.CITATION_TYPE: pc.CITATION_TYPE_PUBMED,
-            pc.CITATION_REFERENCE: '1234',
+            pc.CITATION_DB: pc.CITATION_TYPE_PUBMED,
+            pc.CITATION_IDENTIFIER: '1234',
         },
         'stmt_hash': hash2
     }

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -8,10 +8,8 @@ import pybel.constants as pc
 from indra.assemblers.pybel import assembler as pa
 from indra.databases import hgnc_client
 from indra.statements import *
-from pybel.dsl import (
-    abundance, activity, bioprocess, complex_abundance,
-    hgvs, pmod, protein, reaction,
-)
+from pybel.dsl import abundance, activity, bioprocess, \
+    complex_abundance, hgvs, pmod, protein, reaction
 
 
 def id(gene_name):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def main():
                       'eidos_offline': ['pyyaml>=5.1.0', 'cython', 'pyjnius==1.1.4'],
                       'geneways': ['stemming', 'nltk'],
                       'sofia': ['openpyxl'],
-                      'bel': ['pybel>=0.14.0'],
+                      'bel': ['pybel>=0.14.2'],
                       'sbml': ['python-libsbml'],
                       'obo': ['obonet'],
                       # Tools and analysis

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def main():
                       'eidos_offline': ['pyyaml>=5.1.0', 'cython', 'pyjnius==1.1.4'],
                       'geneways': ['stemming', 'nltk'],
                       'sofia': ['openpyxl'],
-                      'bel': ['pybel'],
+                      'bel': ['pybel>=0.14.0'],
                       'sbml': ['python-libsbml'],
                       'obo': ['obonet'],
                       # Tools and analysis

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def main():
                       'eidos_offline': ['pyyaml>=5.1.0', 'cython', 'pyjnius==1.1.4'],
                       'geneways': ['stemming', 'nltk'],
                       'sofia': ['openpyxl'],
-                      'bel': ['pybel>=0.14.2'],
+                      'bel': ['pybel>=0.14.2,<0.15.0'],
                       'sbml': ['python-libsbml'],
                       'obo': ['obonet'],
                       # Tools and analysis

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def main():
                       'eidos_offline': ['pyyaml>=5.1.0', 'cython', 'pyjnius==1.1.4'],
                       'geneways': ['stemming', 'nltk'],
                       'sofia': ['openpyxl'],
-                      'bel': ['pybel==0.13.2'],
+                      'bel': ['pybel'],
                       'sbml': ['python-libsbml'],
                       'obo': ['obonet'],
                       # Tools and analysis


### PR DESCRIPTION
Closes #993 

PyBEL v0.14 has a new data model that better encapsulates named entities, so the nodelink JSON schema has changed a bit. It also has some high-level API changes:

- all `from_*_file` and `from_*_path` functions have been merged using magical decorators)
- renames to reduce some confusion (e.g., the `pybel.from_path` function has been renamed to `pybel.from_belscript_file`, the `from_json_*` series has been renamed to `from_nodelink_*`)
- deprecation of `pybel.resources` from v0.13 has gone into effect, so all imports are updated to `bel_resources`