### PR TITLE
Improvements for presenting Influences and re-grounding

### DIFF
--- a/indra/sources/eidos/server.py
+++ b/indra/sources/eidos/server.py
@@ -9,8 +9,12 @@ Eidos JSON-LD output.
 """
 
 import json
+import requests
 from flask import Flask, request
 from indra.sources.eidos.reader import EidosReader
+from indra.preassembler.make_wm_ontologies import wm_ont_url
+
+wm_yml = requests.get(wm_ont_url).text
 
 
 app = Flask(__name__)
@@ -25,7 +29,16 @@ def process_text():
     return json.dumps(res)
 
 
+@app.route('/reground_text', methods=['POST'])
+def reground_text():
+    text = request.json.get('text')
+    if not text:
+        return []
+    res = er.reground_texts([text], wm_yml)
+    return json.dumps(res)
+
+
 if __name__ == '__main__':
     er = EidosReader()
     er.process_text('hello', 'json_ld')
-    app.run(host='0.0.0.0')
+    app.run(host='0.0.0.0', port=6666)

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -59,3 +59,15 @@ def test_tag_text():
     print(tagged_text)
     assert tagged_text == '<FooBarBaz>FooBarBaz</FooBarBaz> binds ' \
                           '<Foo>Foo</Foo>.'
+
+
+def test_influence():
+    c2 = Concept('food insecurity',
+                 db_refs={'WM': [('wm/food_insecurity', 1.0)]})
+    c1 = Concept('floods',
+                 db_refs={'WM': [('wm/floods', 1.0)]})
+    c3 = Concept('x', db_refs={})
+    stmt = Influence(Event(c1), Event(c2))
+    stmt2 = Influence(Event(c1), Event(c3))
+    ha = HtmlAssembler([stmt, stmt2])
+    ha.make_model()

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -4,7 +4,7 @@ from itertools import permutations
 from numpy import array, concatenate, zeros
 
 from indra.assemblers.english import EnglishAssembler
-from indra.statements import Agent, get_statement_by_name
+from indra.statements import Agent, Influence, Event, get_statement_by_name
 
 
 logger = logging.getLogger(__name__)
@@ -36,6 +36,14 @@ def _get_keyed_stmts(stmt_list):
             key += (name(ags[0]), s.activity, s.is_active)
         elif verb == 'HasActivity':
             key += (name(ags[0]), s.activity, s.has_activity)
+        elif verb == 'Influence':
+            sns, sid = s.subj.concept.get_grounding()
+            ons, oid = s.obj.concept.get_grounding()
+            skey = s.subj.concept.name if not sid \
+                else sid.split('/')[-1].replace('_', ' ')
+            okey = s.oubj.concept.name if not oid \
+                else oid.split('/')[-1].replace('_', ' ')
+            key += (skey, okey)
         else:
             key += tuple([name(ag) for ag in ags])
 
@@ -160,6 +168,9 @@ def make_stmt_from_sort_key(key, verb):
                          [make_agent(name) for name in inps[2]])
     elif verb == 'ActiveForm' or verb == 'HasActivity':
         stmt = StmtClass(make_agent(inps[0]), inps[1], inps[2])
+    elif verb == 'Influence':
+        stmt = Influence(Event(make_agent(inps[0])),
+                         Event(make_agent(inps[1])))
     else:
         stmt = StmtClass(*[make_agent(name) for name in inps])
     return stmt
@@ -218,5 +229,5 @@ def make_top_level_label_from_names_key(names):
                 tl_label += ", ".join(b_names[1:-1]) + ', and ' + b_names[-1]
         return tl_label
     except Exception as e:
-        logger.error("Could not handle: %s" % names)
+        logger.error("Could not handle: %s" % str(names))
         raise e

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -41,7 +41,7 @@ def _get_keyed_stmts(stmt_list):
             ons, oid = s.obj.concept.get_grounding()
             skey = s.subj.concept.name if not sid \
                 else sid.split('/')[-1].replace('_', ' ')
-            okey = s.oubj.concept.name if not oid \
+            okey = s.obj.concept.name if not oid \
                 else oid.split('/')[-1].replace('_', ' ')
             key += (skey, okey)
         else:


### PR DESCRIPTION
This PR make some changes to `indra.tools.statement_presentation` to work with Influences and enable their HTML-assembly. It also adds an endpoint to the Flask server wrapping an Eidos JAR for grounding entity text.