### PR TITLE
Path stmts

### DIFF
--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import logging
 import indra.statements as ist
+from indra.explanation.reporting import PybelEdge
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +76,8 @@ class EnglishAssembler(object):
                 stmt_strs.append(_assemble_gap(stmt))
             elif isinstance(stmt, ist.Conversion):
                 stmt_strs.append(_assemble_conversion(stmt))
+            elif isinstance(stmt, PybelEdge):
+                stmt_strs.append(_assemble_pybel_edge(stmt))
             else:
                 logger.warning('Unhandled statement type: %s.' % type(stmt))
         if stmt_strs:
@@ -382,6 +385,29 @@ def _assemble_influence(stmt):
 
     stmt_str = '%s causes %s' % (subj_str, obj_str)
     return _make_sentence(stmt_str)
+
+
+def _assemble_pybel_edge(pybel_edge):
+    if isinstance(pybel_edge.source, ist.Agent):
+        source_str = _assemble_agent_str(pybel_edge.source)
+    else:
+        source_str = _assemble_complex(pybel_edge.source).rstrip('.')
+    if isinstance(pybel_edge.target, ist.Agent):
+        target_str = _assemble_agent_str(pybel_edge.target)
+    else:
+        target_str = _assemble_complex(pybel_edge.target).rstrip('.')
+    if pybel_edge.relation == 'hasComponent':
+        if pybel_edge.reverse:
+            rel_str = ' is a part of complex '
+        else:
+            rel_str = ' complex has a component '
+    elif pybel_edge.relation == 'hasVariant':
+        if pybel_edge.reverse:
+            rel_str = ' is a variant of '
+        else:
+            rel_str = ' has a variant '
+    edge_str = source_str + rel_str + target_str
+    return _make_sentence(edge_str)
 
 
 def _make_sentence(txt):

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -388,19 +388,13 @@ def _assemble_influence(stmt):
 
 
 def _assemble_pybel_edge(pybel_edge):
-    if isinstance(pybel_edge.source, ist.Agent):
-        source_str = _assemble_agent_str(pybel_edge.source)
-    else:
-        source_str = _assemble_complex(pybel_edge.source).rstrip('.')
-    if isinstance(pybel_edge.target, ist.Agent):
-        target_str = _assemble_agent_str(pybel_edge.target)
-    else:
-        target_str = _assemble_complex(pybel_edge.target).rstrip('.')
+    source_str = _assemble_agent_str(pybel_edge.source)
+    target_str = _assemble_agent_str(pybel_edge.target)
     if pybel_edge.relation == 'hasComponent':
         if pybel_edge.reverse:
-            rel_str = ' is a part of complex '
+            rel_str = ' is a part of '
         else:
-            rel_str = ' complex has a component '
+            rel_str = ' has a component '
     elif pybel_edge.relation == 'hasVariant':
         if pybel_edge.reverse:
             rel_str = ' is a variant of '

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import logging
 import indra.statements as ist
-from indra.explanation.reporting import PybelEdge
 
 logger = logging.getLogger(__name__)
 
@@ -76,8 +75,6 @@ class EnglishAssembler(object):
                 stmt_strs.append(_assemble_gap(stmt))
             elif isinstance(stmt, ist.Conversion):
                 stmt_strs.append(_assemble_conversion(stmt))
-            elif isinstance(stmt, PybelEdge):
-                stmt_strs.append(_assemble_pybel_edge(stmt))
             else:
                 logger.warning('Unhandled statement type: %s.' % type(stmt))
         if stmt_strs:
@@ -385,23 +382,6 @@ def _assemble_influence(stmt):
 
     stmt_str = '%s causes %s' % (subj_str, obj_str)
     return _make_sentence(stmt_str)
