### PR TITLE
PFAM ID in PyBEL

### DIFF
--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -527,7 +527,7 @@ def _get_agent_grounding(agent):
 
     pfam_id = _get_id(agent, 'PF')
     if pfam_id:
-        return protein('PFAM', pfam_id)
+        return protein('PFAM', name=agent.name, identifier=pfam_id)
 
     ip_id = _get_id(agent, 'IP')
     if ip_id:

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -608,6 +608,8 @@ def get_db_refs_by_ident(ns, ident, node_data):
         #                 'currently handled: %s' % node_data)
     elif ns == 'PUBCHEM.COMPOUND':
         db_refs = {'PUBCHEM': ident}
+    elif ns == 'PFAM':
+        db_refs = {'PF': ident}
     else:
         logger.info("Unhandled namespace %s with name %s and "
                     "identifier %s (%s)." % (ns, name,


### PR DESCRIPTION
This PR handles assembly of agents and processing of nodes with PFAM ID. @bgyori I need to mention I put `name=agent.name` instead of suggested `name=pfam_id` because otherwise in existing example we get an agent `PF00858()` instead of  `AS-C()`. If there's a reason we need to keep the ID there and there's a way to get the correct name from ID, I can update this. 