### PR TITLE
Fixed path length 

### DIFF
--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -284,6 +284,7 @@ class ModelChecker(object):
             # Keep unique sources but use a list (not set) to preserve order
             if source not in sources:
                 sources.append(source)
+        min_length = min(path_lengths)
         logger.info('Finding paths between %s and %s' % (subj, obj))
         # Now, look for paths
         if path_metrics and max_paths == 0:
@@ -427,14 +428,14 @@ class ModelChecker(object):
         raise NotImplementedError("Method must be implemented in child class.")
 
 
-def get_path_iter(graph, source, target):
+def get_path_iter(graph, source, target, path_length):
     """Return a generator of paths from source to target."""
     # If source and target are the same node we need to find paths from source
     # to its predecessors
     if source == target:
         new_targets = graph.predecessors(source)
         for nt in new_targets:
-            path_iter = nx.shortest_simple_paths(graph, source, nt)
+            path_iter = nx.all_simple_paths(graph, source, nt, path_length - 1)
             try:
                 for p in path_iter:
                     path = deepcopy(p)
@@ -445,7 +446,7 @@ def get_path_iter(graph, source, target):
                 pass
     else:
         # Regular path search
-        path_iter = nx.shortest_simple_paths(graph, source, target)
+        path_iter = nx.all_simple_paths(graph, source, target, path_length)
         try:
             for path in path_iter:
                 yield path

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -297,7 +297,7 @@ class ModelChecker(object):
                                 max_paths, max_path_length)
                 pr.path_metrics = path_metrics
                 # Get the first path
-                # Try to find paths using sources found above
+                # Try to find paths of fixed length using sources found above
                 for source in sources:
                     path_iter = get_path_iter(self.graph, source, obj,
                                               min(path_lengths))
@@ -429,7 +429,7 @@ class ModelChecker(object):
 
 
 def get_path_iter(graph, source, target, path_length):
-    """Return a generator of paths from source to target."""
+    """Return a generator of paths with path_length cutoff from source to target."""
     # If source and target are the same node we need to find paths from source
     # to its predecessors
     if source == target:

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -284,7 +284,6 @@ class ModelChecker(object):
             # Keep unique sources but use a list (not set) to preserve order
             if source not in sources:
                 sources.append(source)
-        min_length = min(path_lengths)
         logger.info('Finding paths between %s and %s' % (subj, obj))
         # Now, look for paths
         if path_metrics and max_paths == 0:
@@ -300,7 +299,8 @@ class ModelChecker(object):
                 # Get the first path
                 # Try to find paths using sources found above
                 for source in sources:
-                    path_iter = get_path_iter(self.graph, source, obj)
+                    path_iter = get_path_iter(self.graph, source, obj,
+                                              min(path_lengths))
                     for path in path_iter:
                         pr.add_path(tuple(path))
                         # Do not get next path if reached max_paths

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -1795,16 +1795,16 @@ def test_signed_edges_to_nodes():
 
 def test_path_fixed_length():
     model_stmts = [
-        IncreaseAmount(Agent('A', db_refs={'HGNC': 1}),
-                       Agent('B', db_refs={'HGNC': 2})),
-        IncreaseAmount(Agent('B', db_refs={'HGNC': 2}),
-                       Agent('C', db_refs={'HGNC': 3})),
-        IncreaseAmount(Agent('C', db_refs={'HGNC': 3}),
-                       Agent('D', db_refs={'HGNC': 4})),
-        IncreaseAmount(Agent('A', db_refs={'HGNC': 1}),
-                       Agent('C', db_refs={'HGNC': 3})),
-        IncreaseAmount(Agent('B', db_refs={'HGNC': 2}),
-                       Agent('D', db_refs={'HGNC': 4}))
+        IncreaseAmount(Agent('A', db_refs={'HGNC': '1'}),
+                       Agent('B', db_refs={'HGNC': '2'})),
+        IncreaseAmount(Agent('B', db_refs={'HGNC': '2'}),
+                       Agent('C', db_refs={'HGNC': '3'})),
+        IncreaseAmount(Agent('C', db_refs={'HGNC': '3'}),
+                       Agent('D', db_refs={'HGNC': '4'})),
+        IncreaseAmount(Agent('A', db_refs={'HGNC': '1'}),
+                       Agent('C', db_refs={'HGNC': '3'})),
+        IncreaseAmount(Agent('B', db_refs={'HGNC': '2'}),
+                       Agent('D', db_refs={'HGNC': '4'}))
     ]
     test_stmt = IncreaseAmount(Agent('A', db_refs={'HGNC': 1}),
                                Agent('D', db_refs={'HGNC': 4}))

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -1793,6 +1793,32 @@ def test_signed_edges_to_nodes():
         assert psng_ed.edges[edge]['extra_data']['float'] == 0.123456
 
 
+def test_path_fixed_length():
+    model_stmts = [
+        IncreaseAmount(Agent('A', db_refs={'HGNC': 1}),
+                       Agent('B', db_refs={'HGNC': 2})),
+        IncreaseAmount(Agent('B', db_refs={'HGNC': 2}),
+                       Agent('C', db_refs={'HGNC': 3})),
+        IncreaseAmount(Agent('C', db_refs={'HGNC': 3}),
+                       Agent('D', db_refs={'HGNC': 4})),
+        IncreaseAmount(Agent('A', db_refs={'HGNC': 1}),
+                       Agent('C', db_refs={'HGNC': 3})),
+        IncreaseAmount(Agent('B', db_refs={'HGNC': 2}),
+                       Agent('D', db_refs={'HGNC': 4}))
+    ]
+    test_stmt = IncreaseAmount(Agent('A', db_refs={'HGNC': 1}),
+                               Agent('D', db_refs={'HGNC': 4}))
+    # There are two two-step paths and one three-step path.
+    # ModelChecker should return all two-step paths.
+    ia = IndraNetAssembler(model_stmts)
+    unsigned_model = ia.make_model(graph_type='digraph')
+    umc = UnsignedGraphModelChecker(unsigned_model)
+    res = umc.check_statement(test_stmt, max_paths=10, max_path_length=5)
+    assert res.path_found
+    assert len(res.paths) == 2, len(res.paths)
+    assert len(res.paths[0]) == len(res.paths[1]) == 3  # 3 nodes = 2 edges/steps
+
+
 if __name__ == '__main__':
     test_prune_influence_map_subj_obj()
 


### PR DESCRIPTION
This PR allows to find "all" (no more than max_paths) paths of a fixed length. The fixed length is the same as the shortest existing path. This is the first step to make path finding deterministic - we can consider adding weights as the next step. On the EMMAA side we'd need to change max_paths parameter value in model config files (it's 1 for all models now).