### PR TITLE
Pin the PyBEL version to an earlier one

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def main():
                       'eidos_offline': ['pyyaml>=5.1.0', 'cython', 'pyjnius==1.1.4'],
                       'geneways': ['stemming', 'nltk'],
                       'sofia': ['openpyxl'],
-                      'bel': ['pybel'],
+                      'bel': ['pybel==0.13.2'],
                       'sbml': ['python-libsbml'],
                       'obo': ['obonet'],
                       # Tools and analysis


### PR DESCRIPTION
Pins the PyBEL vesion to 0.13.2 before #994 is finalized to keep PyBEL and INDRA compatible.