-
-
-def _assemble_pybel_edge(pybel_edge):
-    source_str = _assemble_agent_str(pybel_edge.source)
-    target_str = _assemble_agent_str(pybel_edge.target)
-    if pybel_edge.relation == 'hasComponent':
-        if pybel_edge.reverse:
-            rel_str = ' is a part of '
-        else:
-            rel_str = ' has a component '
-    elif pybel_edge.relation == 'hasVariant':
-        if pybel_edge.reverse:
-            rel_str = ' is a variant of '
-        else:
-            rel_str = ' has a variant '
-    edge_str = source_str + rel_str + target_str
-    return _make_sentence(edge_str)
 
 
 def _make_sentence(txt):

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -385,21 +385,23 @@ class PybelAssembler(object):
 
 
 def belgraph_to_signed_graph(
-        belgraph, symmetric_variant_links=False,
-        symmetric_component_links=False):
+        belgraph, include_variants=True, symmetric_variant_links=False,
+        include_components=True, symmetric_component_links=False):
     edge_set = set()
     for u, v, edge_data in belgraph.edges(data=True):
         rel = edge_data.get('relation')
         if rel in pc.CAUSAL_INCREASE_RELATIONS:
             edge_set.add((u, v, 0))
         elif rel in pc.HAS_VARIANT:
-            edge_set.add((u, v, 0))
-            if symmetric_variant_links:
-                edge_set.add((v, u, 0))
+            if include_variants:
+                edge_set.add((u, v, 0))
+                if symmetric_variant_links:
+                    edge_set.add((v, u, 0))
         elif rel in pc.HAS_COMPONENT:
-            edge_set.add((u, v, 0))
-            if symmetric_component_links:
-                edge_set.add((v, u, 0))
+            if include_components:
+                edge_set.add((u, v, 0))
+                if symmetric_component_links:
+                    edge_set.add((v, u, 0))
         elif rel in pc.CAUSAL_DECREASE_RELATIONS:
             edge_set.add((u, v, 1))
         else:

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -436,14 +436,15 @@ def _get_agent_node(agent):
     if not agent.bound_conditions:
         return _get_agent_node_no_bcs(agent)
 
+    # Check if bound conditions are bound to agent
+    bound_conditions = [
+        bc.agent for bc in agent.bound_conditions if bc.is_bound]
+    if not bound_conditions:
+        return _get_agent_node_no_bcs(agent)
     # "Flatten" the bound conditions for the agent at this level
     agent_no_bc = deepcopy(agent)
     agent_no_bc.bound_conditions = []
-    members = [agent_no_bc] + [
-        bc.agent
-        for bc in agent.bound_conditions
-        if bc.is_bound
-    ]
+    members = [agent_no_bc] + bound_conditions
     return _get_complex_node(members)
 
 

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -392,16 +392,14 @@ def belgraph_to_signed_graph(
         rel = edge_data.get('relation')
         if rel in pc.CAUSAL_INCREASE_RELATIONS:
             edge_set.add((u, v, 0))
-        elif rel in pc.HAS_VARIANT:
-            if include_variants:
-                edge_set.add((u, v, 0))
-                if symmetric_variant_links:
-                    edge_set.add((v, u, 0))
-        elif rel in pc.HAS_COMPONENT:
-            if include_components:
-                edge_set.add((u, v, 0))
-                if symmetric_component_links:
-                    edge_set.add((v, u, 0))
+        elif rel in pc.HAS_VARIANT and include_variants:
+            edge_set.add((u, v, 0))
+            if symmetric_variant_links:
+                edge_set.add((v, u, 0))
+        elif rel in pc.HAS_COMPONENT and include_components:
+            edge_set.add((u, v, 0))
+            if symmetric_component_links:
+                edge_set.add((v, u, 0))
         elif rel in pc.CAUSAL_DECREASE_RELATIONS:
             edge_set.add((u, v, 1))
         else:

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -384,27 +384,34 @@ class PybelAssembler(object):
         pass
 
 
-def belgraph_to_signed_graph(belgraph, symmetric_variant_links=False):
-        edge_set = set()
-        for u, v, edge_data in belgraph.edges(data=True):
-            rel = edge_data.get('relation')
-            if rel in pc.CAUSAL_INCREASE_RELATIONS:
-                edge_set.add((u, v, 0))
-            elif rel in (pc.HAS_VARIANT, pc.HAS_COMPONENT):
-                edge_set.add((u, v, 0))
-                if symmetric_variant_links:
-                    edge_set.add((v, u, 0))
-            elif rel in pc.CAUSAL_DECREASE_RELATIONS:
-                edge_set.add((u, v, 1))
-            else:
-                continue
-        # Turn the tuples into dicts
-        graph = nx.MultiDiGraph()
-        graph.add_edges_from(
-            (u, v, dict(sign=sign))
-            for u, v, sign in edge_set
-        )
-        return graph
+def belgraph_to_signed_graph(
+        belgraph, symmetric_variant_links=False,
+        symmetric_part_of_links=False):
+    edge_set = set()
+    for u, v, edge_data in belgraph.edges(data=True):
+        rel = edge_data.get('relation')
+        if rel in pc.CAUSAL_INCREASE_RELATIONS:
+            edge_set.add((u, v, 0))
+        elif rel in pc.HAS_VARIANT:
+            edge_set.add((u, v, 0))
+            if symmetric_variant_links:
+                edge_set.add((v, u, 0))
+        elif rel in pc.HAS_COMPONENT:
+            edge_set.add((u, v, 0))
+            if symmetric_part_of_links:
+                edge_set.add((v, u, 0))
+        elif rel in pc.CAUSAL_DECREASE_RELATIONS:
+            edge_set.add((u, v, 1))
+        else:
+            continue
+    # Turn the tuples into dicts
+    graph = nx.MultiDiGraph()
+    graph.add_edges_from(
+        (u, v, dict(sign=sign))
+        for u, v, sign in edge_set
+    )
+    return graph
+
 
 def _combine_edge_data(relation, subj_edge, obj_edge, stmt_hash, evidences):
     edge_data = {pc.RELATION: relation}

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -386,7 +386,7 @@ class PybelAssembler(object):
 
 def belgraph_to_signed_graph(
         belgraph, symmetric_variant_links=False,
-        symmetric_part_of_links=False):
+        symmetric_component_links=False):
     edge_set = set()
     for u, v, edge_data in belgraph.edges(data=True):
         rel = edge_data.get('relation')
