### PR TITLE
Minor DB compatibility fixes

### DIFF
--- a/indra/tools/reading/readers/__init__.py
+++ b/indra/tools/reading/readers/__init__.py
@@ -5,13 +5,30 @@ from .core import Reader, ReadingError, ReadingData, get_reader, \
 
 from .util import get_dir
 
-from .isi import IsiReader
-from .trips import TripsReader
-from .reach import ReachReader
-from .sparser import SparserReader
-
 from .content import Content
-
 
 logger = logging.getLogger(__name__)
 
+err_msg = ("Could not load {reader} reader: \"{err}\". {reader} will not be "
+           "available.")
+
+# Try loading each reader, and raise a warning if it not available.
+try:
+    from .isi import IsiReader
+except Exception as e:
+    logger.warning(err_msg.format(reader="ISI", err=str(e)))
+
+try:
+    from .trips import TripsReader
+except Exception as e:
+    logger.warning(err_msg.format(reader="Trips", err=str(e)))
+
+try:
+    from .reach import ReachReader
+except Exception as e:
+    logger.warning(err_msg.format(reader="REACH", err=str(e)))
+
+try:
+    from .sparser import SparserReader
+except Exception as e:
+    logger.warning(err_msg.format(reader="Sparser", err=str(e)))

--- a/indra/tools/reading/readers/core.py
+++ b/indra/tools/reading/readers/core.py
@@ -202,7 +202,7 @@ class Reader(object):
         # Make a report of the results.
         logger.info("%s took %s to read %s content and produce %s results, "
                     "with %d of those being null."
-                    % (self.name, end - start, len(read_list),
+                    % (self.name, end - start, len(self.content_ids_read),
                        len(self.results), null_results))
         return ret
 

--- a/indra/tools/reading/readers/sparser/__init__.py
+++ b/indra/tools/reading/readers/sparser/__init__.py
@@ -68,7 +68,7 @@ class SparserReader(Reader):
         return
 
     def _map_id(self, content_id):
-        if content_id.startswith('PMC'):
+        if isinstance(content_id, str) and content_id.startswith('PMC'):
             content_id = content_id[3:]
         content_id = super(SparserReader, self)._map_id(content_id)
         return content_id


### PR DESCRIPTION
This PR makes a couple of small fixes for compatibility with database reading. In particular `read_list` is in general not just a list but should be able to be a generator, thus `len` cannot be used on it. Second, we should allow the readers module to load whatever readers are available without needing to worry about missing dependencies for other readers.