### PR TITLE
Aws util update

### DIFF
--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -295,9 +295,9 @@ def iter_s3_keys(s3, bucket, prefix, date_cutoff=None, after=True,
     prefix : str
         The prefix filtering of the objects for list
     date_cutoff : str|datetime.datetime
-        A datestring of format %Y(-%m-%d-%H-%M-%S) or an instance of a
-        datetime.datetime class. The date is assumed to be in UTC.
-        By default no filtering is done. Default: None.
+        A datestring of format %Y(-%m-%d-%H-%M-%S) or a datetime.datetime
+        object. The date is assumed to be in UTC. By default no filtering
+        is done. Default: None.
     after : bool
         If True, only return objects after the given date cutoff.
         Otherwise, return objects before. Default: True
@@ -372,9 +372,9 @@ def get_s3_file_tree(s3, bucket, prefix, date_cutoff=None, after=True,
     prefix : str
         The prefix filtering of the objects for list
     date_cutoff : str|datetime.datetime
-        A datestring of format %Y(-%m-%d-%H-%M-%S) or an instance of a
-        datetime.datetime class. The date is assumed to be in UTC.
-        By default no filtering is done. Default: None.
+        A datestring of format %Y(-%m-%d-%H-%M-%S) or a datetime.datetime
+        object. The date is assumed to be in UTC. By default no filtering
+        is done. Default: None.
     after : bool
         If True, only return objects after the given date cutoff.
         Otherwise, return objects before. Default: True

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -337,7 +337,7 @@ def iter_s3_keys(s3, bucket, prefix, date_cutoff=None, after=True,
                         entry['LastModified'] < date_cutoff\
                         or \
                         date_cutoff is None:
-                    yield entry['Key'], entry['LastModified'] if with_dt \
+                    yield (entry['Key'], entry['LastModified']) if with_dt \
                         else entry['Key']
 
         is_truncated = resp['IsTruncated']


### PR DESCRIPTION
This PR upgrades two functions on `indra.util.aws.py`, namely `iter_s3_keys` and `get_s3_file_tree`, to handle checking of `LastModified` info of S3 objects.

Added arguments to the two changed functions allows for chronological sorting and time cutoff, so as to only yield object keys that are before or after a certain date and time.

The changes are backwards compatible and should not interfere with existing code.

The changes are relevant for branches in emmaa and for the cwc integrated service for large number of files are gathered from S3.