@@ -398,7 +398,7 @@ def belgraph_to_signed_graph(
                 edge_set.add((v, u, 0))
         elif rel in pc.HAS_COMPONENT:
             edge_set.add((u, v, 0))
-            if symmetric_part_of_links:
+            if symmetric_component_links:
                 edge_set.add((v, u, 0))
         elif rel in pc.CAUSAL_DECREASE_RELATIONS:
             edge_set.add((u, v, 1))

--- a/indra/explanation/model_checker/pybel.py
+++ b/indra/explanation/model_checker/pybel.py
@@ -39,7 +39,7 @@ class PybelModelChecker(ModelChecker):
             self.model,
             include_variants=include_variants,
             symmetric_variant_links=symmetric_variant_links,
-            include_components=True,
+            include_components=include_components,
             symmetric_component_links=symmetric_component_links)
         self.graph = signed_edges_to_signed_nodes(signed_edges)
         return self.graph

--- a/indra/explanation/model_checker/pybel.py
+++ b/indra/explanation/model_checker/pybel.py
@@ -27,8 +27,8 @@ class PybelModelChecker(ModelChecker):
         super().__init__(model, statements, do_sampling, seed)
         self.model_agents = self._get_model_agents()
 
-    def get_graph(self, symmetric_component_links=False,
-                  symmetric_variant_links=False):
+    def get_graph(self, include_variants=False, symmetric_variant_links=False,
+                  include_components=True, symmetric_component_links=True):
         """Convert a PyBELGraph to a graph with signed nodes."""
         # This import is done here rather than at the top level to avoid
         # making pybel an implicit dependency of the model checker
@@ -36,8 +36,11 @@ class PybelModelChecker(ModelChecker):
         if self.graph:
             return self.graph
         signed_edges = belgraph_to_signed_graph(
-            self.model, symmetric_component_links=symmetric_component_links,
-            symmetric_variant_links=symmetric_variant_links)
+            self.model,
+            include_variants=include_variants,
+            symmetric_variant_links=symmetric_variant_links,
+            include_components=True,
+            symmetric_component_links=symmetric_component_links)
         self.graph = signed_edges_to_signed_nodes(signed_edges)
         return self.graph
 

--- a/indra/explanation/model_checker/pybel.py
+++ b/indra/explanation/model_checker/pybel.py
@@ -27,14 +27,17 @@ class PybelModelChecker(ModelChecker):
         super().__init__(model, statements, do_sampling, seed)
         self.model_agents = self._get_model_agents()
 
