### PR TITLE
Regrounding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ indra/literature/cr_clickthrough_key
 indra/benchmarks/assembly_eval/batch4/trips
 indra/benchmarks/assembly_eval/batch4/reach
 models/fallahi_eval/output
+indra/sources/eidos/cache/geonames/index/
 
 # Other
 *.txt

--- a/indra/sources/eidos/server.py
+++ b/indra/sources/eidos/server.py
@@ -34,7 +34,10 @@ def reground_text():
     text = request.json.get('text')
     if not text:
         return []
-    res = er.reground_texts([text], wm_yml)
+    if isinstance(text, str):
+        res = er.reground_texts([text], wm_yml)
+    elif isinstance(text, list):
+        res = er.reground_texts(text, wm_yml)
     return json.dumps(res)
 
 


### PR DESCRIPTION
This PR extends `reground_text` functionality of Eidos Python web-server to allow regrounding of both individual texts and lists of texts.