### PR TITLE
Only place the color key at the top of the page when sources are shown.

### DIFF
--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -184,6 +184,7 @@ class HtmlAssembler(object):
                     evidence_count_str = '%s / %s' % (len(ev_list), tot_ev)
                 else:
                     evidence_count_str = str(len(ev_list))
+
                 stmt_info_list.append({
                     'hash': stmt_hash,
                     'english': english,
@@ -209,11 +210,14 @@ class HtmlAssembler(object):
         # Fill the template.
         if template is None:
             template = default_template
+        if self.source_counts and 'source_key_dict' not in template_kwargs:
+            template_kwargs['source_key_dict'] = SRC_KEY_DICT
+        if 'source_colors' not in template_kwargs:
+            template_kwargs['source_colors'] = SOURCE_COLORS
+
         self.model = template.render(stmt_data=tl_stmts,
                                      metadata=metadata, title=self.title,
                                      db_rest_url=db_rest_url,
-                                     source_colors=SOURCE_COLORS,
-                                     source_key_dict=SRC_KEY_DICT,
                                      **template_kwargs)
         return self.model
 

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -256,17 +256,19 @@
         </button>
       </div>
     </div>
-    <div class="row justify-content-md-center">
-      <div class="col-1 text-right">
-        {{ source_colors[0][0] }}
+    {% if source_key_dict %}
+      <div class="row justify-content-md-center">
+        <div class="col-1 text-right">
+          {{ source_colors[0][0] }}
+        </div>
+        <div class="col col-auto text-center">
+          {{ badges(source_key_dict) }}
+        </div>
+        <div class="col-1 text-left">
+          {{ source_colors[1][0] }}
+        </div>
       </div>
-      <div class="col col-auto text-center">
-        {{ badges(source_key_dict) }}
-      </div>
-      <div class="col-1 text-left">
-        {{ source_colors[1][0] }}
-      </div>
-    </div>
+    {% endif %}
     <hr>
   </div>
   {% for results in stmt_data.values() %}


### PR DESCRIPTION
If no source dictionary is provided, don't put up a color key, which is only confusing if the colors aren't used.