-    def get_graph(self):
+    def get_graph(self, symmetric_component_links=False,
+                  symmetric_variant_links=False):
         """Convert a PyBELGraph to a graph with signed nodes."""
         # This import is done here rather than at the top level to avoid
         # making pybel an implicit dependency of the model checker
         from indra.assemblers.pybel.assembler import belgraph_to_signed_graph
         if self.graph:
             return self.graph
-        signed_edges = belgraph_to_signed_graph(self.model)
+        signed_edges = belgraph_to_signed_graph(
+            self.model, symmetric_component_links=symmetric_component_links,
+            symmetric_variant_links=symmetric_variant_links)
         self.graph = signed_edges_to_signed_nodes(signed_edges)
         return self.graph
 

--- a/indra/explanation/reporting.py
+++ b/indra/explanation/reporting.py
@@ -2,6 +2,8 @@ from collections import namedtuple
 
 from indra.sources.indra_db_rest.api import get_statements_by_hash
 from indra.statements import *
+from indra.assemblers.english.assembler import _assemble_agent_str, \
+    _make_sentence
 
 
 def stmts_from_pysb_path(path, model, stmts):
@@ -86,6 +88,23 @@ def stmts_from_indranet_path(path, model, signed, from_db=True, stmts=None):
 
 PybelEdge = namedtuple(
     'PybelEdge', ['source', 'target', 'relation', 'reverse'])
+
+
+def pybel_edge_to_english(pybel_edge):
+    source_str = _assemble_agent_str(pybel_edge.source)
+    target_str = _assemble_agent_str(pybel_edge.target)
+    if pybel_edge.relation == 'hasComponent':
+        if pybel_edge.reverse:
+            rel_str = ' is a part of '
+        else:
+            rel_str = ' has a component '
+    elif pybel_edge.relation == 'hasVariant':
+        if pybel_edge.reverse:
+            rel_str = ' is a variant of '
+        else:
+            rel_str = ' has a variant '
+    edge_str = source_str + rel_str + target_str
+    return _make_sentence(edge_str)
 
 
 def stmts_from_pybel_path(path, model, from_db=True, stmts=None):

--- a/indra/explanation/reporting.py
+++ b/indra/explanation/reporting.py
@@ -157,17 +157,14 @@ def stmts_from_pybel_path(path, model, from_db=True, stmts=None):
         if not hashes:
             statements = []
             # Can't get statements without hash from db
-            if from_db:
-                continue
-            else:
-                for edge_v in edges.values():
-                    rel = edge_v['relation']
-                    edge = PybelEdge(get_agent(source[0]),
-                                     get_agent(target[0]), rel, reverse)
-                    statements.append(edge)
-                    # Stop if we have an edge to avoid duplicates
-                    if len(statements) > 0:
-                        break
+            for edge_v in edges.values():
+                rel = edge_v['relation']
+                edge = PybelEdge(get_agent(source[0]),
+                                 get_agent(target[0]), rel, reverse)
+                statements.append(edge)
+                # Stop if we have an edge to avoid duplicates
+                if len(statements) > 0:
+                    break
         # If we have hashes, retrieve statements from them
         else:
             if from_db:

--- a/indra/explanation/reporting.py
+++ b/indra/explanation/reporting.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 from indra.sources.indra_db_rest.api import get_statements_by_hash
 from indra.statements import *
 
@@ -151,7 +153,11 @@ def stmts_from_pybel_path(path, model, from_db=True, stmts=None):
     return steps
 
 
-def _stmt_from_other_relation(source, target, model_stmts, relation_type):
+PybelEdge = namedtuple(
+    'PybelEdge', ['source', 'target', 'relation', 'reverse'])
+
+
+def get_agent_or_complex(node, model_stmts):
     from indra.sources.bel.processor import get_agent
     agents = [get_agent(source[0]), get_agent(target[0])]
     for stmt in model_stmts:

--- a/indra/explanation/reporting.py
+++ b/indra/explanation/reporting.py
@@ -159,18 +159,17 @@ PybelEdge = namedtuple(
 
 def get_agent_or_complex(node, model_stmts):
     from indra.sources.bel.processor import get_agent
-    agents = [get_agent(source[0]), get_agent(target[0])]
+    from pybel.dsl import complex_abundance
+    agent = get_agent(node)
+    if isinstance(node, complex_abundance):
+        components = [agent, *[bc.agent for bc in agent.bound_conditions]]
     for stmt in model_stmts:
-        if relation_type == 'hasComponent' and isinstance(stmt, Complex):
-            agents.extend([bc.agent for bc in agents[0].bound_conditions])
-            if set([ag.name for ag in agents]) == set(
-                    [ag.name for ag in stmt.agent_list() if ag is not None]):
+            if isinstance(stmt, Complex):
+                if set([ag.name for ag in components]) == set(
+                    [ag.name for ag in stmt.agent_list()
+                        if ag is not None]):
                 return stmt
-        if relation_type == 'hasVariant':
-            obj = stmt.agent_list()[-1]
-            if obj is not None and obj.name in set([ag.name for ag in agents]):
-                return stmt
-    return None
+    return agent
 
 
 def stmt_from_rule(rule_name, model, stmts):

--- a/indra/explanation/reporting.py
+++ b/indra/explanation/reporting.py
@@ -112,7 +112,13 @@ def stmts_from_pybel_path(path, model, from_db=True, stmts=None):
     for i in range(len(path[:-1])):
         source = path[i]
         target = path[i+1]
-        edges = model[source[0]][target[0]]
+        reverse = False
+        try:
+            edges = model[source[0]][target[0]]
+        except KeyError:
+            # May be a symmetric edge
+            edges = model[target[0]][source[0]]
+            reverse = True
         hashes = set()
         for j in range(len(edges)):
             try:
@@ -125,6 +131,8 @@ def stmts_from_pybel_path(path, model, from_db=True, stmts=None):
         if not hashes:
             statements = []
             for edge_v in edges.values():
+                if reverse:
+                    source, target = target, source
                 stmt = _stmt_from_other_relation(
                     source, target, stmts, edge_v['relation'])
                 if stmt:

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -602,7 +602,7 @@ def get_db_refs_by_ident(ns, ident, node_data):
                 return None, None
     elif ns == 'MIRBASE':
         db_refs = {'MIRBASE': ident}
-    elif ns in ('MGI', 'RGD', 'CHEBI', 'HMDB', 'MESH'):
+    elif ns in ('MGI', 'RGD', 'CHEBI', 'HMDB', 'MESH', 'FPLX'):
         db_refs = {ns: ident}
         # raise ValueError('Identifiers for MGI and RGD databases are not '
         #                 'currently handled: %s' % node_data)

--- a/indra/tests/test_english_assembler.py
+++ b/indra/tests/test_english_assembler.py
@@ -1,5 +1,6 @@
 import indra.assemblers.english.assembler as ea
 from indra.statements import *
+from indra.explanation.reporting import PybelEdge
 
 
 def test_agent_basic():
@@ -432,6 +433,32 @@ def test_active_form():
                     'kinase', True)
     s = _stmt_to_text(st)
     assert s == 'BRAF phosphorylated on T396 is kinase-active.'
+
+
+def test_pybel_edge():
+    pe = PybelEdge(
+        Agent('EGF', bound_conditions=[BoundCondition(Agent('EGFR'))]),
+        Agent('EGF'), 'hasComponent', False)
+    s = _stmt_to_text(pe)
+    assert s == 'EGF bound to EGFR has a component EGF.'
+    pe = PybelEdge(
+        Agent('EGF'),
+        Agent('EGF', bound_conditions=[BoundCondition(Agent('EGFR'))]),
+        'hasComponent', True)
+    s = _stmt_to_text(pe)
+    assert s == 'EGF is a part of EGF bound to EGFR.'
+    pe = PybelEdge(
+        Agent('BRAF'),
+        Agent('BRAF', mods=[ModCondition('phosphorylation', 'T', '396')]),
+        'hasVariant', False)
+    s = _stmt_to_text(pe)
+    assert s == 'BRAF has a variant BRAF phosphorylated on T396.'
+    pe = PybelEdge(
+        Agent('BRAF', mods=[ModCondition('phosphorylation', 'T', '396')]),
+        Agent('BRAF'),
+        'hasVariant', True)
+    s = _stmt_to_text(pe)
+    assert s == 'BRAF phosphorylated on T396 is a variant of BRAF.'
 
 
 def test_get_base_verb():

--- a/indra/tests/test_english_assembler.py
+++ b/indra/tests/test_english_assembler.py
@@ -435,32 +435,6 @@ def test_active_form():
     assert s == 'BRAF phosphorylated on T396 is kinase-active.'
 
 
-def test_pybel_edge():
-    pe = PybelEdge(
-        Agent('EGF', bound_conditions=[BoundCondition(Agent('EGFR'))]),
-        Agent('EGF'), 'hasComponent', False)
-    s = _stmt_to_text(pe)
-    assert s == 'EGF bound to EGFR has a component EGF.'
-    pe = PybelEdge(
-        Agent('EGF'),
-        Agent('EGF', bound_conditions=[BoundCondition(Agent('EGFR'))]),
-        'hasComponent', True)
-    s = _stmt_to_text(pe)
-    assert s == 'EGF is a part of EGF bound to EGFR.'
-    pe = PybelEdge(
-        Agent('BRAF'),
-        Agent('BRAF', mods=[ModCondition('phosphorylation', 'T', '396')]),
-        'hasVariant', False)
-    s = _stmt_to_text(pe)
-    assert s == 'BRAF has a variant BRAF phosphorylated on T396.'
-    pe = PybelEdge(
-        Agent('BRAF', mods=[ModCondition('phosphorylation', 'T', '396')]),
-        Agent('BRAF'),
-        'hasVariant', True)
-    s = _stmt_to_text(pe)
-    assert s == 'BRAF phosphorylated on T396 is a variant of BRAF.'
-
-
 def test_get_base_verb():
     assert ea.statement_base_verb('inhibition') == 'inhibit'
     assert ea.statement_base_verb('dephosphorylation') == 'dephosphorylate'

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -15,7 +15,8 @@ from indra.explanation.model_checker import PysbModelChecker, \
 from indra.explanation.model_checker.pysb import _mp_embeds_into, \
     _cp_embeds_into, _match_lhs, remove_im_params
 from indra.explanation.reporting import stmt_from_rule, stmts_from_pysb_path, \
-    stmts_from_pybel_path, stmts_from_indranet_path, PybelEdge
+    stmts_from_pybel_path, stmts_from_indranet_path, PybelEdge, \
+    pybel_edge_to_english
 from indra.assemblers.pysb.assembler import PysbAssembler, \
     set_base_initial_condition
 from indra.assemblers.indranet import IndraNetAssembler
@@ -1715,6 +1716,32 @@ def test_pybel_edge_types():
     assert results[2][1].path_found
     assert results[3][1].path_found
     assert results[4][1].path_found
+
+
+def test_pybel_edge_to_english():
+    pe = PybelEdge(
+        Agent('EGF', bound_conditions=[BoundCondition(Agent('EGFR'))]),
+        Agent('EGF'), 'hasComponent', False)
+    s = pybel_edge_to_english(pe)
+    assert s == 'EGF bound to EGFR has a component EGF.'
+    pe = PybelEdge(
+        Agent('EGF'),
+        Agent('EGF', bound_conditions=[BoundCondition(Agent('EGFR'))]),
+        'hasComponent', True)
+    s = pybel_edge_to_english(pe)
+    assert s == 'EGF is a part of EGF bound to EGFR.'
+    pe = PybelEdge(
+        Agent('BRAF'),
+        Agent('BRAF', mods=[ModCondition('phosphorylation', 'T', '396')]),
+        'hasVariant', False)
+    s = pybel_edge_to_english(pe)
+    assert s == 'BRAF has a variant BRAF phosphorylated on T396.'
+    pe = PybelEdge(
+        Agent('BRAF', mods=[ModCondition('phosphorylation', 'T', '396')]),
+        Agent('BRAF'),
+        'hasVariant', True)
+    s = pybel_edge_to_english(pe)
+    assert s == 'BRAF phosphorylated on T396 is a variant of BRAF.'
 
 
 # Test graph conversion


### PR DESCRIPTION
This PR introduces new object PybelEdge used to represent 'hasVariant' and 'hasComponent' edges of Pybel model. Function `belgraph_to_signed_graph` (and method `get_graph` calling it in PybelModelchecker) is parameterized to separately include/exclude hasVariant/hasComponent edges and their reversed versions. EnglishAssembler is updated to handle PybelEdges.