### PR TITLE
Update MeSH resources and fix MeSH test 

### DIFF
--- a/indra/resources/mesh_id_label_mappings.tsv
+++ b/indra/resources/mesh_id_label_mappings.tsv
@@ -19,7 +19,7 @@ D000018	Abomasum	Abomasums
 D000019	Abortifacient Agents	Agents, Abortifacient|Contraceptive Agents, Postconception|Agents, Postconception Contraceptive|Postconception Contraceptive Agents|Abortifacients
 D000020	Abortifacient Agents, Nonsteroidal	Agents, Nonsteroidal Abortifacient|Nonsteroidal Abortifacient Agents|Abortifacient Agents, Non-Steroidal|Abortifacient Agents, Non Steroidal|Agents, Non-Steroidal Abortifacient|Non-Steroidal Abortifacient Agents
 D000021	Abortifacient Agents, Steroidal	Agents, Steroidal Abortifacient|Steroidal Abortifacient Agents|Steroid Abortifacients|Abortifacients, Steroid
-D000022	Abortion, Spontaneous	Abortions, Spontaneous|Spontaneous Abortions|Spontaneous Abortion|Early Pregnancy Loss|Early Pregnancy Losses|Pregnancy Loss, Early|Pregnancy Losses, Early|Miscarriage|Miscarriages
+D000022	Abortion, Spontaneous	Abortions, Spontaneous|Spontaneous Abortions|Spontaneous Abortion
 D000023	Abortion Applicants	Abortion Applicant|Applicant, Abortion|Applicants, Abortion|Abortion Seekers|Abortion Seeker|Seeker, Abortion|Seekers, Abortion
 D000024	Abortion, Criminal	Abortions, Criminal|Criminal Abortion|Criminal Abortions|Abortion, Illegal|Illegal Abortion|Abortions, Illegal|Illegal Abortions
 D000025	Abortion, Eugenic	Abortions, Eugenic|Eugenic Abortions|Eugenic Abortion
@@ -40,7 +40,7 @@ D000039	Peritonsillar Abscess	Abscesses, Peritonsillar|Peritonsillar Abscesses|A
 D000040	Abscisic Acid	Abscissins|Abscissic Acid
 D000041	Absenteeism	
 D000042	Absorption	
-D000043	Abstracting and Indexing as Topic	Indexing and Abstracting as Topic|Indexing and Abstracting|Abstracting and Indexing
+D000043	Abstracting and Indexing as Topic	Abstracting and Indexing|Indexing and Abstracting as Topic|Indexing and Abstracting
 D000044	Dental Abutments	Abutments, Dental|Abutment, Dental|Dental Abutment
 D000045	Acacia	Acacias|Wattle Tree|Tree, Wattle|Trees, Wattle|Wattle Trees|Locust Tree|Locust Trees|Tree, Locust|Trees, Locust
 D000046	Academic Medical Centers	Centers, University Medical|Medical Center, Academic|Medical Center, University|University Medical Centers|Medical Centers, University|University Medical Center|Academic Medical Center|Center, Academic Medical|Center, University Medical|Centers, Academic Medical|Medical Centers, Academic
@@ -97,7 +97,7 @@ D000066889	Triticale	Triticosecale|Triticum x Secale
 D000066891	Critical Care Outcomes	Care Outcome, Critical|Care Outcomes, Critical|Critical Care Outcome|Outcome, Critical Care|Outcomes, Critical Care
 D000066908	Simulation Training	Training, Simulation
 D000066928	Millets	Millet
-D000066949	Biobehavioral Sciences	Biobehavioral Science|Science, Biobehavioral|Sciences, Biobehavioral|Biobehavioral Approach|Approach, Biobehavioral|Biobehavioral Model|Biobehavioral Models|Model, Biobehavioral|Models, Biobehavioral
+D000066949	Biobehavioral Sciences	Biobehavioral Science|Science, Biobehavioral|Sciences, Biobehavioral|Biobehavioral Model|Biobehavioral Models|Model, Biobehavioral|Models, Biobehavioral|Biobehavioral Approach|Approach, Biobehavioral
 D000066970	Protein Corona	Corona, Protein
 D000066988	Vegetarians	Vegetarian
 D000066989	Vegans	Vegan
@@ -121,7 +121,7 @@ D000067148	Fungal Viruses	Fungal Virus|Virus, Fungal|Viruses, Fungal|Mycoviruses
 D000067170	Telocytes	Telocyte|Interstitial Cell of Cajal-Like Cells|Interstitial Cell of Cajal Like Cells|Interstitial Cajal-Like Cells|Cajal-Like Cells, Interstitial|Cells, Interstitial Cajal-Like|Interstitial Cajal Like Cells
 D000067190	Exoskeleton Device	Device, Exoskeleton|Devices, Exoskeleton|Exoskeleton Devices
 D000067208	Shellfish Hypersensitivity	Hypersensitivities, Shellfish|Hypersensitivity, Shellfish|Shellfish Hypersensitivities|Shellfish Allergy|Allergies, Shellfish|Allergy, Shellfish|Shellfish Allergies
-D000067248	Failure to Rescue, Health Care	Health Care, Failures to Rescue|Health Care, Failure to Rescue|Failure to Rescue (Health Care)|Failure to Rescues (Health Care)|Rescue, Failure to (Health Care)|Rescues, Failure to (Health Care)
+D000067248	Failure to Rescue, Health Care	Health Care, Failure to Rescue|Health Care, Failures to Rescue|Failure to Rescue (Health Care)|Failure to Rescues (Health Care)|Rescue, Failure to (Health Care)|Rescues, Failure to (Health Care)
 D000067250	Psychiatric Rehabilitation	Rehabilitation, Psychiatric|Mental Health Rehabilitation|Health Rehabilitation, Mental|Rehabilitation, Mental Health|Psychosocial Rehabilitation|Rehabilitation, Psychosocial
 D000067251	Symptom Flare Up	Flare Up, Symptom|Flare Ups, Symptom|Symptom Flare Ups|Symptom Flaring Up|Flaring Up, Symptom|Flaring Ups, Symptom|Symptom Flaring Ups|Acute Symptom Flare|Acute Symptom Flares|Flare, Acute Symptom|Flares, Acute Symptom|Symptom Flare, Acute|Symptom Flares, Acute|Symptom Flareup|Flareup, Symptom|Flareups, Symptom|Symptom Flareups|Symptom Flare-up|Flare-up, Symptom|Flare-ups, Symptom|Symptom Flare-ups
 D000067268	Isolated Heart Preparation	Isolated Heart Preparations|Preparation, Isolated Heart|Preparations, Isolated Heart|Isolated Perfused Heart Model
@@ -143,7 +143,7 @@ D000067404	Social Communication Disorder	Communication Disorder, Social|Communic
 D000067408	Legal Services	Legal Service|Service, Legal|Services, Legal
 D000067448	Defamation	Defamations|Vilification|Vilifications|Calumny|Calumnies
 D000067449	Anger Management Therapy	Therapy, Anger Management|Anger Management Training|Management Training, Anger|Training, Anger Management|Anger Management|Management, Anger
-D000067450	Psychology, Sports	Sports Psychology|Sport Psychology|Psychology, Sport
+D000067450	Psychology, Sports	Sport Psychology|Psychology, Sport|Sports Psychology
 D000067453	War Exposure	Exposure, War|Exposures, War|War Exposures
 D000067454	Childhood-Onset Fluency Disorder	Childhood Onset Fluency Disorder|Childhood-Onset Fluency Disorders|Disorder, Childhood-Onset Fluency|Disorders, Childhood-Onset Fluency|Fluency Disorder, Childhood-Onset|Fluency Disorders, Childhood-Onset
 D000067455	No-Show Patients	No Show Patients|No-Show Patient|Patient, No-Show|Patients, No-Show|Patient Non-Attendance|Non-Attendance, Patient|Patient Non Attendance|Patient No-Show|No-Show, Patient|No-Shows, Patient|Patient No Show
@@ -194,7 +194,7 @@ D000067736	Ataxin-10	Ataxin 10|Atxn-10 Protein|Atxn 10 Protein|Protein, Atxn-10|
 D000067756	Glucagon-Like Peptide Receptors	Glucagon Like Peptide Receptors|Peptide Receptors, Glucagon-Like|Receptors, Glucagon-Like Peptide|Glucagon-Like Receptors|Glucagon Like Receptors|Receptors, Glucagon-Like|GLPR Proteins|Proteins, GLPR
 D000067757	Glucagon-Like Peptide-1 Receptor	Glucagon Like Peptide 1 Receptor|Peptide-1 Receptor, Glucagon-Like|Receptor, Glucagon-Like Peptide-1|GLP-1R Receptor|GLP 1R Receptor|Receptor, GLP-1R|GLP1R Protein|Protein, GLP1R|GLP-1 Receptor|GLP 1 Receptor|Receptor, GLP-1|GLP1R Receptor|Receptor, GLP1R
 D000067758	Glucagon-Like Peptide-2 Receptor	Peptide-2 Receptor, Glucagon-Like|Receptor, Glucagon-Like Peptide-2|GLP-2 Receptor|GLP 2 Receptor|Receptor, GLP-2|GLP2R Protein|Protein, GLP2R|Glucagon-Like Peptide 2 Receptor|Glucagon Like Peptide 2 Receptor|GLP-2R Receptor|GLP 2R Receptor|Receptor, GLP-2R
-D000067759	Receptor for Advanced Glycation End Products	AGE Receptor|Receptor, AGE|RAGE (Receptor for Advanced Glycation End Products)|Advanced Glycosylation End Product Receptors|Advanced Glycosylation End-Product Receptor|Advanced Glycosylation End Product Receptor|Advanced Glycosylation End-Product Receptors|Advanced Glycosylation Endproduct Receptors|Receptor for Advanced Glycation End Products (RAGE)|Receptor for Advanced Glycation Endproducts|Receptor, Advanced Glycosylation End-Product|Receptor, Advanced Glycosylation End Product|Receptor, Advanced Glycosylation End-Products|Receptor, Advanced Glycosylation End Products|Advanced Glycosylation End Product-Specific Receptor|Advanced Glycosylation End Product Specific Receptor|AGER Protein|Protein, AGER|Amphoterin Receptor|Receptor, Amphoterin
+D000067759	Receptor for Advanced Glycation End Products	Receptor for Advanced Glycation Endproducts|Receptor, Advanced Glycosylation End-Product|Receptor, Advanced Glycosylation End Product|Receptor, Advanced Glycosylation End-Products|Receptor, Advanced Glycosylation End Products|Advanced Glycosylation End Product-Specific Receptor|Advanced Glycosylation End Product Specific Receptor|Receptor for Advanced Glycation End Products (RAGE)|Amphoterin Receptor|Receptor, Amphoterin|Advanced Glycosylation Endproduct Receptors|AGE Receptor|RAGE (Receptor for Advanced Glycation End Products)|Advanced Glycosylation End Product Receptors|Advanced Glycosylation End-Product Receptor|Advanced Glycosylation End Product Receptor|Advanced Glycosylation End-Product Receptors|AGER Protein
 D000067776	RNA Recognition Motif Proteins	Ribonucleoprotein Domain Proteins|RNA-Binding Domain Proteins|RNA Binding Domain Proteins|RRM Proteins
 D000067777	ELAV-Like Protein 2	2, ELAV-Like Protein|ELAV Like Protein 2|Protein 2, ELAV-Like|ELAV (Embryonic Lethal, Abnormal Vision, Drosophila)-Like 2 (Hu Antigen B)|HuB Antigen|Antigen, HuB|HuB Protein|Protein, HuB|ELAVL2 protein|protein, ELAVL2|HuB Paraneoplastic Encephalomyelitis Antigen
 D000067778	ELAV-Like Protein 3	3, ELAV-Like Protein|ELAV Like Protein 3|Protein 3, ELAV-Like|HuC Paraneoplastic Encephalomyelitis Antigen|HuC Protein|Protein, HuC|ELAVL3 Protein|Protein, ELAVL3|HuC Antigen|Antigen, HuC
@@ -246,7 +246,7 @@ D000068256	Darbepoetin alfa	Novel Erythropoiesis Stimulating Protein|NESP|Darbep
 D000068257	Efavirenz, Emtricitabine, Tenofovir Disoproxil Fumarate Drug Combination	
 D000068258	Bevacizumab	
 D000068276	Giraffes	Giraffe
-D000068296	Risedronate Sodium	Sodium, Risedronate|2-(3-pyridinyl)-1-hydroxyethylidene-bisphosphonate|1-Hydroxy-2-(3-pyridyl)ethylidene diphosphonate|2-(3-pyridinyl)-1-hydroxyethylidenebisphosphonate|Risedronic Acid, Monosodium Salt|Risedronate
+D000068296	Risedronic Acid	
 D000068297	Fluticasone-Salmeterol Drug Combination	Drug Combination, Fluticasone-Salmeterol|Fluticasone Salmeterol Drug Combination|Fluticasone - Salmeterol|Fluticasone Salmeterol|Fluticasone-Salmeterol Combination|Combination, Fluticasone-Salmeterol|Fluticasone Salmeterol Combination
 D000068298	Fluticasone	
 D000068299	Salmeterol Xinafoate	Xinafoate, Salmeterol
@@ -263,17 +263,17 @@ D000068378	Lamiales
 D000068397	Clinical Study	
 D000068436	Surgical Clearance	Clearance, Surgical|Clearances, Surgical|Surgical Clearances|Medical Clearance|Clearance, Medical|Clearances, Medical|Medical Clearances
 D000068437	Pemetrexed	MTA|N-(4-(2-(2-amino-3,4-dihydro-4-oxo-7H-pyrrolo(2,3-d)pyrimdin-5-yl)ethyl)benzoyl)glutamic acid
-D000068438	Brimonidine Tartrate	Tartrate, Brimonidine|5-Bromo-6-(2-imidazolin-2-ylamino)quinoxaline D-tartrate
+D000068438	Brimonidine Tartrate	5-Bromo-6-(2-imidazolin-2-ylamino)quinoxaline D-tartrate
 D000068456	Clinical Studies as Topic	
 D000068476	Beijing	Peking
 D000068516	African Union	Union, African
 D000068536	Firmicutes	
 D000068538	Dutasteride	17beta-N-(2,5-bis(trifluoromethyl))phenyl-carbamoyl-4-aza-5alpha-androst-1-en-3-one
 D000068543	Calceolariaceae	
-D000068556	Interferon beta-1a	beta-1a, Interferon|Interferon beta 1a|1a, Interferon beta|beta 1a, Interferon
+D000068556	Interferon beta-1a	beta-1a, Interferon|Interferon beta 1a|beta 1a, Interferon
 D000068557	Olmesartan Medoxomil	Medoxomil, Olmesartan|5-Methyl-2-oxo-1,3-dioxolen-4-yl)methoxy-4-(1-hydroxy-1-methylethyl)-2-propyl-1-(4-(2-(tetrazol-5-yl)phenyl)phenyl)methylimidazol-5-carboxylate - T287346
 D000068558	Amlodipine Besylate, Olmesartan Medoxomil Drug Combination	Amlodipine Besylate-Olmesartan Medoxomil Drug Combination|Amlodipine Besylate Olmesartan Medoxomil Drug Combination|Amlodipine Besylate-Olmesartan Medoxomil|Amlodipine Besylate Olmesartan Medoxomil|Besylate-Olmesartan Medoxomil, Amlodipine|Medoxomil, Amlodipine Besylate-Olmesartan|Amlodipine Besylate, Olmesartan Medoxomil
-D000068576	Interferon beta-1b	beta-1b, Interferon|Beta-IFN-1b|Interferon Beta, Ser(17)|Ser(17) IFN-beta|Serine(17) Interferon Beta|Interferon beta 1b|1b, Interferon beta|beta 1b, Interferon|IFN-Beta Ser|Interferon Beta, Serine(17)
+D000068576	Interferon beta-1b	Beta-IFN-1b|Ser(17) IFN-beta|Interferon Beta, Serine(17)|Serine(17) Interferon Beta|Interferon beta 1b|IFN-Beta Ser|Interferon Beta, Ser(17)
 D000068577	Nebivolol	Alpha,Alpha'-(Iminobis(Methylene))bis(6-Fluoro-3,4-dihydro)-2H-1-benzopyran-2-methanol
 D000068579	Celecoxib	4-(5-(4-methylphenyl)-3-(trifluoromethyl)-1H-pyrazol-1-yl)benzenesulfonamide
 D000068580	Varenicline	6,7,8,9-Tetrahydro-6,10-methano-6H-pyrazino(2,3-h)benzazepine
@@ -304,8 +304,8 @@ D000068757	Ononis	Rest-Harrow|Rest Harrow|Rest-Harrows|Restharrow|Restharrows
 D000068758	Mometasone Furoate, Formoterol Fumarate Drug Combination	Mometasone Furoate-Formoterol Fumarate Drug Combination|Mometasone Furoate Formoterol Fumarate Drug Combination
 D000068759	Formoterol Fumarate	Formoterol Fumarate, ((R*,R*)-(+-))-isomer|3-Formylamino-4-hydroxy-alpha-(N-1-methyl-2-p-methoxyphenethylaminomethyl)benzyl alcohol.hemifumarate
 D000068760	Serotonin and Noradrenaline Reuptake Inhibitors	SSRIs and NRIs|NRIs and SSRIs|Serotonin and Noradrenaline Uptake Inhibitors|SNRIs|Serotonin and Norepinephrine Reuptake Inhibitors|Serotonin and Norepinephrine Uptake Inhibitors
-D000068776	Sleep Aids, Pharmaceutical	Pharmaceutical Sleep Aids|Sleep Promoting Agents|Agents, Sleep Promoting|Sleep Inducers
-D000068796	Orexin Receptor Antagonists	Antagonists, Orexin Receptor|Receptor Antagonists, Orexin|Orexin Receptor Blockers|Blockers, Orexin Receptor|Receptor Blockers, Orexin
+D000068776	Sleep Aids, Pharmaceutical	Pharmaceutical Sleep Aids|Sleep Promoting Agents|Sleep Inducers
+D000068796	Orexin Receptor Antagonists	Orexin Receptor Blockers
 D000068797	Orexins	Hypocretins
 D000068798	Hoodia	
 D000068799	Prasugrel Hydrochloride	Hydrochloride, Prasugrel|Prasugrel HCl|HCl, Prasugrel
@@ -324,12 +324,12 @@ D000068858	Kombucha Tea	Kombucha Teas|Tea, Kombucha|Teas, Kombucha
 D000068876	Fingolimod Hydrochloride	Hydrochloride, Fingolimod|2-Amino-2-(2-(4-octylphenyl)ethyl)-1,3-propanediol hydrochloride
 D000068877	Imatinib Mesylate	Mesylate, Imatinib|Imatinib Methanesulfonate|Methanesulfonate, Imatinib
 D000068878	Trastuzumab	
-D000068879	Adalimumab	D2E7 Antibody|Antibody, D2E7
+D000068879	Adalimumab	
 D000068880	Isophane Insulin, Human	Human Isophane Insulin|Insulin, Human Isophane|Protophane|Protophan|NPH Insulin, Human|Human NPH Insulin|Insulin, Human NPH|Insulin, NPH, Human
 D000068881	Animals, Exotic	Exotic Animals|Animal, Exotic|Exotic Animal
 D000068882	Paliperidone Palmitate	Palmitate, Paliperidone
 D000068884	Immunosenescence	
-D000068896	Canagliflozin	Canagliflozin Hemihydrate|Hemihydrate, Canagliflozin
+D000068896	Canagliflozin	
 D000068897	Iridescence	Goniochromism|Iridescent Coloring|Coloring, Iridescent|Colorings, Iridescent|Iridescent Colorings
 D000068898	Raltegravir Potassium	Potassium, Raltegravir
 D000068899	Sitagliptin Phosphate, Metformin Hydrochloride Drug Combination	Sitagliptin Phosphate-Metformin Hydrochloride Drug Combination|Sitagliptin Phosphate Metformin Hydrochloride Drug Combination
@@ -349,7 +349,7 @@ D000069036	Insulin Glargine	Glargine, Insulin|A21-Gly-B31-Arg-B32-Arg-insulin|A2
 D000069056	Lurasidone Hydrochloride	Hydrochloride, Lurasidone|Lurasidone HCl|HCl, Lurasidone
 D000069057	Insulin Detemir	Detemir, Insulin|Basal Insulin Detemir|Detemir, Basal Insulin|Insulin Detemir, Basal
 D000069058	Vardenafil Dihydrochloride	Dihydrochloride, Vardenafil
-D000069059	Atorvastatin Calcium	Calcium, Atorvastatin|Atorvastatin Calcium Trihydrate|Calcium Trihydrate, Atorvastatin|Trihydrate, Atorvastatin Calcium|Atorvastatin, Calcium Salt|Calcium Salt Atorvastatin|Atorvastatin Calcium Hydrate|Calcium Hydrate, Atorvastatin|Hydrate, Atorvastatin Calcium
+D000069059	Atorvastatin	(3R,5R)-7-(2-(4-Fluorophenyl)-5-isopropyl-3-phenyl-4-(phenylcarbamoyl)-1H-pyrrol-1-yl)-3,5-dihydroxyheptanoic acid
 D000069076	Fractures, Multiple	Fracture, Multiple|Multiple Fracture|Multiple Fractures
 D000069077	Memory Consolidation	Consolidation, Memory|Consolidations, Memory|Memory Consolidations
 D000069078	Seroconversion	Seroconversions
@@ -357,7 +357,7 @@ D000069079	Radiation Exposure	Exposure, Radiation
 D000069098	Health Smart Cards	Health Smart Card|Smart Card, Health|Smart Cards, Health|Patient Identification Cards|Card, Patient Identification|Cards, Patient Identification|Identification Card, Patient|Identification Cards, Patient|Patient Identification Card|Smart Cards|Card, Smart|Cards, Smart|Smart Card
 D000069177	Type I Secretion Systems	T1SS Secretion System|Secretion System, T1SS|System, T1SS Secretion|Bacterial Secretion Systems, Type I|Type 1 Secretion Systems|Type I Secretion System|Type 1 Secretion System
 D000069178	Type II Secretion Systems	T2SS Secretion System|Secretion System, T2SS|System, T2SS Secretion|Type 2 Secretion System|Bacterial Secretion System, Type II|Type II Secretion System|Type 2 Secretion Systems
-D000069196	Gastrointestinal Microbiome	Gastrointestinal Microbiomes|Microbiome, Gastrointestinal|Microbiomes, Gastrointestinal|Gut Microflora|Microflora, Gut|Gut Microbiota|Gut Microbiotas|Microbiota, Gut|Microbiotas, Gut|Gastrointestinal Flora|Flora, Gastrointestinal|Gut Flora|Flora, Gut|Gastrointestinal Microbiota|Gastrointestinal Microbiotas|Microbiota, Gastrointestinal|Microbiotas, Gastrointestinal|Gut Microbiome|Gut Microbiomes|Microbiome, Gut|Microbiomes, Gut|Gastrointestinal Microflora|Microflora, Gastrointestinal
+D000069196	Gastrointestinal Microbiome	Gastrointestinal Microbiomes|Microbiome, Gastrointestinal|Gut Microbiome|Gut Microbiomes|Microbiome, Gut|Gut Microflora|Microflora, Gut|Gut Microbiota|Gut Microbiotas|Microbiota, Gut|Gastrointestinal Flora|Flora, Gastrointestinal|Gut Flora|Flora, Gut|Gastrointestinal Microbiota|Gastrointestinal Microbiotas|Microbiota, Gastrointestinal|Gastrointestinal Microbial Community|Gastrointestinal Microbial Communities|Microbial Community, Gastrointestinal|Gastrointestinal Microflora|Microflora, Gastrointestinal
 D000069216	Contraceptive Prevalence Surveys	Contraceptive Prevalence Survey|Survey, Contraceptive Prevalence|Surveys, Contraceptive Prevalence
 D000069236	Pericardial Fluid	Fluid, Pericardial|Fluids, Pericardial|Pericardial Fluids|Pericardium Fluid|Fluid, Pericardium|Fluids, Pericardium|Pericardium Fluids
 D000069237	Arthrocentesis	Arthrocenteses
@@ -373,7 +373,7 @@ D000069281	Autoimmune Hypophysitis	Autoimmune Hypophysitides|Hypophysitides, Aut
 D000069282	Canaliculitis	Canaliculitides|Lacrimal Canaliculitis|Canaliculitides, Lacrimal|Canaliculitis, Lacrimal|Lacrimal Canaliculitides
 D000069283	Rituximab	CD20 Antibody, Rituximab|Rituximab CD20 Antibody
 D000069284	Protein Translocation Systems	Systems, Protein Translocation|Translocation Systems, Protein
-D000069285	Infliximab	MAb cA2|Monoclonal Antibody cA2|cA2, Monoclonal Antibody
+D000069285	Infliximab	Monoclonal Antibody cA2|cA2, Monoclonal Antibody|MAb cA2
 D000069286	Bortezomib	
 D000069287	Capecitabine	N(4)-pentyloxycarbonyl-5'-deoxy-5-fluorocytidine
 D000069289	Parasite Encystment	Encystment, Parasite|Encystments, Parasite|Parasite Encystments|Protozoan Encystment|Encystment, Protozoan|Encystments, Protozoan|Protozoan Encystments|Parasite Encystation|Encystation, Parasite|Encystations, Parasite|Parasite Encystations|Protozoan Encystation|Encystation, Protozoan|Encystations, Protozoan|Protozoan Encystations|Protozoan Parasite Encysment|Encysment, Protozoan Parasite|Encysments, Protozoan Parasite|Parasite Encysment, Protozoan|Parasite Encysments, Protozoan|Protozoan Parasite Encysments|Protozoan Parasite Encystation|Encystation, Protozoan Parasite|Encystations, Protozoan Parasite|Parasite Encystation, Protozoan|Parasite Encystations, Protozoan|Protozoan Parasite Encystations
@@ -397,7 +397,7 @@ D000069341	Transitional Care	Care, Transitional|Cares, Transitional|Transitional
 D000069342	Medical Overuse	Medical Overuses|Overuse, Medical|Overuses, Medical|Overuse, Health Services|Overutilization of Health Services|Health Services Overutilization|Overutilization, Health Services|Health Services Overuse|Health Services Overuses|Overuses, Health Services
 D000069343	Bone-Implant Interface	Bone Implant Interface|Bone-Implant Interfaces|Interface, Bone-Implant|Interfaces, Bone-Implant|Bone-Prosthesis Interface|Bone Prosthesis Interface|Bone-Prosthesis Interfaces|Interface, Bone-Prosthesis|Interfaces, Bone-Prosthesis
 D000069347	Erlotinib Hydrochloride	Hydrochloride, Erlotinib|Erlotinib HCl|HCl, Erlotinib
-D000069348	Quetiapine Fumarate	Fumarate, Quetiapine|Ethanol, 2-(2-(4-dibenzo(b,f)(1,4)thiazepin-11-yl-1-piperazinyl)ethoxy)-, (E)-2-butenedioate (2:1) (salt)
+D000069348	Quetiapine Fumarate	Ethanol, 2-(2-(4-dibenzo(b,f)(1,4)thiazepin-11-yl-1-piperazinyl)ethoxy)-, (E)-2-butenedioate (2:1) (salt)
 D000069349	Linezolid	N-((3-(3-fluoro-4-morpholinylphenyl)-2-oxo-5-oxazolidinyl)methyl)acetamide|Linezolide
 D000069350	Telerehabilitation	Telerehabilitations|Tele-rehabilitation|Tele rehabilitation|Tele-rehabilitations|Remote Rehabilitation|Rehabilitation, Remote|Rehabilitations, Remote|Remote Rehabilitations|Virtual Rehabilitation|Rehabilitation, Virtual|Rehabilitations, Virtual|Virtual Rehabilitations
 D000069356	Tympanocentesis	Tympanocenteses
@@ -416,7 +416,7 @@ D000069445	Atomoxetine Hydrochloride	Hydrochloride, Atomoxetine|N-methyl-gamma-(
 D000069446	Atazanavir Sulfate	
 D000069447	Tiotropium Bromide	Bromide, Tiotropium|7-((hydroxybis(2-thienyl)acetyl)oxy)-9,9-dimethyl-3-oxa-9-azoniatricyclo(3.3.1.0(2,4))nonane bromide
 D000069448	Denosumab	
-D000069449	Cinacalcet Hydrochloride	Hydrochloride, Cinacalcet|Alpha-methyl-N-(3-(3-(trifluoromethyl)phenyl)propyl)-1-naphthalenemethanamine, (alphaR)-hydrochloride
+D000069449	Cinacalcet	
 D000069450	Liraglutide	
 D000069451	Long Term Adverse Effects	Adverse Effects, Long Term
 D000069452	Pathogen-Associated Molecular Pattern Molecules	Pathogen Associated Molecular Pattern Molecules|Molecules, Pathogen-Associated Molecular Pattern|Molecules, Pathogen Associated Molecular Pattern|PAMPs
@@ -430,7 +430,7 @@ D000069459	Teas, Herbal	Herbal Teas|Herbal Tea|Tea, Herbal|Tisanes|Tisane
 D000069460	Teas, Medicinal	Medicinal Teas|Medicinal Tea|Tea, Medicinal
 D000069461	Bendamustine Hydrochloride	Hydrochloride, Bendamustine
 D000069462	Dimethyl Fumarate	Fumarate, Dimethyl|2-butenedioic acid, (2E)-, dimethyl ester|Dimethylfumarate
-D000069463	Olive Oil	Olive Oils|Oil, Olive|Oils, Olive
+D000069463	Olive Oil	Oil, Olive|Oils, Olive|Olive Oils
 D000069464	Solifenacin Succinate	Succinate, Solifenacin|Quinuclidin-3'-yl-1-phenyl-1,2,3,4-tetrahydroisoquinoline-2-carboxylate monosuccinate
 D000069465	Febuxostat	
 D000069466	Red Meat	Meat, Red|Meats, Red|Red Meats
@@ -440,7 +440,7 @@ D000069469	Medical-Surgical Nursing	Nursing, Medical-Surgical|Medical Surgical N
 D000069470	Venlafaxine Hydrochloride	Hydrochloride, Venlafaxine|Cyclohexanol, 1-(2-(dimethylamino)-1-(4-methoxyphenyl)ethyl)-, hydrochloride|1-(2-(dimethylamino)-1-(4-methoxyphenyl)ethyl)cyclohexanol HCl
 D000069471	Neurosurgeons	Neurosurgeon|Neurological Surgeons|Neurological Surgeon|Surgeon, Neurological|Surgeons, Neurological
 D000069472	Colesevelam Hydrochloride	Hydrochloride, Colesevelam|Colesevelam HCl|HCl, Colesevelam
-D000069473	Dose Hypofractionation	Hypofractionation, Dose|Radiotherapy Minibeams|Minibeam, Radiotherapy|Minibeams, Radiotherapy|Radiotherapy Minibeam|Hypofractionated Dose|Dose, Hypofractionated|Doses, Hypofractionated|Hypofractionated Doses
+D000069473	Radiation Dose Hypofractionation	Dose Hypofractionation, Radiation|Hypofractionation, Radiation Dose|Radiotherapy Minibeams|Minibeam, Radiotherapy|Radiotherapy Minibeam|Radiotherapy Dose Hypofractionation|Dose Hypofractionation, Radiotherapy|Hypofractionation, Radiotherapy Dose|Hypofractionations, Radiotherapy Dose|Hypofractionated Dose, Radiation|Radiation Hypofractionated Dose
 D000069474	Sofosbuvir	2-((5-(2,4-dioxo-3,4-dihydro-2H-pyrimidin-1-yl)-4-fluoro-3-hydroxy-4-methyltetrahydrofuran-2-ylmethoxy)phenoxyphosphorylamino)propionic acid isopropyl ester
 D000069475	Re-Irradiation	Reirradiation|Re Irradiation
 D000069476	Linagliptin	(R)-8-(3-amino-piperidin-1-yl)-7-but-2-ynyl-3-methyl-1-(4-methyl-quinazolin-2-ylmethyl)-3,7-dihydro-purine-2,6-dione|1H-purine-2,6-dione, 8-((3r)-3-amino-1-piperidinyl)-7-(2-butynyl)-3,7-dihydro-3-methyl-1-((4-methyl-2-quinazolinyl)methyl)-
@@ -453,7 +453,7 @@ D000069501	Abiraterone Acetate
 D000069502	Budesonide, Formoterol Fumarate Drug Combination	Budesonide Formoterol Drug Combination|Budesonide Formoterol Fumarate Drug Combination|Budesonide-Formoterol Drug Combination|Combination, Budesonide-Formoterol Drug|Drug Combination, Budesonide-Formoterol|Budesonide-Formoterol Fumarate Drug Combination
 D000069503	Vilazodone Hydrochloride	Hydrochloride, Vilazodone|2-benzofurancarboxamide, 5-(4-(4-(5-cyano-1H-indol-3-yl)butyl)-1-piperazinyl)-, hydrochloride (1:1)|Vilazodone HCl|HCl, Vilazodone
 D000069516	International Law	International Laws|Law, International|Laws, International|Law of Nations|Public International Law|International Law, Public
-D000069520	Blogs	Weblogs|Web Blogs
+D000069520	Blog	Weblogs|Blogs|Web Blogs
 D000069537	Adult Day Care Centers	Day Care Center, Adult|Day Care Centers, Adult|Adult Day Care Center
 D000069544	Infectious Encephalitis	Encephalitis, Infectious
 D000069545	Elvitegravir, Cobicistat, Emtricitabine, Tenofovir Disoproxil Fumarate Drug Combination	Elvitegravir, Cobicistat, Emtricitabine, and Tenofovir Disoproxil Fumarate|Elvitegravir, Cobicistat, Emtricitabine, and Tenofovir Disoproxil Fumarate Drug Combination|Elvitegravir-Cobicistat-Emtricitabine-Tenofovir Disoproxil Fumarate Drug Combination|Elvitegravir Cobicistat Emtricitabine Tenofovir Disoproxil Fumarate Drug Combination
@@ -476,7 +476,7 @@ D000069581	Exposure to Violence	Violence, Exposure to|Violence Exposure
 D000069582	Eszopiclone	
 D000069583	Pregabalin	(S)-3-(aminomethyl)-5-methylhexanoic acid|3-isobutyl GABA|3 isobutyl GABA|GABA, 3-isobutyl|3-(aminomethyl)-5-methylhexanoic acid|(R-)-3-isobutyl GABA|(S+)-3-isobutyl GABA
 D000069584	Unilateral Breast Neoplasms	Breast Neoplasm, Unilateral|Breast Neoplasms, Unilateral|Unilateral Breast Cancer|Breast Cancer, Unilateral|Breast Cancers, Unilateral|Unilateral Breast Cancers
-D000069585	Filgrastim	G-CSF Recombinant, Human Methionyl|G CSF Recombinant, Human Methionyl|Recombinant-Methionyl Human Granulocyte Colony-Stimulating Factor|Recombinant Methionyl Human Granulocyte Colony Stimulating Factor|R-metHuG-CSF|R metHuG CSF
+D000069585	Filgrastim	Recombinant-Methionyl Human Granulocyte Colony-Stimulating Factor|Recombinant Methionyl Human Granulocyte Colony Stimulating Factor|G-CSF Recombinant, Human Methionyl|G CSF Recombinant, Human Methionyl|R-metHuG-CSF|R metHuG CSF
 D000069586	Adult Survivors of Child Adverse Events	Adult Survivors of Childhood Trauma
 D000069590	Round Ligaments	Ligament, Round|Ligaments, Round|Round Ligament|Ligamentum Teres|Ligamentum Tere
 D000069592	Round Ligament of Liver	Liver Round Ligament|Liver Round Ligaments|Hepatic Round Ligament|Hepatic Round Ligaments|Ligament, Hepatic Round|Ligaments, Hepatic Round|Round Ligament, Hepatic|Round Ligaments, Hepatic|Ligamentum Teres Hepatis|Ligamentum Teres Hepati
@@ -498,10 +498,10 @@ D000069797	Adipocytes, Beige	Adipocyte, Beige|Beige Adipocyte|Beige Adipocytes|B
 D000069816	SEC Translocation Channels	Channels, SEC Translocation|Translocation Channels, SEC|SEC Translocase|Translocase, SEC|SEC Translocons|Translocons, SEC|SEC Complexes|Complexes, SEC|SEC61 Protein|Protein, SEC61|Sec Protein Translocation Systems
 D000069836	Degloving Injuries	Degloving Injury|Injuries, Degloving|Injury, Degloving|Skin Avulsion|Avulsion, Skin|Avulsions, Skin|Skin Avulsions|Degloving Wounds|Degloving Wound|Wound, Degloving|Wounds, Degloving|Skin Avulsion Injuries|Avulsion Injuries, Skin|Avulsion Injury, Skin|Injuries, Skin Avulsion|Injury, Skin Avulsion|Skin Avulsion Injury
 D000069856	Staghorn Calculi	Calculi, Staghorn|Calculus, Staghorn|Staghorn Calculus
-D000069877	Struvite	Magnesium Ammonium Phosphate|Ammonium Phosphate, Magnesium|Phosphate, Magnesium Ammonium
+D000069877	Struvite	
 D000069896	Transcription Activator-Like Effector Nucleases	Transcription Activator Like Effector Nucleases|Nucleases, Transcription Activator-Like Effector|Nucleases, Transcription Activator Like Effector|TALENs
 D000069916	Endoscopic Mucosal Resection	Endoscopic Mucosal Resections|Mucosal Resection, Endoscopic|Mucosal Resections, Endoscopic|Resection, Endoscopic Mucosal|Resections, Endoscopic Mucosal|Strip Biopsy|Biopsies, Strip|Biopsy, Strip|Strip Biopsies|Endoscopic Mucous Membrane Resection
-D000069956	Chocolate	Chocolates|Cocoa Powder|Cocoa Powders|Powder, Cocoa|Powders, Cocoa
+D000069956	Chocolate	Chocolates
 D000069976	Bacillus licheniformis	
 D000069977	Bacillus amyloliquefaciens	
 D000069978	Bifidobacterium longum	
@@ -544,7 +544,7 @@ D000070098	Bacillus firmus
 D000070099	Streptococcus gallolyticus	
 D000070100	Informal Sector	Sector, Informal
 D000070101	Megasphaera elsdenii	
-D000070116	Loteae	
+D000070116	Lotus	Loteae
 D000070136	Lipid Droplet Associated Proteins	Lipid Droplet Proteins|Proteins, Lipid Droplet
 D000070137	Perilipins	Perilipin-Adipophilin-TIP47 Proteins|Perilipin Adipophilin TIP47 Proteins|Proteins, Perilipin-Adipophilin-TIP47|PLIN Proteins|Proteins, PLIN|PAT Proteins|Proteins, PAT|Perilipin Proteins|Proteins, Perilipin
 D000070156	Nogo Receptors	Receptors, Nogo
@@ -562,9 +562,9 @@ D000070316	Pediatric Emergency Medicine	Emergency Medicine, Pediatric|Medicine, 
 D000070318	Strategic Planning	Planning, Strategic
 D000070319	Student Run Clinic	Clinic, Student Run|Clinics, Student Run|Student Run Clinics|Resident Run Clinic|Clinic, Resident Run|Clinics, Resident Run|Resident Run Clinics
 D000070337	Expropriation	Expropriations
-D000070356	Pilots	Aviators|Aviator|Pilot|Co-Pilot|Co Pilot|Co-Pilots
+D000070356	Pilots	Co-Pilot|Co Pilot|Co-Pilots|Aviators|Aviator|Pilot
 D000070357	Asparagaceae	Nolinoideae|Convallariaceae|Hyacinthaceae|Anemarrhenaceae|Agavaceae
-D000070376	Value-Based Insurance	Insurance, Value-Based|Value Based Insurance|Value-Based Insurance Design|Insurance Designs, Value-Based|Value Based Insurance Design|Value-Based Insurance Designs
+D000070376	Value-Based Health Insurance	Health Insurance, Value-Based|Insurance, Value-Based Health|Value Based Health Insurance|Value-Based Health Insurances|Value-Based Insurance Design|Value Based Insurance Design
 D000070377	Anti-Vaccination Movement	Anti Vaccination Movement|Anti-Vaccination Movements|Movement, Anti-Vaccination|Movements, Anti-Vaccination|Anti-Vaccine Groups|Anti Vaccine Groups|Anti-Vaccine Group|Group, Anti-Vaccine|Groups, Anti-Vaccine|Antivaccination Movement|Antivaccination Movements|Movement, Antivaccination|Movements, Antivaccination|Anti-Vaccine Movement|Anti Vaccine Movement|Anti-Vaccine Movements|Movement, Anti-Vaccine|Movements, Anti-Vaccine|Anti-Vaccination Groups|Anti Vaccination Groups|Anti-Vaccination Group|Group, Anti-Vaccination|Groups, Anti-Vaccination
 D000070378	Amaryllidaceae	
 D000070379	Attentional Bias	Bias, Attentional|Attentional Biases|Biases, Attentional|Biased Attention|Attention, Biased
@@ -664,12 +664,12 @@ D000070918	Synoviocytes	Synoviocyte
 D000070956	MutL Proteins	
 D000070957	MutL Protein Homolog 1	MLH1 Protein|Colon Cancer, Nonpolyposis Type 2 Protein|MutL Homolog 1|COCA2 Protein
 D000070976	Mismatch Repair Endonuclease PMS2	PMS1 Homolog 2, Mismatch Repair Protein|PMS2 Protein|Postmeiotic Segregation Increased-S. cerevisiae-2|Postmeiotic Segregation Increased S. cerevisiae 2|PMS-2 Protein|PMS 2 Protein
-D000070996	ATP Binding Cassette Transporter, Sub-Family G	ATP Binding Cassette Transporter, Sub Family G|ABCG Proteins|ABCG Transporters
-D000070997	ATP Binding Cassette Transporter, Sub-Family G, Member 2	ABCG2 Transporter|ABCG2 Protein|CD338 Antigen|Antigen, CD338
-D000070998	ATP Binding Cassette Transporter, Sub-Family G, Member 1	ABCG1 Transporter|ATP-Binding Cassette Transporter 8|ATP Binding Cassette Transporter 8|ABCG1 Protein|White Protein Homolog
+D000070996	ATP Binding Cassette Transporter, Subfamily G	ABCG Proteins|ABCG Transporters|ATP Binding Cassette Transporter, Sub-Family G|ATP Binding Cassette Transporter, Sub Family G
+D000070997	ATP Binding Cassette Transporter, Subfamily G, Member 2	ABCG2 Transporter|CD338 Antigen|ATP Binding Cassette Transporter, Sub-Family G, Member 2|ABCG2 Protein
+D000070998	ATP Binding Cassette Transporter, Subfamily G, Member 1	ATP-Binding Cassette Transporter 8|ATP Binding Cassette Transporter 8|ABCG1 Transporter|White Protein Homolog|ATP Binding Cassette Transporter, Sub-Family G, Member 1|ABCG1 Protein
 D000071017	Hyperekplexia	Hyperekplexias
-D000071018	ATP Binding Cassette Transporter, Sub-Family G, Member 5	ABCG5 Protein|Sterolin-1 Protein|Sterolin 1 Protein
-D000071019	ATP Binding Cassette Transporter, Sub-Family G, Member 8	ABCG8 Protein|Sterolin-2 Protein|Sterolin 2 Protein
+D000071018	ATP Binding Cassette Transporter, Subfamily G, Member 5	ABCG5 Protein|Sterolin-1 Protein|Sterolin 1 Protein|ATP Binding Cassette Transporter, Sub-Family G, Member 5
+D000071019	ATP Binding Cassette Transporter, Subfamily G, Member 8	ABCG8 Protein|Sterolin-2 Protein|Sterolin 2 Protein|ATP Binding Cassette Transporter, Sub-Family G, Member 8
 D000071020	Hemochromatosis Protein	HLA-H Antigen|Antigen, HLA-H|HLA H Antigen|HFE Protein
 D000071036	Sentinel Lymph Node	Lymph Node, Sentinel|Lymph Nodes, Sentinel|Sentinel Lymph Nodes|Sentinal Node|Node, Sentinal|Nodes, Sentinal|Sentinal Nodes
 D000071037	Place Cells	Cell, Place|Cells, Place|Place Cell|Hippocampal Place Cells|Cell, Hippocampal Place|Cells, Hippocampal Place|Hippocampal Place Cell|Place Cell, Hippocampal|Place Cells, Hippocampal
@@ -696,7 +696,7 @@ D000071071	Microaneurysm	Microaneurysms
 D000071072	Acute Febrile Encephalopathy	Acute Febrile Encephalopathies|Encephalopathies, Acute Febrile|Encephalopathy, Acute Febrile|Febrile Encephalopathies, Acute|Acute Encephalitis Syndrome|Acute Encephalitis Syndromes
 D000071074	Neonatal Sepsis	Neonatal Sepses|Sepses, Neonatal|Sepsis, Neonatal
 D000071075	Small Fiber Neuropathy	Neuropathies, Small Fiber|Neuropathy, Small Fiber|Small Fiber Neuropathies|Small Nerve Fiber Neuropathy|Small Fibre Neuropathy|Neuropathies, Small Fibre|Neuropathy, Small Fibre|Small Fibre Neuropathies
-D000071076	Network Meta-Analysis	Meta-Analyses, Network|Meta-Analysis, Network|Network Meta Analysis|Network Meta-Analyses|Mixed Treatment Meta-Analysis|Meta-Analyses, Mixed Treatment|Meta-Analysis, Mixed Treatment|Mixed Treatment Meta Analysis|Mixed Treatment Meta-Analyses|Multiple Treatment Comparison Meta-Analysis|Multiple Treatment Comparison Meta Analysis
+D000071076	Network Meta-Analysis	Meta-Analyses, Network|Meta-Analysis, Network|Network Meta Analysis|Network Meta-Analyses|Multiple Treatment Comparison Meta-Analysis|Multiple Treatment Comparison Meta Analysis|Mixed Treatment Meta-Analysis|Meta-Analyses, Mixed Treatment|Meta-Analysis, Mixed Treatment|Mixed Treatment Meta Analysis|Mixed Treatment Meta-Analyses
 D000071077	Surgical Oncology	Oncology, Surgical
 D000071078	Stenosis, Pulmonary Vein	Pulmonary Vein Stenoses|Pulmonary Vein Stenosis|Stenoses, Pulmonary Vein|Vein Stenoses, Pulmonary|Vein Stenosis, Pulmonary
 D000071079	Stenosis, Pulmonary Artery	Artery Stenoses, Pulmonary|Artery Stenosis, Pulmonary|Pulmonary Artery Stenoses|Pulmonary Artery Stenosis|Stenoses, Pulmonary Artery
@@ -724,7 +724,7 @@ D000071176	Signaling Lymphocytic Activation Molecule Family	Signaling Lymphocyti
 D000071177	Signaling Lymphocytic Activation Molecule Family Member 1	SLAM Protein|CD150 Antigen|Antigen, CD150|SLAM Receptor|SLAMF1 Receptor|CDw150 Protein|SLAMF1 Protein
 D000071178	CD48 Antigen	Antigen, CD48|Signaling Lymphocytic Activation Molecule 2|Blast1 Antigen|B-Lymphocyte Activation Marker BLAST-1|B Lymphocyte Activation Marker BLAST 1|Leukocyte Antigen MEM-102|Leukocyte Antigen MEM 102|MEM-102, Leukocyte Antigen|Signal-Transducing Glycoprotein-60|Glycoprotein-60, Signal-Transducing|Signal Transducing Glycoprotein 60|P41 Antigen|Antigen, P41|SLAM Family Member 2|SLAMF2 Protein|BCM1 Surface Antigen|Surface Antigen, BCM1|Signaling Lymphocytic Activation Molecule Family Member 2|MRC OX-45 Antigen|Antigen, MRC OX-45|MRC OX 45 Antigen
 D000071179	Signaling Lymphocytic Activation Molecule Associated Protein	SH2D1A Protein|SLAM-Associated Protein|SLAM Associated Protein
-D000071181	ATP-Binding Cassette Sub-Family B Member 2	ATP Binding Cassette Sub Family B Member 2|Transporter 1, ATP-Binding Cassette, Sub-Family B (MDR-TAP)|TAP-1 Protein|TAP 1 Protein|ABCB2 Protein|Really Interesting New Gene 4 Protein|RING4 Protein|Peptide Transporter TAP1|TAP1, Peptide Transporter|Peptide Transporter PSF1|PSF1, Peptide Transporter|Antigen Peptide Transporter-1|Antigen Peptide Transporter 1|TAP1 Protein
+D000071181	ATP Binding Cassette Transporter, Subfamily B, Member 2	Transporter 1, ATP-Binding Cassette, Sub-Family B (MDR-TAP)|ATP-Binding Cassette Sub-Family B Member 2|ATP Binding Cassette Sub Family B Member 2|TAP-1 Protein|TAP 1 Protein|ATP Binding Cassette Transporter, Sub-Family B, Member 2|Really Interesting New Gene 4 Protein|RING4 Protein|Peptide Transporter TAP1|TAP1, Peptide Transporter|Peptide Transporter PSF1|PSF1, Peptide Transporter|ABCB2 Protein|Antigen Peptide Transporter-1|Antigen Peptide Transporter 1|TAP1 Protein
 D000071182	Autophagosomes	Autophagosome
 D000071183	Autophagy-Related Proteins	Autophagy Related Proteins
 D000071184	Pharmacogenomic Variants	Pharmacogenomic Variant|Variant, Pharmacogenomic|Variants, Pharmacogenomic|Pharmacokinetic Genetic Variants|Genetic Variant, Pharmacokinetic|Genetic Variants, Pharmacokinetic|Pharmacokinetic Genetic Variant|Pharmacogenetic Variants|Pharmacogenetic Variant|Variant, Pharmacogenetic|Variants, Pharmacogenetic
@@ -804,7 +804,7 @@ D000071446	Neuronal Outgrowth	Neurite Outgrowth|Axon Outgrowth
 D000071447	N-Myc Proto-Oncogene Protein	N Myc Proto Oncogene Protein|Proto-Oncogene Protein, N-Myc|BHLHE37 Protein|NMYC Protein|Class E Basic Helix-Loop-Helix Protein 37|Class E Basic Helix Loop Helix Protein 37|N-Myc Protein|N Myc Protein|MYCN Protein
 D000071448	Axon Fasciculation	Fasciculation, Axon|Axonal Bundling|Bundling, Axonal|Axonal Fasciculation|Fasciculation, Axonal|Neurite Fasciculation|Fasciculation, Neurite
 D000071449	Proprotein Convertase 9	Convertase 9, Proprotein|Neural Apoptosis-Regulated Convertase 1|Neural Apoptosis Regulated Convertase 1|NARC-1 Protein|NARC 1 Protein|Proprotein Convertase, Subtilisin-Kexin Type 9|Proprotein Convertase, Subtilisin Kexin Type 9
-D000071450	ATP-Binding Cassette, Sub-Family B, Member 3	ABCB3 Protein|Peptide Transporter Tap2|Tap2, Peptide Transporter|Antigen Peptide Transporter-2|Antigen Peptide Transporter 2|Peptide Supply Factor 2
+D000071450	ATP Binding Cassette Transporter, Subfamily B, Member 3	ATP-Binding Cassette, Sub-Family B, Member 3|ATP Binding Cassette Transporter, Sub-Family B, Member 3|Peptide Transporter Tap2|Tap2, Peptide Transporter|ABCB3 Protein|Antigen Peptide Transporter-2|Antigen Peptide Transporter 2|Peptide Supply Factor 2
 D000071451	Chitinase-3-Like Protein 1	Chitinase 3 Like Protein 1|Cartilage Glycoprotein 39|Glycoprotein 39, Cartilage|GP-39 Protein|GP 39 Protein|YLK-40 Protein|YLK 40 Protein|CHI3L1 Protein|CGP-39 Protein|CGP 39 Protein
 D000071456	Sequestosome-1 Protein	Sequestosome 1 Protein|Ubiquitin-Binding Protein p62|Ubiquitin Binding Protein p62|Phosphotyrosine-Independent Ligand For The Lck SH2 Domain Of 62 Kda|Phosphotyrosine Independent Ligand For The Lck SH2 Domain Of 62 Kda|EBI3-Associated Protein of 60 KDa|EBI3 Associated Protein of 60 KDa|EBIAP Protein
 D000071457	DEAD Box Protein 58	DEAD (Asp-Glu-Ala-Asp) Box Polypeptide 58|Probable ATP-Dependent RNA Helicase DDX58|Probable ATP Dependent RNA Helicase DDX58|RIG-I-like Receptor 1|RIG I like Receptor 1
@@ -868,10 +868,9 @@ D000071799	Zinc Finger E-box-Binding Homeobox 1	Zinc Finger E box Binding Homeob
 D000071816	Glycodelin	Progestagen-Associated Endometrial Protein|Endometrial Protein, Progestagen-Associated|Progestagen Associated Endometrial Protein|Pregnancy-Associated Endometrial Alpha-2 Globulin|Pregnancy Associated Endometrial Alpha 2 Globulin
 D000071818	Wnt-5a Protein	Wnt 5a Protein|Wingless-Type MMTV Integration Site Family, Member 5A|Wingless Type MMTV Integration Site Family, Member 5A|Wnt5a Protein
 D000071819	Virophages	Virophage
-D000071820	Emergency Medical Dispatch	Dispatch, Emergency Medical|Medical Dispatch, Emergency|Emergency Police Dispatch|Dispatch, Emergency Police|Dispatchs, Emergency Police|Emergency Police Dispatchs|Police Dispatch, Emergency|Police Dispatchs, Emergency|Emergency Fire Dispatch|Dispatch, Emergency Fire|Fire Dispatch, Emergency
+D000071820	Emergency Medical Dispatch	Dispatch, Emergency Medical|Medical Dispatch, Emergency
 D000071821	Dystonin	Bullous Pemphigoid Antigen 1|230-240 kDa Bullous Pemphigoid Antigen|230 240 kDa Bullous Pemphigoid Antigen|Hemidesmosomal Plaque Protein|230 kDa Bullous Pemphigoid Antigen
 D000071822	Emergency Medical Dispatcher	Dispatcher, Emergency Medical|Dispatchers, Emergency Medical|Emergency Medical Dispatchers|Medical Dispatcher, Emergency|Medical Dispatchers, Emergency
-D000071823	Emergency Police Dispatcher	Dispatcher, Emergency Police|Dispatchers, Emergency Police|Emergency Police Dispatchers|Police Dispatcher, Emergency|Police Dispatchers, Emergency
 D000071825	Extremophiles	
 D000071826	Distracted Driving	Driving, Distracted|Driving While Distracted|Inattentive Driving|Driving, Inattentive
 D000071836	Professional Practice Gaps	Gap, Professional Practice|Gaps, Professional Practice|Practice Gap, Professional|Practice Gaps, Professional|Professional Practice Gap|Practice Gaps|Gap, Practice|Gaps, Practice|Practice Gap
@@ -914,7 +913,7 @@ D000072041	PAX3 Transcription Factor	Transcription Factor, PAX3|Paired Box Trans
 D000072042	Salter-Harris Fractures	Fractures, Salter-Harris|Salter Harris Fractures|Growth Plate Injuries|Growth Plate Injury|Growth Plate Fractures|Fracture, Growth Plate|Fractures, Growth Plate|Growth Plate Fracture
 D000072056	Transcription Factor HES-1	HES-1, Transcription Factor|Transcription Factor HES 1|Hairy-Like Transcription Factor|Hairy Like Transcription Factor|Transcription Factor, Hairy-Like|Hairy and Enhancer of Split 1 Protein
 D000072077	Anesthetists	Anesthetist
-D000072078	Positron Emission Tomography Computed Tomography	PET-CT Scan|PET-CT Scans|Scan, PET-CT|Scans, PET-CT|PET CT Scan|CT Scan, PET|CT Scans, PET|PET CT Scans|Scan, PET CT|Scans, PET CT|CT PET|CT PETs|PET, CT|PETs, CT|Positron Emission Tomography-Computed Tomography|PET-CT|CT PET Scan|CT PET Scans|PET Scan, CT|PET Scans, CT|Scan, CT PET|Scans, CT PET
+D000072078	Positron Emission Tomography Computed Tomography	PET-CT Scan|PET-CT Scans|Scan, PET-CT|Scans, PET-CT|PET CT Scan|CT Scan, PET|CT Scans, PET|PET CT Scans|Scan, PET CT|Scans, PET CT|CT PET|Positron Emission Tomography-Computed Tomography|PET-CT|CT PET Scan|CT PET Scans|PET Scan, CT|PET Scans, CT|Scan, CT PET|Scans, CT PET
 D000072079	Patched Receptors	Receptors, Patched|Patched Sonic Hedgehog Receptors|Patched Receptor|Receptor, Patched|Patched Protein
 D000072080	Anesthesiologists	Anesthesiologist
 D000072081	Patched-1 Receptor	Patched 1 Receptor|Receptor, Patched-1|PTCH1 Protein|Patched Homolog-1|Patched Homolog 1|Patched-1 Protein|Patched 1 Protein|Patched Receptor-1|Patched Receptor 1|Receptor-1, Patched
@@ -965,13 +964,13 @@ D000072199	ADAM12 Protein	ADAM-12 Protein|Meltrin-alpha Protein|Meltrin alpha Pr
 D000072200	Ku Autoantigen	Autoantigen, Ku|Ku Heterodimer|Heterodimer, Ku|Ku Protein|Ku Antigen|Antigen, Ku|G22P1 Antigen|Antigen, G22P1
 D000072216	Zona Pellucida Glycoproteins	Glycoproteins, Zona Pellucida|Pellucida Glycoproteins, Zona|ZP Proteins|Proteins, ZP|Sperm Receptors|Receptors, Sperm
 D000072218	Endodontists	Endodontist
-D000072219	Geriatricians	Geriatrician
+D000072219	Geriatricians	Geriatrician|Gerontologists|Gerontologist
 D000072220	Otolaryngologists	Otolaryngologist
 D000072221	Nurses, Neonatal	Neonatal Nurse|Neonatal Nurses|Nurse, Neonatal
 D000072222	Nurses, Pediatric	Nurse, Pediatric|Pediatric Nurse|Pediatric Nurses
 D000072223	Allergists	Allergist
 D000072224	Bcl-2-Like Protein 11	11, Bcl-2-Like Protein|Bcl 2 Like Protein 11|Protein 11, Bcl-2-Like|Bcl-2-Interacting Mediator of Cell Death|Bcl 2 Interacting Mediator of Cell Death|Bcl-2-Binding Protein, BIM|BIM Bcl-2-Binding Protein|Bcl 2 Binding Protein, BIM|Protein, BIM Bcl-2-Binding|BCL2L11 Protein|Protein, BCL2L11|BIM Protein|Protein, BIM
-D000072226	Computed Tomography Angiography	Angiographies, Computed Tomography|Computed Tomography Angiographies|Tomography Angiographies, Computed|Tomography Angiography, Computed|Angiography, CT|Angiography, Computed Tomography|CT Angiography|Angiographies, CT|CT Angiographies
+D000072226	Computed Tomography Angiography	Angiographies, Computed Tomography|Computed Tomography Angiographies|Tomography Angiographies, Computed|Tomography Angiography, Computed|Angiography, Computed Tomography|Angiography, CT|CT Angiography|Angiographies, CT|CT Angiographies
 D000072227	Shoulder Prosthesis	Prostheses, Shoulder|Prosthesis, Shoulder|Shoulder Prostheses|Prosthetic Shoulder|Prosthetic Shoulders|Shoulder, Prosthetic|Shoulders, Prosthetic|Artificial Shoulder Joint|Artificial Shoulder Joints|Joint, Artificial Shoulder|Joints, Artificial Shoulder|Shoulder Joint, Artificial|Shoulder Joints, Artificial|Humeral Head Prosthesis|Head Prostheses, Humeral|Head Prosthesis, Humeral|Humeral Head Prostheses|Prostheses, Humeral Head|Prosthesis, Humeral Head
 D000072228	Arthroplasty, Replacement, Shoulder	Total Shoulder Replacement|Replacement, Total Shoulder|Replacements, Total Shoulder|Shoulder Replacement, Total|Shoulder Replacements, Total|Total Shoulder Replacements|Shoulder Replacement Arthroplasty|Arthroplasties, Shoulder Replacement|Arthroplasty, Shoulder Replacement|Replacement Arthroplasties, Shoulder|Replacement Arthroplasty, Shoulder|Shoulder Replacement Arthroplasties
 D000072229	Posterior Cruciate Ligament Reconstruction	
@@ -996,7 +995,7 @@ D000072280	Bacteria, Thermoduric	Thermoduric Bacteria
 D000072281	Lymphadenopathy	Lymphadenopathies|Adenopathy|Adenopathies
 D000072282	Extraintestinal Pathogenic Escherichia coli	Extraintestinal Pathogenic E. coli|ExPEC
 D000072283	A549 Cells	A549 Cell|Cell, A549|Cells, A549|A549 Cell Line|A549 Cell Lines|Cell Line, A549|Cell Lines, A549
-D000072296	Bathroom Equipment	Bathroom Equipments|Equipment, Bathroom|Equipments, Bathroom
+D000072296	Bathroom Equipment	Equipment, Bathroom
 D000072316	Dioxins and Dioxin-like Compounds	Dioxins and Dioxin like Compounds
 D000072317	Polychlorinated Dibenzodioxins	Dibenzodioxins, Polychlorinated|Polychlorinated Dibenzo-p-dioxins|Dibenzo-p-dioxins, Polychlorinated|Polychlorinated Dibenzo p dioxins|Chlorinated Dibenzo-p-dioxins|Chlorinated Dibenzo p dioxins|Dibenzo-p-dioxins, Chlorinated|Polychlorinated Dibenzodioxin|Dibenzodioxin, Polychlorinated
 D000072318	Dibenzofurans	Furans, Dibenzo
@@ -1006,7 +1005,7 @@ D000072339	Sexual and Gender Minorities	Non-Heterosexuals|Non Heterosexuals|Non-
 D000072340	NIMA-Interacting Peptidylprolyl Isomerase	Isomerase, NIMA-Interacting Peptidylprolyl|NIMA Interacting Peptidylprolyl Isomerase|Peptidylprolyl Isomerase, NIMA-Interacting|PIN1 Protein|Pin1 Peptidylprolyl Isomerase|Isomerase, Pin1 Peptidylprolyl|Peptidylprolyl Isomerase, Pin1|Peptidyl-Prolyl Cis-Trans Isomerase Pin1|Peptidyl Prolyl Cis Trans Isomerase Pin1
 D000072356	Parenchymal Tissue	Parenchymal Tissues|Tissue, Parenchymal|Tissues, Parenchymal
 D000072357	Applied Behavior Analysis	Analyses, Applied Behavior|Applied Behavior Analyses|Behavior Analyses, Applied|Behavior Analysis, Applied
-D000072358	Work-Life Balance	Life-Work Imbalance
+D000072358	Work-Life Balance	
 D000072359	Trichodesmium	
 D000072376	Oxysterols	Oxysterol
 D000072377	Syk Kinase	Kinase, Syk|SYK Tyrosine Kinase|Kinase, SYK Tyrosine|Tyrosine Kinase, SYK|Spleen Tyrosine Kinase|Kinase, Spleen Tyrosine|Tyrosine Kinase, Spleen
@@ -1018,7 +1017,7 @@ D000072416	Protein Structural Elements	Element, Protein Structural|Elements, Pro
 D000072417	Protein Domains	Peptide Domain|Domain, Peptide|Domains, Peptide|Peptide Domains|Protein Domain|Domain, Protein|Domains, Protein
 D000072436	Transportation Facilities	Facilities, Transportation|Facility, Transportation|Transportation Facility
 D000072437	Calendars as Topic	Calendars as Topics
-D000072438	Calendars	
+D000072438	Calendar	Calendars
 D000072439	Postcards as Topic	Postcards as Topics
 D000072440	Public Health Systems Research	
 D000072441	DNA, Ancient	Ancient DNA
@@ -1151,10 +1150,10 @@ D000073216	Mental Status and Dementia Tests
 D000073218	Wisconsin Card Sorting Test	
 D000073219	Memory and Learning Tests	
 D000073220	Wechsler Memory Scale	
-D000073222	Patient Health Questionnaire	Patient Health Questionnaire 9|PHQ Patient Health Questionnaire|PHQ-9
+D000073222	Patient Health Questionnaire	Patient Health Questionnaire 9|PHQ-9|PHQ Patient Health Questionnaire
 D000073256	Information Technology	Information Technologies|Technology, Information
 D000073276	Models, Spatial Interaction	Interaction Models, Spatial|Spatial Interaction Model|Spatial Interaction Models
-D000073278	Self-Management	Self Management
+D000073278	Self-Management	Self Management|Management, Self
 D000073296	Noncommunicable Diseases	Noncommunicable Disease|Non-infectious Diseases|Non infectious Diseases|Non-infectious Disease|Non-communicable Diseases|Disease, Non-communicable|Diseases, Non-communicable|Non communicable Diseases|Non-communicable Disease|Noninfectious Diseases|Noninfectious Disease
 D000073297	Manual Lymphatic Drainage	Drainage, Manual Lymphatic|Lymphatic Drainage, Manual|Manual Lymph Drainage|Drainage, Manual Lymph|Lymph Drainage, Manual|Lymphatic Drainage Massage|Drainage Massage, Lymphatic|Massage, Lymphatic Drainage
 D000073316	Addiction Medicine	Medicine, Addiction
@@ -1162,11 +1161,11 @@ D000073319	Obesity Management	Management, Obesity|Managements, Obesity|Obesity M
 D000073320	Psycho-Oncology	Psycho Oncology|Psychosocial Oncology|Oncology, Psychosocial|Psychooncology
 D000073336	Whole Genome Sequencing	Genome Sequencing, Whole|Sequencing, Whole Genome|Complete Genome Sequencing|Genome Sequencing, Complete|Sequencing, Complete Genome
 D000073356	Pictorial Works as Topic	
-D000073358	Mycobacterium abscessus	Mycobacterium abscessus Complex
+D000073358	Mycobacterium abscessus	
 D000073359	Whole Exome Sequencing	Exome Sequencing, Whole|Exome Sequencings, Whole|Sequencing, Whole Exome|Sequencings, Whole Exome|Whole Exome Sequencings|Complete Exome Sequencing|Complete Exome Sequencings|Exome Sequencing, Complete|Exome Sequencings, Complete|Sequencing, Complete Exome|Sequencings, Complete Exome
 D000073376	Epileptic Syndromes	Epileptic Syndrome|Epilepsy Syndromes|Epilepsy Syndrome|Syndromic Epilepsies|Epilepsies, Syndromic|Epilepsy, Syndromic|Syndromic Epilepsy
 D000073396	Metal-Organic Frameworks	Frameworks, Metal-Organic|Metal Organic Frameworks|Porous Coordination Networks|Coordination Networks, Porous|Networks, Porous Coordination|Porous Coordination Polymers|Coordination Polymers, Porous|Polymers, Porous Coordination
-D000073397	Occupational Stress	Occupational Stresses|Stress, Occupational|Stresses, Occupational|Job-related Stress|Job related Stress|Job-related Stresses|Stress, Job-related|Stresses, Job-related|Work-related Stress|Stress, Work-related|Stresses, Work-related|Work related Stress|Work-related Stresses|Workplace Stress|Stress, Workplace|Stresses, Workplace|Workplace Stresses|Work Place Stress|Stress, Work Place|Stresses, Work Place|Work Place Stresses|Job Stress|Job Stresses|Stress, Job|Stresses, Job
+D000073397	Occupational Stress	Occupational Stresses|Stress, Occupational|Stresses, Occupational|Job Stress|Job Stresses|Stress, Job|Stresses, Job|Work-related Stress|Stress, Work-related|Stresses, Work-related|Work related Stress|Work-related Stresses|Workplace Stress|Stress, Workplace|Stresses, Workplace|Workplace Stresses|Work Place Stress|Stress, Work Place|Stresses, Work Place|Work Place Stresses|Professional Stress|Professional Stresses|Stress, Professional|Stresses, Professional|Job-related Stress|Job related Stress|Job-related Stresses|Stress, Job-related|Stresses, Job-related
 D000073398	Demethylation	Demethylations
 D000073399	DNA Demethylation	DNA Demethylations|Demethylation, DNA|Demethylations, DNA
 D000073417	Dietary Sugars	Sugars, Dietary|Dietary Sugar|Sugar, Dietary
@@ -1192,7 +1191,7 @@ D000073569	Helicobacteraceae
 D000073571	Laurales	Laurale
 D000073576	Faith-Based Organizations	Faith Based Organizations|Faith-Based Organization|Organization, Faith-Based|Organizations, Faith-Based
 D000073577	Shift Work Schedule	Schedule, Shift Work|Schedules, Shift Work|Work Schedule, Shift
-D000073597	Stakeholder Participation	Stakeholder Participations
+D000073597	Stakeholder Participation	
 D000073599	Health Risk Behaviors	Behavior, Health Risk|Behaviors, Health Risk|Health Risk Behavior|Risk Behavior, Health|Risk Behaviors, Health
 D000073600	Diet, High-Protein	Diet, High Protein|Diets, High-Protein|High-Protein Diets|High-Protein Diet|High Protein Diet
 D000073601	Dietary Approaches To Stop Hypertension	DASH Diet|DASH Diets|Diet, DASH|Diets, DASH|Dietary Approaches To Stop Hypertension Diet
@@ -1221,9 +1220,9 @@ D000073798	Second Harmonic Generation Microscopy
 D000073818	Pain, Procedural	Procedural Pain
 D000073819	Self-Directed Learning as Topic	Self Directed Learning as Topic
 D000073820	Scholarly Communication	Communication, Scholarly|Communications, Scholarly|Scholarly Communications
-D000073839	Trisomy 13 Syndrome	Patau's Syndrome|Pataus Syndrome|Bartholin-Patau Syndrome|Bartholin Patau Syndrome|Chromosome 13 Trisomy Syndrome|Trisomy 13 Syndromes|Patau Syndrome
+D000073839	Trisomy 13 Syndrome	Chromosome 13 Trisomy Syndrome|Patau Syndrome|Trisomy 13 Syndromes|Bartholin-Patau Syndrome|Bartholin Patau Syndrome|Patau's Syndrome|Pataus Syndrome
 D000073840	Copper-transporting ATPases	ATPases, Copper-transporting|Copper transporting ATPases|Cu(+)-transporting ATPases|Copper-transporting Adenosine Triphosphatases|Adenosine Triphosphatases, Copper-transporting|Copper transporting Adenosine Triphosphatases|Triphosphatases, Copper-transporting Adenosine|Copper-transporting ATPase|ATPase, Copper-transporting|Copper transporting ATPase|Cu-transporting ATPases|ATPases, Cu-transporting|Cu transporting ATPases
-D000073842	Trisomy 18 Syndrome	Trisomy 18 Syndromes|Trisomy E Syndrome|Edwards Syndrome
+D000073842	Trisomy 18 Syndrome	Trisomy 18 Syndromes
 D000073843	Equivalence Trial	
 D000073846	Tobacco, Waterpipe	Tobaccos, Waterpipe|Waterpipe Tobacco|Tobacco, Water Pipe|Pipe Tobacco, Water|Water Pipe Tobacco
 D000073847	Smoking, Non-Tobacco Products	Non-Tobacco Products Smoking|Products Smoking, Non-Tobacco|Smoking, Non Tobacco Products|Smokings, Non-Tobacco Products
@@ -1238,18 +1237,18 @@ D000073868	Pipe Smoking	Smoking, Pipe
 D000073869	Tobacco Smoking	Smoking, Tobacco
 D000073871	Triggering Receptor Expressed on Myeloid Cells-1	Triggering Receptor Expressed on Myeloid Cells 1|TREM-1 Protein|TREM 1 Protein|CD354 Antigen|Antigen, CD354
 D000073872	Vascular Ring	Vascular Rings
-D000073874	ATP Binding Cassette Transporter, Sub-Family A	ATP Binding Cassette Transporter, Sub Family A|ABCA Transporters|Transporters, ABCA
+D000073874	ATP Binding Cassette Transporter, Subfamily A	ABCA Transporters|Transporters, ABCA|ATP Binding Cassette Transporter, Sub-Family A|ATP Binding Cassette Transporter, Sub Family A
 D000073878	Palm Oil	Oil, Palm|Palmolein
 D000073879	Rice Bran Oil	Bran Oil, Rice|Oil, Rice Bran
-D000073880	Body Contouring	Contouring, Body
-D000073882	ATP Binding Cassette Transporter, Sub-Family A, Member 4	Retinal-Specific ATP-Binding Cassette Transporter|Retinal Specific ATP Binding Cassette Transporter|Stargardt Disease Protein|ABCA4 Transporter|Transporter, ABCA4
+D000073880	Body Contouring	Contouring, Body|Body Lift Surgery|Body Lift Surgeries|Lift Surgeries, Body|Lift Surgery, Body|Surgeries, Body Lift|Surgery, Body Lift|Body Contour Surgery|Body Contour Surgeries|Contour Surgeries, Body|Contour Surgery, Body|Surgeries, Body Contour|Surgery, Body Contour|Body Contouring Surgery|Body Contouring Surgeries|Contouring Surgeries, Body|Contouring Surgery, Body|Surgeries, Body Contouring|Surgery, Body Contouring
+D000073882	ATP Binding Cassette Transporter, Subfamily A, Member 4	Stargardt Disease Protein|Retinal-Specific ATP-Binding Cassette Transporter|Retinal Specific ATP Binding Cassette Transporter|ATP Binding Cassette Transporter, Sub-Family A, Member 4|ABCA4 Transporter|Transporter, ABCA4
 D000073883	CX3C Chemokine Receptor 1	CX3C Receptor|Receptor, CX3C|V28 Receptor|CX(3)CR1|Receptor, V28|Fractalkine Receptor|Receptor, Fractalkine|CX(3)C Receptor|V28 Receptors|Receptors, V28
 D000073885	C9orf72 Protein	Chromosome 9 Open Reading Frame 72 Protein
 D000073886	Scientific Experimental Error	Error, Scientific Experimental|Errors, Scientific Experimental|Experimental Error, Scientific|Experimental Errors, Scientific|Scientific Experimental Errors|Experimental Error|Error, Experimental|Errors, Experimental|Experimental Errors
 D000073887	Vaccination Coverage	Coverage, Vaccination|Coverages, Vaccination|Vaccination Coverages
 D000073888	Cell-Free Nucleic Acids	Cell Free Nucleic Acids|Nucleic Acids, Cell-Free|Circulating Cell-Free Nucleic Acids|Circulating Cell Free Nucleic Acids|Circulating Nucleic Acids|Acids, Circulating Nucleic|Nucleic Acids, Circulating|Cell-Free Nucleic Acid|Cell Free Nucleic Acid|Nucleic Acid, Cell-Free
 D000073890	Liquid Biopsy	Biopsies, Liquid|Biopsy, Liquid|Liquid Biopsies
-D000073892	Health Information Interoperability	Health Information Interoperabilities|Information Interoperabilities, Health|Information Interoperability, Health|Interoperabilities, Health Information|Interoperability, Health Information
+D000073892	Health Information Interoperability	Health Information Interoperabilities|Information Interoperability, Health|Interoperability, Health Information
 D000073893	Sugars	Sugar
 D000073919	Interdisciplinary Placement	Interdisciplinary Placements|Placement, Interdisciplinary|Placements, Interdisciplinary
 D000073920	Cryobiology	
@@ -1279,7 +1278,7 @@ D000074010	Bone Marrow Stromal Antigen 2	Bone Marrow Stromal Cell Antigen 2|Anti
 D000074011	Peptide Transporter 1	Solute Carrier Family 15 Member 1|Pept-1 Transporter|Pept 1 Transporter|Transporter, Pept-1|PepT1 Protein|hPEPT1 (Cotransporter)|Hydrogen-Peptide Cotransporter PepT1|Hydrogen Peptide Cotransporter PepT1|PepT1, Hydrogen-Peptide Cotransporter|Intestinal H+-Peptide Cotransporter|H+-Peptide Cotransporter, Intestinal|Intestinal H+ Peptide Cotransporter|SLC15A1 Protein
 D000074018	B-Cell CLL-Lymphoma 10 Protein	B Cell CLL Lymphoma 10 Protein|Bcl-10 Protein|Bcl 10 Protein|B-Cell Lymphoma-Leukemia 10 Protein|B Cell Lymphoma Leukemia 10 Protein|Bcl10 Protein
 D000074019	T-Cell Intracellular Antigen-1	Intracellular Antigen-1, T-Cell|T Cell Intracellular Antigen 1|T-Cell-Restricted Intracellular Antigen-1|Intracellular Antigen-1, T-Cell-Restricted|T Cell Restricted Intracellular Antigen 1|RNA-Binding Protein TIA-1|RNA Binding Protein TIA 1|TIA-1, RNA-Binding Protein
-D000074020	ATP Binding Cassette Subfamily B Member 11	ABCB11 Protein|BSEP Protein|Bile Salt Export Pump
+D000074020	ATP Binding Cassette Transporter, Subfamily B, Member 11	ABCB11 Protein|ATP Binding Cassette Subfamily B Member 11|ATP Binding Cassette Transporter, Sub-Family B, Member 11|Bile Salt Export Pump|BSEP Protein
 D000074021	Interatrial Block	Block, Interatrial|Interatrial Blocks|Interatrial Conduction Delay|Conduction Delay, Interatrial|Interatrial Conduction Delays
 D000074022	Anesthesia, Cardiac Procedures	Anesthesias, Cardiac Procedures|Cardiac Procedures Anesthesia|Cardiac Procedures Anesthesias|Anesthesia, Cardiac|Cardiac Anaesthesia|Cardiac Anaesthesias|Cardiothoracic Anaesthesia|Anaesthesia, Cardiothoracic|Cardiac Anesthesia
 D000074024	Immunoturbidimetry	Immunoturbidimetries
@@ -1295,11 +1294,11 @@ D000074050	TWEAK Receptor	Receptor, TWEAK|Fn14 TWEAK Receptor|Receptor, Fn14 TWE
 D000074058	Solute Carrier Family 22 Member 5	High-Affinity Carnitine Transporter|Carnitine Transporter, High-Affinity|High Affinity Carnitine Transporter|Transporter, High-Affinity Carnitine|OCTN2 Protein|Sodium-Dependent Carnitine Cotransporter|Carnitine Cotransporter, Sodium-Dependent|Sodium Dependent Carnitine Cotransporter|Organic Cation-Carnitine Transporter 2|Organic Cation Carnitine Transporter 2|SLC22A5 Protein
 D000074059	Extracorporeal Shockwave Therapy	Extracorporeal Shockwave Therapies|Shockwave Therapies, Extracorporeal|Shockwave Therapy, Extracorporeal|Therapy, Extracorporeal Shockwave|Shock Wave Therapy|Shock Wave Therapies|Therapy, Shock Wave|Extracorporeal Shock Wave Therapy
 D000074060	Bronchial Thermoplasty	Bronchial Thermoplasties|Thermoplasty, Bronchial
-D000074061	ATP Binding Cassette Transporter, Sub-Family D	ATP Binding Cassette Transporter, Sub Family D|ABCD Transporters|Transporters, ABCD|ABCD Proteins|ABC Transporter Subfamily D
+D000074061	ATP Binding Cassette Transporter, Subfamily D	ABCD Proteins|ABCD Transporters|Transporters, ABCD|ATP Binding Cassette Transporter, Sub-Family D|ATP Binding Cassette Transporter, Sub Family D|ABC Transporter Subfamily D
 D000074062	Environmental Biomarkers	Biomarker, Environmental|Biomarkers, Environmental|Environmental Biomarker|Bioindicator|Bioindicators
-D000074063	ATP Binding Cassette Transporter, Sub-Family D, Member 1	ABCD1 Protein|Adrenoleukodystrophy Protein|ABCD1 Transporter|Transporter, ABCD1
-D000074067	Conservation of Water Resources	Resources Conservation, Water|Water Resources Conservations
-D000074079	Undifferentiated Connective Tissue Diseases	Overlap Syndromes|Overlap Syndrome|Undifferentiated Connective Tissue Disease
+D000074063	ATP Binding Cassette Transporter, Subfamily D, Member 1	Adrenoleukodystrophy Protein|ABCD1 Protein|ATP Binding Cassette Transporter, Sub-Family D, Member 1|ABCD1 Transporter
+D000074067	Conservation of Water Resources	Resources Conservation, Water|Water Resources Conservations|Water Resources Conservation|Conservation, Water Resources|Water Conservation|Conservation, Water
+D000074079	Undifferentiated Connective Tissue Diseases	Undifferentiated Connective Tissue Disease
 D000074080	MutS Proteins	
 D000074081	MutS Homolog 3 Protein	Mismatch Repair Protein 1
 D000074082	Sodium-Hydrogen Exchanger 1	Sodium Hydrogen Exchanger 1|SLC9A1 Protein|Na(+)-H(+) Exchanger 1|Solute Carrier Family 9 Member 1
@@ -1308,14 +1307,14 @@ D000074084	THP-1 Cells	Cell, THP-1|Cells, THP-1|THP 1 Cells|THP-1 Cell|THP-1 Cel
 D000074085	Mice, Knockout, ApoE	Apo E Knockout Mice|ApoE Knockout Mice|Knockout Mice, ApoE|Mice, ApoE Knockout
 D000074099	Equivalence Trials as Topic	
 D000074100	Funeral Homes	Funeral Home|Homes, Funeral
-D000074101	Cocaine Smoking	Smoking, Cocaine|Crack Smoking|Smoking, Crack|Crack Cocaine Smoking|Cocaine Smoking, Crack|Smoking, Crack Cocaine
+D000074101	Cocaine Smoking	Smoking, Cocaine|Crack Cocaine Smoking|Cocaine Smoking, Crack|Smoking, Crack Cocaine|Crack Smoking|Smoking, Crack
 D000074121	Protein Kinase C-theta	Protein Kinase C, theta|PRKCQ|Protein Kinase C theta|PKC-theta|PKC theta
 D000074122	Short Stature Homeobox Protein	SHOXY Protein|GCFX Protein|PHOG Protein|SHOX Protein
 D000074141	Circulating Tumor DNA	DNA, Circulating Tumor|Tumor DNA, Circulating|Cell-Free Tumor DNA|Cell Free Tumor DNA|DNA, Cell-Free Tumor|Tumor DNA, Cell-Free
 D000074161	Kazal Motifs	Kazal Motif|Motif, Kazal|Motifs, Kazal|Kazal Domains|Domain, Kazal|Domains, Kazal|Kazal Domain
 D000074162	Serine Peptidase Inhibitors, Kazal Type	SPINK Family Proteins|Serine Protease Inhibitors, Kazal Type
 D000074163	Serine Peptidase Inhibitor Kazal-Type 5	Serine Peptidase Inhibitor Kazal Type 5|LEKTI Protein|SPINK5 Protein|Serine Protease Inhibitor Kazal-Type 5|Serine Protease Inhibitor Kazal Type 5|Lympho-Epithelial Kazal-Type Inhibitor|Inhibitor, Lympho-Epithelial Kazal-Type|Kazal-Type Inhibitor, Lympho-Epithelial|Lympho Epithelial Kazal Type Inhibitor
-D000074164	Nicotine Chewing Gum	Chewing Gum, Nicotine|Chewing Gums, Nicotine|Gum, Nicotine Chewing|Gums, Nicotine Chewing|Nicotine Chewing Gums|Nicorette
+D000074164	Nicotine Chewing Gum	Chewing Gum, Nicotine|Nicotine Chewing Gums
 D000074165	Zinc Finger E-box Binding Homeobox 2	Zinc Finger E box Binding Homeobox 2|Zinc Finger E-box Binding Homeobox 2 Protein|Zinc Finger E box Binding Homeobox 2 Protein|Zeb2 Transcription Factor|Transcription Factor, Zeb2|Smad-Interacting Protein 1|Smad Interacting Protein 1
 D000074166	Circulating MicroRNA	MicroRNA, Circulating|Cell-Free MicroRNA|Cell Free MicroRNA|MicroRNA, Cell-Free
 D000074181	Spastin	Spastic Paraplegia 4 Protein
@@ -1327,8 +1326,8 @@ D000074222	Rumination, Cognitive	Cognitive Rumination
 D000074241	Peanut Oil	Oil, Peanut|Ground Nut Oil|Nut Oil, Ground|Oil, Ground Nut|Arachis Oil|Oil, Arachis
 D000074242	Sunflower Oil	Oil, Sunflower|Sunflower Seed Oil|Oil, Sunflower Seed|Seed Oil, Sunflower
 D000074243	Immune Reconstitution	Immune Regeneration|Immune Restoration
-D000074261	Receptors, Enterotoxin	Enterotoxin-Guanylin Receptors|Enterotoxin Guanylin Receptors|Receptors, Enterotoxin-Guanylin|Receptors, Guanyl Cyclase-C|Receptors, Guanyl Cyclase C|Guanyl Cyclase-C Receptors|Cyclase-C Receptors, Guanyl|Guanyl Cyclase C Receptors|Guanylin-Uroguanylin Receptors|Guanylin Uroguanylin Receptors|Receptors, Guanylin-Uroguanylin|Heat-Stable Enterotoxin Receptors|Enterotoxin Receptors, Heat-Stable|Heat Stable Enterotoxin Receptors|Receptors, Heat-Stable Enterotoxin|Enterotoxin Receptors|GC-C Receptors|GC C Receptors|Receptors, GC-C
-D000074262	Canola Oil	Oil, Canola
+D000074261	Receptors, Enterotoxin	GC-C Receptor|GC C Receptor|Receptor, GC-C|Enterotoxin Receptors|Enterotoxin-Guanylin Receptor|Enterotoxin Guanylin Receptor|Receptor, Enterotoxin-Guanylin|Guanyl Cyclase-C Receptor|Guanyl Cyclase C Receptor|Guanylin-Uroguanylin Receptor|Guanylin Uroguanylin Receptor|Receptor, Guanylin-Uroguanylin|Guanylyl Cyclase C|Cyclase C, Guanylyl|Heat-Stable Enterotoxin Receptor|Enterotoxin Receptor, Heat-Stable|Heat Stable Enterotoxin Receptor|Receptor, Heat-Stable Enterotoxin|Receptor, Enterotoxin|Receptor, Guanyl Cyclase-C|Receptor, Guanyl Cyclase C|Enterotoxin-Guanylin Receptors|Enterotoxin Guanylin Receptors|Receptors, Enterotoxin-Guanylin|GC-C Receptors|GC C Receptors|Receptors, GC-C|Guanyl Cyclase-C Receptors|Cyclase-C Receptors, Guanyl|Guanyl Cyclase C Receptors|Guanylin-Uroguanylin Receptors|Guanylin Uroguanylin Receptors|Receptors, Guanylin-Uroguanylin|Heat-Stable Enterotoxin Receptors|Enterotoxin Receptors, Heat-Stable|Heat Stable Enterotoxin Receptors|Receptors, Heat-Stable Enterotoxin|Receptors, Guanyl Cyclase-C|Receptors, Guanyl Cyclase C|Enterotoxin Receptor
+D000074262	Rapeseed Oil	Oil, Rapeseed
 D000074263	Coconut Oil	Oil, Coconut
 D000074264	Smoking Reduction	Reduction, Smoking
 D000074266	Materials Science	Materials Sciences|Science, Materials|Sciences, Materials|Material Science|Material Sciences|Science, Material|Sciences, Material
@@ -1367,7 +1366,7 @@ D000074407	SAP90-PSD95 Associated Proteins	SAP90 PSD95 Associated Proteins|SAPAP
 D000074408	Aldo-Keto Reductases	Aldo Keto Reductases|Reductases, Aldo-Keto|Aldo-Keto Reductase Superfamily|Aldo Keto Reductase Superfamily|Aldo-Keto Reductase Family|Aldo Keto Reductase Family
 D000074409	Carbonyl Reductase (NADPH)	13,14-dihydroprostaglandin F2alpha Synthetase|13,14 dihydroprostaglandin F2alpha Synthetase|Synthetase, 13,14-dihydroprostaglandin F2alpha|NADPH-Carbonyl Reductase|NADPH Carbonyl Reductase|Reductase, NADPH-Carbonyl|Carbonyl Reductase 1|Daunorubicin Reductase|Reductase, Daunorubicin|Isatin Reductase|Reductase, Isatin|Monomeric Short-Chain Dehydrogenase-Reductase|Dehydrogenase-Reductase, Monomeric Short-Chain|Monomeric Short Chain Dehydrogenase Reductase|Short-Chain Dehydrogenase-Reductase, Monomeric|Ovarian Carbonyl Reductase|Carbonyl Reductase, Ovarian|Reductase, Ovarian Carbonyl|13,14-dihydroprostaglandin F2 alpha Synthetase|13,14 dihydroprostaglandin F2 alpha Synthetase|NADPH-dependent Carbonyl Reductase|Carbonyl Reductase, NADPH-dependent|NADPH dependent Carbonyl Reductase|Reductase, NADPH-dependent Carbonyl
 D000074421	Fermented Foods	Fermented Food|Food, Fermented|Foods, Fermented|Cultured Foods|Cultured Food|Food, Cultured|Foods, Cultured
-D000074422	Aldo-Keto Reductase Family 1 Member C2	Aldo Keto Reductase Family 1 Member C2|Dihydrodiol Dehydrogenase-Bile Acid Binding Protein|Dihydrodiol Dehydrogenase Bile Acid Binding Protein|AKR1C2 Protein|Dihydrodiol Dehydrogenase 2
+D000074422	Aldo-Keto Reductase Family 1 Member C2	Aldo Keto Reductase Family 1 Member C2|AKR1C2 Protein|Dihydrodiol Dehydrogenase-Bile Acid Binding Protein|Dihydrodiol Dehydrogenase Bile Acid Binding Protein|Dihydrodiol Dehydrogenase 2
 D000074423	Celastrales	
 D000074424	Rosanae	
 D000074425	Aldo-Keto Reductase Family 1 Member C3	Aldo Keto Reductase Family 1 Member C3|17-beta-Hydroxysteroid Dehydrogenase Type 5|17 beta Hydroxysteroid Dehydrogenase Type 5|AKR1C3 Protein|Dihydrodiol Dehydrogenase 3
@@ -1389,7 +1388,7 @@ D000074443	Lysine Acetyltransferase 5	KAT5 (TIP60) Protein|HIV-1-Tat Interactive
 D000074462	Positive Regulatory Domain I-Binding Factor 1	Positive Regulatory Domain I Binding Factor 1|PRDI-BF1 Protein|PRDI BF1 Protein|B Lymphocyte-Induced Maturation Protein 1|B Lymphocyte Induced Maturation Protein 1|PRDM1 Protein|BLIMP1 Protein
 D000074463	PR-SET Domains	Domain, PR-SET|Domains, PR-SET|PR SET Domains|PR-SET Domain
 D000074482	Thyroid Nuclear Factor 1	Thyroid Transcription Factor 1|TITF-1 Protein|TITF 1 Protein|Homeobox Protein Nkx-2.1|Homeobox Protein Nkx 2.1|Nkx-2.1, Homeobox Protein|NK2 Homeobox 1 Protein|TITF1 Protein|TTF-1 Thyroid Nuclear Factor|TTF 1 Thyroid Nuclear Factor|Thyroid-Specific Enhancer-Binding Protein|Enhancer-Binding Protein, Thyroid-Specific|Thyroid Specific Enhancer Binding Protein
-D000074502	Receptors, Kisspeptin-1	Kisspeptin-1 Receptors|Receptors, Kisspeptin 1|KISS1 Receptor|Receptor, KISS1|Kisspeptin-1 Receptor|Kisspeptin 1 Receptor|Receptor, Kisspeptin-1|KISS1R|G Protein-Coupled Receptor 54|G Protein Coupled Receptor 54
+D000074502	Receptors, Kisspeptin-1	Kisspeptin-1 Receptors|Receptors, Kisspeptin 1|KISS1R|G Protein-Coupled Receptor 54|G Protein Coupled Receptor 54|Kisspeptin-1 Receptor|Kisspeptin 1 Receptor|Receptor, Kisspeptin-1|KISS1 Receptor|Receptor, KISS1
 D000074522	Consumer Health Informatics	Health Informatics, Consumer|Informatics, Consumer Health
 D000074523	Suprachiasmatic Nucleus Neurons	Suprachiasmatic Nucleus Neuron|Suprachiasmatic Nuclei Neurons|Suprachiasmatic Nuclei Neuron|SCN Neurons
 D000074542	Solute Carrier Organic Anion Transporter Family Member 1B3	OATP8 Protein|Solute Carrier Family 21 Member 8 Protein|Liver-Specific Organic Anion Transporter-2|Liver Specific Organic Anion Transporter 2|OATP1B3 Protein|SLC21A8 Protein|SLCO1B3 Protein
@@ -1402,7 +1401,7 @@ D000074586	Remyelination	Remyelinations
 D000074602	Smoking Devices	Device, Smoking|Devices, Smoking|Smoking Device
 D000074604	Smoking Pipes	Smoking Pipe|Smoking, Pipes
 D000074606	Smoking Prevention	Prevention, Smoking|Preventions, Smoking|Smoking Preventions
-D000074607	Opium Dependence	Dependence, Opium|Opium Use|Opium Uses|Use, Opium|Uses, Opium|Opium Addiction|Addiction, Opium|Opium Abuse|Abuse, Opium|Abuses, Opium|Opium Abuses
+D000074607	Opium Dependence	Dependence, Opium|Opium Addiction|Addiction, Opium
 D000074608	MYND Domains	Domain, MYND|Domains, MYND|MYND Domain|Zinc Finger MYND-Type|Zinc Finger MYND Type|MYND Motif|MYND Motifs|Motif, MYND|Motifs, MYND
 D000074609	Marijuana Use	Marijuana Uses|Use, Marijuana|Uses, Marijuana
 D000074623	Dual Oxidases	Oxidases, Dual|Duox Proteins|Proteins, Duox
@@ -1480,7 +1479,7 @@ D000075262	Hypoadrenocorticism, Familial	Familial Hypoadrenocorticism|Familial H
 D000075282	Incivility	Rudeness|Uncivil Behavior|Behavior, Uncivil|Behaviors, Uncivil|Uncivil Behaviors
 D000075302	Connexin 30	Gap Junction beta-6 Protein|Gap Junction beta 6 Protein|CX30 Channels|Channels, CX30|GJB6 Protein
 D000075322	Heavy Metal Poisoning	Heavy Metal Poisonings|Metal Poisoning, Heavy|Metal Poisonings, Heavy|Poisoning, Heavy Metal|Poisonings, Heavy Metal
-D000075342	Animal Scales	Animal Scale|Scale, Animal|Scales, Animal|Epidermal Scales|Epidermal Scale|Scale, Epidermal|Scales, Epidermal|Cuticular Scales|Cuticular Scale|Scale, Cuticular|Scales, Cuticular|Dermal Scales|Dermal Scale|Scale, Dermal|Scales, Dermal
+D000075342	Animal Scales	Animal Scale|Scale, Animal|Scales, Animal|Dermal Scales|Dermal Scale|Scale, Dermal|Scales, Dermal|Epidermal Scales|Epidermal Scale|Scale, Epidermal|Scales, Epidermal|Cuticular Scales|Cuticular Scale|Scale, Cuticular|Scales, Cuticular
 D000075362	Leukocyte Immunoglobulin-like Receptor B1	Leukocyte Immunoglobulin like Receptor B1|CD85J Antigen|Antigen, CD85J|Immunoglobulin-like Transcript 2 Protein|Immunoglobulin like Transcript 2 Protein|Leukocyte Ig-like Receptor B1|Leukocyte Ig like Receptor B1|LIR-1 Protein|LIR 1 Protein|ILT2 Protein|LILRB1|CD85 Antigen|Antigen, CD85
 D000075363	Immunoglobulin Light-chain Amyloidosis	Immunoglobulin Light chain Amyloidosis|Immunoglobulin Light-chain Amyloidoses|Amyloidosis, Primary|AL Amyloidosis|AL Amyloidoses|Primary Systemic Amyloidosis|Amyloidoses, Primary Systemic|Amyloidosis, Primary Systemic|Primary Systemic Amyloidoses|Systemic Amyloidoses, Primary|Systemic Amyloidosis, Primary|Amyloidosis, Immunoglobulin Light-chain|Amyloidosis, Immunoglobulin Light chain|Primary Amyloidosis|Amyloidoses, Primary|Primary Amyloidoses
 D000075364	Deleted in Azoospermia 1 Protein	DAZ1 Protein|DAZ-1 Protein|DAZ 1 Protein|SPGY Protein
@@ -1542,7 +1541,7 @@ D000075863	Science in Literature	Literatures, Science in|in Literature, Science|
 D000075884	Indochina	French Indochina
 D000075902	Clinical Deterioration	Clinical Deteriorations|Deterioration, Clinical
 D000075906	Chemokine CCL26	CCL26, Chemokine|Eotaxin-3|Eotaxin 3|CCL26 Chemokine|Chemokine, CCL26
-D000075923	Wildfires	Wildfire|Wildland Fires|Fire, Wildland|Fires, Wildland|Wildland Fire|Brush Fires|Brush Fire|Fire, Brush|Fires, Brush|Forest Fires|Fire, Forest|Fires, Forest|Forest Fire|Wild Fires|Fire, Wild|Fires, Wild|Wild Fire
+D000075923	Wildfires	Wildfire|Wildland Fires|Brush Fires|Brush Fire|Fire, Brush|Fires, Brush|Forest Fires|Fire, Forest|Fires, Forest|Forest Fire|Wild Fires|Fire, Wild|Fires, Wild|Wild Fire
 D000075924	X-linked Nuclear Protein	Nuclear Protein, X-linked|X linked Nuclear Protein|RAD54 Homolog Protein|Homolog Protein, RAD54|ATRX Protein
 D000075925	PHD Zinc Fingers	Finger, PHD Zinc|Fingers, PHD Zinc|Zinc Finger, PHD|Zinc Fingers, PHD|PHD Fingers|Finger, PHD|Fingers, PHD|PHD Finger|PHD Motifs|PHD Domains|Domain, PHD|Domains, PHD|PHD Domain|PHD Zinc Finger|PHD Finger Domain|Domain, PHD Finger|Domains, PHD Finger|Finger Domain, PHD|Finger Domains, PHD|PHD Finger Domains|PHD Motif|Motif, PHD|Motifs, PHD
 D000075926	FERM Domains	Domain, FERM|Domains, FERM|Band 4.1-Ezrin-Radixin-Moesin Domain|Band 4.1 Ezrin Radixin Moesin Domain|Band 4.1-Ezrin-Radixin-Moesin Domains|Domain, Band 4.1-Ezrin-Radixin-Moesin|Domains, Band 4.1-Ezrin-Radixin-Moesin|Ezrin-like Domain|Domain, Ezrin-like|Domains, Ezrin-like|Ezrin like Domain|Ezrin-like Domains|FERM Domain
@@ -1568,8 +1567,8 @@ D000076107	Diet, High-Protein Low-Carbohydrate	Diet, High Protein Low Carbohydra
 D000076122	Disks Large Homolog 4 Protein	Postsynaptic Density Protein 95|Discs Large Homolog 4 Protein|SAP-90 Protein|SAP 90 Protein|PSD95 Protein|PSD-95 Protein|PSD 95 Protein|Synapse-Associated Protein 90|Synapse Associated Protein 90|SAP90 Protein
 D000076123	DNA (Cytosine-5-)-Methyltransferase 1	DNMT1 Enzyme|Enzyme, DNMT1
 D000076142	Virtual Reality	Reality, Virtual
-D000076144	Egypt, Ancient	
-D000076145	Greece, Ancient	
+D000076144	Egypt, Ancient	Ancient Egypt
+D000076145	Greece, Ancient	Ancient Greece
 D000076162	Therapeutic Index	Index, Therapeutic
 D000076164	Fanconi Anemia Complementation Group N Protein	FANCN Protein|PALB2 Protein|Partner and Localizer of BRCA2 Protein
 D000076182	Sp7 Transcription Factor	Transcription Factor, Sp7|Osterix Protein
@@ -1587,7 +1586,7 @@ D000076226	Rapamycin-Insensitive Companion of mTOR Protein	Rapamycin Insensitive
 D000076227	Stereolithography	Stereolithographies
 D000076228	MRE11 Homologue Protein	Homologue Protein, MRE11|MRE11A Protein|Meiotic Recombination 11 Homolog 1 Protein
 D000076242	MTOR Associated Protein, LST8 Homolog	G protein beta Subunit-like Polypeptide|G protein beta Subunit like Polypeptide|mLST8 Protein|GBetaL Protein
-D000076244	Lepisma	Lepismas|Lepisma saccharina|Lepisma saccharinas|saccharina, Lepisma|Silverfish
+D000076244	Lepisma	
 D000076245	Heterogeneous Nuclear Ribonucleoprotein A1	hnRNP Protein A1|A1 HnRNP|hnRNP A1 Protein|hnRNP A1
 D000076246	CCCTC-Binding Factor	CCCTC Binding Factor|DNA-Binding Protein CTCF|CTCF, DNA-Binding Protein|DNA Binding Protein CTCF|CTCF Protein
 D000076247	Centromere Protein A	CENPA Protein|Centromere Protein 17K|CENP-A Protein|CENP A Protein|Centromere Autoantigens 17K|Autoantigens 17K, Centromere
@@ -1603,7 +1602,428 @@ D000076342	Protein-Arginine Deiminases	Deiminases, Protein-Arginine|Protein Argi
 D000076362	Adaptive Clinical Trial	
 D000076363	Academic Success	Academic Successes|Success, Academic|Successes, Academic|Academic Achievement|Academic Achievements|Achievement, Academic|Achievements, Academic
 D000076385	Diverticular Diseases	Diverticular Disease
-D000077	Acetabulum	Acetabulums|Acetabula|Acetabulas|Cotyloid Cavity|Cavities, Cotyloid|Cavity, Cotyloid|Cotyloid Cavities
+D000076482	Daphniphyllum	
+D000076502	Sustainable Development	Developments, Sustainable
+D000076522	Retention in Care	Care Retention
+D000076542	Clinical Observation Units	Observation Units|Observation Unit|Clinical Decision Units|Clinical Decision Unit
+D000076562	Nurses Improving Care for Health System Elders	NICHE Hospital Programs|NICHE Hospital Program|Nurses Improving Care for Healthsystem Elders.
+D000076563	Mentalization	
+D000076602	Population Health Management	Health Management, Population|Management, Population Health|Population Health Managements
+D000076603	Syndemic	Syndemics
+D000076604	Physical Functional Performance	Functional Performance, Physical|Functional Performances, Physical|Performance, Physical Functional|Performances, Physical Functional|Physical Functional Performances
+D000076605	Disenfranchised Grief	Grief, Disenfranchised
+D000076607	Saxifragales	Saxiphragales
+D000076608	Daphniphyllaceae	
+D000076609	Brugmansia	
+D000076610	Genetic Profile	Genetic Profiles|Profile, Genetic|Profiles, Genetic|Genotype Profile|Genotype Profiles|Profile, Genotype|Profiles, Genotype
+D000076622	Malpighiales	
+D000076623	Flacourtia	
+D000076624	Built Environment	Built Environments
+D000076625	Dicentra	
+D000076642	Desulfovibrionales	
+D000076643	Maesa	
+D000076644	Myrsine	Rapanea
+D000076662	Host Microbial Interactions	Host Microbial Interaction|Microbe Host Interactions|Microbe Host Interaction|Microbiota Host Interactions|Microbiota Host Interaction|Microbial Host Interactions|Microbial Host Interaction|Host Microbe Interactions|Host Microbe Interaction|Host Microbiota Interactions|Host Microbiota Interaction
+D000076663	Endurance Training	Training, Endurance
+D000076664	Ranunculales	Ranunculale
+D000076665	Ventilation-Perfusion Scan	Ventilation Perfusion Scan|Ventilation-Perfusion Scans|Pulmonary Ventilation Perfusion Scans|V-Q Scintigraphy|V-Q Scintigraphies|Ventilation-Perfusion Scintigraphy|Ventilation Perfusion Scintigraphy|Ventilation-Perfusion Scintigraphies|VQ Lung Scan|VQ Lung Scans|Ventilation Perfusion Lung Scan|Lung Ventilation Perfusion Scans|Lung VQ Scan|Lung VQ Scans
+D000076666	Solanales	Convolvulales|Sphenocleales|Hydroleales|Nolanales|Cestrales|Cuscutales
+D000076667	Austrobaileyales	
+D000076682	Preprints as Topic	Pre-Prints as Topic|Pre Prints as Topic|Pre-Prints as Topics|Topic, Pre-Prints as|Topics, Pre-Prints as|as Topic, Pre-Prints|as Topics, Pre-Prints
+D000076702	International Health Regulations	International Health Regulation
+D000076722	Drug Development	Development, Drug|Pharmaceutical Development|Development, Pharmaceutical|Medication Development|Development, Medication
+D000076723	Negative Results	Negative Result|Null Results|Null Result
+D000076724	Collaborative Cross Mice	Mouse, Collaborative Cross|Collaborative Cross Mouse|Mice, Collaborative Cross
+D000076742	Synthetic Drugs	Drugs, Synthetic|Synthesized Drugs|Drugs, Synthesized|Synthetic Drug|Drug, Synthetic
+D000076764	Traffic-Related Pollution	Pollution, Traffic-Related|Traffic Related Pollution|Traffic Pollution|Pollution, Traffic
+D000076782	Race Factors	Race Factor|Racial Factors|Racial Factor
+D000076783	Adverse Childhood Experiences	Adverse Childhood Experience|Childhood Experience, Adverse|Childhood Experiences, Adverse
+D000076822	Pinealectomy	
+D000076862	Diagnostic Screening Programs	Diagnostic Screening Program|Program, Diagnostic Screening|Programs, Diagnostic Screening|Screening Program, Diagnostic|Screening Programs, Diagnostic
+D000076889	Gray Literature	Grey Literature
+D000076892	UNESCO	United Nations Educational, Scientific and Cultural Organization
+D000076942	Preprint	Pre-Print|Preprints
+D000076944	Rickettsiales	Rickettsias
+D000076962	Receptors, Chimeric Antigen	Antigen Receptors, Chimeric|Artificial T-Cell Receptors|Artificial T Cell Receptors|Receptors, Artificial T-Cell|T-Cell Receptors, Artificial|Chimeric T-Cell Receptors|Chimeric T Cell Receptors|Receptors, Chimeric T-Cell|T-Cell Receptors, Chimeric|Chimeric Antigen Receptors|Chimeric Immunoreceptors|Immunoreceptors, Chimeric
+D000076983	Histone Methyltransferases	Methyltransferases, Histone|Histone Methyltransferase|Methyltransferase, Histone|Histone Methylase|Methylase, Histone
+D000076984	Neonatal Brachial Plexus Palsy	Obstetrical Brachial Plexus Lesion|Obstetrical Brachial Plexus Palsy
+D000076985	Saporins	Ribosome-Inactivating Protein|Ribosome Inactivating Protein|RIP Protein|Saporin Protein|Saporin
+D000076987	CRISPR-Associated Protein 9	CRISPR Associated Protein 9|Cas9 Enzyme|Enzyme, Cas9|Cas9 Protein|Cas9 Endonuclease|Endonuclease, Cas9
+D000076988	Sulfate Transporters	Transporters, Sulfate|Sulphate Transporters|Transporters, Sulphate
+D000077	Acetabulum	Acetabulums|Cotyloid Cavity|Cavities, Cotyloid|Cavity, Cotyloid|Cotyloid Cavities|Acetabula|Acetabulas
+D000077002	GRADE Approach	GRADE Assessment
+D000077003	Sodium Sulfate Cotransporter	Cotransporter, Sodium Sulfate|Slc13a1 Protein|NaS1 Sulfate Transporter|Na(+)-SO4(2-) Cotransporter|NaSi-1 Cotransporter|Cotransporter, NaSi-1|NaSi 1 Cotransporter
+D000077004	Tuberous Sclerosis Complex 1 Protein	Hamartin
+D000077005	Tuberous Sclerosis Complex 2 Protein	Tuberous Sclerosis 2 Protein|Tuberin
+D000077022	Survivin	BIRC5 Protein|Baculoviral IAP Repeat-containing Protein 5|Baculoviral IAP Repeat containing Protein 5
+D000077062	Burnout, Psychological	Psychological Burnout|Burn-out Syndrome|Burn out Syndrome|Burnout|Burnout Syndrome|Burn-out|Burn out|Psychological Burn-out|Burn-out, Psychological|Psychological Burn out
+D000077085	Birth Setting	Birth Settings|Setting, Birth|Settings, Birth|Birthplace Setting|Setting, Birthplace
+D000077102	Apium	
+D000077105	Chlorophyceae	
+D000077107	Gait Analysis	Analysis, Gait|Gait Analyses
+D000077108	Public Expenditures	Expenditures, Public
+D000077109	Disability Studies	
+D000077122	Sugammadex	
+D000077123	Rocuronium	1-(17-(Acetoyl)-3-hydroxy-2-(4-morpholinyl)androstan-16-yl)-1-(2-propenyl)pyrrolidinium
+D000077142	Malvales	
+D000077143	Docetaxel	Docetaxel Trihydrate|Docetaxol|Docetaxel Hydrate
+D000077144	Clopidogrel	
+D000077145	Sulfanilamide	4-aminobenzenesulfonamide|4 aminobenzenesulfonamide|Sulphanilamide
+D000077146	Irinotecan	Irrinotecan|Camptothecin-11|Camptothecin 11
+D000077148	Myrtales	
+D000077149	Sevoflurane	Fluoromethyl-2,2,2-trifluoro-1-(trifluoromethyl)ethyl Ether|Fluoromethyl Hexafluoroisopropyl Ether
+D000077150	Oxaliplatin	1,2-Diamminocyclohexane(trans-1)oxolatoplatinum(II)|Platinum(II)-1,2-cyclohexanediamine Oxalate|Oxalato-(1,2-cyclohexanediamine)platinum II|Oxaliplatin, (SP-4-2-(1R-trans))-isomer|Oxaliplatine|1,2-Diaminocyclohexane Platinum Oxalate|1,2 Diaminocyclohexane Platinum Oxalate|L-OHP Cpd
+D000077152	Olanzapine	2-Methyl-4-(4-methyl-1-piperazinyl)-10H-thieno(2,3-b)(1,5)benzodiazepine
+D000077153	Progranulins	Proepithelin|Granulin Precursor|Granulin Precursor Protein|PC Cell-Derived Growth Factor|PC Cell Derived Growth Factor|Acrogranin|Progranulin
+D000077154	Rosiglitazone	
+D000077155	Granulins	Granulin Peptides|Epithelins
+D000077156	Gefitinib	N-(3-Chloro-4-fluorophenyl)-7-methoxy-6-(3-(4-morpholinyl)propoxy)-4-quinazolinamide
+D000077157	Sorafenib	
+D000077162	Neurolymphomatosis	Neurolymphomatoses
+D000077182	Polylactic Acid-Polyglycolic Acid Copolymer	Polylactic Acid Polyglycolic Acid Copolymer|PLG Polymer|PLG Polymers|Polymer, PLG|Polymers, PLG|Poly (Lactic-co-glycolic Acid) -|PLGA Cpd|Poly(Lactic-co-glycolic Acid)|Polylactic-co-glycolic Acid Copolymer|Copolymer, Polylactic-co-glycolic Acid|Copolymers, Polylactic-co-glycolic Acid|Polylactic co glycolic Acid Copolymer|Polylactic-co-glycolic Acid Copolymers|PLGA Compound|PLGA Compounds|PL-PG Copolymer|Copolymer, PL-PG|Copolymers, PL-PG|PL PG Copolymer|PL-PG Copolymers|Poly(Glycolide-co-lactide)
+D000077183	Occlusion Body Matrix Proteins	Viral Occlusion Body Matrix Proteins
+D000077185	Resveratrol	3,5,4'-Trihydroxystilbene|3,4',5-Trihydroxystilbene|3,4',5-Stilbenetriol
+D000077190	Interferon alpha-2	Interferon alpha 2|Interferon-alpha 2|Interferon alpha-A|Interferon alpha A|LeIF A|IFN-alpha 2|IFN-alpha-2
+D000077191	Wortmannin	
+D000077192	Adenocarcinoma of Lung	Lung Adenocarcinomas|Lung Adenocarcinoma|Adenocarcinoma, Lung|Adenocarcinomas, Lung
+D000077194	Chlorophyll A	
+D000077195	Squamous Cell Carcinoma of Head and Neck	Squamous Cell Carcinoma of the Head and Neck|Squamous Cell Carcinoma, Head And Neck|Carcinoma, Squamous Cell of Head and Neck|Head and Neck Squamous Cell Carcinoma
+D000077202	Dispensatory	Dispensatories
+D000077203	Sodium-Glucose Transporter 2 Inhibitors	Sodium Glucose Transporter 2 Inhibitors|SGLT2 Inhibitors|SGLT-2 Inhibitors|SGLT 2 Inhibitors|Gliflozins
+D000077204	Temozolomide	8-Carbamoyl-3-methylimidazo(5,1-d)-1,2,3,5-tetrazin-4(3H)-one|Methazolastone
+D000077205	Pioglitazone	5-(4-(2-(5-Ethyl-2-pyridyl)ethoxy)benzyl)-2,4-thiazolidinedione
+D000077206	Gabapentin	1-(Aminomethyl)cyclohexaneacetic Acid
+D000077207	Chondrosarcoma, Clear Cell	Clear Cell Chondrosarcoma|Chondrosarcomas, Clear Cell|Clear Cell Chondrosarcomas
+D000077208	Remifentanil	3-(4-Methoxycarbonyl-4-((1-oxopropyl)phenylamino)-1-piperidine)propanoic Acid Methyl Ester
+D000077209	Decitabine	5-Aza-2'-deoxycytidine|5 Aza 2' deoxycytidine|5-AzadC|AzadC Compound|Compound, AzadC|5AzadC|2'-Deoxy-5-azacytidine|2' Deoxy 5 azacytidine|5-Azadeoxycytidine|5 Azadeoxycytidine
+D000077210	Sunitinib	5-(5-Fluoro-2-oxo-1,2-dihydroindolylidenemethyl)-2,4-dimethyl-1H-pyrrole-3-carboxylic acid (2-diethylaminoethyl)amide
+D000077211	Zoledronic Acid	2-(Imidazol-1-yl)-1-hydroxyethylidene-1,1-bisphosphonic acid
+D000077212	Ropivacaine	1-Propyl-2',6'-pipecoloxylidide|1 Propyl 2',6' pipecoloxylidide
+D000077213	Lamotrigine	3,5-Diamino-6-(2,3-dichlorophenyl)-as-triazine|3,5-Diamino-6-(2,3-dichlorophenyl)-1,2,4-triazine
+D000077214	Becaplermin	Platelet-Derived Growth Factor BB, Recombinant|Platelet Derived Growth Factor BB, Recombinant|rPDGF-BB|PDGF-BB|rhPDGF-BB|Platelet-Derived Growth Factor BB|Platelet Derived Growth Factor BB|Recombinant Platelet-Derived Growth Factor BB|Recombinant Platelet Derived Growth Factor BB
+D000077215	Clay	Clays
+D000077216	Carcinoma, Ovarian Epithelial	Carcinomas, Ovarian Epithelial|Epithelial Carcinoma, Ovarian|Epithelial Carcinomas, Ovarian|Ovarian Epithelial Carcinomas|Epithelial Ovarian Cancer|Ovarian Epithelial Cancer|Cancer, Ovarian Epithelial|Cancers, Ovarian Epithelial|Epithelial Cancer, Ovarian|Epithelial Cancers, Ovarian|Ovarian Epithelial Cancers|Ovarian Cancer, Epithelial|Cancer, Epithelial Ovarian|Cancers, Epithelial Ovarian|Epithelial Ovarian Cancers|Ovarian Cancers, Epithelial|Ovarian Epithelial Carcinoma|Epithelial Ovarian Carcinoma|Carcinoma, Epithelial Ovarian|Carcinomas, Epithelial Ovarian|Epithelial Ovarian Carcinomas|Ovarian Carcinoma, Epithelial|Ovarian Carcinomas, Epithelial
+D000077221	Calcitonin Gene-Related Peptide Receptor Antagonists	Calcitonin Gene Related Peptide Receptor Antagonists|CGRP Receptor Antagonists|Antagonists, CGRP Receptor|Receptor Antagonists, CGRP
+D000077222	Limonene	Limonene, (+-)-|4-Mentha-1,8-diene|4 Mentha 1,8 diene|1-Methyl-4-(1-methylethenyl)cyclohexene|Dipentene
+D000077224	Cyberbullying	
+D000077228	Caspian Sea	Caspian Lake
+D000077230	Internet Access	Access, Internet
+D000077235	Vinorelbine	5'-Nor-anhydrovinblastine|5' Nor anhydrovinblastine
+D000077236	Topiramate	2,3-4,5-bis-O-(1-methylethylidene)-beta-D-fructopyranose sulfamate
+D000077237	Arsenic Trioxide	As2O3|Arsenous Anhydride|Diarsenic Trioxide|Arsenic Oxide (As2O3)|Arsenic(III) Oxide
+D000077239	Meloxicam	Miloxicam
+D000077250	Calcium Aluminosilicate	Aluminosilicate, Calcium
+D000077252	Dialectical Behavior Therapy	Behavior Therapy, Dialectical|Dialectical Behavior Therapies
+D000077253	Online Social Networking	Networking, Online Social|Social Networking, Online
+D000077260	Sleepiness	Somnolence
+D000077261	Carvedilol	
+D000077262	Ciona	
+D000077264	Calcium-Regulating Hormones and Agents	Calcium Regulating Hormones and Agents
+D000077265	Donepezil	
+D000077266	Moxifloxacin	1-Cyclopropyl--7-(2,8-diazabicyclo(4.3.0)non-8-yl)-6-fluoro-8-methoxy-1,4-dihydro-4-oxo-3-quinolinecarboxylic acid
+D000077267	Fulvestrant	7-(9-(4,4,5,5,5-pentafluoropentylsulfinyl)nonyl)estra-1,3,5(10)-triene-3,17-diol
+D000077268	Pamidronate	Amino-1-hydroxypropane-1,1-diphosphonate|Amino 1 hydroxypropane 1,1 diphosphonate|AHPrBP|Aminopropanehydroxydiphosphonate|Amidronate|(3-Amino-1-hydroxypropylidene)-1,1-biphosphonate|Aminohydroxypropylidene Diphosphonate
+D000077269	Lenalidomide	3-(4-Amino-1-oxoisoindolin-2-yl)piperidine-2,6-dione|2,6-Piperidinedione, 3-(4-amino-1,3-dihydro-1-oxo-2H- isoindol-2-yl)-|IMiD3 Cpd
+D000077270	Exenatide	
+D000077271	Imiquimod	1-Isobutyl-1H-imidazo(4,5-c)quinolin-4-amine
+D000077272	Latent Class Analysis	Latent Class Analyses|Latent Variable Modeling|Latent Variable Modelings|Modeling, Latent Variable|Variable Modeling, Latent
+D000077273	Thyroid Cancer, Papillary	Cancer, Papillary Thyroid|Cancers, Papillary Thyroid|Papillary Thyroid Cancer|Papillary Thyroid Cancers|Thyroid Cancers, Papillary|Thyroid Carcinoma, Papillary|Carcinoma, Papillary Thyroid|Carcinomas, Papillary Thyroid|Papillary Thyroid Carcinomas|Thyroid Carcinomas, Papillary|Papillary Carcinoma Of Thyroid|Papillary Thyroid Carcinoma
+D000077274	Nasopharyngeal Carcinoma	Carcinoma, Nasopharyngeal|Carcinomas, Nasopharyngeal|Nasopharyngeal Carcinomas
+D000077275	Craniofacial Fibrous Dysplasia	Craniofacial Fibrous Dysplasias|Craniomaxillofacial Fibrous Dysplasia|Craniomaxillofacial Fibrous Dysplasias|Fibrous Dysplasia, Craniomaxillofacial|Fibrous Dysplasia, Craniofacial
+D000077276	Lycopene	
+D000077277	Esophageal Squamous Cell Carcinoma	
+D000077278	RNA, Mitochondrial	mtRNA|Mitochondrial RNA
+D000077279	Protein Carbamylation	Carbamylation, Protein|Protein Carbamylations|Protein Carbamoylation|Carbamoylation, Protein|Protein Carbamoylations
+D000077280	Bone-Anchored Prosthesis	Bone Anchored Prosthesis|Bone-Anchored Prostheses|Prostheses, Bone-Anchored|Prosthesis, Bone-Anchored|Osseo-Anchored Prosthesis|Osseo Anchored Prosthesis|Osseo-Anchored Prostheses|Prostheses, Osseo-Anchored|Prosthesis, Osseo-Anchored
+D000077283	Forensic Psychology	Psychology, Forensic
+D000077284	Abciximab	c7E3 Fab|Chimeric 7E3 Fab|Fab, Chimeric 7E3
+D000077285	Rimonabant	
+D000077286	Cetrimonium	Cetriminium
+D000077287	Levetiracetam	Etiracetam, S-isomer|Etiracetam, S isomer|S-isomer Etiracetam
+D000077288	Troglitazone	5-(4-((6-Hydroxy-2,5,7,8-tetramethylchroman-2-yl-methoxy)benzyl)-2,4-thiazolidinedione) - T
+D000077289	Letrozole	4,4'-(1H-1,2,4-triazol-1-yl-methylene)-bis(benzonitrile)
+D000077290	Harmala Alkaloids	Alkaloids, Harmala
+D000077291	Terbinafine	
+D000077293	Receptor, Transforming Growth Factor-beta Type I	TGF-beta Type I Receptor|TGF beta Type I Receptor|TGF-beta Type I Receptors|TGF beta Type I Receptors|TbetaR-I Kinase|Kinase, TbetaR-I|TbetaR I Kinase|Type I TGF-beta Receptors|Type I TGF beta Receptors|TGF-beta RPK|Receptor, TGF-beta Type I|Activin Receptor-like Kinase 5|Activin Receptor like Kinase 5|Serine-Threonine-Protein Kinase Receptor R4|Serine Threonine Protein Kinase Receptor R4|Transforming Growth Factor beta Receptor I|Transforming Growth Factor, beta Receptor 1|TGFBR1|TGF-beta Receptor Protein Kinase|TGF beta Receptor Protein Kinase|Type I TGF-beta Receptor|Type I TGF beta Receptor
+D000077294	Receptor, Transforming Growth Factor-beta Type II	Receptor, Transforming Growth Factor beta Type II|TGF-beta Type II Receptor|TGF beta Type II Receptor|TGF-beta Type II Receptors|TGF beta Type II Receptors|Type II TGF-beta Receptors|Type II TGF beta Receptors|Transforming Growth Factor-beta Type II Receptor|Transforming Growth Factor beta Type II Receptor|Transforming Growth Factor-beta Type II Receptors|Transforming Growth Factor beta Type II Receptors|Type II TGF-beta Receptor|Type II TGF beta Receptor|TGFBR2|TbetaR-II Kinase|Kinase, TbetaR-II|TbetaR II Kinase
+D000077295	Urinary Bladder, Underactive	Underactive Bladder|Detrusor Underactivity|Underactivity, Detrusor|Bladder, Underactive|Underactive Bladders|Underactive Urinary Bladder|Underactive Urinary Bladders
+D000077296	Niemann-Pick C1 Protein	Niemann Pick C1 Protein|NPC1 Protein
+D000077297	Pregnane X Receptor	NR1I2|Steroid X Receptor|SXR Receptor|Nuclear Receptor Subfamily 1, Group I, Member 2|Steroid and Xenobiotic Receptor
+D000077298	Flexural Strength	Flexural Strengths|Strength, Flexural|Strengths, Flexural|Modulus of Rupture|Rupture Modulus|Flexural Resistance|Flexural Resistances|Resistance, Flexural|Resistances, Flexural|Fracture Strength|Fracture Strengths|Strength, Fracture|Strengths, Fracture|Bend Strength|Bend Strengths|Strength, Bend|Strengths, Bend|Flexural Properties|Flexural Property|Properties, Flexural|Property, Flexural
+D000077299	Healthcare-Associated Pneumonia	Healthcare Associated Pneumonia|Healthcare-Associated Pneumonias|Pneumonia, Healthcare-Associated|Nosocomial Pneumonia|Nosocomial Pneumonias|Pneumonia, Nosocomial
+D000077300	Bosentan	4-t-Butyl-N-(6-(2-hydroxyethoxy)-5-(2-methoxyphenoxy)-2,2'-bipyrimidin-4-yl)benzenesulfonamide
+D000077310	Sleep, Slow-Wave	Sleep, Slow Wave|Slow-Wave Sleep|Slow Wave Sleep|N3 Sleep|Sleep, N3|Deep Sleep|Sleep, Deep|NREM Stage 3|Stage 3, NREM|Delta Sleep|Sleep, Delta
+D000077314	Aggressive Driving	Driving, Aggressive
+D000077315	Road Rage	
+D000077317	Extracellular Polymeric Substance Matrix	Biofilm Matrix|Biofilm Matrices|Matrix, Biofilm|EPS Matrix|EPS Matrices|Matrix, EPS
+D000077318	Density Functional Theory	Density Functional Theories|KS-DFT|Kohn-Sham Density Functional Theory|Kohn Sham Density Functional Theory
+D000077319	Pyrolysis	Pyrolyses
+D000077320	Biomineralization	Biomineralizations|Biocrystallization|Biocrystallizations|Bioprecipitation|Bioprecipitations
+D000077321	Deep Learning	Learning, Deep|Hierarchical Learning|Learning, Hierarchical
+D000077322	Alginic Acid	Polymannuronic Acid|Polymannuronic-Guluronic Acid|Polymannuronic Guluronic Acid|Poly(Mannuronic Acid)
+D000077323	Salt Stress	Salt Stresses|Stress, Salt|Salinity Stress|Salinity Stresses|Stress, Salinity
+D000077324	Crystalloid Solutions	Solutions, Crystalloid|Crystalloid
+D000077325	Ringer's Lactate	Lactate, Ringer's|Hartmanns Solution|Lactated Ringers Solution|Ringers Solution, Lactated|Ringers Lactate|Lactate, Ringers|Ringer's, Lactated|Lactated Ringer's|Lactated Ringer's Solution|Lactated Ringer Solution|Ringer's Solution, Lactated|Hartmann's Solution
+D000077329	Agammaglobulinaemia Tyrosine Kinase	Kinase, Agammaglobulinaemia Tyrosine|Tyrosine Kinase, Agammaglobulinaemia|Bruton's Tyrosine Kinase|Bruton Tyrosine Kinase|Brutons Tyrosine Kinase|Kinase, Bruton's Tyrosine|Tyrosine Kinase, Bruton's|B Cell Progenitor Kinase
+D000077330	Saline Solution	0.9% Saline|Saline, 0.9%|0.9% NaCl|Normal Saline|Saline, Normal
+D000077331	Ringer's Solution	Ringer Solution|Ringers Solution
+D000077332	Artesunate	
+D000077333	Telmisartan	4'-((1,4'-Dimethyl-2'-propyl(2,6'-bi-1H-benzimidazol)-1'-yl)methyl)-(1,1'-biphenyl)-2-carboxylic acid
+D000077334	Zolpidem	
+D000077335	Desflurane	
+D000077336	Caspofungin	
+D000077337	Vorinostat	N1-Hydroxy-N8-phenyloctanediamide|N1 Hydroxy N8 phenyloctanediamide|NHNPODA|Suberoyl Anilide Hydroxamic Acid|Suberoylanilide Hydroxamic Acid|N-Hydroxy-N'-phenyloctanediamide|N Hydroxy N' phenyloctanediamide|Suberanilohydroxamic Acid
+D000077338	Latanoprost	
+D000077339	Leflunomide	N-(4-Trifluoromethyphenyl)-5-methylisoxazole-4-carboxamide
+D000077340	Fluvastatin	
+D000077341	Lapatinib	N-(3-chloro-4-(((3-fluorobenzyl)oxy)phenyl)-6-(5-(((2-methylsulfonyl)ethyl)amino)methyl) -2-furyl)-4-quinazolinamine
+D000077342	Post-Lyme Disease Syndrome	Post-Lyme Disease Syndromes|Syndrome, Post-Lyme Disease|Syndromes, Post-Lyme Disease|Post Lyme Disease Syndrome|Chronic Lyme Disease|Lyme Disease, Chronic
+D000077362	Verteporfin	BPD-MA|Benzoporphyrin Derivative Monoacid Ring A|Verteporphin|18-Ethenyl-4,4a-dihydro-3,4-bis(methoxycarbonyl)-4a,8,14,19-tetramethyl-23H,25H-benzo(b)porphine-9,13-dipropanoic acid monomethyl ester|BPD Verteporfin
+D000077384	Anastrozole	2,2'-(5-(1H-1,2,4-triazol-1-ylmethyl)-1,3-phenylene)bis(2-methylpropionitrile)|Anastrazole
+D000077385	Silybin	Silibinin|Silybinin|Silibin
+D000077402	Pantoprazole	
+D000077403	Orlistat	Tetrahydrolipstatin|THLP|Tetrahydrolipastatin
+D000077404	Cidofovir	HPMPC
+D000077405	Irbesartan	
+D000077406	History of Pharmacy	Pharmacy History|Pharmacy, History
+D000077407	Cilostazol	6-(4-(1-Cyclohexyl-1H-tetrazol-5-yl)butoxy)-3,4-dihydro-2(1H)-quinolinone
+D000077408	Modafinil	2-((Diphenylmethyl)sulfinyl)acetamide
+D000077409	Tamsulosin	
+D000077410	Aluminum Chloride	Aluminum Trichloride|AlCl3
+D000077422	Enrofloxacin	Endrofloxicin
+D000077423	Polidocanol	Polidocanols|Laureth 9|Laureth-9
+D000077425	Fondaparinux	
+D000077426	Gastric Artery	Arteries, Gastric|Artery, Gastric|Gastric Arteries
+D000077427	Lipoglycopeptides	
+D000077428	GATA2 Deficiency	GATA2 Deficiencies|Immunodeficiency type 21|MonoMac Syndrome|MonoMac Syndromes|GATA2 Haploinsufficiency|GATA2 Haploinsufficiencies
+D000077430	Nabumetone	Nabumeton|4-(6-Methoxy-2-naphthyl)-2-butanone
+D000077431	Oxaprozin	4,5-Diphenyl-2-oxazolepropionic Acid|4,5 Diphenyl 2 oxazolepropionic Acid
+D000077432	Tapentadol	3-((1R,2R)-3-(dimethylamino)-1-ethyl-2-methylpropyl)phenol
+D000077442	Lidocaine, Prilocaine Drug Combination	Eutectic Mixture of Local Anesthetics|Lidocaine Prilocaine|Prilocaine, Lidocaine|Lidocaine-Prilocaine Drug Combination|Lidocaine Prilocaine Drug Combination|Eutectic Lidocaine-Prilocaine|Eutectic Lidocaine Prilocaine|Lidocaine-Prilocaine, Eutectic
+D000077443	Acamprosate	Acamprostate|N-Acetylhomotaurine|N Acetylhomotaurine
+D000077444	Smoking Cessation Agents	
+D000077463	Carbamide Peroxide	Urea Hydrogen Peroxide|Hydrogen Peroxide, Urea|Urea Peroxide
+D000077464	Simendan	((4-(1,4,5,6-tetrahydro-4-methyl-6-oxo-3-pyridazinyl)phenyl)hydrazono)propanedinitrile
+D000077465	Cabergoline	1-((6-allylergolin-8beta-yl)carbonyl)-1-(3-(dimethylamino)propyl)-3-ethylurea
+D000077466	Tirofiban	N-(Butylsulfonyl)-O-(4-(4-piperidyl)butyl)-L-tyrosine
+D000077482	Carbon Fiber	Carbon Fibers|Fiber, Carbon|Fibers, Carbon|Carbon Fibre|Carbon Fibres|Fibre, Carbon|Fibres, Carbon|Carbon Felt|Carbon Felts|Felt, Carbon|Felts, Carbon
+D000077483	Valacyclovir	Valaciclovir
+D000077484	Vemurafenib	
+D000077485	Meglumine Antimoniate	
+D000077486	Ticagrelor	
+D000077487	Pramipexole	4,5,6,7-Tetrahydro-N6-propyl-2,6-benzothiazole-diamine|Pramipexol|2-Amino-4,5,6,7-tetrahydro-6-propylaminobenzothiazole
+D000077488	Data Science	Data Sciences|Science, Data|Sciences, Data
+D000077489	Piperazine	1,4-Diazacyclohexane|1,4 Diazacyclohexane|1,4-Piperazine|1,4 Piperazine
+D000077502	Glymphatic System	Glymphatic Pathway|Glymphatic Pathways|Pathway, Glymphatic|Glymphatic Clearance System
+D000077522	Clinical Trial, Veterinary	
+D000077525	Cefdinir	
+D000077526	Tropisetron	
+D000077542	Eptifibatide	Epifibratide|Epifibatide
+D000077543	Deferiprone	1,2-Dimethyl-3-hydroxy-4-pyridinone|1,2 Dimethyl 3 hydroxy 4 pyridinone|DMOHPO|1,2-Dimethyl-3-hydroxypyrid-4-one|1,2 Dimethyl 3 hydroxypyrid 4 one|3-Hydroxy-1,2-dimethyl-4-pyridinone|3 Hydroxy 1,2 dimethyl 4 pyridinone|HDMPP|1,2-Dimethyl-3-hydroxypyridin-4-one|1,2 Dimethyl 3 hydroxypyridin 4 one
+D000077544	Panitumumab	Panitumumab Antibody, Human|Human Panitumumab Antibody|ABX-EGF MAb|ABX-EGF Monoclonal Antibody|ABX EGF Monoclonal Antibody|Monoclonal Antibody, ABX-EGF
+D000077545	Eplerenone	Eplerenon
+D000077546	Roscovitine	(2R)-2-((6-Benzylamino-9-(propan-2-yl)-9H-purin-2-yl)amino)butan-1-ol
+D000077547	Crizotinib	
+D000077548	Anaplastic Lymphoma Kinase	ALK Tyrosine Kinase Receptor|NPM-ALK|Anaplastic Lymphoma Receptor Tyrosine Kinase|Nucleophosmin-Anaplastic Lymphoma Kinase|Nucleophosmin Anaplastic Lymphoma Kinase|ALK Kinase|CD246 Antigen
+D000077549	Artemether	O-Methyldihydroartemisinine|O Methyldihydroartemisinine
+D000077550	Ivabradine	
+D000077551	Micafungin	
+D000077552	Basiliximab	
+D000077553	Edaravone	Norantipyrine|Norphenazone|Edarabone
+D000077554	Levobupivacaine	
+D000077555	Methylprednisolone Acetate	Methylprednisolone-21-acetate|Methylprednisolone 21 acetate|Acetyl-Methylprednisolone|Acetyl Methylprednisolone
+D000077556	Alitretinoin	9cRA Compound|9-cis-Retinoic Acid|9 cis Retinoic Acid
+D000077557	Ibandronic Acid	
+D000077558	Big Data	
+D000077559	Sodium Citrate	
+D000077560	Enfuvirtide	Pentafuside
+D000077561	Daclizumab	Dacliximab
+D000077562	Valganciclovir	Ganciclovir L-valyl Ester|Ganciclovir L valyl Ester
+D000077563	Norethindrone Acetate	Norethisterone Acetate
+D000077564	Focused Assessment with Sonography of Trauma	FAST Exam|Focused Assessment Sonography|Assessment Sonographies, Focused|Assessment Sonography, Focused|Focused Assessment Sonographies|Sonographies, Focused Assessment|Sonography, Focused Assessment
+D000077582	Amisulpride	4-Amino-N-((1-ethyl-2-pyrrolidinyl)methyl)-5-(ethylsulfonyl)-2-methoxybenzamide
+D000077583	Quinapril	
+D000077584	2-Methoxyestradiol	2 Methoxyestradiol|2-Methoxyoestradiol|2 Methoxyoestradiol|(17 beta)-2-methoxyestra-1,3,5(10)-triene-3,17-diol
+D000077585	Terlipressin	Glycylpressin|TGLVP|Terlypressin|Triglycyl Lysine Vasopressin|Triglycylvasopressin|Glipressin|Glypressin
+D000077587	Natural Disasters	Natural Disaster|Disaster, Natural|Disasters, Natural
+D000077588	Deferasirox	4-(3,5-Bis-(2-hydroxyphenyl)-(1,2,4)-triazol-1-yl)benzoic acid
+D000077589	Sulfathiazole	N(1)-2-thiazolylsulfanilamide|Norsulfazole
+D000077590	Mivacurium	
+D000077591	Eucalyptol	1,8-Cineole|1,8 Cineole|1,8-Epoxy-p-menthane|1,8 Epoxy p menthane|1,8-Cineol|1,8 Cineol
+D000077592	Maraviroc	4,4-Difluoro-N-((1S)-3-(exo-3-(3-isopropyl-5-methyl-4H-1,2,4-triazol-4-yl)-8-azabicyclo(3.2.1)oct-8-yl)-1-phenylpropyl)cyclohexanecarboxamide
+D000077593	Reboxetine	
+D000077594	Nivolumab	
+D000077595	Famciclovir	9-(4-Acetoxy-3-(acetoxymethyl)but-1-yl)-2-aminopurine
+D000077596	Thymalfasin	Thymosin alpha(1)|Thymosin alpha1|alpha1-Thymosin|alpha1 Thymosin
+D000077597	Vildagliptin	(2S)-(((3-Hydroxyadamantan-1-yl)amino)acetyl)pyrrolidine-2-carbonitrile
+D000077602	Tolvaptan	7-Chloro-5-hydroxy-1-(2-methyl-4-(2-methylbenzoylamino)benzoyl)2,3,4,5-tetrahydro-1H-1-benzazepine
+D000077603	Nandrolone Decanoate	17 beta-Hydroxyestr-4-en-3-one 17-decanoate|17 beta Hydroxyestr 4 en 3 one 17 decanoate
+D000077604	Fomepizole	4-Methylpyrazole|4 Methylpyrazole
+D000077605	Ferric Oxide, Saccharated	Saccharated Ferric Oxide|Iron-Saccharate|Iron Saccharate|Iron Oxide (Saccharated)|Iron Sucrose|Ferri-Saccharate|Ferri Saccharate|Ferric Saccharate
+D000077606	Trabectedin	
+D000077607	Icodextrin	
+D000077608	Aprepitant	
+D000077609	O-(Chloroacetylcarbamoyl)fumagillol	5-Methoxy-4-(2-methyl-3-(3-methyl-2-butenyl)oxiranyl)-1-oxaspiro(2,5)oct-6-yl(chloroacetyl) carbamate
+D000077610	Bexarotene	3-methyl-TTNEB|4-(1-(3,5,5,8,8-Pentamethyl-5,6,7,8-tetrahydro-2-naphthyl)ethenyl)benzoic acid
+D000077611	Artemether, Lumefantrine Drug Combination	Artemether - Benflumetol|Artemether-Lumefantrine Combination|Artemether Lumefantrine Combination|Artemether, Benflumetol Drug Combination|Artemether-Benflumetol Combination|Artemether Benflumetol Combination|Co-Artemether|Co Artemether|Artemether Lumefantrine|Lumefantrine, Artemether|Artemether Benflumetol|Benflumetol, Artemether
+D000077612	Anidulafungin	1-((4R,5R)-4,5-Dihydroxy-N2-((4''-(pentyloxy)(1,1':4',1''-terphenyl)-4-yl)carbonyl)-L-ornithine)-echinocandin B
+D000077613	Etoricoxib	
+D000077614	Golgi Matrix Proteins	
+D000077626	Implementation Science	Implementation Sciences
+D000077642	Family Separation	Family Separations|Separation, Family|Family Left Behind|Behind, Family Left|Left Behind, Family
+D000077682	Triclabendazole	6-chloro-5-(2,3-dichlorophenoxy)-2-methylthiobenzimidazole
+D000077684	Cauda Equina Syndrome	Cauda Equina Syndromes
+D000077704	Tirapazamine	3-Amino-1,2,4-benzotriazine-1,4-dioxide
+D000077705	Screen Time	Screen Times
+D000077708	Sitting Position	Position, Sitting|Sitting Positions
+D000077711	Self-Neglect	Self Neglect
+D000077712	Telbivudine	1-(2-Deoxy-beta-L-erythropentafuranosyl)-5-methyl-2,4(1H,3H)-pyrimidinedione|beta-L-2'-Deoxythymidine|beta L 2' Deoxythymidine|Telbivudin
+D000077713	17 alpha-Hydroxyprogesterone Caproate	17 alpha Hydroxyprogesterone Caproate|17-alpha-Hydroxy-Progesterone Caproate|17 alpha Hydroxy Progesterone Caproate|Caproate, 17-alpha-Hydroxy-Progesterone|Oxyprogesterone Caproate|Hydroxyprogesterone Caproate|Hydroxyprogesterone Hexanoate|17 alpha-Oxyprogesterone Capronate|17 alpha Oxyprogesterone Capronate|17-Hydroxyprogesterone Capronate|17 Hydroxyprogesterone Capronate
+D000077715	Nateglinide	Senaglinide|Nate-Glinide
+D000077716	Afatinib	(2E)-N-(4-(3-Chloro-4-fluoroanilino)-7-(((3S)-oxolan-3-yl)oxy)quinoxazolin-6-yl)-4-(dimethylamino)but-2-enamide
+D000077722	Ceftibuten	7-(2-(2-amino-4-thiazolyl)-4-carboxy-2-butenoylamino)-3-cephem-4-carboxylic acid
+D000077723	Cefepime	Cefepim
+D000077725	Piperacillin, Tazobactam Drug Combination	Piperacillin-Tazobactam Combination Product|Piperacillin Tazobactam Combination Product|Piperacillin - Tazobactam|Piperacillin Tazobactam|Tazobactam, Piperacillin -
+D000077726	Doripenem	
+D000077727	Ertapenem	
+D000077728	Cilastatin, Imipenem Drug Combination	Imipenem - Cilastatin|Imipenem-Cilastatin|Imipenem Cilastatin|Cilastatin, Imipenem
+D000077731	Meropenem	
+D000077732	Fidaxomicin	Lipiarmycin|Tiacumicin B|Lipiarmycin A3
+D000077733	Immunoglobulin G4-Related Disease	G4-Related Disease, Immunoglobulin|G4-Related Diseases, Immunoglobulin|Immunoglobulin G4 Related Disease|Immunoglobulin G4-Related Diseases|IgG4 Related Systemic Disease|IgG4-RD|IgG4-Associated Autoimmune Disease|Autoimmune Disease, IgG4-Associated|Autoimmune Diseases, IgG4-Associated|IgG4 Associated Autoimmune Disease|IgG4-Associated Autoimmune Diseases|IgG4-Related Disease|IgG4 Related Disease|IgG4-Related Diseases
+D000077734	Gatifloxacin	1-cyclopropyl-1,4-dihydro-6-fluoro-8-methoxy-7-(3-methyl-1-piperazinyl)-4-oxo-3-quinolinecarboxylic acid|Gatifloxacine
+D000077735	Gemifloxacin	
+D000077740	Procalcitonin	Calcitonin Precursor Polyprotein|Calcitonin-1|Calcitonin 1|Calcitonin Related Polypeptide Alpha|Pro-Calcitonin
+D000077743	Diterpene Alkaloids	Alkaloids, Diterpene
+D000077744	Orthodontic Appliances, Fixed	Appliance, Fixed Orthodontic|Appliances, Fixed Orthodontic|Fixed Orthodontic Appliance|Fixed Orthodontic Appliances|Orthodontic Appliance, Fixed|Fixed Functional Appliances|Appliance, Fixed Functional|Appliances, Fixed Functional|Fixed Functional Appliance|Functional Appliance, Fixed|Functional Appliances, Fixed|Fixed Retainer|Fixed Retainers|Retainer, Fixed|Retainers, Fixed|Bonded Retainer|Bonded Retainers|Retainer, Bonded|Retainers, Bonded|Fixed Appliances|Appliance, Fixed|Appliances, Fixed|Fixed Appliance|Permanent Retainer|Permanent Retainers|Retainer, Permanent|Retainers, Permanent
+D000077764	Dronedarone	
+D000077765	Cone Dystrophy	Cone Dystrophies|Dystrophies, Cone|Dystrophy, Cone
+D000077767	Panobinostat	
+D000077768	Ciclopirox	Cyclopirox
+D000077769	Rilmenidine	2-(N-(Dicyclopropylmethyl)amino)oxazoline|Oxaminozoline
+D000077770	Amifampridine	3,4-Diaminopyridine|3,4 Diaminopyridine
+D000077771	Methantheline	
+D000077772	Shared Governance, Nursing	Nursing Shared Governance
+D000077773	Hospitals, Rehabilitation	Rehabilitation Hospitals|Hospital, Rehabilitation
+D000077776	Insurance, Vision	Vision Insurance|Vision Care Insurance|Insurance, Vision Care
+D000077777	Myopericytoma	Myopericytomas
+D000077779	Pancreatic Intraductal Neoplasms	Intraductal Neoplasm, Pancreatic|Intraductal Neoplasms, Pancreatic|Neoplasm, Pancreatic Intraductal|Pancreatic Intraductal Neoplasm
+D000077780	Plastination	Plastinations
+D000077784	Axitinib	
+D000077785	Tenecteplase	
+D000077786	Torsemide	Torasemide
+D000077803	Dictionary, Classical	
+D000077823	Dictionary, Medical	
+D000077824	Dictionary, Dental	
+D000077825	Dictionary, Pharmaceutic	
+D000077844	Dictionary, Chemical	
+D000077845	Lipoabdominoplasty	Lipoabdominoplasties
+D000077862	Manuscript, Medical	
+D000077863	Homoharringtonine	Omacetaxine Mepesuccinate
+D000077866	Clofarabine	Cl-F-ara-A|2-Chloro-9-(2-deoxy-2-fluoro-beta-D-arbinofuranosyl)adenine|2-Chloro-9-(2-deoxy-2-fluoroarabinofuranosyl)adenine|2-Chloro-2'-arabino-fluoro-2'-deoxyadenosine|2 Chloro 2' arabino fluoro 2' deoxyadenosine|2-Chloro-2'-fluoroarabino-2'-deoxyadenosine|2 Chloro 2' fluoroarabino 2' deoxyadenosine
+D000077867	Tolcapone	
+D000077868	Atrasentan	
+D000077922	Thiamethoxam	
+D000077923	Societies, Veterinary	Veterinary Society|Society, Veterinary|Veterinary Societies
+D000077924	Palonosetron	2-QHBIQO
+D000077944	Alefacept	LFA-3 IgG1 Fusion Protein|LFA 3 IgG1 Fusion Protein|LFA-3 IgG(1) Fusion Protein
+D000077962	Body-Weight Trajectory	Body Weight Trajectory|Body-Weight Trajectories|Trajectories, Body-Weight|Trajectory, Body-Weight|Weight Trajectory|Trajectories, Weight|Trajectory, Weight|Weight Trajectories
+D000077982	Progression-Free Survival	Progression Free Survival|Survival, Progression-Free
+D000078002	Posttraumatic Growth, Psychological	Growth, Psychological Posttraumatic|Psychological Posttraumatic Growth|Post-traumatic Growth, Psychological|Growth, Psychological Post-traumatic|Post traumatic Growth, Psychological|Psychological Post-traumatic Growth|Psychological Post-traumatic Growths|Posttraumatic Growth|Growth, Posttraumatic
+D000078003	Change Management	Management, Change|Organizational Change Management|Change Management, Organizational|Change Managements, Organizational|Management, Organizational Change|Managements, Organizational Change|Organizational Change Managements
+D000078022	Economic Status	
+D000078062	Leucanthemum	Leucanthemums
+D000078064	Gestational Weight Gain	Weight Gain, Gestational|Maternal Weight Gain|Weight Gain, Maternal|Pregnancy Weight Gain|Weight Gain, Pregnancy
+D000078065	Aegilops	
+D000078102	Lumefantrine	Benflumetol
+D000078122	Eucalyptus Oil	
+D000078142	Tazobactam	
+D000078162	Tobramycin, Dexamethasone Drug Combination	Tobramycin-Dexamethasone Drug Combination|Tobramycin Dexamethasone Drug Combination
+D000078182	Systematic Review	Review, Systematic
+D000078183	Oxindoles	Indolinones|Indolinone Derivatives|Oxindole Alkaloid Derivatives|Oxindole Alkaloids|Oxindole Derivatives|Oxazolidinone Derivatives
+D000078202	Systematic Reviews as Topic	Reviews Systematic as Topic
+D000078222	Tinzaparin	
+D000078223	5-Methoxypsoralen	5 Methoxypsoralen|Bergapten|5-Methoxy Psoralen|5 Methoxy Psoralen
+D000078224	Lenograstim	
+D000078262	Rifaximin	4-Deoxy-4'-methylpyrido(1',2'-1,2)imidazo(5,4C)rifamycin
+D000078303	Data Aggregation	Aggregation, Data
+D000078304	Tigecycline	TBG-MINO|9-(tert-Butylglycylamido)minocycline
+D000078305	Zonisamide	
+D000078306	Clobazam	
+D000078308	Tiagabine	N-(4,4-di(3-Methylthien-2-yl)but-3-enyl)nipecotic acid
+D000078323	Observational Study, Veterinary	
+D000078325	Clinical Trial Protocol	Trial Protocols|Clinical Trial Protocols
+D000078326	Data Visualization	Visualization, Data
+D000078327	Data Systems	Systems, Data
+D000078328	Felbamate	2-Phenyl-1,3-propanediol dicarbamate|2 Phenyl 1,3 propanediol dicarbamate
+D000078329	Workforce	Workforces|Human Resources|Human Resource|Womanpower|Womanpowers|Staffing|Staffings|Labor Supply|Labor Supplies|Supply, Labor|Manpower|Manpowers
+D000078330	Oxcarbazepine	10,11-Dihydro-10-oxo-5H-dibenz(b,f)azepine-5-carboxamide
+D000078331	Correlation of Data	Data Correlation|Data Correlations
+D000078332	Data Analysis	Analyses, Data|Analysis, Data|Data Analyses
+D000078334	Lacosamide	
+D000078336	Facilities and Services Utilization	
+D000078337	Procedures and Techniques Utilization	
+D000078338	Equipment and Supplies Utilization	
+D000078382	Disgust	
+D000078383	Conscientious Refusal to Treat	Refusal to Treat, Conscientious
+D000078385	Embarrassment	
+D000078402	Gun Violence	Violence, Gun
+D000078404	Epidermal Cells	Cell, Epidermal|Epidermic Cells|Cell, Epidermic|Cells, Epidermic|Epidermic Cell|Epidermal Cell
+D000078405	Non-Smokers	Non-Smoker|Nonsmokers|Nonsmoker
+D000078422	Allogeneic Cells	Allogeneic Cell|Cell, Allogeneic|Cells, Allogeneic|Allocells|Allocell|Homologous Cells|Cell, Homologous|Cells, Homologous|Homologous Cell
+D000078462	Therapeutic Alliance	Alliance, Therapeutic|Alliances, Therapeutic|Therapeutic Alliances
+D000078463	Child Labor	
+D000078482	Prior Authorization	Authorization, Prior|Prior Authorizations|Pre-Authorization|Pre Authorization|Pre-Authorizations|Pre-Approval|Pre Approval|Pre-Approvals|Prior Approval|Prior Approvals
+D000078483	Regenerative Endodontics	Endodontic, Regenerative|Endodontics, Regenerative|Regenerative Endodontic
+D000078502	Meat Proteins	Meat Protein
+D000078503	Poultry Proteins	Poultry Protein
+D000078504	Fish Proteins, Dietary	Dietary Fish Protein|Fish Protein, Dietary|Proteins, Dietary Fish|Dietary Fish Proteins
+D000078522	Grain Proteins	Grain Protein
+D000078542	Proctectomy	Proctectomies|Rectum Excision|Excision, Rectum|Rectum Excisions|Rectum Resection|Rectum Resections|Resection, Rectum
+D000078562	Fruit Proteins	Protein, Fruit|Proteins, Fruit|Fruit Protein
+D000078563	Nut Proteins	Nut Protein|Protein, Nut|Proteins, Nut
+D000078582	Shellfish Proteins	Protein, Shellfish|Proteins, Shellfish|Shellfish Protein
+D000078602	Sadness	Unhappiness
+D000078604	Secretagogues	Secretogogue|Secretagogue|Secretogogues
+D000078622	Nutrients	Nutrient
+D000078623	Wool Fiber	Fiber, Wool|Fibers, Wool|Wool Fibers|Woolen Fiber|Fiber, Woolen|Fibers, Woolen|Woolen Fibers
+D000078625	Euthanasia, Involuntary	Involuntary Euthanasia
+D000078642	Medical Countermeasures	Countermeasures, Medical|Medical Countermeasure
+D000078646	Diary as Topic	Diary as Topics|Diaries as Topic|Diaries as Topics
+D000078662	Collections as Topic	Collections as Topics
+D000078663	Egocentrism	
+D000078665	Clinical Trials, Veterinary as Topic	Clinical Trials Veterinary as Topic
+D000078682	Respect	
+D000078702	Radiofrequency Therapy	Radiofrequency Therapies|Therapies, Radiofrequency|Therapy, Radiofrequency|Radio-Frequency Therapy|Radio Frequency Therapy|Radio-Frequency Therapies|Therapies, Radio-Frequency|Therapy, Radio-Frequency
+D000078703	Radiofrequency Ablation	Ablation, Radiofrequency|Radio Frequency Ablation|Ablation, Radio Frequency|Radio-Frequency Ablation|Ablation, Radio-Frequency
+D000078704	Quantitative Light-Induced Fluorescence	Fluorescence, Quantitative Light-Induced|Quantitative Light Induced Fluorescence
+D000078722	PC-3 Cells	Cells, PC-3|PC 3 Cells|PC-3 Cell|Human Prostatic Carcinoma Cell Line PC3|PC3 Cell Line|Cell Line, PC3|PC-3 (Human Prostatic Carcinoma) Cell Line|PC3 Cells|Cells, PC3|PC-3 Cell Line|Cell Line, PC-3|Line, PC-3 Cell|PC 3 Cell Line
+D000078723	Nuclear Receptor Interacting Protein 1	Receptor Interacting Protein, 140 kDa|RIP140 Protein|Nuclear Receptor-Interacting Protein 1|NRIP1 Protein
+D000078724	Pea Proteins	Pea Protein
+D000078742	Substandard Drugs	Drugs, Substandard|Substandard Medicines|Medicines, Substandard
+D000078763	Forms as Topic	
+D000078764	Milnacipran	Midalcipran
+D000078782	Vaccinology	
+D000078783	Standing Position	Position, Standing|Standing Positions
+D000078784	Vortioxetine	1-(2-(2,4-Dimethylphenylsulfanyl)phenyl)piperazine
+D000078785	Mirtazapine	6-Azamianserin|6 Azamianserin
+D000078787	Neuroglobin	
+D000078789	Polyacetylene Polymer	Polyacetylene Polymers|Polymer, Polyacetylene|Polymers, Polyacetylene|Polyacetylene
+D000078790	Insulin Secretion	Secretion, Insulin
+D000078791	Tandem Affinity Purification	Affinity Purification, Tandem
+D000078792	Midkine	Amphiregulin-Associated Protein|Amphiregulin Associated Protein|Cytokine MK
+D000078822	Ex-Smokers	Ex-Smoker|Exsmokers|Exsmoker
+D000078842	Cytoglobin	Histoglobin
+D000078862	Levomilnacipran	
+D000078882	Web Archives as Topic	
+D000078903	Catalog, Drug	
+D000078922	Catalog, Union	
+D000078925	Catalog, Commercial	Catalogs, Commercial|Commercial Catalogs
+D000078928	Formulary, Homeopathic	Formularies, Homeopathic
+D000078929	Formularies, Hospital	Hospital Formularies|Formulary, Hospital
+D000078930	Pharmacopoeia, Homeopathic	Pharmacopoeias, Homeopathic
+D000078942	Web Archive	Web Archives
+D000078984	Formularies, Dental	
+D000078985	Clinical Trial Protocols as Topic	
 D000079	Acetaldehyde	Ethanal
 D000080	Acetals	
 D000081	Acetamides	
@@ -1654,7 +2074,7 @@ D000127	Acholeplasma
 D000128	Acholeplasma laidlawii	Mycoplasma laidlawii
 D000129	Acholeplasmataceae	
 D000130	Achondroplasia	Achondroplasias
-D000134	Acid Etching, Dental	Etching, Dental Acid|Dental Acid Etching
+D000134	Acid Etching, Dental	Dental Acid Etching|Etching, Dental Acid
 D000135	Acid Phosphatase	
 D000136	Acid-Base Equilibrium	Acid Base Equilibrium|Equilibrium, Acid-Base|Acid-Base Balance|Acid Base Balance|Balance, Acid-Base
 D000137	Acid-Base Imbalance	Acid Base Imbalance|Acid-Base Imbalances|Imbalance, Acid-Base|Imbalances, Acid-Base
@@ -1671,15 +2091,15 @@ D000148	Acids, Noncarboxylic	Noncarboxylic Acids
 D000149	Acidulated Phosphate Fluoride	Phosphate Fluoride, Acidulated|Fluoride, Acidulated Phosphate|Acid Phosphate Fluoride|Fluoride, Acid Phosphate
 D000150	Acinetobacter	
 D000151	Acinetobacter Infections	Mimae Infections|Infections, Mimae|Infection, Mimae|Mimae Infection|Infections, Acinetobacter|Acinetobacter Infection|Infection, Acinetobacter
-D000152	Acne Vulgaris	Acne
+D000152	Acne Vulgaris	
 D000153	Acne Keloid	Acne Keloids|Keloid, Acne|Keloids, Acne|Keloidal Acne|Acne, Keloidal|Keloidal Acnes|Lichen Keloidalis Nuchae|Keloidalis Nuchae, Lichen|Nuchae, Lichen Keloidalis|Folliculitis Keloidalis Nuchae|Keloidalis Nuchae, Folliculitis|Nuchae, Folliculitis Keloidalis|Dermatitis Papillaris Capillitii|Capillitii, Dermatitis Papillaris|Capillitius, Dermatitis Papillaris|Dermatitis Papillaris Capillitius|Papillaris Capillitii, Dermatitis|Papillaris Capillitius, Dermatitis|Nuchal Keloid Acne|Acne, Nuchal Keloid|Acnes, Nuchal Keloid|Keloid Acne, Nuchal|Keloid Acnes, Nuchal|Nuchal Keloid Acnes|Folliculitis Keloidalis|Acne Keloidalis
 D000154	Aconitate Hydratase	Hydratase, Aconitate|Citrate Hydrolyase|Hydrolyase, Citrate|Isocitrate Hydro-Lyase|Hydro-Lyase, Isocitrate|Isocitrate Hydro Lyase|Aconitase|Citrate Hydro-Lyase|Citrate Hydro Lyase|Hydro-Lyase, Citrate
-D000156	Aconitic Acid	Acid, Aconitic|Aconitate|Acontic Acid|Acid, Acontic|Pyrocitric Acid|Acid, Pyrocitric|Carboxyglutaconic Acid|Acid, Carboxyglutaconic|Citridic Acid|Acid, Citridic|Citridinic Acid|Acid, Citridinic|Equisetic Acid|Acid, Equisetic|Achilleic Acid|Acid, Achilleic|Adonic Acid|Acid, Adonic
+D000156	Aconitic Acid	
 D000157	Aconitine	Acetylbenzoylaconine|Acetylbenzoyl-aconine|Acetylbenzoyl aconine
 D000158	Acoustic Impedance Tests	Impedance Tests, Acoustic|Acoustic Impedance Test|Impedance Test, Acoustic|Test, Acoustic Impedance|Tests, Acoustic Impedance
 D000159	Vestibulocochlear Nerve	Nerve, Vestibulocochlear|Nerves, Vestibulocochlear|Vestibulocochlear Nerves|Eighth Cranial Nerve|Cranial Nerve, Eighth|Cranial Nerves, Eighth|Eighth Cranial Nerves|Nerve, Eighth Cranial|Nerves, Eighth Cranial|Statoacoustic Nerve|Nerve, Statoacoustic|Nerves, Statoacoustic|Statoacoustic Nerves|Cranial Nerve VIII|Cranial Nerve VIIIs|Nerve VIIIs, Cranial|VIIIs, Cranial Nerve|Cochleovestibular Nerve|Cochleovestibular Nerves|Nerve, Cochleovestibular|Nerves, Cochleovestibular
 D000160	Vestibulocochlear Nerve Diseases	Vestibulocochlear Nerve Disease|Cranial Nerve VIII Disorders|Eighth Cranial Nerve Diseases|Cranial Nerve VIII Diseases
-D000161	Acoustic Stimulation	Auditory Stimulation|Stimulation, Auditory|Stimulation, Acoustic
+D000161	Acoustic Stimulation	Stimulation, Acoustic|Auditory Stimulation|Stimulation, Auditory
 D000162	Acoustics	Acoustic
 D000163	Acquired Immunodeficiency Syndrome	Immunologic Deficiency Syndrome, Acquired|Acquired Immune Deficiency Syndrome|Acquired Immuno-Deficiency Syndrome|Acquired Immuno Deficiency Syndrome|Acquired Immuno-Deficiency Syndromes|Immuno-Deficiency Syndrome, Acquired|Immuno-Deficiency Syndromes, Acquired|Syndrome, Acquired Immuno-Deficiency|Syndromes, Acquired Immuno-Deficiency|Immunodeficiency Syndrome, Acquired|Acquired Immunodeficiency Syndromes|Immunodeficiency Syndromes, Acquired|Syndrome, Acquired Immunodeficiency|Syndromes, Acquired Immunodeficiency|AIDS
 D000164	Acremonium	Acremoniums|Cephalosporium|Cephalosporiums
@@ -1828,15 +2248,15 @@ D000313	Adrenal Medulla	Adrenal Medullas|Medulla, Adrenal|Medullas, Adrenal
 D000314	Adrenal Rest Tumor	Adrenal Rest Tumors|Rest Tumor, Adrenal|Rest Tumors, Adrenal|Tumor, Adrenal Rest|Tumors, Adrenal Rest|Adrenal Cortical Rest Tumor
 D000315	Adrenalectomy	Adrenalectomies
 D000316	Adrenergic alpha-Agonists	Adrenergic alpha Agonists|alpha-Agonists, Adrenergic|Receptor Agonists, Adrenergic alpha|Receptor Agonists, alpha-Adrenergic|Agonists, alpha-Adrenergic Receptor|Receptor Agonists, alpha Adrenergic|alpha-Adrenergic Receptor Agonist|Agonist, alpha-Adrenergic Receptor|Receptor Agonist, alpha-Adrenergic|alpha Adrenergic Receptor Agonist|alpha-Adrenergic Receptor Agonists|alpha Adrenergic Receptor Agonists|Adrenergic alpha-Agonist|Adrenergic alpha Agonist|alpha-Agonist, Adrenergic|alpha-Adrenergic Agonist|Agonist, alpha-Adrenergic|alpha Adrenergic Agonist|alpha-Adrenergic Agonists|Agonists, alpha-Adrenergic|alpha Adrenergic Agonists|Adrenergic alpha-Receptor Agonist|Adrenergic alpha Receptor Agonist|Agonist, Adrenergic alpha-Receptor|alpha-Receptor Agonist, Adrenergic|Adrenergic alpha-Receptor Agonists|Adrenergic alpha Receptor Agonists|Agonists, Adrenergic alpha-Receptor|alpha-Receptor Agonists, Adrenergic
-D000317	Adrenergic alpha-Antagonists	Adrenergic alpha Antagonists|alpha-Antagonists, Adrenergic|Adrenergic alpha-Receptor Blockaders|Adrenergic alpha Receptor Blockaders|Blockaders, Adrenergic alpha-Receptor|alpha-Receptor Blockaders, Adrenergic|alpha-Adrenergic Blocking Agents|Agents, alpha-Adrenergic Blocking|Blocking Agents, alpha-Adrenergic|alpha Adrenergic Blocking Agents|alpha-Adrenergic Blockers|Blockers, alpha-Adrenergic|alpha Adrenergic Blockers|alpha-Blockers, Adrenergic|alpha Blockers, Adrenergic|alpha-Adrenergic Receptor Blockaders|Blockaders, alpha-Adrenergic Receptor|Receptor Blockaders, alpha-Adrenergic|alpha Adrenergic Receptor Blockaders|Adrenergic alpha-Blockers|Adrenergic alpha Blockers
+D000317	Adrenergic alpha-Antagonists	Adrenergic alpha Antagonists|alpha-Antagonists, Adrenergic|alpha-Adrenergic Receptor Blockaders|Blockaders, alpha-Adrenergic Receptor|Receptor Blockaders, alpha-Adrenergic|alpha Adrenergic Receptor Blockaders|alpha-Blockers, Adrenergic|alpha Blockers, Adrenergic|alpha-Adrenergic Blocking Agents|Agents, alpha-Adrenergic Blocking|Blocking Agents, alpha-Adrenergic|alpha Adrenergic Blocking Agents|Adrenergic alpha-Blockers|Adrenergic alpha Blockers|alpha-Adrenergic Blockers|Blockers, alpha-Adrenergic|alpha Adrenergic Blockers|alpha-Adrenergic Antagonists|Antagonists, alpha-Adrenergic|alpha Adrenergic Antagonists|Adrenergic alpha-Receptor Blockaders|Adrenergic alpha Receptor Blockaders|Blockaders, Adrenergic alpha-Receptor|alpha-Receptor Blockaders, Adrenergic
 D000318	Adrenergic beta-Agonists	Adrenergic beta Agonists|beta-Agonists, Adrenergic|Adrenergic beta-Receptor Agonist|Adrenergic beta Receptor Agonist|Agonist, Adrenergic beta-Receptor|beta-Receptor Agonist, Adrenergic|Adrenergic beta-Receptor Agonists|Adrenergic beta Receptor Agonists|Agonists, Adrenergic beta-Receptor|beta-Receptor Agonists, Adrenergic|beta-Adrenergic Agonist|Agonist, beta-Adrenergic|beta Adrenergic Agonist|Receptors Agonists, Adrenergic beta|beta-Adrenergic Receptor Agonist|Agonist, beta-Adrenergic Receptor|Receptor Agonist, beta-Adrenergic|beta Adrenergic Receptor Agonist|beta-Adrenergic Receptor Agonists|Agonists, beta-Adrenergic Receptor|beta Adrenergic Receptor Agonists|Betamimetics|Receptor Agonists, beta-Adrenergic|Receptor Agonists, beta Adrenergic|Adrenergic beta-Agonist|Adrenergic beta Agonist|beta-Agonist, Adrenergic|beta-Adrenergic Agonists|Agonists, beta-Adrenergic|beta Adrenergic Agonists
-D000319	Adrenergic beta-Antagonists	Adrenergic beta Antagonists|beta-Antagonists, Adrenergic|beta-Adrenergic Receptor Blockaders|Blockaders, beta-Adrenergic Receptor|Receptor Blockaders, beta-Adrenergic|beta Adrenergic Receptor Blockaders|beta-Adrenergic Blockers|Blockers, beta-Adrenergic|beta Adrenergic Blockers|beta-Blockers, Adrenergic|Adrenergic beta-Blockers|beta Blockers, Adrenergic|Adrenergic beta-Receptor Blockaders|Adrenergic beta Receptor Blockaders|Blockaders, Adrenergic beta-Receptor|beta-Receptor Blockaders, Adrenergic|beta-Adrenergic Blocking Agents|Agents, beta-Adrenergic Blocking|Blocking Agents, beta-Adrenergic|beta Adrenergic Blocking Agents
+D000319	Adrenergic beta-Antagonists	Adrenergic beta Antagonists|beta-Antagonists, Adrenergic|beta-Adrenoceptor Antagonists|Antagonists, beta-Adrenoceptor|beta Adrenoceptor Antagonists|beta-Blockers, Adrenergic|Adrenergic beta-Blockers|beta Blockers, Adrenergic|beta-Adrenergic Receptor Blockaders|Blockaders, beta-Adrenergic Receptor|Receptor Blockaders, beta-Adrenergic|beta Adrenergic Receptor Blockaders|beta-Adrenergic Blocking Agents|Agents, beta-Adrenergic Blocking|Blocking Agents, beta-Adrenergic|beta Adrenergic Blocking Agents|beta-Adrenergic Blockers|Blockers, beta-Adrenergic|beta Adrenergic Blockers|beta-Adrenergic Antagonists|Antagonists, beta-Adrenergic|beta Adrenergic Antagonists|Adrenergic beta-Receptor Blockaders|Adrenergic beta Receptor Blockaders|Blockaders, Adrenergic beta-Receptor|beta-Receptor Blockaders, Adrenergic
 D000320	Adrenergic Fibers	Adrenergic Fiber|Fiber, Adrenergic|Fibers, Adrenergic|Sympathetic Fibers|Fiber, Sympathetic|Fibers, Sympathetic|Sympathetic Fiber
 D000322	Adrenergic Agonists	Agonists, Adrenergic|Receptor Agonists, Adrenergic|Adrenomimetics|Adrenergic Agonist|Agonist, Adrenergic|Adrenergic Receptor Agonists|Agonists, Adrenergic Receptor|Adrenergic Receptor Agonist|Agonist, Adrenergic Receptor|Receptor Agonist, Adrenergic
 D000323	Adrenochrome	
 D000324	Adrenocorticotropic Hormone	Hormone, Adrenocorticotropic|ACTH (1-39)|ACTH|Corticotrophin|Corticotropin|Corticotropin (1-39)|Corticotrophin (1-39)|Adrenocorticotrophic Hormone|Hormone, Adrenocorticotrophic|1-39 ACTH|Adrenocorticotropin
 D000325	Adrenodoxin	
-D000326	Adrenoleukodystrophy	Melanodermic Leukodystrophy|Leukodystrophies, Melanodermic|Leukodystrophy, Melanodermic|Siemerling-Creutzfeldt Disease|Siemerling Creutzfeldt Disease|Addison Disease and Cerebral Sclerosis|X-ALD|X ALD|Bronze Schilder Disease|X-Linked Adrenoleukodystrophy|Adrenoleukodystrophy, X-Linked|X Linked Adrenoleukodystrophy|ALD (Adrenoleukodystrophy)|X-ALD (X-Linked Adrenoleukodystrophy)|X ALD (X Linked Adrenoleukodystrophy)|Schilder-Addison Complex|Schilder Addison Complex
+D000326	Adrenoleukodystrophy	Bronze Schilder Disease|Melanodermic Leukodystrophy|Leukodystrophies, Melanodermic|Leukodystrophy, Melanodermic|Siemerling-Creutzfeldt Disease|Siemerling Creutzfeldt Disease|X-ALD|X ALD|Addison Disease and Cerebral Sclerosis|X-Linked Adrenoleukodystrophy|Adrenoleukodystrophy, X-Linked|X Linked Adrenoleukodystrophy|ALD (Adrenoleukodystrophy)|X-ALD (X-Linked Adrenoleukodystrophy)|X ALD (X Linked Adrenoleukodystrophy)|Schilder-Addison Complex|Schilder Addison Complex
 D000327	Adsorption	Adsorptions
 D000328	Adult	Adults
 D000329	Advertising as Topic	Advertisement as Topic
@@ -1856,12 +2276,12 @@ D000343	Afferent Loop Syndrome	Afferent Loop Syndromes|Loop Syndrome, Afferent|L
 D000344	Afferent Pathways	Afferent Pathway|Pathway, Afferent|Pathways, Afferent
 D000345	Affinity Labels	Labels, Affinity|Affinity Labeling Reagents|Labeling Reagents, Affinity|Reagents, Affinity Labeling
 D000346	Afghanistan	
-D000347	Afibrinogenemia	Afibrinogenemias|Fibrinogen Deficiency|Deficiency, Fibrinogen|Fibrinogen Deficiencies
+D000347	Afibrinogenemia	Afibrinogenemias
 D000348	Aflatoxins	Aflatoxin
 D000349	Africa	
 D000350	Africa, Central	Central Africa
 D000351	Africa, Eastern	East Africa|Eastern Africa
-D000352	Africa, Northern	French Speaking Africa|Northern Africa|Maghreb|Maghrib|North Africa|Africa, French-Speaking|French-Speaking Africa
+D000352	Africa, Northern	Northern Africa|North Africa|Maghreb|Maghrib
 D000353	Africa, Southern	Southern Africa
 D000354	Africa, Western	Africa, West|West Africa|Western Africa
 D000355	African Horse Sickness	African Horse Sicknesses|Horse Sickness, African|Horse Sicknesses, African|Sickness, African Horse|Sicknesses, African Horse|Equine Plague|Equine Plagues|Plague, Equine|Plagues, Equine|African Horsesickness|African Horsesicknesses|Horsesickness, African|Horsesicknesses, African
@@ -1963,11 +2383,11 @@ D000454	Aleutian Mink Disease Virus	Aleutian Mink Disease Parvovirus|Aleutian Di
 D000455	Medicago sativa	Alfalfa|Lucerne
 D000458	Cyanobacteria	Blue Green Algae|Blue-Green Algae|Algae, Blue-Green|Blue-Green Bacteria|Algae, Blue Green|Bacteria, Blue Green|Bacteria, Blue-Green|Blue Green Bacteria|Cyanophyceae
 D000459	Phaeophyta	Brown Algae|Phaeophyceae|Algae, Brown
-D000460	Chlorophyta	Green Algae|Algae, Green
+D000460	Chlorophyta	Algae, Green|Green Algae
 D000461	Rhodophyta	Red Algae|Algae, Red
 D000462	Algeria	
 D000463	Algestone Acetophenide	Acetophenide, Algestone|Dihydroxyprogesterone Acetophenide|Acetophenide, Dihydroxyprogesterone|Alphasone Acetophenide|Acetophenide, Alphasone
-D000464	Alginates	
+D000464	Alginates	Alginate
 D000465	Algorithms	Algorithm
 D000466	Alkadienes	Diolefins
 D000468	Alkalies	Alkalis|Alkali
@@ -2018,8 +2438,8 @@ D000514	alpha 1-Antichymotrypsin	alpha 1 Antichymotrypsin|Serpin A3|alpha(1)-Ant
 D000515	alpha 1-Antitrypsin	alpha 1 Antitrypsin|alpha 1 Antiprotease|Antiprotease, alpha 1|Serpin A1|alpha 1-Protease Inhibitor|Inhibitor, alpha 1-Protease|alpha 1 Protease Inhibitor|alpha 1-Proteinase Inhibitor|Inhibitor, alpha 1-Proteinase|alpha 1 Proteinase Inhibitor|Trypsin Inhibitor, alpha 1-Antitrypsin|Trypsin Inhibitor, alpha 1 Antitrypsin|A1PI|alpha 1-Antiproteinase|1-Antiproteinase, alpha|alpha 1 Antiproteinase
 D000516	alpha-Amylases	alpha Amylases|alpha-1,4-D-Glucanglucanohydrolase|alpha 1,4 D Glucanglucanohydrolase|alpha-Amylase|alpha Amylase
 D000517	alpha-Chlorohydrin	alpha Chlorohydrin|3-Chloropropanediol|3 Chloropropanediol|Glycerol alpha-Monochlorohydrin|Glycerol alpha Monochlorohydrin|alpha-Monochlorohydrin, Glycerol|3-Monochloropropane-1,2-diol|3 Monochloropropane 1,2 diol|alpha-Chlorhydrin|alpha Chlorhydrin|3-Chloro-1,2-propanediol|3 Chloro 1,2 propanediol|3-MCPD
-D000518	Eflornithine	alpha-Difluoromethyl Ornithine|Ornithine, alpha-Difluoromethyl|alpha Difluoromethyl Ornithine|alpha-Difluoromethylornithine|alpha Difluoromethylornithine
-D000519	alpha-Galactosidase	alpha Galactosidase|alpha-Galactosidases|alpha Galactosidases|Melibiase|alpha-Galactosidase A|alpha Galactosidase A
+D000518	Eflornithine	DL-alpha-Difluoromethylornithine|DL alpha Difluoromethylornithine|alpha-Difluoromethylornithine|alpha Difluoromethylornithine|alpha-Difluoromethyl Ornithine|Ornithine, alpha-Difluoromethyl|alpha Difluoromethyl Ornithine|Difluoromethylornithine
+D000519	alpha-Galactosidase	alpha Galactosidase|alpha-D-Galactosidase|alpha D Galactosidase|Melibiase|alpha-Galactosidase A|alpha Galactosidase A|alpha-Galactosidases|alpha Galactosidases|alpha-D-Galactopyranosidase|alpha D Galactopyranosidase|alpha-Galactisidase|alpha Galactisidase
 D000520	alpha-Glucosidases	alpha Glucosidases|Maltases|alpha-Glucosidase|alpha Glucosidase|Maltase-Glucoamylase|Maltase Glucoamylase
 D000521	alpha-MSH	alpha MSH|alpha-Melanotropin|alpha Melanotropin|Acetylated ACTH (1-13)NH2|alpha-Melanocyte-Stimulating Hormone|Hormone, alpha-Melanocyte-Stimulating|alpha Melanocyte Stimulating Hormone|MSH, alpha
 D000522	Alphaprodine	
@@ -2048,7 +2468,7 @@ D000544	Alzheimer Disease	Alzheimer's Disease|Dementia, Senile|Senile Dementia|D
 D000545	Amanita	Amanitas
 D000546	Amanitins	
 D000547	Amantadine	1-Aminoadamantane|1 Aminoadamantane|Adamantylamine
-D000548	Amaranth Dye	Acid Red 27|Azorubin S|AR27 Compound|Compound, AR27
+D000548	Amaranth Dye	Azorubin S|Acid Red 27|C.I. Acid Red 27|C.I. Food Red 9|AR27 Compound|Compound, AR27
 D000549	Ambenonium Chloride	Chloride, Ambenonium
 D000550	Amblyopia	Amblyopias
 D000551	Ambroxol	4-(((2-Amino-3,5-dibromophenyl)methyl)amino)cyclohexanol|Bromhexine Metabolite VIII|Metabolite VIII, Bromhexine
@@ -2154,14 +2574,14 @@ D000654	Amobarbital	Amylobarbitone
 D000655	Amodiaquine	Amodiaquin|Amodiachin
 D000656	Amoeba	Ameba
 D000657	Amoxapine	2-Chloro-11-(1-piperazinyl)dibenz(b,f)(1,4)oxazepine|Desmethylloxapine
-D000658	Amoxicillin	Amoxycillin|Amoxicillin Trihydrate|Trihydrate, Amoxicillin|Hydroxyampicillin
+D000658	Amoxicillin	Amoxycillin|Amoxicilline
 D000659	AMP Deaminase	Deaminase, AMP|Adenylate Deaminase|Deaminase, Adenylate|Myoadenylate Deaminase|Deaminase, Myoadenylate|AMP Aminohydrolase|Aminohydrolase, AMP|5'-AMP Deaminase|5' AMP Deaminase|Deaminase, 5'-AMP|AMP Aminase|Aminase, AMP
 D000661	Amphetamine	Amfetamine|Phenopromin|Desoxynorephedrin|Phenamine
 D000662	Amphetamines	
 D000663	Amphibians	Amphibian|Amphibia
 D000664	Amphibian Venoms	Venoms, Amphibian|Amphibian Venom|Venom, Amphibian
 D000665	Ampholyte Mixtures	Mixtures, Ampholyte|Isoelectric Focusing Agents|Agents, Isoelectric Focusing|Focusing Agents, Isoelectric|Carrier Ampholytes|Ampholytes, Carrier|Ampholines
-D000666	Amphotericin B	Amphotericin
+D000666	Amphotericin B	
 D000667	Ampicillin	Aminobenzylpenicillin|Penicillin, Aminobenzyl|Aminobenzyl Penicillin
 D000668	Ampicillin Resistance	Ampicillin Resistances|Resistance, Ampicillin|Resistances, Ampicillin
 D000669	Amplifiers, Electronic	Amplifier, Electronic|Electronic Amplifier|Electronic Amplifiers
@@ -2190,13 +2610,13 @@ D000694	Anal Gland Neoplasms	Perianal Gland Neoplasms|Neoplasms, Circumanal Glan
 D000695	Anal Sacs	Anal Sac|Anal Glands, Animal|Anal Gland, Animal
 D000697	Central Nervous System Stimulants	Central Stimulants|Stimulants, Central
 D000698	Analgesia	Analgesias
-D000699	Pain Insensitivity, Congenital	Congenital Insensitivity To Pain|Congenital Pain Indifference|Congenital Pain Insensitivity|Insensitivity To Pain, Congenital|Congenital Analgesia|Pain Indifference, Congenital|Congenital Pain Indifferences|Analgesia, Congenital|Channelopathy-Associated Insensitivity To Pain|Congenital Indifference to Pain|Insensitivity, Congenital Pain
+D000699	Pain Insensitivity, Congenital	Congenital Insensitivity To Pain|Congenital Pain Indifference|Congenital Pain Insensitivity|Congenital Analgesia|Insensitivity, Congenital Pain|Pain Indifference, Congenital|Congenital Pain Indifferences|Analgesia, Congenital|Channelopathy-Associated Insensitivity To Pain|Congenital Indifference to Pain|Insensitivity To Pain, Congenital
 D000700	Analgesics	Analgesic Drugs|Drugs, Analgesic|Anodynes|Analgesic Agents|Agents, Analgesic
 D000701	Analgesics, Opioid	Opioid Analgesics
 D000703	Analog-Digital Conversion	Analog Digital Conversion|Analog-Digital Conversions|Conversion, Analog-Digital|Conversions, Analog-Digital|Analogue-Digital Conversion|Analogue Digital Conversion|Analogue-Digital Conversions|Conversion, Analogue-Digital|Conversions, Analogue-Digital
 D000704	Analysis of Variance	ANOVA|Analysis, Variance|Analyses, Variance|Variance Analyses|Variance Analysis
 D000705	Anaphase	Anaphases
-D000706	Anaphylatoxins	
+D000706	Anaphylatoxins	Anaphylatoxin
 D000707	Anaphylaxis	Shock, Anaphylactic|Anaphylactic Shock|Anaphylactic Reaction|Anaphylactic Reactions|Reaction, Anaphylactic|Reactions, Anaphylactic
 D000708	Anaplasia	Anaplasias
 D000709	Anaplasma	
@@ -2400,7 +2820,7 @@ D000918	Antibody Specificity	Antibody Specificities|Specificities, Antibody|Spec
 D000919	Antibody-Coated Bacteria Test, Urinary	Urinary Antibody-Coated Bacteria Test|Urinary Antibody Coated Bacteria Test|Antibody Coated Bacteria Test, Urinary
 D000920	Antibody-Dependent Cell Cytotoxicity	Antibody Dependent Cell Cytotoxicity|Cell Cytoxicity, Antibody-Dependent|Antibody-Dependent Cell Cytoxicities|Antibody-Dependent Cell Cytoxicity|Cell Cytoxicities, Antibody-Dependent|Cell Cytoxicity, Antibody Dependent|Cytoxicities, Antibody-Dependent Cell|Cytoxicity, Antibody-Dependent Cell|ADCC|Cytotoxicity, Antibody-Dependent Cell|Antibody-Dependent Cell Cytotoxicities|Cell Cytotoxicities, Antibody-Dependent|Cell Cytotoxicity, Antibody-Dependent|Cytotoxicities, Antibody-Dependent Cell|Cytotoxicity, Antibody Dependent Cell
 D000921	Antibody-Producing Cells	Antibody Producing Cells|Antibody-Producing Cell|Cell, Antibody-Producing|Cells, Antibody-Producing|Immunoglobulin-Producing Cells|Cell, Immunoglobulin-Producing|Cells, Immunoglobulin-Producing|Immunoglobulin Producing Cells|Immunoglobulin-Producing Cell
-D000922	Immunotoxins	Cytotoxin-Antibody Conjugates|Conjugates, Cytotoxin-Antibody|Cytotoxin Antibody Conjugates|Immunotoxin|Antibody-Toxin Hybrids|Antibody Toxin Hybrids|Hybrids, Antibody-Toxin|Affinotoxins|Antibody-Toxin Conjugates|Antibody Toxin Conjugates|Conjugates, Antibody-Toxin|Toxin-Antibody Conjugates|Conjugates, Toxin-Antibody|Toxin Antibody Conjugates|Toxin-Antibody Hybrids|Hybrids, Toxin-Antibody|Toxin Antibody Hybrids|Monoclonal Antibody-Toxin Conjugates|Antibody-Toxin Conjugates, Monoclonal|Conjugates, Monoclonal Antibody-Toxin|Monoclonal Antibody Toxin Conjugates
+D000922	Immunotoxins	Antibody-Toxin Conjugates|Antibody Toxin Conjugates|Conjugates, Antibody-Toxin|Toxin-Antibody Conjugates|Conjugates, Toxin-Antibody|Toxin Antibody Conjugates|Antibody-Toxin Hybrids|Antibody Toxin Hybrids|Hybrids, Antibody-Toxin|Monoclonal Antibody-Toxin Conjugates|Antibody-Toxin Conjugates, Monoclonal|Conjugates, Monoclonal Antibody-Toxin|Monoclonal Antibody Toxin Conjugates|Cytotoxin-Antibody Conjugates|Conjugates, Cytotoxin-Antibody|Cytotoxin Antibody Conjugates|Immunotoxin|Affinotoxins|Toxin-Antibody Hybrids|Hybrids, Toxin-Antibody|Toxin Antibody Hybrids
 D000923	Anticestodal Agents	Agents, Anticestodal
 D000924	Anticholesteremic Agents	Agents, Anticholesteremic|Inhibitors, Cholesterol|Cholesterol Inhibitors|Anticholesteremic Drugs|Drugs, Anticholesteremic|Anticholesteremics
 D000925	Anticoagulants	Anticoagulation Agents|Agents, Anticoagulation|Anticoagulant Agents|Agents, Anticoagulant|Anticoagulant Drugs|Drugs, Anticoagulant|Anticoagulant
@@ -2426,7 +2846,7 @@ D000944	Antigens, Differentiation, B-Lymphocyte	Differentiation Antigens, B-Cell
 D000945	Antigens, Differentiation, T-Lymphocyte	T-Cell Differentiation Antigens|Antigens, T-Cell Differentiation|T Cell Differentiation Antigens|Differentiation Antigens, T-Cell|Differentiation Antigens, T Cell|Leu Antigens, T-Lymphocyte|Antigens, T-Lymphocyte Leu|Leu Antigens, T Lymphocyte|T-Lymphocyte Leu Antigens|Differentiation Antigens, T Lymphocyte|T-Lymphocyte Differentiation Antigens|Antigens, T-Lymphocyte Differentiation|Differentiation Antigens, T-Lymphocyte|T Lymphocyte Differentiation Antigens|Antigens, Differentiation, T-Cell|Antigens, Differentiation, T Lymphocyte
 D000946	Antigens, Fungal	Fungal Antigens
 D000947	Antigens, Helminth	Helminth Antigens
-D000949	Histocompatibility Antigens Class II	Class II Antigens|Antigens, Class II|Class II Histocompatibility Antigens|Ia-Like Antigens|Antigens, Ia-Like|Ia Like Antigens|IA Antigen|Antigen, IA|I-A Antigen|Antigen, I-A|Antigens, Immune Response|Immune Response Antigens|Immune-Response-Associated Antigens|Antigens, Immune-Response-Associated|Immune Response Associated Antigens|Class II Major Histocompatibility Antigens|I-A-Antigen|I A Antigen|Class II Antigen|Antigen, Class II|Ia Antigens|Antigens, Ia
+D000949	Histocompatibility Antigens Class II	I-A Antigen|Antigen, I-A|MHC-II Molecules|MHC II Molecules|Molecules, MHC-II|MHC II Peptides|Peptides, MHC II|Class II MHC Proteins|Class II Antigen|Antigen, Class II|Class II Antigens|Antigens, Class II|Class II Histocompatibility Antigens|Ia-Like Antigens|Antigens, Ia-Like|Ia Like Antigens|IA Antigen|Antigen, IA|Ia Antigens|Antigens, Ia|Antigens, Immune Response|Immune Response Antigens|Immune-Response-Associated Antigens|Antigens, Immune-Response-Associated|Immune Response Associated Antigens|Class II Major Histocompatibility Antigens|I-A-Antigen|I A Antigen|MHC Class II Molecules|Class II Major Histocompatibility Molecules
 D000950	Antigens, Ly	Ly Antigens
 D000951	Antigens, Neoplasm	Neoplasm Antigens
 D000952	Antigens, Polyomavirus Transforming	Polyomavirus Tumor Antigens|Antigens, Polyomavirus Tumor|Tumor Antigens, Polyomavirus|Polyomavirus Transforming Antigens|Transforming Antigens, Polyomavirus
@@ -2451,7 +2871,7 @@ D000970	Antineoplastic Agents	Agents, Antineoplastic|Antineoplastic Drugs|Drugs,
 D000971	Antineoplastic Combined Chemotherapy Protocols	Combined Antineoplastic Agents|Antineoplastic Agents, Combined|Agent, Combined Antineoplastic|Agents, Combined Antineoplastic|Antineoplastic Agent, Combined|Combined Antineoplastic Agent|Antineoplastic Combined Chemotherapy Regimens|Drug Combinations, Antineoplastic|Anticancer Drug Combinations|Anticancer Drug Combination|Drug Combination, Anticancer|Drug Combinations, Anticancer|Antineoplastic Drug Combinations|Antineoplastic Drug Combination|Combinations, Antineoplastic Drug|Drug Combination, Antineoplastic
 D000972	Antineoplastic Agents, Phytogenic	Agents, Phytogenic Antineoplastic|Phytogenic Antineoplastic Agents|Antineoplastics, Phytogenic|Phytogenic Antineoplastics|Antineoplastics, Botanical|Botanical Antineoplastics
 D000974	Antibodies, Antinuclear	Antinuclear Factors|Factors, Antinuclear|Antinuclear Factor|Factor, Antinuclear|Antinuclear Antibodies|Antinuclear Antibody|Antibody, Antinuclear
-D000975	Antioxidants	
+D000975	Antioxidants	Anti-Oxidants|Anti Oxidants
 D000976	Antipain	
 D000977	Antiparasitic Agents	Agents, Antiparasitic|Antiparasitic Drugs|Drugs, Antiparasitic|Parasiticides|Antiparasitics
 D000978	Antiparkinson Agents	Agents, Antiparkinson|Antiparkinsonian Agents|Agents, Antiparkinsonian|Antiparkinsonians|Antiparkinson Drugs|Drugs, Antiparkinson
@@ -2538,7 +2958,7 @@ D001063	Appendiceal Neoplasms	Appendiceal Neoplasm|Neoplasm, Appendiceal|Neoplas
 D001064	Appendicitis	
 D001065	Appendix	Vermiform Appendix|Appendix, Vermiform
 D001066	Appetite	Appetites
-D001067	Appetite Depressants	Depressants, Appetite|Anorectics|Anorexic Drugs|Drugs, Anorexic|Appetite Suppressants|Suppressants, Appetite|Appetite-Depressing Drugs|Appetite Depressing Drugs|Drugs, Appetite-Depressing|Appetite-Suppressant Drugs|Appetite Suppressant Drugs|Drugs, Appetite-Suppressant|Anorectic Agents|Agents, Anorectic|Anorexigenic Drugs|Drugs, Anorexigenic
+D001067	Appetite Depressants	Depressants, Appetite|Appetite Suppressants|Suppressants, Appetite|Anorectic Agents|Agents, Anorectic|Appetite-Depressing Drugs|Appetite Depressing Drugs|Drugs, Appetite-Depressing|Anorexic Drugs|Drugs, Anorexic|Appetite-Suppressant Drugs|Appetite Suppressant Drugs|Drugs, Appetite-Suppressant|Anorectics|Anorexigenic Drugs|Drugs, Anorexigenic
 D001068	Feeding and Eating Disorders	Eating and Feeding Disorders
 D001069	Appetite Regulation	Regulation, Appetite|Appetite Regulations|Regulations, Appetite
 D001070	Appetitive Behavior	Appetitive Behaviors|Behavior, Appetitive|Behaviors, Appetitive|Searching Behavior|Behavior, Searching|Behaviors, Searching|Searching Behaviors
@@ -2575,12 +2995,12 @@ D001102	Arbovirus Infections	Arbovirus Infection|Infection, Arbovirus|Infections
 D001103	Arboviruses	Arbovirus|Arthropod-Borne Viruses|Arthropod Borne Viruses|Arthropod-Borne Virus|Virus, Arthropod-Borne|Viruses, Arthropod-Borne
 D001104	Arbutin	
 D001105	Archaea	Archaeobacteria|Archebacteria|Archaebacteria|Archaeon
-D001106	Archaeology	Archeology|Bioarchaeology
+D001106	Archaeology	Archeology
 D001107	Architectural Accessibility	Accessibility, Architectural
 D001108	Architecture	
 D001109	Archives	Archive
 D001110	Arctic Regions	
-D001111	Arcuate Nucleus of Hypothalamus	Hypothalamus Arcuate Nucleus|Infundibular Nucleus|Nucleus, Infundibular|Arcuate Nucleus|Nucleus, Arcuate
+D001111	Arcuate Nucleus of Hypothalamus	Hypothalamus Arcuate Nucleus|Arcuate Nucleus|Nucleus, Arcuate|Infundibular Nucleus|Nucleus, Infundibular
 D001112	Arcus Senilis	Arcus Corneae|Corneal Arcus|Arcus, Corneal
 D001113	Area Health Education Centers	Area Health Education Center
 D001114	Areca	Arecas
@@ -2643,7 +3063,7 @@ D001172	Arthritis, Rheumatoid	Rheumatoid Arthritis
 D001173	Arthrobacter	
 D001174	Arthrodesis	Arthrodeses
 D001175	Arthrography	Arthrographies
-D001176	Arthrogryposis	Arthrogryposes|Arthromyodysplasia, Congenital|Arthromyodysplasias, Congenital|Congenital Arthromyodysplasias|Congenital Arthromyodysplasia|Guerin-Stern Syndrome|Guerin Stern Syndrome|Syndrome, Guerin-Stern|Myodystrophia Fetalis Deformans|Arthrogryposis Multiplex Congenita (AMC)|Arthrogryposis Multiplex Congenitas (AMC)|Congenita, Arthrogryposis Multiplex (AMC)|Congenitas, Arthrogryposis Multiplex (AMC)|Multiplex Congenita, Arthrogryposis (AMC)|Multiplex Congenitas, Arthrogryposis (AMC)|Fibrous Ankylosis of Multiple Joints|Guérin-Stern Syndrome|Guérin Stern Syndrome|Syndrome, Guérin-Stern|Otto Syndrome|Syndrome, Otto|Rocher-Sheldon Syndrome|Rocher Sheldon Syndrome|Syndrome, Rocher-Sheldon|Rossi Syndrome|Syndrome, Rossi|Arthrogryposis Multiplex Congenita|Arthrogryposis Multiplex Congenitas|Congenita, Arthrogryposis Multiplex|Congenitas, Arthrogryposis Multiplex|Multiplex Congenita, Arthrogryposis|Multiplex Congenitas, Arthrogryposis|Amyoplasia Congenita|Congenital Multiple Arthrogryposis|Arthrogryposes, Congenital Multiple|Arthrogryposis, Congenital Multiple|Congenital Multiple Arthrogryposes|Multiple Arthrogryposes, Congenital|Multiple Arthrogryposis, Congenital
+D001176	Arthrogryposis	Arthrogryposes|Arthromyodysplasia, Congenital|Arthromyodysplasias, Congenital|Congenital Arthromyodysplasias|Congenital Arthromyodysplasia|Guerin-Stern Syndrome|Guerin Stern Syndrome|Syndrome, Guerin-Stern|Myodystrophia Fetalis Deformans|Arthrogryposis Multiplex Congenita|Arthrogryposis Multiplex Congenitas|Congenita, Arthrogryposis Multiplex|Congenitas, Arthrogryposis Multiplex|Multiplex Congenita, Arthrogryposis|Multiplex Congenitas, Arthrogryposis|Congenital Multiple Arthrogryposis|Arthrogryposes, Congenital Multiple|Arthrogryposis, Congenital Multiple|Congenital Multiple Arthrogryposes|Multiple Arthrogryposes, Congenital|Multiple Arthrogryposis, Congenital|Fibrous Ankylosis of Multiple Joints|Guérin-Stern Syndrome|Guérin Stern Syndrome|Syndrome, Guérin-Stern|Otto Syndrome|Syndrome, Otto|Rocher-Sheldon Syndrome|Rocher Sheldon Syndrome|Syndrome, Rocher-Sheldon|Rossi Syndrome|Syndrome, Rossi|Amyoplasia Congenita|Arthrogryposis Multiplex Congenita (AMC)|Arthrogryposis Multiplex Congenitas (AMC)|Congenita, Arthrogryposis Multiplex (AMC)|Congenitas, Arthrogryposis Multiplex (AMC)|Multiplex Congenita, Arthrogryposis (AMC)|Multiplex Congenitas, Arthrogryposis (AMC)
 D001177	Arthropathy, Neurogenic	Arthropathies, Neurogenic|Neurogenic Arthropathies|Neurogenic Arthropathy|Charcot's Joint|Charcot Joint|Charcots Joint|Joint, Charcot's
 D001178	Arthroplasty	Arthroplasties
 D001179	Arthropod Vectors	Arthropod Vector|Vector, Arthropod|Vectors, Arthropod
@@ -2734,7 +3154,7 @@ D001266	Atlantic Islands
 D001267	Atlantic Ocean	
 D001268	Atlanto-Axial Joint	Atlanto-Axial Joints|Joint, Atlanto-Axial|Joints, Atlanto-Axial|Atlantoaxial Joint|Atlantoaxial Joints|Joint, Atlantoaxial|Joints, Atlantoaxial|Atlanto Axial Joint|Atlanto Axial Joints|Joint, Atlanto Axial|Joints, Atlanto Axial
 D001269	Atlanto-Occipital Joint	Atlanto Occipital Joint|Atlanto-Occipital Joints|Joint, Atlanto-Occipital|Joints, Atlanto-Occipital|Atloido-Occipital Joint|Atloido Occipital Joint|Atloido-Occipital Joints|Joint, Atloido-Occipital|Joints, Atloido-Occipital
-D001270	Cervical Atlas	C1 Vertebra|C1 Vertebras|Vertebra, C1|Vertebras, C1|Atlas, Cervical
+D001270	Cervical Atlas	Atlas, Cervical|C1 Vertebra|C1 Vertebras|Vertebra, C1|Vertebras, C1
 D001271	Atlases as Topic	Atlases as Topics
 D001272	Atmosphere	Atmospheres
 D001273	Atmosphere Exposure Chambers	Atmosphere Exposure Chamber|Chamber, Atmosphere Exposure|Chambers, Atmosphere Exposure|Exposure Chamber, Atmosphere|Exposure Chambers, Atmosphere
@@ -2790,12 +3210,12 @@ D001325	Autobiography as Topic
 D001326	Autogenic Training	Training, Autogenic|Progressive Relaxation|Relaxation, Progressive|Progressive Muscle Relaxation|Muscle Relaxation, Progressive|Relaxation, Progressive Muscle
 D001327	Autoimmune Diseases	Disease, Autoimmune|Diseases, Autoimmune|Autoimmune Disease
 D001329	Autolysis	Autolyses
-D001330	Automatic Data Processing	Computer Data Processing|Data Processing, Computer|Processing, Computer Data|Electronic Data Processing|Data Processing, Electronic|Processing, Electronic Data|Data Processing, Automatic|Processing, Automatic Data
+D001330	Electronic Data Processing	Data Processing, Electronic|Processing, Electronic Data|Data Processing, Automatic|Computer Data Processing|Data Processing, Computer|Processing, Computer Data|Automatic Data Processing|Processing, Automatic Data
 D001331	Automation	Automations
 D001332	Automatism	
 D001333	Automobile Driver Examination	Driver Examination, Automobile|Automobile Driver Examinations|Driver Examinations, Automobile|Examinations, Automobile Driver|Examination, Automobile Driver
 D001334	Automobile Driving	Automobile Drivings|Driving, Automobile|Drivings, Automobile
-D001335	Vehicle Emissions	Emission, Vehicle|Emissions, Vehicle|Vehicle Emission|Vehicular Emissions|Emission, Vehicular|Emissions, Vehicular|Vehicular Emission
+D001335	Vehicle Emissions	Emissions, Vehicle|Vehicular Emissions|Emissions, Vehicular
 D001336	Automobiles	Automobile
 D001337	Autonomic Agents	Agents, Autonomic|Autonomic Drugs|Drugs, Autonomic
 D001338	Autonomic Fibers, Postganglionic	Autonomic Fiber, Postganglionic|Fiber, Postganglionic Autonomic|Fibers, Postganglionic Autonomic|Postganglionic Autonomic Fiber|Postganglionic Autonomic Fibers
@@ -2826,7 +3246,7 @@ D001364	Awareness	Awarenesses|Situational Awareness|Awareness, Situational|Aware
 D001365	Axilla	
 D001366	Axillary Artery	Arteries, Axillary|Artery, Axillary|Axillary Arteries
 D001367	Axillary Vein	Axillary Veins|Vein, Axillary|Veins, Axillary
-D001368	Axis, Cervical Vertebra	Epistropheus|C2 Vertebra|C2 Vertebras|Cervical Vertebra Axis|Vertebra Axis, Cervical
+D001368	Axis, Cervical Vertebra	C2 Vertebra|C2 Vertebras|Epistropheus|Cervical Vertebra Axis|Vertebra Axis, Cervical
 D001369	Axons	Axon
 D001370	Axonal Transport	Axonal Transports|Transport, Axonal|Transports, Axonal|Axoplasmic Transport|Axoplasmic Transports|Transport, Axoplasmic|Transports, Axoplasmic
 D001371	trans-1,4-Bis(2-chlorobenzaminomethyl)cyclohexane Dihydrochloride	
@@ -2841,7 +3261,7 @@ D001379	Azathioprine	Azothioprine
 D001380	Azauridine	2-beta-D-Ribofuranosyl-1,2,4-triazine-3,5(2H,4H)-dione|6-Azauridine|6 Azauridine
 D001381	Azepines	Hexamethyleneimines
 D001382	Azerbaijan	Azerbaijan SSR|Azerbaijan S.S.R.
-D001383	Azetidinecarboxylic Acid	Acid, Azetidinecarboxylic|Azetidine-2-carboxylic Acid|Acid, Azetidine-2-carboxylic|Azetidine 2 carboxylic Acid
+D001383	Azetidinecarboxylic Acid	Azetidine-2-carboxylic Acid|Azetidine 2 carboxylic Acid
 D001384	Azetidines	
 D001385	Azetines	
 D001386	Azides	
@@ -2881,11 +3301,11 @@ D001420	Bacteria, Aerobic	Aerobic Bacteria
 D001421	Bacteria, Anaerobic	Anaerobic Bacteria
 D001422	Bacterial Adhesion	Adhesion, Bacterial|Adhesions, Bacterial|Bacterial Adhesions
 D001423	Bacterial Infections and Mycoses	
-D001424	Bacterial Infections	Infections, Bacterial|Bacterial Infection|Infection, Bacterial
+D001424	Bacterial Infections	Infection, Bacterial|Infections, Bacterial|Bacterial Infection
 D001425	Bacterial Outer Membrane Proteins	OMP Proteins|Outer Membrane Proteins, Bacterial
 D001426	Bacterial Proteins	Bacterial Gene Product|Bacterial Gene Products|Bacterial Gene Protein|Protein, Bacterial|Bacterial Protein|Gene Product, Bacterial|Gene Products, Bacterial|Gene Protein, Bacterial|Gene Proteins, Bacterial|Proteins, Bacterial|Bacterial Gene Proteins
 D001427	Bacterial Toxins	Toxins, Bacterial
-D001428	Bacterial Vaccines	Vaccine, Bacterial|Bacterin|Bacterial Vaccine|Vaccines, Bacterial
+D001428	Bacterial Vaccines	Bacterin|Vaccines, Bacterial|Bacterial Vaccine|Vaccine, Bacterial
 D001429	Bacteriochlorophylls	Bacteriochlorophyll
 D001430	Bacteriocins	
 D001431	Bacteriological Techniques	Technique, Bacteriological|Techniques, Bacteriological|Technics, Bacteriological|Bacteriologic Technics|Bacteriologic Techniques|Bacteriologic Technique|Technique, Bacteriologic|Techniques, Bacteriologic|Technic, Bacteriological|Bacteriological Technic|Bacteriological Technics|Bacteriological Technique|Bacteriologic Technic|Technic, Bacteriologic|Technics, Bacteriologic
@@ -2934,7 +3354,7 @@ D001477	Bartter Syndrome	Syndrome, Bartter|Juxtaglomerular Hyperplasia with Seco
 D001478	Basal Cell Nevus Syndrome	Gorlin Syndrome|Syndrome, Gorlin|Gorlin-Goltz Syndrome|Gorlin Goltz Syndrome|Syndrome, Gorlin-Goltz|NBCCS|Nevoid Basal Cell Carcinoma Syndrome|Nevus Syndrome, Basal Cell|Fifth Phacomatosis|Fifth Phacomatoses|Multiple Basal Cell Nevi, Odontogenic Keratocysts, and Skeletal Anomalies
 D001479	Basal Ganglia	Basal Nuclei|Nuclei, Basal|Ganglion, Basal|Ganglia, Basal
 D001480	Basal Ganglia Diseases	Basal Ganglia Disease|Basal Ganglia Disorders|Basal Ganglia Disorder
-D001481	Basal Metabolism	Metabolism, Basal|Resting Metabolic Rate|Metabolic Rate, Resting|Rate, Resting Metabolic|Resting Metabolic Rates|Metabolic Rate, Basal|Basal Metabolic Rates|Rate, Basal Metabolic
+D001481	Basal Metabolism	Metabolism, Basal
 D001482	Base Composition	Base Compositions|Composition, Base|Compositions, Base
 D001483	Base Sequence	Base Sequences|Sequence, Base|Sequences, Base|Nucleotide Sequence|Nucleotide Sequences|Sequence, Nucleotide|Sequences, Nucleotide
 D001484	Baseball	
@@ -2966,7 +3386,7 @@ D001510	Bed Rest	Bed Rests|Rest, Bed|Rests, Bed|Bedrest|Bedrests
 D001511	Bedbugs	Bedbug|Bed Bugs|Bed Bug|Cimex
 D001512	Bedding and Linens	Linens and Bedding
 D001513	Beds	Bed
-D001514	Bee Venoms	Venoms, Bee|Apis Venoms|Venoms, Apis|Bee Venom|Venom, Bee
+D001514	Bee Venoms	Venoms, Bee|Bee Venom|Venom, Bee|Apis Venoms|Venoms, Apis
 D001515	Beer	Beers
 D001516	Bees	Bee
 D001517	Coleoptera	Beetles|Beetle
@@ -3004,7 +3424,7 @@ D001552	Benzazepines
 D001553	Benzbromarone	Benzbromaron
 D001554	Benzene	Benzole|Cyclohexatriene|Benzol
 D001555	Benzene Derivatives	Derivatives, Benzene
-D001556	Lindane	gamma-Benzene Hexachloride|Hexachloride, gamma-Benzene|gamma Benzene Hexachloride|Hexachlorane|Hexachlorocyclohexane|Benzene Hexachloride|Hexachloride, Benzene|gamma-Hexachlorocyclohexane|gamma Hexachlorocyclohexane
+D001556	Hexachlorocyclohexane	Benzene Hexachloride|Hexachloride, Benzene|Hexachlorane
 D001557	Benzenesulfonates	
 D001558	Benzethonium	
 D001559	Benzhydryl Compounds	Compounds, Benzhydryl|Diphenylmethyl Compounds|Compounds, Diphenylmethyl
@@ -3058,7 +3478,7 @@ D001608	Beryllium
 D001609	Beta-Globulins	Beta Globulins|Beta-Globulin|Beta Globulin
 D001610	Beta Particles	Beta Particle|Particle, Beta|Particles, Beta
 D001611	Beta Rhythm	Beta Rhythms|Rhythm, Beta|Rhythms, Beta
-D001613	beta 2-Microglobulin	2-Microglobulin, beta|beta 2 Microglobulin|Thymotaxin
+D001613	beta 2-Microglobulin	beta 2 Microglobulin|Thymotaxin
 D001614	beta-Amylase	beta Amylase
 D001615	beta-Endorphin	beta Endorphin|beta-Endorphin (1-31)|Endorphin, beta
 D001616	beta-Galactosidase	beta Galactosidase|beta-Galactosidases|beta Galactosidases|lac Z Protein|Protein, lac Z|Lactases|beta-D-Galactosidase|beta D Galactosidase
@@ -3101,7 +3521,7 @@ D001652	Bile Ducts	Bile Duct|Duct, Bile|Ducts, Bile
 D001653	Bile Ducts, Intrahepatic	Bile Duct, Intrahepatic|Duct, Intrahepatic Bile|Ducts, Intrahepatic Bile|Intrahepatic Bile Duct|Intrahepatic Bile Ducts
 D001654	Bile Pigments	Pigments, Bile|Bile Pigment|Pigment, Bile
 D001655	Bile Reflux	Reflux, Bile
-D001656	Biliary Atresia	Biliary Atresia, Extrahepatic|Atresia, Extrahepatic Biliary|Biliary Atresias, Extrahepatic|Extrahepatic Biliary Atresia|Extrahepatic Biliary Atresias|Atresia, Biliary
+D001656	Biliary Atresia	Atresia, Biliary
 D001657	Biliary Dyskinesia	Biliary Dyskinesias|Dyskinesia, Biliary|Dyskinesias, Biliary
 D001658	Biliary Fistula	Biliary Fistulas|Fistula, Biliary|Fistulas, Biliary
 D001659	Biliary Tract	Tract, Biliary|Biliary Tree|Tree, Biliary|Biliary System|System, Biliary
@@ -3116,7 +3536,7 @@ D001667	Binding, Competitive	Competitive Binding
 D001668	Biobibliography as Topic	Biobibliography as Topics
 D001669	Biochemical Phenomena	Biochemical Concepts|Biochemical Concept|Concept, Biochemical|Concepts, Biochemical|Biochemical Phenomenon|Phenomenon, Biochemical|Phenomena, Biochemical
 D001671	Biochemistry	
-D001672	Biocompatible Materials	Materials, Biocompatible|Biomaterials
+D001672	Biocompatible Materials	Biocompatible Material|Material, Biocompatible|Biomaterials|Biomaterial
 D001673	Biodegradation, Environmental	Environmental Biodegradation
 D001674	Bioelectric Energy Sources	Bioelectric Energy Source|Energy Source, Bioelectric|Energy Sources, Bioelectric|Source, Bioelectric Energy|Sources, Bioelectric Energy
 D001675	Bioethics	
@@ -3130,7 +3550,7 @@ D001683	Biological Clocks	Clocks, Biological|Biological Clock|Clock, Biological|
 D001684	Biological Dressings	Biologic Dressing|Biologic Dressings|Dressing, Biologic|Dressings, Biologic|Dressing, Biological|Biological Dressing|Dressings, Biological
 D001685	Biological Factors	Factor, Biological|Factors, Biological|Biologic Agents|Agents, Biologic|Biologic Factors|Factors, Biologic|Factor, Biologic|Biologic Factor|Biological Agents|Agents, Biological|Biological Factor
 D001686	Biological Phenomena	Biological Phenomenon|Phenomenon, Biological|Biologic Phenomena|Phenomena, Biologic|Phenomena, Biological
-D001688	Biological Products	Biologic Products|Products, Biologic|Biologics|Products, Biological
+D001688	Biological Products	Biologic Products|Products, Biological
 D001689	Biological Psychiatry	Biologic Psychiatry|Psychiatry, Biologic|Psychiatry, Biological
 D001690	Biological Science Disciplines	Biological Science Discipline|Discipline, Biological Science|Disciplines, Biological Science|Science Discipline, Biological|Science Disciplines, Biological|Biological Science|Sciences, Biological|Life Sciences|Life Science|Science, Life|Sciences, Life|Science, Biological|Biologic Sciences|Biologic Science|Science, Biologic|Sciences, Biologic|Biological Sciences
 D001691	Biological Therapy	Biological Therapies|Therapies, Biological|Therapy, Biological|Biologic Therapy|Biologic Therapies|Therapies, Biologic|Therapy, Biologic|Biotherapy|Biotherapies
@@ -3180,9 +3600,9 @@ D001735	Bithionol
 D001736	Biureas	
 D001737	Biuret	Carbamylurea|Allophanamide
 D001738	Biuret Reaction	Biuret Reactions|Reaction, Biuret|Reactions, Biuret
-D001739	BK Virus	Polyomavirus, BK|Polyomavirus hominis 1|BK polyomavirus|Human Polyomavirus BK|Polyomavirus BK, Human
+D001739	BK Virus	BK polyomavirus|Polyomavirus, BK|Polyomavirus hominis 1|Human Polyomavirus BK|Polyomavirus BK, Human
 D001740	Black Widow Spider	Black Widow Spiders|Spider, Black Widow|Spiders, Black Widow|Widow Spider, Black|Widow Spiders, Black|Latrodectus mactans|Latrodectus mactan|mactan, Latrodectus
-D001741	African Americans	Americans, African
+D001741	African Americans	African-Americans|African-American
 D001742	Blackwater Fever	Blackwater Fevers|Fever, Blackwater|Fevers, Blackwater|Malaria, Hemolytic|Hemolytic Malaria|Hemolytic Malarias|Malarias, Hemolytic|Black Water Fever|Black Water Fevers|Fever, Black Water|Fevers, Black Water
 D001743	Urinary Bladder	Bladder, Urinary|Bladder
 D001744	Urinary Bladder Calculi	Bladder Calculi, Urinary|Bladder Calculus, Urinary|Calculi, Urinary Bladder|Calculus, Urinary Bladder|Urinary Bladder Calculus|Bladder Stones|Bladder Stone|Stone, Bladder|Stones, Bladder|Calculi of Urinary Bladder|Urinary Bladder Stones|Bladder Stone, Urinary|Bladder Stones, Urinary|Stone, Urinary Bladder|Stones, Urinary Bladder|Urinary Bladder Stone|Vesical Calculi|Calculi, Vesical|Calculus, Vesical|Vesical Calculus|Bladder Calculi|Bladder Calculus|Calculi, Bladder|Calculus, Bladder|Cystoliths|Cystolith
@@ -3306,14 +3726,14 @@ D001863	Bone Screws	Bone Screw|Screw, Bone|Screws, Bone
 D001864	Bone Wires	Bone Wire|Wire, Bone|Wires, Bone
 D001865	Bongkrekic Acid	Flavotoxin A
 D001867	Book Classification	Classification, Book|Book Classifications|Classifications, Book
-D001868	Book Collecting	Book Collectings|Collecting, Book|Collectings, Book
-D001869	Book Imprints	Book Imprint|Imprint, Book|Imprints, Book
+D001868	Book Collecting	Collecting, Book
+D001869	Book Imprints	Book Imprint|Imprints, Book
 D001870	Book Industry	Industry, Book|Book Industries|Industries, Book
 D001871	Book Ornamentation	Book Ornamentations|Ornamentation, Book|Ornamentations, Book
-D001872	Book Prices	Book Price|Price, Book|Prices, Book
+D001872	Book Prices	
 D001873	Book Reviews as Topic	
 D001874	Book Selection	Book Selections|Selection, Book|Selections, Book
-D001875	Bookbinding	Bookbindings
+D001875	Bookbinding	
 D001876	Bookplates as Topic	Bookplates as Topics|Book Plates as Topic
 D001877	Books	Book
 D001878	Books, Illustrated	Illustrated Books|Book, Illustrated
@@ -3358,7 +3778,7 @@ D001917	Brachial Plexus	Plexus, Brachial
 D001918	Brachytherapy	Radioisotope Brachytherapy|Curietherapy|Brachytherapy, Radioisotope
 D001919	Bradycardia	Bradycardias|Bradyarrhythmias|Bradyarrhythmia
 D001920	Bradykinin	Arg-Pro-Pro-Gly-Phe-Ser-Pro-Phe-Arg|Arg Pro Pro Gly Phe Ser Pro Phe Arg
-D001921	Brain	Brains|Encephalon|Encephalons
+D001921	Brain	Encephalon
 D001922	Brain Abscess	Abscess, Brain|Brain Abscesses
 D001923	Brain Chemistry	Chemistry, Brain|Brain Chemistries|Chemistries, Brain
 D001924	Brain Concussion	Brain Concussions|Concussion, Brain|Commotio Cerebri|Cerebral Concussion|Cerebral Concussions|Concussion, Cerebral
@@ -3485,7 +3905,7 @@ D002051	Burkitt Lymphoma	Burkitt Leukemia|Leukemia, Burkitt|Leukemia, Lymphoblas
 D002052	Myanmar	Myanma|Burma
 D002053	Burn Units	Burn Unit|Unit, Burn|Units, Burn
 D002054	Burning Mouth Syndrome	Burning Mouth Syndromes|Mouth Syndrome, Burning|Mouth Syndromes, Burning|Syndrome, Burning Mouth|Syndromes, Burning Mouth
-D002055	Burnout, Professional	Professional Burnout|Occupational Burnout|Burnout, Occupational
+D002055	Burnout, Professional	Professional Burnout|Occupational Burnout|Burnout, Occupational|Career Burnout|Burnout, Career
 D002056	Burns	Burn
 D002057	Burns, Chemical	Chemical Burns|Burn, Chemical|Chemical Burn
 D002058	Burns, Electric	Electric Burns|Burn, Electric|Electric Burn
@@ -3510,7 +3930,7 @@ D002080	Butterflies	Butterfly
 D002081	Buttocks	Buttock
 D002082	Butylamines	
 D002083	Butylated Hydroxyanisole	Hydroxyanisole, Butylated|Butylhydroxyanisole|Butyl Methoxyphenol|Methoxyphenol, Butyl|(1,1-Dimethylethyl)-4-methoxyphenol|BHA
-D002084	Butylated Hydroxytoluene	Hydroxytoluene, Butylated|Butylhydroxytoluene|4-Methyl-2,6-ditertbutylphenol|4 Methyl 2,6 ditertbutylphenol|2,6-Di-t-butyl-4-methylphenol|2,6 Di t butyl 4 methylphenol|2,6-Di-tert-butyl-p-cresol|2,6 Di tert butyl p cresol|BHT|2,6-Bis(1,1-dimethylethyl)-4-methylphenol
+D002084	Butylated Hydroxytoluene	Hydroxytoluene, Butylated|2,6-Di-tert-butyl-4-methylphenol|2,6 Di tert butyl 4 methylphenol|2,6-Di-t-butyl-4-methylphenol|2,6 Di t butyl 4 methylphenol|2,6-Di-tert-butyl-p-cresol|2,6 Di tert butyl p cresol|2,6-Bis(1,1-dimethylethyl)-4-methylphenol|BHT|Butylhydroxytoluene|Di-tert-butyl-methylphenol|Di tert butyl methylphenol|4-Methyl-2,6-ditertbutylphenol|4 Methyl 2,6 ditertbutylphenol
 D002085	Butylhydroxybutylnitrosamine	N-Nitrosobutyl-4-hydroxybutylamine|N Nitrosobutyl 4 hydroxybutylamine|N-Nitroso-N-butyl-(4-hydroxybutyl)amine|Butylbutanolnitrosamine|N-Butyl-N-(4-hydroxybutyl)nitrosamine
 D002086	Butylscopolammonium Bromide	Bromide, Butylscopolammonium|Scopolaminebutylbromide|Hyoscine N-Butylbromide|Hyoscine N Butylbromide|N-Butylbromide, Hyoscine|N-Butylscopolammonium Bromide|Bromide, N-Butylscopolammonium|N Butylscopolammonium Bromide|Butylscopolamine|Hyoscinbutylbromide
 D002087	Butyrates	
@@ -3522,7 +3942,7 @@ D002094	Republic of Belarus
 D002095	Byssinosis	Byssinoses|Brown Lung|Brown Lungs|Brown Lung Disease|Brown Lung Diseases
 D002096	C-Peptide	C Peptide|Connecting Peptide|Proinsulin C-Peptide|Proinsulin C Peptide|C-Peptide, Proinsulin|C Peptide, Proinsulin
 D002097	C-Reactive Protein	C Reactive Protein|Protein, C-Reactive
-D002099	Cacao	Cacaos|Theobroma cacao|Cocoa Plant|Cocoa Plants|Plant, Cocoa|Plants, Cocoa
+D002099	Cacao	Cocoa Plant|Plant, Cocoa|Theobroma cacao
 D002100	Cachexia	
 D002101	Cacodylic Acid	Acid, Cacodylic|Dimethylarsinic Acid|Acid, Dimethylarsinic
 D002102	Cadaver	Cadavers|Corpse|Corpses
@@ -3536,16 +3956,16 @@ D002109	Caffeic Acids	Acids, Caffeic
 D002110	Caffeine	1,3,7-Trimethylxanthine
 D002111	Calcaneus	Heel Bone|Bone, Heel
 D002112	Calcifediol	25-Hydroxyvitamin D 3|25 Hydroxyvitamin D 3|25-Hydroxycholecalciferol Monohydrate|25 Hydroxycholecalciferol Monohydrate|Monohydrate, 25-Hydroxycholecalciferol|25-Hydroxyvitamin D3|25 Hydroxyvitamin D3|Calcidiol|25-Hydroxycholecalciferol|25 Hydroxycholecalciferol
-D002113	Calcification, Physiologic	Calcification, Physiological|Physiological Calcification|Physiologic Calcification
+D002113	Calcification, Physiologic	Physiologic Calcification|Calcification, Physiological|Physiological Calcification
 D002114	Calcinosis	Calcinoses|Calcification, Pathologic|Pathologic Calcification
 D002115	Calciphylaxis	Calciphylaxes|Idiopathic Calciphylaxis|Calciphylaxis, Idiopathic
 D002116	Calcitonin	Calcitrin|Thyrocalcitonin|Calcitonin(1-32)
-D002117	Calcitriol	1 alpha,25-Dihydroxyvitamin D3|1 alpha,25 Dihydroxyvitamin D3|D3, 1 alpha,25-Dihydroxyvitamin|alpha,25-Dihydroxyvitamin D3, 1|1,25-Dihydroxyvitamin D3|1,25 Dihydroxyvitamin D3|D3, 1,25-Dihydroxyvitamin|1 alpha,25-Dihydroxycholecalciferol|1 alpha,25 Dihydroxycholecalciferol|1,25-Dihydroxycholecalciferol|1,25 Dihydroxycholecalciferol
-D002118	Calcium	Factor IV|Blood Coagulation Factor IV|Calcium-40|Calcium 40|Coagulation Factor IV|Factor IV, Coagulation
+D002117	Calcitriol	1 alpha,25-Dihydroxyvitamin D3|1 alpha,25 Dihydroxyvitamin D3|D3, 1 alpha,25-Dihydroxyvitamin|1,25-Dihydroxyvitamin D3|1,25 Dihydroxyvitamin D3|D3, 1,25-Dihydroxyvitamin|1 alpha,25-Dihydroxycholecalciferol|1,25-Dihydroxycholecalciferol|1,25 Dihydroxycholecalciferol
+D002118	Calcium	Blood Coagulation Factor IV|Coagulation Factor IV|Factor IV, Coagulation|Calcium-40|Calcium 40|Factor IV
 D002119	Calcium Carbonate	Carbonate, Calcium
-D002120	Calcium Channel Agonists	Agonists, Calcium Channel|Channel Agonists, Calcium|Calcium Channel Activators|Activators, Calcium Channel|Channel Activators, Calcium|Calcium Channel Agonist|Agonist, Calcium Channel|Channel Agonist, Calcium
-D002121	Calcium Channel Blockers	Blockers, Calcium Channel|Channel Blockers, Calcium|Calcium Channel Antagonists|Antagonists, Calcium Channel|Calcium Channel Blocking Drugs
-D002122	Calcium Chloride	Chloride, Calcium|Calcium Chloride Dihydrate|Chloride Dihydrate, Calcium|Dihydrate, Calcium Chloride
+D002120	Calcium Channel Agonists	Agonists, Calcium Channel|Channel Agonists, Calcium|Calcium Channel Agonist|Agonist, Calcium Channel|Channel Agonist, Calcium|Calcium Channel Activators|Activators, Calcium Channel|Channel Activators, Calcium
+D002121	Calcium Channel Blockers	Blockers, Calcium Channel|Channel Blockers, Calcium|Calcium Channel Blocking Drugs|Calcium Channel Antagonists|Antagonists, Calcium Channel
+D002122	Calcium Chloride	
 D002123	Calcium Dobesilate	Dobesilate, Calcium|Dobesilate Calcium|Calcium, Dobesilate
 D002124	Calcium Fluoride	Fluoride, Calcium
 D002125	Calcium Gluconate	Gluconate, Calcium
@@ -3601,7 +4021,7 @@ D002177	Candidiasis	Candidiases|Moniliasis|Moniliases
 D002178	Candidiasis, Chronic Mucocutaneous	Candidiases, Chronic Mucocutaneous|Chronic Mucocutaneous Candidiases|Chronic Mucocutaneous Candidiasis|Mucocutaneous Candidiases, Chronic|Mucocutaneous Candidiasis, Chronic
 D002179	Candidiasis, Cutaneous	Candidiases, Cutaneous|Cutaneous Candidiases|Cutaneous Candidiasis|Moniliasis, Cutaneous|Cutaneous Moniliases|Cutaneous Moniliasis|Moniliases, Cutaneous
 D002180	Candidiasis, Oral	Candidiases, Oral|Oral Candidiases|Oral Candidiasis|Thrush|Moniliasis, Oral|Moniliases, Oral|Oral Moniliases|Oral Moniliasis
-D002181	Candidiasis, Vulvovaginal	Vulvovaginal Candidiases|Vulvovaginal Candidiasis|Moniliasis, Vulvovaginal|Vulvovaginal Moniliases|Vulvovaginal Moniliasis|Vaginal Yeast Infections|Infection, Vaginal Yeast|Infections, Vaginal Yeast|Yeast Infection, Vaginal|Yeast Infections, Vaginal|Vaginal Yeast Infection|Genital Vulvovaginal Candidiasis|Candidiases, Genital Vulvovaginal|Candidiasis, Genital Vulvovaginal|Genital Vulvovaginal Candidiases|Vulvovaginal Candidiases, Genital|Vulvovaginal Candidiasis, Genital|Candidiasis, Genital|Candidiases, Genital|Genital Candidiases|Genital Candidiasis
+D002181	Candidiasis, Vulvovaginal	Vulvovaginal Candidiasis
 D002182	Candy	Candies|Confection|Confections
 D002183	Canes	Cane|Walking Sticks|Stick, Walking|Sticks, Walking|Walking Stick
 D002184	Herpesvirus 1, Canid	Canine Herpesvirus 1|Herpesvirus 1, Canine|Herpesvirus 1 (alpha), Canine|Canine Tracheobronchitis Virus|Canine Tracheobronchitis Viruses|Tracheobronchitis Virus, Canine|Tracheobronchitis Viruses, Canine|Canid Herpesvirus 1
@@ -3640,7 +4060,7 @@ D002216	Captopril	(S)-1-(3-Mercapto-2-methyl-1-oxopropyl)-L-proline
 D002217	Carbachol	Carbocholine|Carbacholine
 D002218	Carbadox	
 D002219	Carbamates	
-D002220	Carbamazepine	Carbamazepine Anhydrous
+D002220	Carbamazepine	
 D002221	Carbamyl Phosphate	Phosphate, Carbamyl|Carbamoyl Phosphate|Phosphate, Carbamoyl
 D002222	Carbamoyl-Phosphate Synthase (Ammonia)	Carbamyl Phosphate Synthase (Ammonia)|Carbamyl-Phosphate Synthase (Ammonia)|Carbamoyl-Phosphate Synthetase I|Synthetase I, Carbamoyl-Phosphate|Carbamoyl-Phosphate Synthetase (Ammonia)|Carbamoyl Phosphate Synthetase I|Carbamoylphosphate Synthetase I|Synthetase I, Carbamoylphosphate|CP Synthase I|Synthase I, CP
 D002223	Carbamoyl-Phosphate Synthase (Glutamine-Hydrolyzing)	Carbamyl Phosphate Synthase (Glutamine)|Carbamoyl-Phosphate Synthase (Glutamine)|Carbamyl-Phosphate Synthase (Glutamine)
@@ -3699,7 +4119,7 @@ D002278	Carcinoma in Situ	Carcinoma, Preinvasive|Preinvasive Carcinoma|Carcinoma
 D002279	Carcinoma 256, Walker	Walker Carcinoma 256|Carcinosarcoma 256, Walker|Walker Carcinosarcoma 256
 D002280	Carcinoma, Basal Cell	Basal Cell Carcinoma|Basal Cell Carcinomas|Carcinomas, Basal Cell|Rodent Ulcer|Rodent Ulcers|Ulcers, Rodent|Ulcer, Rodent|Epithelioma, Basal Cell|Basal Cell Epithelioma|Basal Cell Epitheliomas|Epitheliomas, Basal Cell
 D002281	Carcinoma, Basosquamous	Basosquamous Carcinoma|Basosquamous Carcinomas|Carcinomas, Basosquamous
-D002282	Adenocarcinoma, Bronchiolo-Alveolar	Adenocarcinoma, Bronchiolo Alveolar|Adenocarcinomas, Bronchiolo-Alveolar|Bronchiolo-Alveolar Adenocarcinoma|Bronchiolo-Alveolar Adenocarcinomas|Alveolar Cell Carcinoma|Carcinoma, Alveolar|Alveolar Carcinoma|Alveolar Carcinomas|Carcinomas, Alveolar|Carcinoma, Bronchiolo-Alveolar|Bronchiolo-Alveolar Carcinoma|Bronchiolo-Alveolar Carcinomas|Carcinoma, Bronchiolo Alveolar|Carcinomas, Bronchiolo-Alveolar|Carcinoma, Bronchioloalveolar|Bronchioloalveolar Carcinoma|Bronchioloalveolar Carcinomas|Carcinomas, Bronchioloalveolar|Adenocarcinoma, Alveolar|Adenocarcinomas, Alveolar|Alveolar Adenocarcinoma|Alveolar Adenocarcinomas|Carcinoma, Bronchiolar|Bronchiolar Carcinoma|Bronchiolar Carcinomas|Carcinomas, Bronchiolar
+D002282	Adenocarcinoma, Bronchiolo-Alveolar	Adenocarcinoma, Bronchiolo Alveolar|Adenocarcinomas, Bronchiolo-Alveolar|Bronchiolo-Alveolar Adenocarcinoma|Bronchiolo-Alveolar Adenocarcinomas|Adenocarcinoma, Alveolar|Adenocarcinomas, Alveolar|Alveolar Adenocarcinoma|Alveolar Adenocarcinomas|Carcinoma, Alveolar|Alveolar Carcinoma|Alveolar Carcinomas|Carcinomas, Alveolar|Carcinoma, Bronchiolo-Alveolar|Bronchiolo-Alveolar Carcinoma|Bronchiolo-Alveolar Carcinomas|Carcinoma, Bronchiolo Alveolar|Carcinomas, Bronchiolo-Alveolar|Alveolar Cell Carcinoma|Alveolar Cell Carcinomas|Carcinoma, Alveolar Cell|Carcinomas, Alveolar Cell|Carcinoma, Bronchiolar|Bronchiolar Carcinoma|Bronchiolar Carcinomas|Carcinomas, Bronchiolar|Carcinoma, Bronchioloalveolar|Bronchioloalveolar Carcinoma|Bronchioloalveolar Carcinomas|Carcinomas, Bronchioloalveolar
 D002283	Carcinoma, Bronchogenic	Bronchogenic Carcinoma|Bronchogenic Carcinomas|Carcinomas, Bronchogenic|Carcinoma, Bronchial|Bronchial Carcinoma|Bronchial Carcinomas|Carcinomas, Bronchial
 D002284	Carcinoma, Brown-Pearce	Brown-Pearce Carcinoma|Carcinoma, Brown Pearce|Epithelioma, Brown-Pearce|Brown-Pearce Epithelioma|Epithelioma, Brown Pearce
 D002285	Carcinoma, Intraductal, Noninfiltrating	Carcinoma, Intraductal|Carcinomas, Intraductal|Intraductal Carcinoma|Intraductal Carcinomas|DCIS|Ductal Carcinoma In Situ|Intraductal Carcinoma, Noninfiltrating|Carcinoma, Noninfiltrating Intraductal|Carcinomas, Noninfiltrating Intraductal|Intraductal Carcinomas, Noninfiltrating|Noninfiltrating Intraductal Carcinoma|Noninfiltrating Intraductal Carcinomas
@@ -3733,7 +4153,7 @@ D002313	Cardiomyopathy, Restrictive	Cardiomyopathies, Restrictive|Restrictive Ca
 D002314	Cardioplegic Solutions	Solutions, Cardioplegic|Cardioplegic Solution|Solution, Cardioplegic
 D002315	Cardiopulmonary Bypass	Heart-Lung Bypass|Bypass, Heart-Lung|Bypasses, Heart-Lung|Heart Lung Bypass|Heart-Lung Bypasses|Bypass, Cardiopulmonary|Bypasses, Cardiopulmonary|Cardiopulmonary Bypasses
 D002316	Cardiotonic Agents	Cardiac Stimulants|Inotropic Agents, Positive Cardiac|Cardiotonic Drugs|Cardiotonics|Myocardial Stimulants|Cardioprotective Agents
-D002317	Cardiovascular Agents	Agents, Cardiovascular|Cardiovascular Drugs|Drugs, Cardiovascular
+D002317	Cardiovascular Agents	Agents, Cardiovascular|Cardioactive Drugs|Drugs, Cardioactive|Cardiovascular Drugs|Drugs, Cardiovascular
 D002318	Cardiovascular Diseases	Cardiovascular Disease|Disease, Cardiovascular|Diseases, Cardiovascular
 D002319	Cardiovascular System	Cardiovascular Systems|Circulatory System|Circulatory Systems
 D002320	Cardiovascular Physiological Phenomena	Cardiovascular Physiological Phenomenas|Phenomena, Cardiovascular Physiological|Physiological Phenomena, Cardiovascular|Cardiovascular Physiology|Cardiovascular Physiological Phenomenon|Phenomenon, Cardiovascular Physiological|Physiological Phenomenon, Cardiovascular|Physiology, Cardiovascular|Cardiovascular Physiological Concepts|Cardiovascular Physiological Concept|Concept, Cardiovascular Physiological|Concepts, Cardiovascular Physiological|Physiological Concept, Cardiovascular|Physiological Concepts, Cardiovascular
@@ -3791,12 +4211,12 @@ D002374	Catalase
 D002375	Catalepsy	Catalepsies|Anochlesia|Anochlesias
 D002376	Cataloging	
 D002377	Catalogs as Topic	Catalogs as Topics|Topic, Catalogs as|Topics, Catalogs as|as Topic, Catalogs|as Topics, Catalogs
-D002378	Catalogs, Booksellers'	Catalogs, Bookseller|Catalogs, Booksellers|Booksellers' Catalogs|Bookseller Catalogs|Booksellers Catalogs|Booksellers' Catalog|Catalog, Booksellers'
-D002379	Catalogs, Commercial	Catalog, Commercial|Commercial Catalog|Commercial Catalogs
-D002380	Catalogs, Drug	Drug Catalogs|Catalog, Drug|Drug Catalog
+D002378	Catalog, Bookseller	Booksellers' Catalogs|Catalogs, Booksellers'
+D002379	Catalogs, Commercial as Topic	Commercial Catalogs as Topic
+D002380	Catalogs, Drug as Topic	Drug Catalogs as Topic
 D002381	Catalogs, Library	Catalog, Library|Library Catalog|Library Catalogs
-D002382	Catalogs, Publishers'	Catalogs, Publisher|Catalogs, Publishers|Publishers' Catalogs|Catalog, Publishers'|Publisher Catalogs|Publisher's Catalogs|Publishers Catalogs|Publishers' Catalog
-D002383	Catalogs, Union	Catalog, Union|Union Catalog|Union Catalogs
+D002382	Catalog, Publisher	Publishers' Catalogs|Catalogs, Publishers'
+D002383	Catalogs, Union as Topic	Union Catalog as Topic
 D002384	Catalysis	Catalyses
 D002385	Cataplexy	Tonelessness Syndrome|Syndrome, Tonelessness|Syndromes, Tonelessness|Tonelessness Syndromes|Cataleptic Attacks|Attack, Cataleptic|Attacks, Cataleptic|Cataleptic Attack|Henneberg Syndrome|Syndrome, Henneberg
 D002386	Cataract	Cataracts
@@ -3804,7 +4224,7 @@ D002387	Cataract Extraction	Cataract Extractions|Extraction, Cataract|Extraction
 D002388	Catastrophic Illness	Catastrophic Illnesses|Illness, Catastrophic|Illnesses, Catastrophic
 D002389	Catatonia	Catatonias
 D002391	Catchment Area (Health)	Area, Catchment (Health)|Areas, Catchment (Health)|Catchment Areas (Health)|Health Service Area|Service Area, Health|Area, Health Service|Areas, Health Service|Health Service Areas|Service Areas, Health
-D002392	Catechin	(+)-Catechin|Cianidanol|Catechinic Acid|Acid, Catechinic|Catechuic Acid|Acid, Catechuic|(+)-Cyanidanol|3,3',4',5,7-Flavanpentol
+D002392	Catechin	(+)-Catechin|Cianidanol|Catechinic Acid|Catechuic Acid|(+)-Cyanidanol|3,3',4',5,7-Flavanpentol
 D002393	Estrogens, Catechol	Catecholestrogens|Catechol Estrogens
 D002394	Catechol O-Methyltransferase	O-Methyltransferase, Catechol|Catechol-O-Methyltransferase|Catechol O Methyltransferase|Catechol Methyltransferase|Methyltransferase, Catechol
 D002395	Catecholamines	Sympathins
@@ -3844,8 +4264,8 @@ D002429	Cecal Diseases	Cecal Disease|Disease, Cecal|Diseases, Cecal
 D002430	Cecal Neoplasms	Cecal Neoplasm|Neoplasm, Cecal|Neoplasms, Cecal
 D002431	Cecostomy	Cecostomies
 D002432	Cecum	Cecums
-D002433	Cefaclor	Cefaclor Monohydrate|Monohydrate, Cefaclor
-D002434	Cefadroxil	Cefadroxil Monohydrate|Monohydrate, Cefadroxil|Cephadroxyl|4-Hydroxycephalexin|4 Hydroxycephalexin
+D002433	Cefaclor	
+D002434	Cefadroxil	
 D002435	Cefamandole	Cephamandole
 D002436	Cefatrizine	
 D002437	Cefazolin	Cephazolin
@@ -3853,7 +4273,7 @@ D002438	Cefoperazone	Cefoperazon
 D002439	Cefotaxime	Cephotaxim|Cefotaxim
 D002440	Cefoxitin	
 D002441	Cefsulodin	
-D002442	Ceftazidime	Ceftazidime Pentahydrate|Pentahydrate, Ceftazidime
+D002442	Ceftazidime	
 D002443	Ceftriaxone	Ceftriaxon|Cefatriaxone
 D002444	Cefuroxime	Cephuroxime
 D002445	Celiac Artery	Arteries, Celiac|Artery, Celiac|Celiac Arteries
@@ -3881,7 +4301,7 @@ D002467	Cell Nucleus	Cell Nuclei|Nuclei, Cell|Nucleus, Cell
 D002468	Cell Physiological Phenomena	Phenomena, Cell Physiological|Cell Physiological Phenomenon|Phenomenon, Cell Physiological|Physiology, Cell|Cell Physiology
 D002469	Cell Separation	Cell Separations|Separation, Cell|Separations, Cell|Cell Segregation|Cell Segregations|Segregation, Cell|Segregations, Cell|Isolation, Cell|Cell Isolations|Isolations, Cell|Cell Isolation
 D002470	Cell Survival	Survival, Cell|Cell Viability|Cell Viabilities|Viabilities, Cell|Viability, Cell
-D002471	Cell Transformation, Neoplastic	Tumorigenic Transformation|Transformation, Tumorigenic|Transformations, Tumorigenic|Tumorigenic Transformations|Transformation, Neoplastic Cell|Neoplastic Cell Transformation|Cell Transformations, Neoplastic|Neoplastic Cell Transformations|Transformations, Neoplastic Cell|Neoplastic Transformation, Cell|Cell Neoplastic Transformation|Cell Neoplastic Transformations|Neoplastic Transformations, Cell|Transformation, Cell Neoplastic|Transformations, Cell Neoplastic
+D002471	Cell Transformation, Neoplastic	Transformation, Neoplastic Cell|Neoplastic Transformation, Cell|Cell Neoplastic Transformation|Cell Neoplastic Transformations|Neoplastic Transformations, Cell|Transformation, Cell Neoplastic|Transformations, Cell Neoplastic|Tumorigenic Transformation|Transformation, Tumorigenic|Transformations, Tumorigenic|Tumorigenic Transformations|Neoplastic Cell Transformation|Cell Transformations, Neoplastic|Neoplastic Cell Transformations|Transformations, Neoplastic Cell
 D002472	Cell Transformation, Viral	Cell Transformations, Viral|Transformations, Viral Cell|Viral Cell Transformations|Transformation, Viral Cell|Viral Cell Transformation
 D002473	Cell Wall	Cell Walls|Wall, Cell|Walls, Cell
 D002474	Cell-Free System	Cell Free System|Cell-Free Systems|System, Cell-Free|Systems, Cell-Free|Cellfree System|Cellfree Systems|System, Cellfree|Systems, Cellfree
@@ -3895,12 +4315,12 @@ D002481	Cellulitis
 D002482	Cellulose	Polyanhydroglucuronic Acid|Acid, Polyanhydroglucuronic|alpha-Cellulose|alpha Cellulose
 D002483	Cellulose, Oxidized	Oxidized Cellulose|Oxycellulose|Cellulosic Acid|Absorbable Cellulose|Cellulose, Absorbable|Carboxycellulose
 D002484	Cementation	Cementations
-D002485	Cementoma	Cementomas
+D002485	Cementoma	Cementomas|Cemento-Ossifying Fibroma|Cemento Ossifying Fibroma|Cemento-Ossifying Fibromas|Fibroma, Cemento-Ossifying|Periapical Fibrous Dysplasia|Dysplasia, Periapical Fibrous|Fibrous Dysplasia, Periapical|Fibrous Dysplasias, Periapical|Periapical Fibrous Dysplasias
 D002486	Centchroman	
 D002487	Centers for Disease Control and Prevention (U.S.)	Centers for Disease Control|Centers for Disease Control (U.S.)|United States Centers for Disease Control|CDCP|Center for Disease Control and Prevention|Centers for Disease Control and Prevention|United States Centers for Disease Control and Prevention|Center for Disease Control|CDC
 D002488	Central African Republic	Ubangi-Shari
 D002489	Central America	
-D002490	Central Nervous System	Central Nervous Systems|Nervous System, Central|Nervous Systems, Central|System, Central Nervous|Systems, Central Nervous|Cerebrospinal Axis|Axi, Cerebrospinal|Axis, Cerebrospinal|Cerebrospinal Axi
+D002490	Central Nervous System	Central Nervous Systems|Nervous System, Central|Nervous Systems, Central|Systems, Central Nervous|Cerebrospinal Axis|Axi, Cerebrospinal|Axis, Cerebrospinal|Cerebrospinal Axi
 D002491	Central Nervous System Agents	Central Nervous System Drugs
 D002492	Central Nervous System Depressants	CNS Depressants|Depressants, CNS
 D002493	Central Nervous System Diseases	Central Nervous System Disorders|CNS Diseases|CNS Disease
@@ -3916,7 +4336,7 @@ D002502	Centrioles	Centriole
 D002503	Centromere	Centromeres
 D002504	Meclofenoxate	Centrophenoxine
 D002505	Cephacetrile	Cefacetrile
-D002506	Cephalexin	Cephalexin Monohydrate|Monohydrate, Cephalexin|Cefalexin
+D002506	Cephalexin	Cefalexin
 D002507	Cephaloglycin	Cefaloglycin|Cephaloglycine
 D002508	Cephalometry	
 D002509	Cephaloridine	Cefaloridine|Cephaloridin|Cephalomycine
@@ -4016,7 +4436,7 @@ D002605	Character	Characters
 D002606	Charcoal	
 D002607	Charcot-Marie-Tooth Disease	Charcot Marie Tooth Disease|Muscular Atrophy, Peroneal|Atrophies, Peroneal Muscular|Atrophy, Peroneal Muscular|Muscular Atrophies, Peroneal|Peroneal Muscular Atrophies|Peroneal Muscular Atrophy|Charcot-Marie-Tooth Hereditary Neuropathy|Charcot Marie Tooth Hereditary Neuropathy|Hereditary Neuropathy, Charcot-Marie-Tooth|Atrophy, Muscular, Peroneal|Charcot-Marie Disease|Charcot Marie Disease|Charcot-Marie-Tooth Syndrome|Charcot Marie Tooth Syndrome|Syndrome, Charcot-Marie-Tooth
 D002608	Charities	Charity
-D002609	Chediak-Higashi Syndrome	Chediak Higashi Syndrome|Syndrome, Chediak-Higashi|Oculocutaneous Albinism with Leukocyte Defect|Chediak-Steinbrinck-Higashi Syndrome
+D002609	Chediak-Higashi Syndrome	Chediak Higashi Syndrome|Syndrome, Chediak-Higashi|Oculocutaneous Albinism with Leukocyte Defect|Chediak-Steinbrinck-Higashi Syndrome|Chediak Steinbrinck Higashi Syndrome|Chediak-Steinbrinck-Higashi Syndromes|Syndrome, Chediak-Steinbrinck-Higashi|Syndromes, Chediak-Steinbrinck-Higashi
 D002610	Cheek	Cheeks|Bucca|Buccas
 D002611	Cheese	Cheeses
 D002612	Acinonyx	Cheetahs|Cheetah
@@ -4247,7 +4667,7 @@ D002842	Chromatids	Chromatid
 D002843	Chromatin	Chromatins
 D002844	Chromatium	
 D002845	Chromatography	Chromatographies
-D002846	Chromatography, Affinity	Bioaffinity Chromatography|Chromatography, Bioaffinity|Affinity Chromatography
+D002846	Chromatography, Affinity	Chromatography, Bioaffinity|Bioaffinity Chromatography|Affinity Chromatography
 D002847	Chromatography, Agarose	Chromatography, Sepharose|Sepharose Chromatography|Chromatographies, Sepharose|Sepharose Chromatographies|Agarose Chromatography|Agarose Chromatographies|Chromatographies, Agarose
 D002848	Chromatography, DEAE-Cellulose	Chromatography, DEAE Cellulose|DEAE-Cellulose Chromatography|DEAE Cellulose Chromatography
 D002849	Chromatography, Gas	Gas Chromatography|Chromatographies, Gas|Gas Chromatographies
@@ -4325,7 +4745,7 @@ D002921	Cicatrix	Scar|Scars
 D002922	Ciguatoxins	Ciguatoxin
 D002923	Cilia	Cilium
 D002924	Ciliary Body	Bodies, Ciliary|Body, Ciliary|Ciliary Bodies|Corpus Ciliaris|Ciliari, Corpus|Ciliaris, Corpus|Corpus Ciliari|Corpus Ciliare|Ciliare, Corpus|Ciliares, Corpus|Corpus Ciliares
-D002925	Ciliary Motility Disorders	Ciliary Motility Disorder|Disorder, Ciliary Motility|Disorders, Ciliary Motility|Ciliary Dyskinesia|Ciliary Dyskinesias|Dyskinesia, Ciliary|Dyskinesias, Ciliary|Immotile Cilia Syndrome|Cilia Syndrome, Immotile|Cilia Syndromes, Immotile|Immotile Cilia Syndromes|Syndrome, Immotile Cilia|Syndromes, Immotile Cilia
+D002925	Ciliary Motility Disorders	Ciliary Motility Disorder|Disorder, Ciliary Motility|Ciliary Dyskinesia|Ciliary Dyskinesias|Dyskinesia, Ciliary
 D002927	Cimetidine	N-Cyano-N'-methyl-N''-(2-(((5-methyl-1H-imidazol-4-yl)methyl)thio)ethyl)guanidine
 D002928	Cinanserin	
 D002929	Cinchona	Cinchonas
@@ -4336,10 +4756,10 @@ D002934	Cinnamates
 D002935	Cinnamomum zeylanicum	Cinnamomum verum
 D002936	Cinnarizine	Cinarizine|1-(Diphenylmethyl)-4-(3-phenyl-2-propenyl)piperazine
 D002937	Cinoxacin	Clinoxacin|Azolinic Acid|Acid, Azolinic
-D002938	Ciona intestinalis	Ciona intestinali|intestinali, Ciona
+D002938	Ciona intestinalis	Yellow Sea Squirt|Sea Squirt, Yellow|Sea Squirts, Yellow|Yellow Sea Squirts|Vase Tunicate|Vase Tunicates
 D002939	Ciprofloxacin	
 D002940	Circadian Rhythm	Circadian Rhythms|Rhythm, Circadian|Rhythms, Circadian|Twenty-Four Hour Rhythm|Rhythm, Twenty-Four Hour|Rhythms, Twenty-Four Hour|Twenty Four Hour Rhythm|Twenty-Four Hour Rhythms|Nyctohemeral Rhythm|Nyctohemeral Rhythms|Rhythm, Nyctohemeral|Rhythms, Nyctohemeral|Nycthemeral Rhythm|Nycthemeral Rhythms|Rhythm, Nycthemeral|Rhythms, Nycthemeral
-D002941	Circle of Willis	Willis' Circle|Circle, Willis'|Willis Circle|Cerebral Arterial Circle|Arterial Circle, Cerebral
+D002941	Circle of Willis	Cerebral Arterial Circle|Arterial Circle, Cerebral|Willis' Circle|Circle, Willis'|Willis Circle
 D002942	Circular Dichroism	Dichroism, Circular
 D002943	Circulatory and Respiratory Physiological Phenomena	Circulatory and Respiratory Physiological Phenomenon|Physiology, Circulatory and Respiratory|Circulatory and Respiratory Physiology
 D002944	Circumcision, Male	Male Circumcision|Circumcisions, Male|Male Circumcisions
@@ -4379,7 +4799,7 @@ D002981	Clindamycin	Chlolincocin|7-Chloro-7-deoxylincomycin|7 Chloro 7 deoxylinc
 D002982	Clinical Clerkship	Clinical Clerkships|Clerkships, Clinical|Clinical Apprenticeship|Apprenticeship, Clinical|Apprenticeships, Clinical|Clinical Apprenticeships|Clerkship, Clinical
 D002983	Clinical Competence	Competency, Clinical|Competence, Clinical|Clinical Competency|Clinical Competencies|Competencies, Clinical
 D002984	Clinical Laboratory Information Systems	Laboratory Information Systems|Information System, Laboratory|Information Systems, Laboratory|Laboratory Information System|System, Laboratory Information|Systems, Laboratory Information|Information Systems, Clinical Laboratory
-D002985	Clinical Protocols	Protocols, Clinical|Clinical Protocol|Protocol, Clinical
+D002985	Clinical Protocols	Protocol, Clinical|Protocols, Clinical|Clinical Protocol
 D002986	Clinical Trials as Topic	Clinical Trial as Topic
 D002987	Clitoris	
 D002988	Cloaca	Cloacas
@@ -4402,7 +4822,7 @@ D003005	Clopamide
 D003006	Clopenthixol	
 D003007	Clopidol	Meticlorpindol|Clopindol|3,5-Dichloro-2,6-dimethyl-4-pyridinol
 D003008	Cloprostenol	
-D003009	Clorazepate Dipotassium	Dipotassium, Clorazepate|Dipotassium Chlorazepate|Chlorazepate, Dipotassium
+D003009	Clorazepate Dipotassium	Dipotassium Chlorazepate
 D003010	Clorgyline	Clorgilin|Clorgiline|Chlorgyline
 D003011	Closing Volume	Closing Volumes|Volume, Closing|Volumes, Closing
 D003012	Microbial Collagenase	Clostridium histolyticum Collagenase|Collagenase, Clostridium histolyticum|Nucleolysin|Collagenase, Microbial|Collalysine|Clostridiopeptidase A|Collagenase Clostridium histolyticum|Clostridium histolyticum, Collagenase|histolyticum, Collagenase Clostridium
@@ -4492,7 +4912,7 @@ D003099	College Admission Test	Admission Test, College|Admission Tests, College|
 D003100	Colles' Fracture	Colles Fracture|Fracture, Colles'
 D003101	Collodion	
 D003102	Colloids	Colloid
-D003103	Coloboma	Colobomas|Coloboma, Uveoretinal|Coloboma Of Iris, Choroid, And Retina|Uveoretinal Coloboma|Coloboma, Ocular|Ocular Coloboma
+D003103	Coloboma	Colobomas|Ocular Coloboma|Coloboma, Ocular|Colobomas, Ocular|Ocular Colobomas
 D003104	Colobus	Monkey, Colobus|Colobus Monkey|Colobus Monkeys|Monkeys, Colobus
 D003105	Colombia	
 D003106	Colon	
@@ -4506,7 +4926,7 @@ D003113	Colonoscopy	Colonoscopies
 D003114	Colony-Forming Units Assay	Colony Forming Units Assay|Colony-Forming Units Assays|Assay, Colony-Forming Units|Assays, Colony-Forming Units|Clonogenic Cell Assay|Stem Cell Assay|Clonogenic Cell Assays|Assay, Clonogenic Cell|Assays, Clonogenic Cell|Colony Forming Units Assays|Stem Cell Assays|Assay, Stem Cell|Assays, Stem Cell
 D003115	Colony-Stimulating Factors	Colony Stimulating Factors|Colony-Stimulating Factor|MGI-1 Protein|MGI 1 Protein|Myeloid Cell-Growth Inducer|Cell-Growth Inducer, Myeloid|Inducer, Myeloid Cell-Growth|Myeloid Cell Growth Inducer|Colony Stimulating Factor|MGI-1
 D003116	Color	Colors
-D003117	Color Vision Defects	Color Vision Defect|Defect, Color Vision|Defects, Color Vision|Vision Defect, Color|Vision Defects, Color|Color Vision Deficiency
+D003117	Color Vision Defects	Color Vision Defect|Defect, Color Vision|Defects, Color Vision|Vision Defect, Color|Vision Defects, Color|Color Vision Deficiency|Color Vision Deficiencies|Deficiencies, Color Vision|Deficiency, Color Vision|Vision Deficiencies, Color|Vision Deficiency, Color
 D003118	Color Perception	Color Perceptions|Perception, Color|Perceptions, Color
 D003119	Color Perception Tests	Color Perception Test|Perception Test, Color|Perception Tests, Color|Test, Color Perception|Tests, Color Perception
 D003120	Colorado	
@@ -4599,7 +5019,7 @@ D003209	Concentration Camps	Camp, Concentration|Camps, Concentration|Concentrati
 D003210	Concept Formation	Concept Formations|Formation, Concept|Formations, Concept
 D003211	Concurrent Review	Review, Concurrent|Concurrent Reviews|Reviews, Concurrent
 D003212	Condiments	Condiment
-D003213	Conditioning (Psychology)	Conditionings (Psychology)|Conditioning
+D003213	Conditioning (Psychology)	Conditioning
 D003214	Conditioning, Classical	Classical Conditioning|Classical Conditionings|Conditionings, Classical
 D003215	Conditioning, Eyelid	Eyelid Conditioning|Conditionings, Eyelid|Eyelid Conditionings
 D003216	Conditioning, Operant	Learning, Instrumental|Instrumental Learnings|Learnings, Instrumental|Operant Conditioning|Conditionings, Operant|Operant Conditionings|Instrumental Learning
@@ -4692,7 +5112,7 @@ D003304	Coproporphyrinogen Oxidase	Oxidase, Coproporphyrinogen|Coproporphyrinoge
 D003305	Coproporphyrinogens	
 D003306	Coproporphyrins	
 D003307	Copulation	Copulations
-D003308	Copying Processes	Duplicating Processes|Duplicating Process|Process, Duplicating|Processes, Duplicating|Copying Process|Process, Copying|Processes, Copying
+D003308	Copying Processes	Duplicating Process|Process, Duplicating|Processes, Duplicating|Duplicating Processes|Copying Process|Process, Copying|Processes, Copying
 D003309	Copyright	Copyrights
 D003310	Cor Triatriatum	Subdivided Left Atrium|Atrium, Subdivided Left|Atriums, Subdivided Left|Left Atrium, Subdivided|Left Atriums, Subdivided|Subdivided Left Atriums|Triatrial Heart|Heart, Triatrial|Hearts, Triatrial|Triatrial Hearts|Cor Triatriatum Sinistrum
 D003311	Cord Factors	Factors, Cord|Trehalose Dimycolates|Dimycolates, Trehalose|Cord Factor|Factor, Cord
@@ -4805,7 +5225,7 @@ D003426	Crop, Avian	Avian Crop
 D003427	Cross Circulation	Circulation, Cross|Circulations, Cross|Cross Circulations
 D003428	Cross Infection	Health Care Associated Infections|Infection, Cross|Cross Infections|Infections, Cross|Health Care Associated Infection|Healthcare Associated Infections|Healthcare Associated Infection|Infection, Healthcare Associated|Infections, Healthcare Associated
 D003429	Cross Reactions	Cross Reaction|Reaction, Cross|Reactions, Cross
-D003430	Cross-Sectional Studies	Cross Sectional Studies|Cross-Sectional Study|Studies, Cross-Sectional|Study, Cross-Sectional|Cross Sectional Analysis|Analyses, Cross Sectional|Cross Sectional Analyses|Disease Frequency Surveys|Surveys, Disease Frequency|Disease Frequency Survey|Survey, Disease Frequency|Analysis, Cross-Sectional|Analyses, Cross-Sectional|Analysis, Cross Sectional|Cross-Sectional Analyses|Cross-Sectional Analysis|Cross-Sectional Survey|Cross Sectional Survey|Cross-Sectional Surveys|Survey, Cross-Sectional|Surveys, Cross-Sectional
+D003430	Cross-Sectional Studies	Cross Sectional Studies|Cross-Sectional Study|Studies, Cross-Sectional|Study, Cross-Sectional|Cross Sectional Analysis|Analyses, Cross Sectional|Cross Sectional Analyses|Disease Frequency Surveys|Cross-Sectional Survey|Cross Sectional Survey|Cross-Sectional Surveys|Survey, Cross-Sectional|Surveys, Cross-Sectional|Surveys, Disease Frequency|Disease Frequency Survey|Survey, Disease Frequency|Analysis, Cross-Sectional|Analyses, Cross-Sectional|Analysis, Cross Sectional|Cross-Sectional Analyses|Cross-Sectional Analysis
 D003431	Cross-Cultural Comparison	Comparison, Cross-Cultural|Comparisons, Cross-Cultural|Cross Cultural Comparison|Cross-Cultural Comparisons
 D003432	Cross-Linking Reagents	Reagents, Cross-Linking|Crosslinking Reagents|Reagents, Crosslinking|Bifunctional Reagents|Reagents, Bifunctional|Cross Linking Reagents|Linking Reagents, Cross|Reagents, Cross Linking
 D003433	Crosses, Genetic	Genetic Crosses|Cross, Genetic|Genetic Cross
@@ -4826,7 +5246,7 @@ D003450	Cryoglobulins
 D003451	Cryoprotective Agents	Agents, Cryoprotective
 D003452	Cryosurgery	Cryosurgeries|Cryoablation|Cryoablations
 D003453	Cryptococcosis	Cryptococcoses|Cryptococcus neoformans Infection|Cryptococcus neoformans Infections|Infection, Cryptococcus neoformans|Torulosis|Toruloses
-D003454	Cryptococcus	Torula|Torulas
+D003454	Cryptococcus	
 D003455	Cryptococcus neoformans	Cryptococcus neoforman|neoformans, Cryptococcus
 D003456	Cryptorchidism	Testes, Undescended|Undescended Testes|Undescended Testis|Cryptorchidism, Unilateral Or Bilateral|Cryptorchism|Testis, Undescended
 D003457	Cryptosporidiosis	Cryptosporidioses|Cryptosporidium Infection|Cryptosporidium Infections|Infection, Cryptosporidium
@@ -4888,7 +5308,7 @@ D003516	Cycloparaffins	Cyclic Olefins|Olefins, Cyclic|Cycloalkanes
 D003517	Cyclopentanes	
 D003518	Cyclopenthiazide	Cyclomethiazide
 D003519	Cyclopentolate	
-D003520	Cyclophosphamide	Cytophosphane|Cyclophosphamide Monohydrate|Monohydrate, Cyclophosphamide|Cyclophosphane
+D003520	Cyclophosphamide	
 D003521	Cyclopropanes	
 D003523	Cycloserine	R-4-Amino-3-isoxazolidinone
 D003524	Cyclosporins	Cyclosporines
@@ -4920,14 +5340,14 @@ D003550	Cystic Fibrosis	Fibrosis, Cystic|Mucoviscidosis
 D003551	Cysticercosis	Cysticercoses
 D003552	Cysticercus	
 D003553	Cystine	L-Cystine|L Cystine
-D003554	Cystinosis	Cystine Disease|Cystine Diseases|Cystine Storage Disease|Cystine Storage Diseases|Storage Disease, Cystine|Storage Diseases, Cystine|Cystinoses|Lysosomal Cystine Transport Protein, Defect Of|Cystinosin, Defect of|Defect of Cystinosin|Defect of Cystinosins|Nephropathic Cystinosis|Cystine Diathesis|Cystine Diatheses|Diatheses, Cystine|Diathesis, Cystine|Cystinosis, Nephropathic|Cystinoses, Nephropathic|Nephropathic Cystinoses
+D003554	Cystinosis	Cystinoses
 D003555	Cystinuria	Cystinurias
 D003556	Cystitis	Cystitides
 D003557	Phyllodes Tumor	Phyllodes Tumors|Tumor, Phyllodes|Tumors, Phyllodes|Cystosarcoma Phyllodes|Cystosarcoma Phylloides
 D003558	Cystoscopy	Cystoscopies
 D003559	Cystostomy	Cystostomies|Vesicostomy|Vesicostomies
 D003560	Cysts	Cyst
-D003561	Cytarabine	Arabinofuranosylcytosine|Aracytidine|Cytosine Arabinoside|Arabinoside, Cytosine|Arabinosylcytosine
+D003561	Cytarabine	Arabinosylcytosine|Cytosine Arabinoside|Arabinoside, Cytosine|Arabinofuranosylcytosine|Aracytidine
 D003562	Cytidine	Cytosine Riboside|Riboside, Cytosine|Cytosine Ribonucleoside|Ribonucleoside, Cytosine
 D003563	Cyclic CMP	CMP, Cyclic|Cytidine Cyclic 3,5 Monophosphate|Cytidine Cyclic-3',5'-Monophosphate|Cyclic-3',5'-Monophosphate, Cytidine|Cytidine Cyclic 3',5' Monophosphate|Cytidine Cyclic Monophosphate|Cyclic Monophosphate, Cytidine|Monophosphate, Cytidine Cyclic
 D003564	Cytidine Deaminase	Deaminase, Cytidine|Cytidine Aminohydrolase|Aminohydrolase, Cytidine
@@ -4991,14 +5411,14 @@ D003624	Darkness	Darknesses
 D003625	Data Collection	Collection, Data
 D003626	Data Display	Data Displays|Display, Data|Displays, Data|Information Display|Display, Information|Displays, Information|Information Displays
 D003627	Data Interpretation, Statistical	Data Analysis, Statistical|Statistical Data Interpretation|Statistical Data Analysis|Analyses, Statistical Data|Analysis, Statistical Data|Data Analyses, Statistical|Statistical Data Analyses|Data Interpretations, Statistical|Interpretations, Statistical Data|Statistical Data Interpretations|Interpretation, Statistical Data
-D003628	Database Management Systems	Database Management System|System, Database Management|Systems, Database Management|Systems, Data Base Management|Management Systems, Data Base|System, Data Base Management|Data Base Management Systems|Management System, Data Base
+D003628	Database Management Systems	Database Management System|Management Systems, Data Base|Data Base Management Systems|Management System, Data Base|System, Data Base Management|Systems, Data Base Management
 D003629	Modems	Modem|Dataphones|Dataphone
 D003630	Daunorubicin	Daunomycin|Rubomycin|Dauno-Rubidomycine|Dauno Rubidomycine|Rubidomycin
 D003631	Day Care, Medical	Medical Day Care|Hospitalization, Partial|Partial Hospitalization|Day Care|Care, Day
 D003632	Dichlorodiphenyldichloroethane	TDE|DDD
 D003633	Dichlorodiphenyl Dichloroethylene	Dichloroethylene, Dichlorodiphenyl|DDMU|1,1-Dichloro-2,2-bis(p-chlorophenyl)ethylene|p,p'-DDE|p,p-Dichlorodiphenyldichloroethylene|DDE|DDX
 D003634	DDT	4,4'-DDT|4,4' DDT|4,4'-Dichlorodiphenyltrichloroethane|4,4' Dichlorodiphenyltrichloroethane|p',p'-DDT|TbisC-ethane|TbisC ethane|Chlorophenothane|1,1,1-trichloro-2,2-bis(p-chlorophenyl)ethane|Benzochloryl
-D003635	De Lange Syndrome	Syndrome, De Lange|Cornelia de Lange Syndrome 1|De Lange's Syndrome|Syndrome, De Lange's|Typus Degenerativus Amstelodamensis|Amstelodamensis, Typus Degenerativus|Brachmann-De Lange Syndrome|Brachmann De Lange Syndrome|Syndrome, Brachmann-De Lange|Cornelia De Lange Syndrome
+D003635	De Lange Syndrome	Syndrome, De Lange|Cornelia de Lange Syndrome 1|Cornelia De Lange Syndrome|Typus Degenerativus Amstelodamensis|Amstelodamensis, Typus Degenerativus|De Lange's Syndrome|Syndrome, De Lange's|Brachmann-De Lange Syndrome|Brachmann De Lange Syndrome|Syndrome, Brachmann-De Lange
 D003636	DEAE-Cellulose	DEAE Cellulose
 D003637	DEAE-Dextran	DEAE Dextran|Diethylaminoethyldextran
 D003638	Deafness	
@@ -5056,7 +5476,7 @@ D003690	Deja Vu	Vu, Deja
 D003691	Delaware	
 D003692	Delayed-Action Preparations	Delayed Action Preparations|Delayed-Action Preparation
 D003693	Delirium	
-D003695	Delivery of Health Care	Healthcare Delivery|Deliveries, Healthcare|Delivery, Healthcare|Delivery of Healthcare|Healthcare Deliveries|Health Care Delivery|Delivery, Health Care
+D003695	Delivery of Health Care	Delivery of Healthcare|Healthcare Deliveries|Healthcare Delivery|Deliveries, Healthcare|Delivery, Healthcare|Health Care Delivery|Delivery, Health Care
 D003696	Delivery Rooms	Centers, Hospital Birthing|Hospital Birthing Centers|Birthing Centers, Hospital|Delivery Room|Centers, Hospital Birth|Rooms, Delivery|Birth Centers, Hospital|Birth Center, Hospital|Hospital Birth Center|Hospital Birth Centers|Center, Hospital Birth|Center, Hospital Birthing|Birthing Center, Hospital|Hospital Birthing Center|Room, Delivery
 D003697	Delphi Technique	Delphi Techniques|Technique, Delphi|Techniques, Delphi|Delphi Technic|Delphi Technics|Technic, Delphi|Technics, Delphi
 D003698	Hepatitis Delta Virus	Delta Virus, Hepatitis|Delta Viruses, Hepatitis|Hepatitis Delta Viruses|Delta Virus|Delta Viruses|Delta Agent|Delta Agents|Hepatitis D Virus|Hepatitis D Viruses
@@ -5082,10 +5502,10 @@ D003719	Dens in Dente	Dens in Dentes|Dente, Dens in|Dentes, Dens in|in Dente, De
 D003720	Densitometry	Densitometries
 D003722	Dental Alloys	Alloys, Dental|Dental Alloy|Alloy, Dental
 D003723	Dental Amalgam	Dental Amalgams|Amalgam, Dental|Amalgams, Dental
-D003724	Dental Arch	Dental Arches|Arch, Dental|Arches, Dental
+D003724	Dental Arch	Arches, Dental|Dental Arches|Arch, Dental
 D003725	Dental Articulators	Dental Articulator|Articulator, Dental|Articulators, Dental
-D003726	Dental Assistants	Assistants, Dental|Nurses, Dental|Dental Nurses|Dental Nurse|Nurse, Dental|Assistant, Dental|Dental Assistant
-D003727	Dental Auxiliaries	Dental Auxiliary|Auxiliaries, Dental|Auxiliary, Dental
+D003726	Dental Assistants	Nurses, Dental|Dental Assistant|Dental Nurses|Dental Nurse|Nurse, Dental|Assistant, Dental|Assistants, Dental
+D003727	Dental Auxiliaries	Auxiliary, Dental|Dental Auxiliary|Auxiliaries, Dental
 D003728	Dental Calculus	Tartar|Calculus, Dental
 D003729	Dental Care	Care, Dental
 D003730	Dental Care for Disabled	Dental Care for Handicapped
@@ -5103,7 +5523,7 @@ D003741	Dental Deposits	Materia Alba|Deposits, Dental|Dental Deposit|Deposit, De
 D003742	Dental Devices, Home Care	Home Care Dental Devices
 D003743	Dental Enamel	Enamel, Dental|Enamel|Enamels|Dental Enamels|Enamels, Dental
 D003744	Dental Enamel Hypoplasia	Hypoplastic Enamel|Enamel, Hypoplastic|Enamel Hypoplasia, Dental|Hypoplasia, Dental Enamel|Enamel Agenesis|Ageneses, Enamel|Agenesis, Enamel|Enamel Ageneses|Enamel Hypoplasia|Enamel Hypoplasias|Hypoplasia, Enamel|Hypoplasias, Enamel
-D003745	Dental Enamel Permeability	Enamel Permeability, Dental|Permeability, Dental Enamel
+D003745	Dental Enamel Permeability	Permeability, Dental Enamel|Enamel Permeability, Dental
 D003746	Dental Enamel Proteins	Enamel Proteins, Dental|Proteins, Dental Enamel
 D003747	Dental Enamel Solubility	Enamel Solubility, Dental|Solubility, Dental Enamel
 D003748	Dental Equipment	Equipment, Dental|Dental Equipments|Equipments, Dental
@@ -5114,7 +5534,7 @@ D003752	Dental Health Services	Health Services, Dental|Dental Health Service|Hea
 D003753	Dental Health Surveys	Surveys, Dental Health|Health Surveys, Dental|Survey, Dental Health|Dental Health Survey|Health Survey, Dental
 D003754	Dental High-Speed Equipment	Dental High Speed Equipment|Dental High-Speed Equipments|Equipment, Dental High-Speed|Equipments, Dental High-Speed|High-Speed Equipment, Dental|High-Speed Equipments, Dental|High Speed Dental Equipment
 D003755	Dental High-Speed Technique	Dental High Speed Technique|Technics, High-Speed Dental|Technics, High Speed Dental|High-Speed Techniques, Dental|High Speed Techniques, Dental|Technique, Dental High-Speed|Technique, Dental High Speed|Techniques, Dental High-Speed|Techniques, Dental High Speed|Dental Technique, High-Speed|Dental Technique, High Speed|Dental Techniques, High-Speed|Dental Techniques, High Speed|High-Speed Dental Technique|High Speed Dental Technique|High-Speed Dental Techniques|High Speed Dental Techniques|Technique, High-Speed Dental|Technique, High Speed Dental|Techniques, High-Speed Dental|Techniques, High Speed Dental|Dental High-Speed Technic|Dental High Speed Technic|Dental High-Speed Technics|Dental High Speed Technics|Dental Technic, High-Speed|Dental Technic, High Speed|Dental Technics, High-Speed|Dental Technics, High Speed|High-Speed Dental Technic|High Speed Dental Technic|High-Speed Dental Technics|High Speed Dental Technics|High-Speed Technic, Dental|High Speed Technic, Dental|High-Speed Technics, Dental|High Speed Technics, Dental|Technic, Dental High-Speed|Technic, Dental High Speed|Technic, High-Speed Dental|Technic, High Speed Dental|Technics, Dental High-Speed|Technics, Dental High Speed|Dental High-Speed Techniques|Dental High Speed Techniques|High-Speed Technique, Dental|High Speed Technique, Dental
-D003756	Dental Hygienists	Hygienists, Dental|Dental Hygienist|Hygienist, Dental
+D003756	Dental Hygienists	Hygienist, Dental|Hygienists, Dental|Dental Hygienist
 D003757	Dental Implantation	Dental Prosthesis Implantation|Prosthesis Implantation, Dental|Implantation, Dental|Implantation, Dental Prosthesis|Dental Prosthesis Implantations|Implantations, Dental Prosthesis|Prosthesis Implantations, Dental
 D003758	Dental Implantation, Endosseous	Implantation, Endosseous Dental|Endosseous Dental Implantation
 D003759	Dental Implantation, Endosseous, Endodontic	Endosseous Implantation, Endodontic|Endodontic Stabilization|Endodontic Stabilizations|Stabilization, Endodontic|Stabilizations, Endodontic|Endodontic Endosseous Implantation|Endodontic Endosseous Implantations|Endosseous Implantations, Endodontic|Implantation, Endodontic Endosseous|Implantations, Endodontic Endosseous
@@ -5154,10 +5574,10 @@ D003793	Dental Restoration, Permanent	Restorations, Permanent Dental|Permanent D
 D003794	Dental Restoration, Temporary	Restoration, Temporary Dental|Temporary Dental Restoration|Temporary Dental Restorations|Dental Restorations, Temporary|Restorations, Temporary Dental
 D003795	Dental Sac	Follicle, Dental|Follicles, Dental|Dental Sacs|Sac, Dental|Sacs, Dental|Dental Follicles|Dental Follicle
 D003796	Dental Service, Hospital	Hospital Dental Service|Service, Hospital Dental|Dental Services, Hospital|Hospital Dental Services|Services, Hospital Dental
-D003797	Dental Staff	Staffs, Dental|Dental Staffs|Staff, Dental
-D003798	Dental Staff, Hospital	Hospital Dental Staffs|Staffs, Hospital Dental|Hospital Dental Staff|Dental Staffs, Hospital|Staff, Hospital Dental
+D003797	Dental Staff	Staff, Dental|Staffs, Dental|Dental Staffs
+D003798	Dental Staff, Hospital	Hospital Dental Staff|Staff, Hospital Dental|Staffs, Hospital Dental|Dental Staffs, Hospital|Hospital Dental Staffs
 D003799	Dental Stress Analysis	Analysis, Dental Stress|Stress Analysis, Dental|Analyses, Dental Stress|Dental Stress Analyses|Stress Analyses, Dental
-D003800	Dental Technicians	Technicians, Dental|Dental Technician|Technician, Dental
+D003800	Dental Technicians	Technician, Dental|Technicians, Dental|Dental Technician
 D003801	Dental Veneers	Veneer, Dental|Veneers, Dental|Dental Laminates|Dental Laminate|Laminate, Dental|Laminates, Dental|Dental Veneer
 D003802	Dentifrices	Dentifrice
 D003803	Dentigerous Cyst	Cyst, Dentigerous|Cysts, Dentigerous|Dentigerous Cysts
@@ -5186,7 +5606,7 @@ D003825	Denture, Complete, Immediate
 D003826	Denture, Complete, Lower	
 D003827	Denture, Complete, Upper	
 D003828	Denture, Overlay	Dentures, Overlay|Overlay Denture|Overlay Dentures|Overdenture|Overdentures
-D003829	Denture, Partial	Dentures, Partial|Partial Denture|Partial Dentures|Dental Bridgework|Dental Bridgeworks|Bridgeworks, Dental|Bridgework, Dental
+D003829	Denture, Partial	Dentures, Partial|Partial Denture|Partial Dentures|Bridgework, Dental|Bridgeworks, Dental|Dental Bridgeworks|Dental Bridgework
 D003830	Denture, Partial, Fixed	Fixed Bridge|Bridge, Fixed|Bridges, Fixed|Fixed Bridges|Fixed Partial Denture|Denture, Fixed Partial|Dentures, Fixed Partial|Fixed Partial Dentures|Partial Denture, Fixed|Partial Dentures, Fixed
 D003831	Denture, Partial, Immediate	
 D003832	Denture, Partial, Removable	Removable Partial Denture|Denture, Removable Partial|Dentures, Removable Partial|Partial Denture, Removable|Partial Dentures, Removable|Removable Partial Dentures
@@ -5203,7 +5623,7 @@ D003842	Deoxycytidine Kinase	Kinase, Deoxycytidine
 D003843	Deoxycytidine Monophosphate	Monophosphate, Deoxycytidine|Deoxycytidylic Acid|Acid, Deoxycytidylic|DCMP
 D003844	DCMP Deaminase	Deaminase, DCMP|Deoxycytidylate Aminohydrolase|Aminohydrolase, Deoxycytidylate|Deoxycytidylate Deaminase|Deaminase, Deoxycytidylate|Deoxycytidine Monophosphate Deaminase|Deaminase, Deoxycytidine Monophosphate|Monophosphate Deaminase, Deoxycytidine
 D003845	Deoxycytosine Nucleotides	Nucleotides, Deoxycytosine|Deoxycytidine Phosphates|Phosphates, Deoxycytidine
-D003846	Deoxyepinephrine	Methyldopamine|Desoxyepinephrine|Deoxyadrenaline|Desoxyadrenaline
+D003846	Deoxyepinephrine	Deoxyadrenaline|Methyldopamine|Desoxyadrenaline|Desoxyepinephrine
 D003847	Deoxyglucose	2-Deoxyglucose|2 Deoxyglucose|2-Deoxy-D-glucose|2 Deoxy D glucose|2-Desoxy-D-glucose|2 Desoxy D glucose
 D003848	Deoxyguanine Nucleotides	Nucleotides, Deoxyguanine|Deoxyguanosine Phosphates|Phosphates, Deoxyguanosine
 D003849	Deoxyguanosine	
@@ -5221,7 +5641,7 @@ D003861	Depersonalization	Depersonalizations
 D003862	Depreciation	Depreciations
 D003863	Depression	Depressions
 D003864	Depression, Chemical	Chemical Depression|Chemical Depressions|Depressions, Chemical
-D003865	Depressive Disorder, Major	Depressive Disorders, Major|Disorder, Major Depressive|Disorders, Major Depressive|Major Depressive Disorders|Major Depressive Disorder
+D003865	Depressive Disorder, Major	Depressive Disorders, Major|Major Depressive Disorders|Major Depressive Disorder
 D003866	Depressive Disorder	Depressive Disorders|Disorder, Depressive|Disorders, Depressive|Neurosis, Depressive|Depressive Neuroses|Depressive Neurosis|Neuroses, Depressive
 D003867	Depth Perception	Depth Perceptions|Perception, Depth|Perceptions, Depth|Stereoscopic Vision|Stereoscopic Visions|Vision, Stereoscopic|Visions, Stereoscopic|Stereopsis|Stereopses
 D003868	Dequalinium	
@@ -5238,7 +5658,7 @@ D003878	Dermatoglyphics	Dermatoglyphic
 D003879	Dermatologic Agents	Dermatological Agents|Agents, Dermatological|Agents, Dermatologic|Dermatologic Agent|Agent, Dermatologic|Agent, Dermatological|Dermatological Agent
 D003880	Dermatology	
 D003881	Dermatomycoses	Dermatomycosis|Skin Diseases, Fungal|Fungal Skin Diseases|Fungal Skin Disease|Skin Disease, Fungal|Dermatophyte Infection|Dermatophyte Infections|Infection, Dermatophyte|Infections, Dermatophyte
-D003882	Dermatomyositis	Dermatomyositides|Juvenile Myositis|Juvenile Myositides|Myositides, Juvenile|Myositis, Juvenile|Dermatopolymyositis|Dermatopolymyositides|Polymyositis-Dermatomyositis|Polymyositis Dermatomyositis|Polymyositis-Dermatomyositides|Juvenile Dermatomyositis|Dermatomyositides, Juvenile|Dermatomyositis, Juvenile|Juvenile Dermatomyositides
+D003882	Dermatomyositis	
 D003883	Arthrodermataceae	Cutaneous Fungi|Fungi, Cutaneous|Fungus, Cutaneous|Dermatomyces|Dermatomyce|Dermatophytes|Dermatophyte|Cutaneous Fungus
 D003884	Dermoid Cyst	Cyst, Dermoid|Cysts, Dermoid|Dermoid Cysts|Dermoid|Dermoids
 D003885	Dermotoxins	Dermatotoxins
@@ -5268,7 +5688,7 @@ D003908	Dexamethasone Isonicotinate	Isonicotinate, Dexamethasone
 D003909	Dexetimide	Dexbenzetimid|dextro-Benzetimide|dextro Benzetimide|Dexbenzetimide
 D003910	Dextranase	
 D003911	Dextrans	Dextran Derivatives
-D003912	Dextrins	
+D003912	Dextrins	Dextrin
 D003913	Dextroamphetamine	Dexamphetamine|Dexamfetamine|dextro-Amphetamine|dextro Amphetamine|d-Amphetamine|d Amphetamine
 D003914	Dextrocardia	Dextrocardias
 D003915	Dextromethorphan	d-Methorphan
@@ -5278,7 +5698,7 @@ D003918	Dextrothyroxine	D-T4 Thyroid Hormone|D-Thyroxine|D Thyroxine
 D003919	Diabetes Insipidus	
 D003920	Diabetes Mellitus	
 D003921	Diabetes Mellitus, Experimental	Experimental Diabetes Mellitus
-D003922	Diabetes Mellitus, Type 1	Diabetes Mellitus, Brittle|Brittle Diabetes Mellitus|Diabetes Mellitus, Insulin-Dependent|Diabetes Mellitus, Insulin Dependent|Insulin-Dependent Diabetes Mellitus|Diabetes Mellitus, Juvenile-Onset|Diabetes Mellitus, Juvenile Onset|Juvenile-Onset Diabetes Mellitus|Diabetes Mellitus, Ketosis-Prone|Diabetes Mellitus, Ketosis Prone|Ketosis-Prone Diabetes Mellitus|Juvenile-Onset Diabetes|Diabetes, Juvenile-Onset|Juvenile Onset Diabetes|Diabetes Mellitus, Type I|Diabetes Mellitus, Sudden-Onset|Diabetes Mellitus, Sudden Onset|Mellitus, Sudden-Onset Diabetes|Sudden-Onset Diabetes Mellitus|Type 1 Diabetes Mellitus|Diabetes Mellitus, Insulin-Dependent, 1|Insulin-Dependent Diabetes Mellitus 1|Insulin Dependent Diabetes Mellitus 1|Type 1 Diabetes|Diabetes, Type 1|IDDM
+D003922	Diabetes Mellitus, Type 1	Type 1 Diabetes Mellitus|Diabetes Mellitus, Type I|Type 1 Diabetes|Diabetes, Type 1
 D003923	Diabetes Mellitus, Lipoatrophic	Lipoatrophic Diabetes Mellitus|Lipoatrophic Diabetes|Diabete, Lipoatrophic|Diabetes, Lipoatrophic|Lipoatrophic Diabete
 D003924	Diabetes Mellitus, Type 2	Diabetes Mellitus, Noninsulin-Dependent|Diabetes Mellitus, Ketosis-Resistant|Diabetes Mellitus, Ketosis Resistant|Ketosis-Resistant Diabetes Mellitus|Diabetes Mellitus, Non Insulin Dependent|Diabetes Mellitus, Non-Insulin-Dependent|Non-Insulin-Dependent Diabetes Mellitus|Diabetes Mellitus, Stable|Stable Diabetes Mellitus|Diabetes Mellitus, Type II|NIDDM|Diabetes Mellitus, Noninsulin Dependent|Diabetes Mellitus, Maturity-Onset|Diabetes Mellitus, Maturity Onset|Maturity-Onset Diabetes Mellitus|Maturity Onset Diabetes Mellitus|MODY|Diabetes Mellitus, Slow-Onset|Diabetes Mellitus, Slow Onset|Slow-Onset Diabetes Mellitus|Type 2 Diabetes Mellitus|Noninsulin-Dependent Diabetes Mellitus|Noninsulin Dependent Diabetes Mellitus|Maturity-Onset Diabetes|Diabetes, Maturity-Onset|Maturity Onset Diabetes|Type 2 Diabetes|Diabetes, Type 2|Diabetes Mellitus, Adult-Onset|Adult-Onset Diabetes Mellitus|Diabetes Mellitus, Adult Onset
 D003925	Diabetic Angiopathies	Angiopathies, Diabetic|Angiopathy, Diabetic|Diabetic Angiopathy|Diabetic Vascular Diseases|Diabetic Vascular Disease|Vascular Disease, Diabetic|Vascular Diseases, Diabetic|Diabetic Vascular Complications|Diabetic Vascular Complication|Vascular Complication, Diabetic|Vascular Complications, Diabetic
@@ -5314,19 +5734,19 @@ D003957	Diamfenetide	Diamphenethide|Acemidophen|Di-(2-(4-acetamidophenoxy)ethyl)
 D003958	Diamide	Tetramethylazoformamide|Dizene Dicarboxylic Acid Bis(N,N-dimethylamide)|Dizenedicarboxylic Acid Bis(N,N-dimethylamide)|Diazodicarboxylic Acid Bis(N,N-dimethyl)amide|Diazodicarboxylic Acid Bisdimethylamide|Acid Bisdimethylamide, Diazodicarboxylic|Bisdimethylamide, Diazodicarboxylic Acid
 D003959	Diamines	
 D003960	Diaminopimelic Acid	Acid, Diaminopimelic|2,6-Diaminopimelic Acid|2,6 Diaminopimelic Acid|Acid, 2,6-Diaminopimelic
-D003961	Dianhydrogalactitol	Diepoxydulcitol|1,2,5,6-Dianhydrogalactitol|Dianhydrodulcitol|Diepoxygalactitol
+D003961	Dianhydrogalactitol	1,2-5,6-Dianhydrogalactitol|Diepoxygalactitol|1,2,5,6-Dianhydrogalactitol|Dianhydrodulcitol|Diepoxydulcitol
 D003962	Dianisidine	O-Dianisidine|O Dianisidine|3,3'-Dimethoxybenzidine|3,3' Dimethoxybenzidine
 D003963	Diaper Rash	Rash, Diaper|Diaper Rashes|Rashes, Diaper
 D003964	Diaphragm	Diaphragms|Respiratory Diaphragm|Diaphragm, Respiratory|Diaphragms, Respiratory|Respiratory Diaphragms
 D003965	Diaphragmatic Eventration	Eventration, Diaphragmatic|Eventration of Diaphragm|Diaphragm Eventration
-D003966	Camurati-Engelmann Syndrome	Camurati Engelmann Syndrome|Diaphyseal Dysplasia, Progressive|Diaphyseal Dysplasias, Progressive|Dysplasia, Progressive Diaphyseal|Dysplasias, Progressive Diaphyseal|Diaphyseal Hyperostosis|Engelmann's Disease|Progressive Diaphyseal Dysplasia|Camurati-Engelmann Disease|Camurati Engelmann Disease|Engelmann Disease
+D003966	Camurati-Engelmann Syndrome	Camurati Engelmann Syndrome|Engelmann's Disease|Engelmann Disease|Camurati-Engelmann Disease|Camurati Engelmann Disease|Diaphyseal Dysplasia, Progressive|Diaphyseal Hyperostosis|Diaphyseal Hyperostoses|Hyperostoses, Diaphyseal|Hyperostosis, Diaphyseal|Diaphyseal Dysplasia 1, Progressive|Progressive Diaphyseal Dysplasia|Diaphyseal Dysplasias, Progressive|Dysplasia, Progressive Diaphyseal|Dysplasias, Progressive Diaphyseal
 D003967	Diarrhea	Diarrheas
 D003968	Diarrhea, Infantile	Diarrheas, Infantile|Infantile Diarrheas|Infantile Diarrhea
 D003969	Vipoma	Vipomas|Diarrheogenic Tumor|Diarrheogenic Tumors|Tumor, Diarrheogenic|Tumors, Diarrheogenic|Pancreatic VIPoma|Pancreatic VIPomas|VIPoma, Pancreatic|VIPomas, Pancreatic|Vasoactive Intestinal Peptide-Producing Tumor|Vasoactive Intestinal Peptide Producing Tumor|VIP-Secreting Tumor (VIPoma)|Tumor, VIP-Secreting (VIPoma)|Tumors, VIP-Secreting (VIPoma)|VIP Secreting Tumor (VIPoma)|VIP-Secreting Tumors (VIPoma)|Diarrheogenic Islet Cell Tumor|Vasoactive Intestinal Peptide (VIP) Tumor
 D003970	Diastema	Diastemas|Diastemata
 D003971	Diastole	Diastoles
 D003972	Diathermy	Diathermies
-D003973	Diatrizoate	Urogranoic Acid|Acid, Urogranoic|Amidotrezoate|Amidotrizoate
+D003973	Diatrizoate	
 D003974	Diatrizoate Meglumine	Meglumine, Diatrizoate|Meglumine Amidotrizoate|Amidotrizoate, Meglumine|Methylglucamine Diatrizoate|Diatrizoate, Methylglucamine|Meglumine Diatrizoate|Diatrizoate, Meglumine|Diatrizoate Methylglucamine|Methylglucamine, Diatrizoate
 D003975	Diazepam	7-Chloro-1,3-dihydro-1-methyl-5-phenyl-2H-1,4-benzodiazepin-2-one
 D003976	Diazinon	Dimpylate
@@ -5365,12 +5785,12 @@ D004011	Dicrocoeliasis	Dicrocoeliases
 D004012	Dicrocoeliidae	
 D004013	Dicrocoelium	Dicrocoeliums
 D004014	Dictionaries as Topic	Dictionaries as Topics
-D004015	Dictionaries, Chemical	Dictionary, Chemical|Chemical Dictionaries|Chemical Dictionary
-D004016	Dictionaries, Classical as Topic	Dictionaries, Classical|Classical Dictionaries|Dictionary, Classical
-D004017	Dictionaries, Dental as Topic	Dictionaries, Dental|Dictionary, Dental|Dental Dictionaries|Dental Dictionary
-D004018	Dictionaries, Medical	Medical Dictionary|Dictionary, Medical|Medical Dictionaries
-D004019	Dictionaries, Pharmaceutic as Topic	Pharmaceutic Dictionaries|Pharmaceutic Dictionary|Dictionaries, Pharmaceutic|Dictionaries, Pharmacy|Dictionary, Pharmacy|Pharmacy Dictionary|Dictionaries, Pharmaceutical|Dictionary, Pharmaceutical|Pharmaceutical Dictionaries|Pharmaceutical Dictionary|Dictionary, Pharmaceutic|Pharmacy Dictionaries
-D004020	Dictionaries, Polyglot as Topic	Dictionaries, Polyglot|Dictionary, Polyglot|Polyglot Dictionaries|Polyglot Dictionary
+D004015	Dictionaries, Chemical as Topic	
+D004016	Dictionaries, Classical as Topic	
+D004017	Dictionaries, Dental as Topic	
+D004018	Dictionaries, Medical as Topic	
+D004019	Dictionaries, Pharmaceutic as Topic	Dictionaries, Pharmacy as Topic|Pharmaceutical Dictionary|Pharmacy Dictionaries|Pharmacy Dictionary|Pharmaceutical Dictionaries|Dictionaries, Pharmacy|Dictionary, Pharmacy
+D004020	Dictionary, Polyglot	
 D004021	Dictyocaulus	
 D004022	Dictyocaulus Infections	Infections, Dictyocaulus|Dictyocaulus Infection|Infection, Dictyocaulus|Dictyocauliasis|Dictyocauliases
 D004023	Dictyostelium	Dictyosteliums
@@ -5520,10 +5940,10 @@ D004173	Dipodomys	Kangaroo Rats|Kangaroo Rat|Rat, Kangaroo|Rats, Kangaroo
 D004174	Diprenorphine	
 D004175	Diptera	Dipteras|Flies, True|Fly, True|True Flies|True Fly|Flies|Fly
 D004176	Dipyridamole	Dipyramidole
-D004177	Dipyrone	Metamizole|Noramidopyrine Methanesulfonate Sodium|Methanesulfonate Sodium, Noramidopyrine|Novamidazophen|Metamizol|Methamizole|Dipyronium|Methampyrone
+D004177	Dipyrone	Methamizole|Metamizol|Dipyronium|Metamizole
 D004178	Diquat	
 D004179	Cobra Cardiotoxin Proteins	Cardiotoxin Proteins, Cobra|Cobra Cytotoxin Proteins|Cytotoxin Proteins, Cobra|Cobra Cardiotoxin|Cardiotoxin, Cobra|Direct Lytic Factors|Lytic Factors, Direct
-D004180	Direct Service Costs	Service Costs, Direct|Cost, Direct Service|Direct Service Cost|Service Cost, Direct|Costs, Direct Service
+D004180	Direct Service Costs	Costs, Direct Service|Service Costs, Direct|Cost, Direct Service|Direct Service Cost|Service Cost, Direct
 D004181	Directories as Topic	Directories as Topics
 D004182	Dirofilaria	Dirofilarias
 D004183	Dirofilaria immitis	Dirofilaria immitides|immitis, Dirofilaria|Dog Heartworm|Dog Heartworms|Heartworm, Dog|Heartworms, Dog
@@ -5533,7 +5953,7 @@ D004186	Disaccharidases
 D004187	Disaccharides	
 D004188	Disarticulation	Disarticulations
 D004189	Disaster Planning	Planning, Disaster
-D004190	Disasters	Disaster
+D004190	Disasters	
 D004191	Behavioral Disciplines and Activities	
 D004192	Discrimination (Psychology)	Discriminations (Psychology)|Discrimination
 D004193	Discrimination Learning	Discrimination Learnings|Learning, Discrimination|Learnings, Discrimination
@@ -5549,7 +5969,7 @@ D004203	Disinfection
 D004204	Joint Dislocations	Dislocation, Joint|Dislocations, Joint|Joint Dislocation
 D004205	Cromolyn Sodium	Sodium Cromoglycate|Cromoglycate, Sodium|Disodium Cromoglycate|Cromoglycate, Disodium
 D004206	Disopyramide	Diisopyramide
-D004207	Dispensatories	Dispensatory
+D004207	Dispensatories as Topic	Dispensatories as Topics
 D004208	Displacement (Psychology)	Displacements (Psychology)|Displacement
 D004209	Disposable Equipment	Equipment, Disposable
 D004210	Dissection	Dissections
@@ -5650,11 +6070,11 @@ D004310	Double Outlet Right Ventricle	Double-Outlet Right Ventricle
 D004311	Double-Blind Method	Double Blind Method|Double-Blind Methods|Method, Double-Blind|Methods, Double-Blind|Double-Masked Method|Double Masked Method|Double-Masked Methods|Method, Double-Masked|Methods, Double-Masked|Double-Masked Study|Double Masked Study|Double-Masked Studies|Studies, Double-Masked|Study, Double-Masked|Double-Blind Study|Double Blind Study|Double-Blind Studies|Studies, Double-Blind|Study, Double-Blind
 D004312	Douglas' Pouch	Douglas Pouch|Pouch, Douglas'|Cul-de-Sac, Douglas'|Cul de Sac, Douglas'|Cul-de-Sac, Douglas|Douglas' Cul-de-Sac|Cul-de-Sac of Douglas|Cul de Sac of Douglas|Douglas Cul-de-Sac|Sac of Douglas|Douglas Sac|Rectouterine Pouch|Pouch, Rectouterine
 D004313	Dourine	Dourines
-D004314	Down Syndrome	Syndrome, Down|Mongolism|Trisomy 21|47,XX,+21|47,XY,+21|Down's Syndrome|Downs Syndrome|Syndrome, Down's|Trisomy G
+D004314	Down Syndrome	Syndrome, Down|Mongolism|47,XY,+21|Trisomy G|47,XX,+21|Down's Syndrome|Downs Syndrome|Syndrome, Down's|Trisomy 21
 D004315	Doxapram	
 D004316	Doxepin	
 D004317	Doxorubicin	
-D004318	Doxycycline	Alpha-6-Deoxyoxytetracycline|Alpha 6 Deoxyoxytetracycline|Doxycycline Monohydrate
+D004318	Doxycycline	Doxycycline Monohydrate
 D004319	Doxylamine	
 D004320	Dracunculiasis	Dracunculiases|Guinea Worm Infection|Infection, Guinea Worm|Guinea Worm Disease|Disease, Guinea Worm|Diseases, Guinea Worm|Guinea Worm Diseases|Worm Disease, Guinea|Dracunculosis|Dracunculoses
 D004321	Dracunculus Nematode	Dracunculus Nematodes|Nematode, Dracunculus|Nematodes, Dracunculus
@@ -5675,7 +6095,7 @@ D004335	Drug and Narcotic Control	Narcotic and Drug Control
 D004336	Drug Antagonism	Antagonism, Drug|Antagonisms, Drug|Drug Antagonisms
 D004337	Drug Carriers	Drug Carrier
 D004338	Drug Combinations	Combinations, Drug
-D004339	Drug Compounding	Compounding, Drug|Drug Preparation|Drug Preparations|Preparation, Drug|Preparations, Drug
+D004339	Drug Compounding	Compounding, Drug|Drug Preparation|Preparation, Drug
 D004340	Drug Contamination	Contamination, Drug|Contaminations, Drug|Drug Contaminations
 D004341	Drug Evaluation	Drug Evaluations|Evaluation, Drug|Evaluations, Drug|Evaluation Studies, Drug|Drug Evaluation Studies|Drug Evaluation Study|Evaluation Study, Drug|Studies, Drug Evaluation|Study, Drug Evaluation
 D004342	Drug Hypersensitivity	Drug Hypersensitivities|Hypersensitivities, Drug|Drug Allergy|Allergies, Drug|Drug Allergies|Hypersensitivity, Drug|Allergy, Drug
@@ -5689,9 +6109,9 @@ D004349	Drug Packaging	Packaging, Drug|Drug Packagings|Packagings, Drug
 D004350	Drug Residues	Drug Residue|Residue, Drug|Residues, Drug
 D004351	Drug Resistance	Resistance, Drug
 D004352	Drug Resistance, Microbial	Drug Resistances, Microbial|Antimicrobial Drug Resistance|Antimicrobial Drug Resistances
-D004353	Drug Evaluation, Preclinical	Drug Evaluations, Preclinical|Drug Screening|Drug Screenings|Screening, Drug|Screenings, Drug|Evaluation Studies, Drug, Pre-Clinical|Preclinical Drug Evaluations|Evaluation, Preclinical Drug|Evaluations, Preclinical Drug|Preclinical Drug Evaluation|Drug Evaluation Studies, Preclinical|Evaluation Studies, Drug, Preclinical
+D004353	Drug Evaluation, Preclinical	Evaluation, Preclinical Drug|Evaluations, Preclinical Drug|Preclinical Drug Evaluation|Evaluation Studies, Drug, Preclinical|Drug Screening|Drug Screenings|Screening, Drug|Screenings, Drug|Evaluation Studies, Drug, Pre-Clinical|Drug Evaluation Studies, Preclinical|Drug Evaluations, Preclinical|Preclinical Drug Evaluations
 D004354	Drug Screening Assays, Antitumor	Antitumor Drug Screening Assays|Cancer Drug Tests|Cancer Drug Test|Drug Test, Cancer|Drug Tests, Cancer|Test, Cancer Drug|Tests, Cancer Drug|Drug Screening Tests, Tumor-Specific|Drug Screening Tests, Tumor Specific|Antitumor Drug Screens|Antitumor Drug Screen|Drug Screen, Antitumor|Drug Screens, Antitumor|Screen, Antitumor Drug|Screens, Antitumor Drug|Anti-Cancer Drug Screens|Anti Cancer Drug Screens|Anti-Cancer Drug Screen|Drug Screen, Anti-Cancer|Drug Screens, Anti-Cancer|Screen, Anti-Cancer Drug|Screens, Anti-Cancer Drug|Anticancer Drug Sensitivity Tests|Tumor-Specific Drug Screening Tests|Tumor Specific Drug Screening Tests
-D004355	Drug Stability	Stability, Drug
+D004355	Drug Stability	Drug Stabilities
 D004356	Drug Storage	Drug Storages|Storage, Drug|Storages, Drug
 D004357	Drug Synergism	Drug Synergisms|Synergism, Drug|Synergisms, Drug
 D004358	Drug Therapy	Therapy, Drug|Drug Therapies|Therapies, Drug|Chemotherapy|Chemotherapies|Pharmacotherapy|Pharmacotherapies
@@ -5699,12 +6119,12 @@ D004359	Drug Therapy, Combination	Combination Chemotherapy|Drug Polytherapy|Drug
 D004360	Drug Therapy, Computer-Assisted	Drug Therapy, Computer Assisted|Therapy, Computer-Assisted Drug|Computer-Assisted Drug Therapies|Drug Therapies, Computer-Assisted|Therapies, Computer-Assisted Drug|Therapy, Computer Assisted Drug|Computer-Assisted Drug Therapy|Computer Assisted Drug Therapy
 D004361	Drug Tolerance	Drug Tolerances|Tolerance, Drug|Tolerances, Drug
 D004363	Drug Utilization	Utilization, Drug|Drug Utilizations|Utilizations, Drug
-D004364	Pharmaceutical Preparations	Pharmaceutic Preparations|Preparations, Pharmaceutic|Preparations, Pharmaceutical|Drugs|Pharmaceutical Products|Products, Pharmaceutical
+D004364	Pharmaceutical Preparations	Preparations, Pharmaceutical|Pharmaceutic Preparations|Preparations, Pharmaceutic|Pharmaceutical Products|Products, Pharmaceutical|Pharmaceuticals|Drugs
 D004365	Drugs, Chinese Herbal	Chinese Drugs, Plant|Chinese Herbal Drugs|Herbal Drugs, Chinese
 D004366	Nonprescription Drugs	Drugs, Nonprescription|Medicines, Patent|OTC Drugs|Drugs, OTC|Over-the-Counter Drugs|Drugs, Over-the-Counter|Over the Counter Drugs|Patent Medicines|Drugs, Non-Prescription|Drugs, Non Prescription|Non-Prescription Drugs|Non Prescription Drugs
 D004367	Dry Ice	Ice, Dry|Carbon Dioxide Snow|Dioxide Snow, Carbon|Snow, Carbon Dioxide
 D004368	Dry Socket	Dry Sockets|Socket, Dry|Sockets, Dry|Osteitis, Alveolar|Alveolitis Sicca Dolorosa|Alveolar Periostitis|Alveolar Periostitides|Periostitides, Alveolar|Periostitis, Alveolar|Alveolar Osteitis|Alveolar Osteitides|Osteitides, Alveolar
-D004369	Pentetic Acid	Diethylenetriamine Pentaacetic Acid|Acid, Diethylenetriamine Pentaacetic|Pentaacetic Acid, Diethylenetriamine|Penthanil|Pentaind|DETAPAC|DTPA
+D004369	Pentetic Acid	Penthanil|DTPA|Pentaind|DETAPAC|Diethylenetriamine Pentaacetic Acid|Pentaacetic Acid, Diethylenetriamine
 D004370	Duane Retraction Syndrome	Retraction Syndrome, Duane|Syndrome, Duane Retraction|Duane Anomaly|Anomaly, Duane|Duane Anomaly, Isolated|Anomalies, Isolated Duane|Anomaly, Isolated Duane|Duane Anomalies, Isolated|Isolated Duane Anomalies|Isolated Duane Anomaly|Stilling-Turk-Duane Syndrome|Stilling Turk Duane Syndrome|Stilling-Turk-Duane Syndromes|Syndrome, Stilling-Turk-Duane|Syndromes, Stilling-Turk-Duane|Duane's Syndrome|Duanes Syndrome|Syndrome, Duane's|Isolated Duane Retraction Syndrome|Ocular Retraction Syndrome|Ocular Retraction Syndromes|Retraction Syndrome, Ocular|Retraction Syndromes, Ocular|Syndrome, Ocular Retraction|Syndromes, Ocular Retraction|Retraction Syndrome|Retraction Syndromes|Syndrome, Retraction|Syndromes, Retraction|Co-Contractive Retraction Syndrome|Co Contractive Retraction Syndrome|Co-Contractive Retraction Syndromes|Retraction Syndrome, Co-Contractive|Retraction Syndromes, Co-Contractive|Syndrome, Co-Contractive Retraction|Syndromes, Co-Contractive Retraction|Duane Syndrome|Syndrome, Duane
 D004371	Hepatitis Virus, Duck	Duck Hepatitis Viruses|Duck Hepatitis Virus
 D004372	Ducks	Duck
@@ -5737,13 +6157,13 @@ D004398	Dyneins	Adenosine Triphosphatase, Dynein|Dynein Adenosine Triphosphatase
 D004399	Dynorphins	Dynorphin
 D004400	Dyphylline	Diphylline|Dihydroxypropyltheophylline|Diprophylline
 D004401	Dysarthria	Dysarthrias|Dysarthosis|Dysarthoses
-D004402	Dysautonomia, Familial	HSAN Type III|Riley-Day Syndrome|Riley Day Syndrome|Hereditary-Sensory and Autonomic Neuropathy Type III|Hereditary Sensory and Autonomic Neuropathy Type III|Neuropathy, Hereditary and Autonomic, Type III|Dominant Hereditary Sensory Neuropathy, Type III|Hereditary Sensory Neuropathy, Dominant, Type 3|Hereditary Sensory Neuropathy, Dominant, Type III|HSN-III|HSAN (Hereditary Sensory and Autonomic Neuropathy) Type III|Type III Hereditary Sensory Neuropathy, Dominant|Type 3 Hereditary Sensory Neuropathy, Dominant|HSAN 3|Hereditary Sensory Neuropathy Type 3|Hereditary Sensory and Autonomic Neuropathy 3|HSAN III|Familial Dysautonomia|HSAN3|Neuropathy, Hereditary Sensory And Autonomic, Type III|Hereditary Sensory Neuropathy, Type 3, Dominant
+D004402	Dysautonomia, Familial	Type III Hereditary Sensory Neuropathy, Dominant|Hereditary Sensory Neuropathy Type 3|Hereditary Sensory and Autonomic Neuropathy 3|HSAN III|Familial Dysautonomia|HSAN3|HSN-III|Neuropathy, Hereditary Sensory And Autonomic, Type III|HSAN Type III|Riley-Day Syndrome|Riley Day Syndrome|Hereditary-Sensory and Autonomic Neuropathy Type III|Hereditary Sensory and Autonomic Neuropathy Type III|Neuropathy, Hereditary and Autonomic, Type III|Dominant Hereditary Sensory Neuropathy, Type III|Hereditary Sensory Neuropathy, Dominant, Type 3|Hereditary Sensory Neuropathy, Dominant, Type III|Hereditary Sensory Neuropathy, Type 3, Dominant|HSAN (Hereditary Sensory and Autonomic Neuropathy) Type III|Type 3 Hereditary Sensory Neuropathy, Dominant|HSAN 3
 D004403	Dysentery	Infectious Diarrheal Disease|Diarrheal Disease, Infectious|Infectious Diarrheal Diseases
 D004404	Dysentery, Amebic	Amebic Dysentery|Amebic Dysenteries|Dysenteries, Amebic|Amebiasis, Intestinal|Amebiases, Intestinal|Intestinal Amebiases|Intestinal Entamoeba histolytica Infection|Amoebiasis, Intestinal|Amoebiases, Intestinal|Intestinal Amoebiases|Intestinal Amoebiasis|Amoebic Colitis|Amoebic Colitides|Colitides, Amoebic|Colitis, Amoebic|Amoebic Dysentery|Amoebic Dysenteries|Dysenteries, Amoebic|Dysentery, Amoebic|Colitis, Amebic|Amebic Colitides|Amebic Colitis|Colitides, Amebic|Intestinal Amebiasis
 D004405	Dysentery, Bacillary	Bacillary Dysentery
 D004406	Dysgammaglobulinemia	Dysgammaglobulinemias
 D004407	Dysgerminoma	Dysgerminomas|Disgerminoma|Disgerminomas
-D004408	Dysgeusia	Dysgeusias|Taste, Distorted|Distorted Taste|Parageusia|Parageusias
+D004408	Dysgeusia	Dysgeusias|Taste, Distorted|Distorted Taste
 D004409	Dyskinesia, Drug-Induced	Drug-Induced Dyskinesia|Drug-Induced Dyskinesias|Dyskinesia, Drug Induced|Dyskinesias, Drug-Induced
 D004410	Dyslexia	Dyslexias|Word Blindness|Blindness, Word|Blindnesses, Word|Word Blindnesses|Reading Disorder|Disorder, Reading|Disorders, Reading|Reading Disorders
 D004411	Dyslexia, Acquired	Acquired Dyslexia|Word Blindness, Acquired|Acquired Word Blindness|Acquired Word Blindnesses|Blindness, Acquired Word|Blindnesses, Acquired Word|Word Blindnesses, Acquired|Reading Disability, Acquired|Acquired Reading Disabilities|Acquired Reading Disability|Disabilities, Acquired Reading|Disability, Acquired Reading|Reading Disabilities, Acquired
@@ -5777,7 +6197,7 @@ D004439	Eccrine Glands	Eccrine Gland|Gland, Eccrine|Glands, Eccrine
 D004440	Ecdysone	Molting Hormone
 D004441	Ecdysterone	Crustecdysone|20-Hydroxyecdysone|20 Hydroxyecdysone|Beta-Ecdysone|Beta Ecdysone
 D004442	Echidna	Spiny Anteater|Anteater, Spiny|Anteaters, Spiny|Spiny Anteaters|Spiny Ant-Eater|Ant-Eater, Spiny|Ant-Eaters, Spiny|Spiny Ant Eater|Spiny Ant-Eaters
-D004443	Echinococcosis	Echinococcoses|Echinococcus Infection|Echinococcus Infections|Infection, Echinococcus|Hydatidosis|Hydatidoses|Cysts, Hydatid|Cyst, Hydatid|Hydatid Cysts|Hydatid Cyst|Hydatid Disease|Hydatid Diseases
+D004443	Echinococcosis	Echinococcoses|Echinococcus Infection|Echinococcus Infections|Infection, Echinococcus
 D004444	Echinococcosis, Hepatic	Echinococcoses, Hepatic|Hepatic Echinococcoses|Hepatic Echinococcosis|Echinococcosis, Hepatic Alveolar|Alveolar Echinococcoses, Hepatic|Alveolar Echinococcosis, Hepatic|Echinococcoses, Hepatic Alveolar|Hepatic Alveolar Echinococcoses|Hepatic Alveolar Echinococcosis|Hydatidosis, Hepatic|Hepatic Hydatidoses|Hepatic Hydatidosis|Hydatidoses, Hepatic|Alveolar Echinococcis, Hepatic|Echinococcis, Hepatic Alveolar|Hepatic Alveolar Echinococcis|Hydatid Cyst, Hepatic|Cyst, Hepatic Hydatid|Cysts, Hepatic Hydatid|Hepatic Hydatid Cyst|Hepatic Hydatid Cysts|Hydatid Cysts, Hepatic
 D004445	Echinococcosis, Pulmonary	Cysts, Pulmonary Hydatid|Echinococcoses, Pulmonary|Hydatid Cyst, Pulmonary|Hydatid Cysts, Pulmonary|Pulmonary Hydatidosis|Hydatidosis, Pulmonary|Pulmonary Echinococcoses|Pulmonary Echinococcosis|Pulmonary Hydatid Cyst|Pulmonary Hydatid Cysts|Pulmonary Hydatidoses|Cyst, Pulmonary Hydatid|Hydatidoses, Pulmonary
 D004446	Echinococcus	
@@ -5961,7 +6381,7 @@ D004630	Emergencies	Emergency
 D004631	Emergency Medical Service Communication Systems	EMS Communication Systems|Communication Systems, EMS|Communication Systems, Emergency Medical Service|Communication System, EMS|EMS Communication System|System, EMS Communication|Systems, EMS Communication
 D004632	Emergency Medical Services	Emergency Services, Medical|Emergency Service, Medical|Medical Emergency Service|Medical Emergency Services|Service, Medical Emergency|Services, Medical Emergency|Medical Services, Emergency|Emergency Medical Service|Medical Service, Emergency|Service, Emergency Medical|Services, Emergency Medical
 D004633	Emergency Medical Tags	Medical Tag, Emergency|Tag, Emergency Medical|Tags, Emergency Medical|Emergency Medical Tag|Medical Tags, Emergency
-D004634	Emergency Medical Technicians	Technician, Emergency Medical|Medical Technician, Emergency|Paramedics, Emergency|Emergency Paramedic|Emergency Paramedics|Paramedic, Emergency|Emergency Medicine Technicians|Emergency Medicine Technician|Technician, Emergency Medicine|Technicians, Emergency Medicine|Emergency Medical Technician|Medical Technicians, Emergency|Technicians, Emergency Medical
+D004634	Emergency Medical Technicians	Medical Technician, Emergency|Emergency Medicine Technicians|Emergency Medicine Technician|Technician, Emergency Medicine|Technicians, Emergency Medicine|Technician, Emergency Medical|Technicians, Emergency Medical|Paramedics, Emergency|Emergency Paramedic|Emergency Paramedics|Paramedic, Emergency|Emergency Medical Technician|Medical Technicians, Emergency
 D004635	Emergency Medicine	Medicine, Emergency
 D004636	Emergency Service, Hospital	Emergency Services, Hospital|Hospital Emergency Services|Services, Hospital Emergency|Emergency Departments|Department, Emergency|Departments, Emergency|Emergency Department|Emergency Hospital Service|Emergency Hospital Services|Hospital Service, Emergency|Hospital Services, Emergency|Service, Emergency Hospital|Services, Emergency Hospital|Service, Hospital Emergency|Emergency Units|Emergency Unit|Unit, Emergency|Units, Emergency|Emergency Ward|Emergency Wards|Ward, Emergency|Wards, Emergency|Hospital Emergency Service|Hospital Service Emergency|Emergencies, Hospital Service|Emergency, Hospital Service|Hospital Service Emergencies|Service Emergencies, Hospital|Service Emergency, Hospital|Accident and Emergency Department|Emergency Room|Emergency Rooms|Room, Emergency|Rooms, Emergency
 D004637	Emergency Services, Psychiatric	Services, Psychiatric Emergency|Services, Emergency Psychiatric|Psychiatric Emergency Services|Emergency Service, Psychiatric|Psychiatric Emergency Service|Service, Psychiatric Emergency|Emergency Psychiatric Services|Emergency Psychiatric Service|Psychiatric Service, Emergency|Psychiatric Services, Emergency|Service, Emergency Psychiatric
@@ -5985,7 +6405,7 @@ D004654	Empyema, Tuberculous	Empyemas, Tuberculous|Tuberculous Empyema|Tuberculo
 D004655	Emulsions	
 D004656	Enalapril	
 D004658	Enamel Organ	Enamel Organs|Organ, Enamel|Organs, Enamel
-D004659	Enbucrilate	Enbucrilates|Butyl 2-Cyanacrylate|Butyl 2 Cyanacrylate|Butyl 2-Cyanacrylates|NBCA compound|NBCA compounds|N-butyl-2-cyanoacrylate|N butyl 2 cyanoacrylate|N-butyl-2-cyanoacrylates|N-butyl-cyanoacrylate|N butyl cyanoacrylate|N-butyl-cyanoacrylates|2-Cyanobutylacrylate|2 Cyanobutylacrylate|2-Cyanobutylacrylates|Enbucrylate|Enbucrylates
+D004659	Enbucrilate	Enbucrilates|Butyl 2-Cyanacrylate|Butyl 2 Cyanacrylate|Butyl 2-Cyanacrylates|N-Butyl-2-Cyanoacrylate|N Butyl 2 Cyanoacrylate|N-Butyl-2-Cyanoacrylates|NBCA compound|NBCA compounds|N-Butyl-Cyanoacrylate|N Butyl Cyanoacrylate|N-Butyl-Cyanoacrylates|2-Cyanobutylacrylate|2 Cyanobutylacrylate|2-Cyanobutylacrylates|Enbucrylate|Enbucrylates
 D004660	Encephalitis	Brain Inflammation|Inflammation, Brain|Brain Inflammations
 D004663	Encephalitis Virus, Eastern Equine	Encephalomyelitis Virus, Eastern Equine|Eastern Equine Encephalomyelitis Virus|Eastern equine encephalitis virus|EEE Virus|EEE Viruses
 D004664	Encephalitis Virus, Japanese	Virus, Japanese Encephalitis|Japanese B Encephalitis Virus|Japanese Encephalitis Virus
@@ -5994,12 +6414,12 @@ D004666	Encephalitis Virus, Venezuelan Equine	Venezuelan equine encephalitis vir
 D004667	Encephalitis Virus, Western Equine	Virus, Western Equine Encephalitis|Viruses, Western Equine Encephalitis|WEE Virus|WEE Viruses|Western Equine Encephalitis Viruses|Encephalomyelitis Virus, Western Equine|Encephalitis Viruses, Western Equine|Western equine encephalitis virus
 D004668	Encephalitis Viruses	Viruses, Encephalitis|Encephalitis Virus|Virus, Encephalitis
 D004669	Encephalitis Viruses, Tick-Borne	Encephalitis Viruses, Tick Borne|Encephalitis Virus, Tick-Borne|Encephalitis Virus, Tick Borne|Viruses, Tick-Borne Encephalitis|Tick-Borne Encephalitis Virus|Tick Borne Encephalitis Virus|Tick-Borne Encephalitis Viruses|Tick Borne Encephalitis Viruses
-D004670	Encephalitis, California	Viral Encephalitis, California|California Viral Encephalitis|California Viral Encephalitides|Encephalitides, California Viral|Encephalitis, California Viral|Viral Encephalitides, California|Encephalitis, California, Viral|La Crosse Encephalitis|Encephalitis, La Crosse|California Encephalitis
+D004670	Encephalitis, California	California Encephalitis
 D004671	Encephalitis, Arbovirus	Arbovirus Encephalitides|Arbovirus Encephalitis|Encephalitides, Arbovirus|Encephalitis, Epidemic|Viral Encephalitis, Arthropod-Borne|Viral Encephalitis, Arthropod Borne|Arthropod-Borne Viral Encephalitis|Arthropod Borne Viral Encephalitis|Arthropod-Borne Viral Encephalitides|Encephalitides, Arthropod-Borne Viral|Encephalitis, Arthropod-Borne Viral|Viral Encephalitides, Arthropod-Borne|Encephalitis, Arthropod-Borne|Encephalitis, Arthropod Borne|Epidemic Encephalitis|Encephalitides, Epidemic|Epidemic Encephalitides|Arthropod-Borne Encephalitis|Arthropod Borne Encephalitis|Arthropod-Borne Encephalitides|Encephalitides, Arthropod-Borne
 D004672	Encephalitis, Japanese	Encephalitis, Japanese B|Viral Encephalitis, Japanese B|Japanese B Viral Encephalitis|Japanese B Encephalitis|Japanese Encephalitis
 D004673	Encephalomyelitis, Acute Disseminated	Disseminated Encephalomyelitis, Acute|Acute Disseminated Encephalomyelitis|Acute Disseminated Encephalomyelitides|Disseminated Encephalomyelitides, Acute|Encephalomyelitides, Acute Disseminated
 D004674	Encephalitis, St. Louis	Lethargic Encephalitis, Type C|Saint Louis Encephalitis|Encephalitis, Saint Louis|Encephalitis, Viral, St. Louis|Type C Lethargic Encephalitis|St. Louis Encephalitis|St. Louis Viral Encephalitis
-D004675	Encephalitis, Tick-Borne	Encephalitis, Tick Borne|Tick-Borne Encephalitis|Encephalitides, Tick-Borne|Tick Borne Encephalitis|Tick-Borne Encephalitides
+D004675	Encephalitis, Tick-Borne	Encephalitis, Tick Borne|Tick-Borne Encephalitis|Tick Borne Encephalitis
 D004676	Myelin Basic Protein	
 D004677	Encephalocele	Encephaloceles|Cephalocele|Cephaloceles|Cranial Meningoencephalocele|Cranial Meningoencephaloceles|Meningoencephalocele, Cranial|Meningoencephaloceles, Cranial|Cranium Bifidum|Bifidum, Cranium|Bifidums, Cranium|Cranium Bifidums|Hernia, Cerebral|Cerebral Hernia|Cerebral Hernias|Hernias, Cerebral|Bifid Cranium|Bifid Craniums|Cranium, Bifid|Craniums, Bifid|Craniocele|Cranioceles
 D004678	Encephalomalacia	Encephalomalacias|Cerebromalacia|Cerebromalacias
@@ -6107,7 +6527,7 @@ D004781	Environmental Exposure	Exposure, Environmental|Environmental Exposures|E
 D004782	Environmental Health	Environmental Healths|Healths, Environmental|Environmental Health Science|Environmental Health Sciences|Health Science, Environmental|Health Sciences, Environmental|Science, Environmental Health|Sciences, Environmental Health|Health, Environmental
 D004783	Environmental Microbiology	Microbiology, Environmental
 D004784	Environmental Monitoring	Monitoring, Environmental|Environmental Surveillance|Surveillance, Environmental
-D004785	Environmental Pollutants	Pollutants, Environmental
+D004785	Environmental Pollutants	Pollutants|Pollutants, Environmental
 D004786	Toxic Actions	Actions, Toxic
 D004787	Environmental Pollution	Pollution, Environmental
 D004789	Enzyme Activation	Activation, Enzyme|Activations, Enzyme|Enzyme Activations
@@ -6133,7 +6553,7 @@ D004811	Epichlorohydrin	Epichlorohydrin, (+-)-Isomer|Epichlorhydrin
 D004812	Epidemiologic Methods	Epidemiological Methods|Epidemiological Method|Method, Epidemiological|Methods, Epidemiological|Epidemiologic Method|Method, Epidemiologic|Methods, Epidemiologic
 D004813	Epidemiology	
 D004814	Epidermal Cyst	Cyst, Epidermal|Cysts, Epidermal|Epidermal Cysts|Sebaceous Cyst|Cyst, Sebaceous|Cysts, Sebaceous|Sebaceous Cysts|Epidermoid Cyst|Cyst, Epidermoid|Cysts, Epidermoid|Epidermoid Cysts
-D004815	Epidermal Growth Factor	Growth Factor, Epidermal|Urogastrone|Epidermal Growth Factor-Urogastrone|Growth Factor-Urogastrone, Epidermal|Human Urinary Gastric Inhibitor|beta-Urogastrone|beta Urogastrone|EGF
+D004815	Epidermal Growth Factor	Growth Factor, Epidermal|Urogastrone|EGF|Human Urinary Gastric Inhibitor|beta-Urogastrone|beta Urogastrone|Epidermal Growth Factor-Urogastrone|Growth Factor-Urogastrone, Epidermal
 D004817	Epidermis	
 D004818	Epidermitis, Exudative, of Swine	Exudative Dermatitis of Swine|Swine Exudative Dermatitides|Swine Exudative Dermatitis|Greasy Pig Disease|Disease, Greasy Pig|Epidermitis, Exudative of Swine
 D004819	Epidermodysplasia Verruciformis	Lewandowsky-Lutz Disease|Disease, Lewandowsky-Lutz|Lewandowsky Lutz Disease|Lutz-Lewandowsky Disease|Disease, Lutz-Lewandowsky|Lutz Lewandowsky Disease
@@ -6145,11 +6565,11 @@ D004824	Epidural Space	Epidural Spaces|Space, Epidural|Spaces, Epidural
 D004825	Epiglottis	Epiglottic Cartilage|Cartilage, Epiglottic|Cartilages, Epiglottic|Epiglottic Cartilages
 D004826	Epiglottitis	Epiglottitides
 D004827	Epilepsy	Epilepsies|Seizure Disorder|Seizure Disorders
-D004828	Epilepsies, Partial	Partial Epilepsies|Epilepsy, Localization-Related|Epilepsies, Localization-Related|Localization-Related Epilepsies|Localization-Related Epilepsy|Epilepsy, Partial|Seizure Disorder, Partial|Partial Epilepsy|Partial Seizure Disorder|Disorders, Partial Seizure|Partial Seizure Disorders|Seizure Disorders, Partial|Seizure Disorder, Focal|Epilepsy, Focal|Epilepsies, Focal|Focal Epilepsies|Focal Epilepsy|Focal Seizure Disorder|Disorders, Focal Seizure|Focal Seizure Disorders|Seizure Disorders, Focal
+D004828	Epilepsies, Partial	Partial Epilepsy|Seizure Disorder, Partial|Epilepsy, Focal|Epilepsies, Focal|Focal Epilepsies|Focal Epilepsy|Partial Seizure Disorder|Disorders, Partial Seizure|Partial Seizure Disorders|Seizure Disorders, Partial|Epilepsy, Localization-Related|Epilepsies, Localization-Related|Localization-Related Epilepsies|Localization-Related Epilepsy|Focal Seizure Disorder|Disorders, Focal Seizure|Focal Seizure Disorders|Seizure Disorders, Focal|Seizure Disorder, Focal|Epilepsy, Partial|Partial Epilepsies
 D004829	Epilepsy, Generalized	Epilepsies, Generalized|Generalized Epilepsies|Generalized Epilepsy|Seizure Disorder, Generalized|Generalized Seizure Disorder|Generalized Seizure Disorders|Seizure Disorders, Generalized
 D004830	Epilepsy, Tonic-Clonic	Epilepsies, Tonic-Clonic|Epilepsy, Tonic Clonic|Tonic-Clonic Epilepsies|Tonic-Clonic Epilepsy|Epilepsy, Grand Mal|Grand Mal Epilepsy|Epilepsy, Major|Major Epilepsies|Major Epilepsy|Grand Mal Seizure Disorder|Major Motor Seizure Disorder|Tonic-Clonic Seizure Syndrome|Seizure Syndrome, Tonic-Clonic|Seizure Syndromes, Tonic-Clonic|Syndrome, Tonic-Clonic Seizure|Syndromes, Tonic-Clonic Seizure|Tonic Clonic Seizure Syndrome|Tonic-Clonic Seizure Syndromes|Seizure Disorder, Major Motor|Seizure Disorder, Tonic Clonic|Tonic Clonic Convulsions|Convulsion, Tonic Clonic|Convulsions, Tonic Clonic|Tonic Clonic Convulsion|Tonic-Clonic Convulsion Disorder|Convulsion Disorder, Tonic-Clonic|Convulsion Disorders, Tonic-Clonic|Disorder, Tonic-Clonic Convulsion|Disorders, Tonic-Clonic Convulsion|Tonic Clonic Convulsion Disorder|Tonic-Clonic Convulsion Disorders|Tonic-Clonic Convulsion Syndrome|Convulsion Syndrome, Tonic-Clonic|Convulsion Syndromes, Tonic-Clonic|Syndrome, Tonic-Clonic Convulsion|Syndromes, Tonic-Clonic Convulsion|Tonic Clonic Convulsion Syndrome|Tonic-Clonic Convulsion Syndromes|Tonic-Clonic Seizure Disorder|Disorder, Tonic-Clonic Seizure|Disorders, Tonic-Clonic Seizure|Seizure Disorder, Tonic-Clonic|Seizure Disorders, Tonic-Clonic|Tonic Clonic Seizure Disorder|Tonic-Clonic Seizure Disorders|Convulsions, Grand Mal|Convulsion, Grand Mal|Grand Mal Convulsion|Grand Mal Convulsions|Seizure Disorder, Grand Mal
-D004831	Epilepsies, Myoclonic	Epilepsy, Myoclonic|Myoclonic Epilepsies|Myoclonic Seizure Disorder|Myoclonic Seizure Disorders|Seizure Disorder, Myoclonic|Seizure Disorders, Myoclonic|Myoclonic Epilepsy|Epilepsy, Myoclonus|Myoclonus Epilepsies|Myoclonus Epilepsy
-D004832	Epilepsy, Absence	Absence Epilepsy|Pyknolepsy|Pyknolepsies|Epilepsy, Petit Mal|Petit Mal Epilepsies|Absence Seizure Disorder|Absence Seizure Disorders|Seizure Disorders, Absence|Pykno-Epilepsy|Pykno Epilepsy|Pykno-Epilepsies|Seizure Disorder, Absence|Petit Mal Epilepsy|Epilepsy, Minor|Minor Epilepsies|Minor Epilepsy
+D004831	Epilepsies, Myoclonic	Epilepsy, Myoclonic|Myoclonic Epilepsies|Myoclonic Epilepsy|Myoclonic Seizure Disorder|Myoclonic Seizure Disorders|Seizure Disorder, Myoclonic|Seizure Disorders, Myoclonic|Epilepsy, Myoclonus|Myoclonus Epilepsies|Myoclonus Epilepsy
+D004832	Epilepsy, Absence	Absence Epilepsy
 D004833	Epilepsy, Temporal Lobe	Epilepsies, Temporal Lobe|Temporal Lobe Epilepsies|Temporal Lobe Epilepsy
 D004834	Epilepsy, Post-Traumatic	Epilepsies, Post-Traumatic|Epilepsy, Post Traumatic|Post-Traumatic Epilepsies|Post-Traumatic Epilepsy|Post-Traumatic Seizure Disorder|Post Traumatic Seizure Disorder|Epilepsy, Traumatic|Epilepsies, Traumatic|Traumatic Epilepsies|Traumatic Epilepsy|Seizure Disorder, Post-Traumatic|Disorder, Post-Traumatic Seizure|Disorders, Post-Traumatic Seizure|Post-Traumatic Seizure Disorders|Seizure Disorder, Post Traumatic|Seizure Disorders, Post-Traumatic
 D004836	Epimestrol	
@@ -6308,14 +6728,14 @@ D004995	Ethics, Professional	Ethic, Professional|Professional Ethic|Professional
 D004996	Ethidium	
 D004997	Ethinyl Estradiol	Estradiol, Ethinyl|Ethinyloestradiol|Ethynyl Estradiol|Estradiol, Ethynyl
 D004998	Ethiodized Oil	Oil, Ethiodized|Ethiodized Oil (Injection)|Ethiodized Oils|Oils, Ethiodized
-D004999	Amifostine	Amifostine Trihydrate|Trihydrate, Amifostine|APAETP
+D004999	Amifostine	APAETP
 D005000	Ethionamide	Ethioniamide|Amidazine
 D005001	Ethionine	
 D005002	Ethiopia	Federal Democratic Republic of Ethiopia
 D005003	Ethisterone	17 alpha-Ethynyltestosterone|17 alpha Ethynyltestosterone|Pregneninolone|Anhydrohydroxyprogesterone
 D005004	Ethmoid Bone	Bone, Ethmoid|Bones, Ethmoid|Ethmoid Bones
 D005005	Ethmoid Sinus	Sinus, Ethmoid
-D005006	Ethnic Groups	Ethnic Group|Group, Ethnic|Groups, Ethnic
+D005006	Ethnic Groups	Ethnic Group
 D005007	Ethnology	
 D005008	Ethnopsychology	Transcultural Psychology|Psychology, Transcultural
 D005009	Ethoglucid	Etoglucid
@@ -6352,7 +6772,7 @@ D005042	Etimizol	Aethimizole|Ethymizol|Ethimizole|Ethymisole|Ethylnorantifeine|E
 D005043	Etiocholanolone	5-beta-Androsterone|5 beta Androsterone|3-alpha-Hydroxy-5-beta-Androstan-17-One|3 alpha Hydroxy 5 beta Androstan 17 One
 D005044	Etioporphyrins	
 D005045	Etomidate	Ethomidate
-D005047	Etoposide	Demethyl Epipodophyllotoxin Ethylidine Glucoside|Eposide
+D005047	Etoposide	Eposide|Demethyl Epipodophyllotoxin Ethylidine Glucoside
 D005048	Etorphine	Ethorphine
 D005050	Etretinate	Ethyl Etrinoate|Etrinoate, Ethyl
 D005051	Eubacterium	
@@ -6385,7 +6805,7 @@ D005077	Exanthema Subitum	Sixth Disease|Disease, Sixth|Roseola Infantum
 D005078	Exchange Transfusion, Whole Blood	
 D005079	Excipients	
 D005080	Exercise Test	Exercise Tests|Test, Exercise|Tests, Exercise
-D005081	Exercise Therapy	Therapy, Exercise|Exercise Therapies|Therapies, Exercise|Rehabilitation Exercise|Exercise, Rehabilitation|Exercises, Rehabilitation|Rehabilitation Exercises|Remedial Exercise|Exercise, Remedial|Exercises, Remedial|Remedial Exercises
+D005081	Exercise Therapy	Remedial Exercise|Exercise, Remedial|Exercises, Remedial|Remedial Exercises|Therapy, Exercise|Exercise Therapies|Therapies, Exercise|Rehabilitation Exercise|Exercise, Rehabilitation|Exercises, Rehabilitation|Rehabilitation Exercises
 D005082	Physical Exertion	Exertion, Physical|Exertions, Physical|Physical Exertions|Physical Effort|Effort, Physical|Efforts, Physical|Physical Efforts
 D005083	Exfoliatins	Staphylococcal Exfoliative Toxin|Exfoliative Toxin, Staphylococcal|Toxin, Staphylococcal Exfoliative|Epidermolysins
 D005084	Exhibitionism	Exhibitionisms
@@ -6483,9 +6903,9 @@ D005175	Factor XII Deficiency	Deficiency, Factor Twelve|Deficiencies, Factor Twe
 D005176	Factor XIII	Factor Thirteen|Coagulation Factor XIII|Factor XIII, Coagulation|XIII, Coagulation Factor|Factor XIII Transamidase|Transamidase, Factor XIII|Fibrinase|Laki Lorand Factor|Laki-Lorand Factor|Blood Coagulation Factor XIII|Factor 13|Fibrin Stabilizing Factor|Stabilizing Factor, Fibrin
 D005177	Factor XIII Deficiency	Deficiency, Factor Thirteen|Deficiencies, Factor Thirteen|Factor Thirteen Deficiencies|Factor Thirteen Deficiency|Deficiency, Factor XIII|Deficiencies, Factor XIII|Factor XIII Deficiencies|Deficiency, Factor 13|Deficiencies, Factor 13|Factor 13 Deficiencies|Factor 13 Deficiency
 D005178	Faculty	
-D005179	Faculty, Dental	Faculties, Dental|Dental Faculties|Dental Faculty
-D005180	Faculty, Medical	Medical Faculty|Faculties, Medical|Medical Faculties
-D005181	Faculty, Nursing	Nursing Faculty|Faculties, Nursing|Nursing Faculties
+D005179	Faculty, Dental	Dental Faculty|Faculties, Dental|Dental Faculties
+D005180	Faculty, Medical	Medical Faculties|Medical Faculty|Faculties, Medical
+D005181	Faculty, Nursing	Faculties, Nursing|Nursing Faculties|Nursing Faculty
 D005182	Flavin-Adenine Dinucleotide	Dinucleotide, Flavin-Adenine|Flavin Adenine Dinucleotide|FAD
 D005183	Failure to Thrive	Thrive, Failure to
 D005184	Fallopian Tube Diseases	Disease, Fallopian Tube|Diseases, Fallopian Tube|Fallopian Tube Disease
@@ -6501,7 +6921,7 @@ D005193	Family Planning Services	Family Planning Service|Planning Service, Famil
 D005194	Family Practice	Family Practices|Practice, Family|Practices, Family
 D005195	Family Relations	Family Relation|Relation, Family|Relations, Family|Family Relationship|Family Relationships|Relationship, Family|Relationships, Family
 D005196	Family Therapy	Therapy, Family|Family Therapies|Therapies, Family
-D005197	Famous Persons	Famous Person|Person, Famous|Persons, Famous
+D005197	Famous Persons	Famous Person|Persons, Famous
 D005198	Fanconi Syndrome	Syndrome, Fanconi|Proximal Renal Tubular Dysfunction
 D005199	Fanconi Anemia	Anemias, Fanconi|Fanconi Anemias|Fanconi's Anemia|Anemia, Fanconi's|Fanconi Pancytopenia|Fanconi Panmyelopathy|Anemia, Fanconi|Fanconi Hypoplastic Anemia
 D005200	FANFT	N-4-(5-Nitro-2-furyl)-2-thiazolylformamide
@@ -6542,7 +6962,7 @@ D005236	Favism	Favisms
 D005239	Fear	Fears
 D005240	Feasibility Studies	Feasibility Study|Studies, Feasibility|Study, Feasibility
 D005241	Feathers	Feather
-D005242	Fecal Incontinence	Fecal Incontinences|Incontinence, Fecal|Incontinences, Fecal
+D005242	Fecal Incontinence	Incontinence, Fecal|Bowel Incontinence|Incontinence, Bowel
 D005243	Feces	
 D005244	Fecal Impaction	Impaction, Fecal
 D005245	Fee Schedules	Fee Schedule|Schedule, Fee|Schedules, Fee
@@ -6550,8 +6970,8 @@ D005246	Feedback	Feedbacks
 D005247	Feeding Behavior	Behavior, Feeding|Behaviors, Feeding|Feeding Behaviors|Eating Behavior|Behavior, Eating|Behaviors, Eating|Eating Behaviors
 D005248	Feeding Methods	Feeding Method|Method, Feeding|Methods, Feeding
 D005249	Fees and Charges	Charges and Fees
-D005250	Fees, Dental	Fee, Dental|Dental Fee|Dental Fees
-D005251	Fees, Medical	Medical Fees|Fee, Medical|Medical Fee
+D005250	Fees, Dental	Dental Fees|Fee, Dental|Dental Fee
+D005251	Fees, Medical	Medical Fee|Medical Fees|Fee, Medical
 D005252	Fees, Pharmaceutical	Fees, Pharmaceutic|Fee, Pharmaceutic|Pharmaceutic Fee|Pharmaceutic Fees|Pharmacy Fee|Pharmaceutical Fees|Fee, Pharmaceutical|Pharmaceutical Fee|Fee, Pharmacy|Fees, Pharmacy|Pharmacy Fees
 D005253	Sarcoma Viruses, Feline	Feline Sarcoma Viruses
 D005254	Feline Panleukopenia	Feline Panleukopenias|Panleukopenias, Feline|Agranulocytosis, Feline|Agranulocytoses, Feline|Feline Agranulocytoses|Feline Agranulocytosis|Feline Infectious Enteritis|Enteritides, Feline Infectious|Enteritis, Feline Infectious|Feline Infectious Enteritides|Infectious Enteritides, Feline|Infectious Enteritis, Feline|Ataxia, Feline|Ataxias, Feline|Feline Ataxias|Cat Plague|Cat Plagues|Plague, Cat|Plagues, Cat|Show Fever|Fever, Show|Fevers, Show|Show Fevers|Panleukopenia, Feline|Distemper, Feline|Distempers, Feline|Feline Distemper|Feline Distempers|Feline Ataxia
@@ -6578,7 +6998,7 @@ D005276	Fenestration, Labyrinth	Fenestrations, Labyrinth|Labyrinth Fenestration|
 D005277	Fenfluramine	
 D005278	Fenitrothion	Metathion
 D005279	Fenoprofen	
-D005280	Fenoterol	Phenoterol|p-Hydroxyphenyl-orciprenaline|p Hydroxyphenyl orciprenaline|p-Hydroxyphenylorciprenaline|p Hydroxyphenylorciprenaline
+D005280	Fenoterol	p-Hydroxyphenyl-orciprenaline|p Hydroxyphenyl orciprenaline|Phenoterol|p-Hydroxyphenylorciprenaline|p Hydroxyphenylorciprenaline
 D005283	Fentanyl	Phentanyl
 D005284	Fenthion	
 D005285	Fermentation	Fermentations
@@ -6608,7 +7028,7 @@ D005313	Fetal Death	Death, Fetal|Deaths, Fetal|Fetal Deaths|Fetal Demise|Demise,
 D005314	Embryonic and Fetal Development	Embryo and Fetal Development
 D005315	Fetal Diseases	Disease, Fetal|Diseases, Fetal|Fetal Disease
 D005316	Fetal Distress	Nonreassuring Fetal Status|Fetal Status, Nonreassuring
-D005317	Fetal Growth Retardation	Fetal Growth Restriction|Intrauterine Growth Retardation|Growth Retardation, Intrauterine|Intrauterine Growth Restriction
+D005317	Fetal Growth Retardation	Intrauterine Growth Retardation|Growth Retardation, Intrauterine|Intrauterine Growth Restriction|Fetal Growth Restriction
 D005318	Fetal Heart	Fetal Hearts|Heart, Fetal|Hearts, Fetal
 D005319	Fetal Hemoglobin	Hemoglobin, Fetal|Hemoglobin F
 D005320	Fetal Macrosomia	Fetal Macrosomias|Macrosomias, Fetal|Macrosomia, Fetal
@@ -6640,15 +7060,15 @@ D005345	Fibrinopeptide B	Fibrinopeptides B
 D005346	Fibroblast Growth Factors	Growth Factors, Fibroblast|Fibroblast Growth Factor|Growth Factor, Fibroblast|Fibroblast Growth Regulatory Factor|DNA Synthesis Factor
 D005347	Fibroblasts	Fibroblast
 D005348	Fibrocystic Breast Disease	Breast Disease, Fibrocystic|Disease, Fibrocystic Breast|Mammary Dysplasia|Dysplasia, Mammary|Fibrocystic Disease of Breast|Breast Fibrocystic Disease|Fibrocystic Mastopathy|Mastopathy, Fibrocystic|Breast Dysplasia|Dysplasia, Breast|Fibrocystic Changes of Breast|Breast Fibrocystic Change|Breast Fibrocystic Changes
-D005349	Fibroins	Fibroin
+D005349	Fibroins	Silk Fibroins|Fibroins, Silk|Silk Fibroin|Fibroin, Silk|Fibroin
 D005350	Fibroma	Fibromas
 D005351	Fibromatosis, Gingival	Gingival Fibromatosis|Fibromatoses, Gingival|Gingival Fibromatoses|Fibromatosis Gingivae
-D005352	Fibromuscular Dysplasia	Dysplasia, Fibromuscular|Dysplasias, Fibromuscular|Fibromuscular Dysplasias
+D005352	Fibromuscular Dysplasia	Dysplasia, Fibromuscular|Fibromuscular Dysplasias|Fibromuscular Dysplasia of Arteries|Arteries Fibromuscular Dysplasia|Arteries Fibromuscular Dysplasias
 D005353	Fibronectins	Opsonic alpha(2)SB Glycoprotein|Opsonic Glycoprotein|Glycoprotein, Opsonic|LETS Proteins|Proteins, LETS|alpha 2-Surface Binding Glycoprotein|alpha 2 Surface Binding Glycoprotein|Fibronectin|Cold-Insoluble Globulins|Cold Insoluble Globulins|Globulins, Cold-Insoluble
 D005354	Fibrosarcoma	Fibrosarcomas
 D005355	Fibrosis	Fibroses
 D005356	Fibromyalgia	Fibromyalgias|Fibromyalgia-Fibromyositis Syndrome|Fibromyalgia Fibromyositis Syndrome|Fibromyalgia-Fibromyositis Syndromes|Syndrome, Fibromyalgia-Fibromyositis|Syndromes, Fibromyalgia-Fibromyositis|Rheumatism, Muscular|Muscular Rheumatism|Fibrositis|Fibrositides|Myofascial Pain Syndrome, Diffuse|Diffuse Myofascial Pain Syndrome|Fibromyositis-Fibromyalgia Syndrome|Fibromyositis Fibromyalgia Syndrome|Fibromyositis-Fibromyalgia Syndromes|Syndrome, Fibromyositis-Fibromyalgia|Syndromes, Fibromyositis-Fibromyalgia
-D005357	Fibrous Dysplasia of Bone	Bone Fibrous Dysplasia|Bone Fibrous Dysplasias|Osteitis Fibrosa Disseminata
+D005357	Fibrous Dysplasia of Bone	Bone Fibrous Dysplasia|Bone Fibrous Dysplasias|Osteitis Fibrosa Disseminata|Jaffe-Lichtenstein Disease|Jaffe Lichtenstein Disease
 D005358	Fibrous Dysplasia, Monostotic	Dysplasia, Monostotic Fibrous|Dysplasias, Monostotic Fibrous|Fibrous Dysplasias, Monostotic|Monostotic Fibrous Dysplasia|Monostotic Fibrous Dysplasias
 D005359	Fibrous Dysplasia, Polyostotic	Dysplasia, Polyostotic Fibrous|Dysplasias, Polyostotic Fibrous|Fibrous Dysplasias, Polyostotic|Polyostotic Fibrous Dysplasias|Polyostotic Fibrous Dysplasia
 D005360	Fibula	Fibulas
@@ -6746,7 +7166,7 @@ D005453	Fluorescence
 D005454	Fluorescence Polarization	Polarization, Fluorescence|Fluorescence Polarizations|Polarizations, Fluorescence
 D005455	Fluorescent Antibody Technique	Antibody Technique, Fluorescent|Antibody Techniques, Fluorescent|Fluorescent Antibody Techniques|Technique, Fluorescent Antibody|Techniques, Fluorescent Antibody|Fluorescent Antinuclear Antibody Test|Immunofluorescence Technic|Immunofluorescence Technics|Technic, Immunofluorescence|Technics, Immunofluorescence|Immunofluorescence Technique|Immunofluorescence Techniques|Technique, Immunofluorescence|Techniques, Immunofluorescence|Fluorescent Antibody Technic|Antibody Technic, Fluorescent|Antibody Technics, Fluorescent|Fluorescent Antibody Technics|Technic, Fluorescent Antibody|Technics, Fluorescent Antibody|Coon's Technic|Coon Technic|Coons Technic|Technic, Coon's|Antinuclear Antibody Test, Fluorescent|Coon's Technique|Coon Technique|Coons Technique|Technique, Coon's
 D005456	Fluorescent Dyes	Dyes, Fluorescent|Fluorescence Agents|Agents, Fluorescence|Fluorescent Agents|Agents, Fluorescent
-D005457	Fluoridation	Water Fluoridation|Fluoridation, Water
+D005457	Fluoridation	
 D005458	Fluoride Poisoning	Poisoning, Fluoride|Fluoride Poisonings|Poisonings, Fluoride
 D005459	Fluorides	Fluoride
 D005460	Fluorides, Topical	Topical Fluorides
@@ -6769,7 +7189,7 @@ D005476	Fluphenazine	Flufenazin
 D005477	Fluprednisolone	
 D005478	Flurandrenolone	Flurandrenolide
 D005479	Flurazepam	
-D005480	Flurbiprofen	Fluriproben|2-Fluoro-alpha-methyl-(1,1'-biphenyl)-4-acetic Acid|Flubiprofen
+D005480	Flurbiprofen	2-Fluoro-alpha-methyl-(1,1'-biphenyl)-4-acetic Acid|Flubiprofen|Fluriproben
 D005481	Flurothyl	Fluorothyl|Flurotyl
 D005483	Flushing	Flushings
 D005484	Fluspirilene	Spirodiflamine
@@ -6835,7 +7255,7 @@ D005546	Forehead	Foreheads
 D005547	Foreign Bodies	Bodies, Foreign|Body, Foreign|Foreign Body|Foreign Objects|Foreign Object|Object, Foreign|Objects, Foreign
 D005548	Foreign-Body Migration	Foreign Body Migration|Foreign-Body Migrations|Migration, Foreign-Body|Migrations, Foreign-Body
 D005549	Foreign-Body Reaction	Foreign Body Reaction|Reaction, Foreign-Body
-D005550	Foreign Medical Graduates	Graduate, Foreign Medical|Medical Graduate, Foreign|Medical Graduates, Foreign|Foreign Medical Graduate|Graduates, Foreign Medical
+D005550	Foreign Medical Graduates	Medical Graduates, Foreign|Graduates, Foreign Medical|Medical Graduate, Foreign|Foreign Medical Graduate|Graduate, Foreign Medical
 D005551	Foreign Professional Personnel	Personnel, Foreign Professional|Professional Personnel, Foreign
 D005552	Forelimb	Forelimbs
 D005553	Forensic Dentistry	Dentistry, Forensic
@@ -6853,12 +7273,12 @@ D005565	Formiminoglutamic Acid	Acid, Formiminoglutamic|FIGLU
 D005566	Formocresols	
 D005568	Forms and Records Control	
 D005569	Formularies as Topic	
-D005570	Formularies, Dental as Topic	Formularies, Dental|Formulary, Dental|Dental Formularies|Dental Formulary
-D005571	Formularies, Homeopathic	Formulary, Homeopathic|Homeopathic Formularies|Homeopathic Formulary
-D005572	Formularies, Hospital	Hospital Formulary|Formulary, Hospital|Hospital Formularies
+D005570	Formularies, Dental as Topic	
+D005571	Formularies, Homeopathic as Topic	Homeopathic Formularies as Topic
+D005572	Formularies, Hospital as Topic	Hospital Formularies as Topic
 D005573	Formycins	
 D005574	Formate-Tetrahydrofolate Ligase	Formate Tetrahydrofolate Ligase|Ligase, Formate-Tetrahydrofolate|Formyltetrahydrofolate Synthetase|Synthetase, Formyltetrahydrofolate|Tetrahydrofolate Formylase|Formylase, Tetrahydrofolate
-D005575	Formyltetrahydrofolates	Formyltetrahydrofolic Acids|Acids, Formyltetrahydrofolic
+D005575	Formyltetrahydrofolates	
 D005576	Colforsin	N,N-Dimethyl-beta-alanine-5-(acetyloxy)-3-ethenyldodecahydro-10,10b-dihydroxy-3,4a,7,7,10a-pentamethyl-1-oxo-1H-naphtho(2,1-b)pyran-6-yl Ester HCl|Coleonol|Forskolin
 D005577	Forssman Antigen	Antigen, Forssman
 D005578	Fosfomycin	Phosphomycin|Phosphonomycin
@@ -6868,7 +7288,7 @@ D005581	Foster Home Care	Care, Foster Home
 D005582	Foundations	Foundation
 D005583	Fourier Analysis	Analysis, Fourier|Cyclic Analysis|Analysis, Cyclic|Analyses, Cyclic|Cyclic Analyses
 D005584	Fovea Centralis	
-D005585	Influenza in Birds	Influenza in Bird|Influenza, Avian|Avian Influenzas|Influenzas, Avian|Fowl Plague|Plague, Fowl|Avian Flu|Flu, Avian|Avian Influenza
+D005585	Influenza in Birds	Influenza in Bird|Influenza, Avian|Avian Influenzas|Influenzas, Avian|Avian Flu|Flu, Avian|Fowl Plague|Plague, Fowl|Avian Influenza
 D005586	Fowlpox	Variola Avium|Fowl Pox|Pox, Fowl|Epithelioma Contagiosum|Fowl Diphtheria|Diphtheria, Fowl|Diphtherias, Fowl|Fowl Diphtherias
 D005587	Fowlpox virus	Fowlpox viruses|Fowl Pox Virus|Fowl Pox Viruses
 D005588	Fox-Fordyce Disease	Disease, Fox-Fordyce|Fox Fordyce Disease|Fox-Fordyce Syndrome|Fox Fordyce Syndrome|Syndrome, Fox-Fordyce|Miliaria, Apocrine|Apocrine Miliaria
@@ -6882,14 +7302,13 @@ D005596	Fractures, Closed	Closed Fracture|Closed Fractures|Fracture, Closed
 D005597	Fractures, Open	Fracture, Open|Open Fracture|Open Fractures|Fractures, Compound|Compound Fracture|Compound Fractures|Fracture, Compound
 D005598	Fractures, Spontaneous	Fracture, Spontaneous|Spontaneous Fracture|Spontaneous Fractures|Fracture, Pathological|Fractures, Pathologic|Pathologic Fracture|Pathologic Fractures|Pathological Fractures|Fractures, Pathological|Fracture, Pathologic|Pathological Fracture
 D005599	Fractures, Ununited	Fracture, Ununited|Ununited Fracture|Ununited Fractures
-D005600	Fragile X Syndrome	Fragile X Syndromes|Syndrome, Fragile X|Syndromes, Fragile X|Fragile X Mental Retardation Syndrome|X-Linked Mental Retardation and Macroorchidism|X Linked Mental Retardation and Macroorchidism|Martin-Bell Syndrome|Martin Bell Syndrome|Syndrome, Martin-Bell|Mental Retardation, X-Linked, Associated With Marxq28|Fra(X) Syndrome|Marker X Syndrome|Marker X Syndromes|Syndrome, Marker X|Syndromes, Marker X
+D005600	Fragile X Syndrome	Fragile X Syndromes|Syndrome, Fragile X|Syndromes, Fragile X|Marker X Syndrome|Marker X Syndromes|Syndrome, Marker X|Syndromes, Marker X|Mental Retardation, X-Linked, Associated With Marxq28|X-Linked Mental Retardation and Macroorchidism|X Linked Mental Retardation and Macroorchidism|Fragile X Mental Retardation Syndrome|Martin-Bell Syndrome|Martin Bell Syndrome|Syndrome, Martin-Bell|Fra(X) Syndrome
 D005601	Framycetin	Neomycin B|Antibiotic 10676
 D005602	France	
 D005603	Francisella	
 D005604	Francisella tularensis	Pasteurella tularensis
 D005605	Francium	
-D005606	Rhamnus	
-D005607	Fraud	Frauds
+D005607	Fraud	
 D005608	Free Association	Association, Free|Associations, Free|Free Associations
 D005609	Free Radicals	Radicals, Free
 D005610	Freedom	Freedoms|Liberty
@@ -7066,7 +7485,7 @@ D005785	Gene Conversion	Conversion, Gene|Conversions, Gene|Gene Conversions
 D005786	Gene Expression Regulation	Gene Action Regulation|Regulation, Gene Expression|Regulation of Gene Expression|Regulation, Gene Action|Expression Regulation, Gene
 D005787	Gene Frequency	Frequencies, Gene|Frequency, Gene|Gene Frequencies|Allele Frequency|Allele Frequencies|Frequencies, Allele|Frequency, Allele
 D005788	Gene Pool	Gene Pools|Pool, Gene|Pools, Gene
-D005789	Genealogy and Heraldry	Heraldry and Geneology|Geneology and Heraldry|Heraldry and Genealogy
+D005789	Genealogy and Heraldry	Geneology and Heraldry|Heraldry and Geneology|Heraldry and Genealogy
 D005790	General Adaptation Syndrome	Adaptation Syndrome, General|Adaptation Syndromes, General|General Adaptation Syndromes|Syndrome, General Adaptation|Syndromes, General Adaptation
 D005791	Patient Care	Care, Patient
 D005792	General Practice, Dental	Dental General Practices|Practice, Dental General|Practices, Dental General|Dental General Practice|General Practices, Dental
@@ -7079,7 +7498,7 @@ D005798	Genes, Bacterial	Bacterial Genes|Gene, Bacterial|Bacterial Gene
 D005799	Genes, Dominant	Dominant Gene|Dominant Genes|Gene, Dominant
 D005800	Genes, Fungal	Fungal Genes|Fungal Gene|Gene, Fungal
 D005801	Genes, Homeobox	Gene, Homeobox|Homeobox Gene|Homeobox Genes|Genes, Homeotic|Gene, Homeotic|Homeotic Gene|Hox Genes|Gene, Hox|Genes, Hox|Hox Gene|Genes, Homeo Box|Gene, Homeo Box|Homeo Box Gene|Homeo Box Genes|Homeotic Genes
-D005802	Genes, MHC Class II	Genes, Class II|MHC Class II Genes|Class II Genes|Class II Gene|Gene, Class II|Genes, HLA Class II
+D005802	Genes, MHC Class II	MHC Class II Genes|Genes, HLA Class II|Class II Genes|Class II Gene|Gene, Class II|Genes, Class II
 D005803	Genes, Immunoglobulin	Immunoglobulin Genes|Gene, Immunoglobulin|Immunoglobulin Gene|Genes, Ig|Gene, Ig|Ig Gene|Ig Genes
 D005804	Genes, Lethal	Gene, Lethal|Lethal Gene|Lethal Genes
 D005805	Genes, MHC Class I	MHC Class I Genes|Class I Genes|Class I Gene|Gene, Class I|Genes, Class I
@@ -7103,15 +7522,15 @@ D005824	Genetics, Behavioral	Behavioral Genetics
 D005826	Genetics, Medical	Medical Genetics
 D005827	Genetics, Microbial	Microbial Genetics|Genetic, Microbial|Microbial Genetic
 D005828	Genetics, Population	Population Genetics
-D005829	Geniculate Bodies	Bodies, Geniculate|Geniculate Body|Metathalamus|Geniculate Nucleus|Nucleus, Geniculate
+D005829	Geniculate Bodies	Bodies, Geniculate|Geniculate Body|Geniculate Nucleus|Nucleus, Geniculate|Metathalamus
 D005830	Geniculate Ganglion	Ganglion, Geniculate|Geniculate Ganglia|Ganglia, Geniculate
 D005831	Genital Diseases, Female	Gynecologic Diseases|Diseases, Gynecologic|Gynecologic Disease|Female Genital Diseases|Diseases, Female Genital|Female Genital Disease|Genital Disease, Female
 D005832	Genital Diseases, Male	Disease, Male Genital|Diseases, Male Genital|Genital Disease, Male|Male Genital Disease|Male Genital Diseases
 D005833	Genital Neoplasms, Female	Neoplasms, Female Genital|Gynecologic Neoplasms|Neoplasms, Gynecologic|Gynecologic Neoplasm|Neoplasm, Gynecologic|Female Genital Neoplasms|Female Genital Neoplasm|Genital Neoplasm, Female|Neoplasm, Female Genital
 D005834	Genital Neoplasms, Male	Neoplasms, Male Genital|Male Genital Neoplasms|Genital Neoplasm, Male|Male Genital Neoplasm|Neoplasm, Male Genital
 D005835	Genitalia	Genital Organs|Genital Organ|Organ, Genital|Organs, Genital|Genital System|Genital Systems|System, Genital|Systems, Genital|Genitals|Genital|Reproductive Organs|Organ, Reproductive|Organs, Reproductive|Reproductive Organ|Reproductive System|Reproductive Systems|System, Reproductive|Systems, Reproductive
-D005836	Genitalia, Female	Female Genitalia|Genitals, Female|Female Genital|Female Genitals|Genital, Female|Genital Organs, Female|Female Genital Organs|Organs, Female Genital|Reproductive System, Female|Female Reproductive System|Female Reproductive Systems|Reproductive Systems, Female|System, Female Reproductive|Systems, Female Reproductive
-D005837	Genitalia, Male	Male Genitalia|Genitals, Male|Genital, Male|Male Genital|Male Genitals|Genital Organs, Male|Male Genital Organs|Organs, Male Genital|Reproductive System, Male|Male Reproductive System|Male Reproductive Systems|Reproductive Systems, Male|System, Male Reproductive|Systems, Male Reproductive
+D005836	Genitalia, Female	Female Genitalia|Genital Organs, Female|Female Genital Organ|Female Genital Organs|Genital Organ, Female|Genitals, Female|Female Genital|Female Genitals|Genital, Female
+D005837	Genitalia, Male	Male Genitalia|Genital Organs, Male|Male Genital Organs|Genitals, Male|Genital, Male|Male Genital|Male Genitals
 D005838	Genotype	Genotypes
 D005839	Gentamicins	Gentamycins
 D005840	Gentian Violet	Violet, Gentian|Methylrosaniline Chloride|Chloride, Methylrosaniline|Methyl Violet|Violet, Methyl|Crystal Violet|Violet, Crystal|Hexamethylpararosaniline Chloride|Chloride, Hexamethylpararosaniline
@@ -7201,11 +7620,11 @@ D005925	Glomus Jugulare Tumor	Jugulare Tumor, Glomus|Jugulare Tumors, Glomus|Tum
 D005926	Glossalgia	Glossalgias|Glossodynia|Glossodynias
 D005927	Glossectomy	Glossectomies
 D005928	Glossitis	Glossitides
-D005929	Glossitis, Benign Migratory	Benign Migratory Glossitis|Migratory Glossitis, Benign|Geographic Tongue|Glossitis Areata Exfoliativa|Erythema Migrans, Lingual|Erythema Migran, Lingual|Lingual Erythema Migran|Lingual Erythema Migrans|Migran, Lingual Erythema|Migrans, Lingual Erythema|Tongue, Geographic
+D005929	Glossitis, Benign Migratory	Benign Migratory Glossitis|Migratory Glossitis, Benign|Geographic Tongue|Glossitis Areata Exfoliativa|Erythema Migrans, Lingual|Lingual Erythema Migrans|Tongue, Geographic
 D005930	Glossopharyngeal Nerve	Glossopharyngeal Nerves|Nerve, Glossopharyngeal|Nerves, Glossopharyngeal|Ninth Cranial Nerve|Cranial Nerve, Ninth|Cranial Nerves, Ninth|Nerve, Ninth Cranial|Nerves, Ninth Cranial|Ninth Cranial Nerves|Cranial Nerve IX|Cranial Nerve IXs
 D005931	Glottis	
 D005932	Gloves, Surgical	Surgical Gloves|Glove, Surgical|Surgical Glove
-D005934	Glucagon	Proglucagon (33-61)|HG-Factor|HG Factor|Hyperglycemic-Glycogenolytic Factor|Hyperglycemic Glycogenolytic Factor|Glucagon (1-29)|Glukagon
+D005934	Glucagon	Proglucagon (33-61)|HG-Factor|HG Factor|Glukagon|Glucagon (1-29)|Hyperglycemic-Glycogenolytic Factor|Hyperglycemic Glycogenolytic Factor
 D005935	Glucagonoma	Glucagonomas|alpha-Cell Tumor|Tumor, alpha-Cell|Tumors, alpha-Cell|alpha Cell Tumor|alpha-Cell Tumors|Glucagonoma Syndrome|Glucagonoma Syndromes|Syndrome, Glucagonoma|Syndromes, Glucagonoma|Adenoma, alpha-Cell|Adenoma, alpha Cell|Adenomas, alpha-Cell|alpha-Cell Adenoma|alpha-Cell Adenomas
 D005936	Glucans	Glucose Polymer|Polymer, Glucose|Polyglucoses
 D005937	Glucaric Acid	D-Saccharic Acid|D Saccharic Acid|Saccharic Acid|Acid, Saccharic|Tetrahydroxyadipic Acid|D-Glucaric Acid|D Glucaric Acid|Glucosaccharic Acid
@@ -7251,7 +7670,7 @@ D005979	Glutathione Peroxidase	Peroxidase, Glutathione
 D005980	Glutathione Reductase	Reductase, Glutathione|Glutathione-Disulfide Reductase|Reductase, Glutathione-Disulfide
 D005981	Glutathione Synthase	Synthase, Glutathione|Glutathione Synthetase|Synthetase, Glutathione
 D005982	Glutathione Transferase	Transferase, Glutathione|Glutathione S-Alkyltransferase|Glutathione S Alkyltransferase|S-Alkyltransferase, Glutathione|Glutathione S-Aryltransferase|Glutathione S Aryltransferase|S-Aryltransferase, Glutathione|Glutathione S-Epoxidetransferase|Glutathione S Epoxidetransferase|S-Epoxidetransferase, Glutathione|S-Hydroxyalkyl Glutathione Lyase|Glutathione Lyase, S-Hydroxyalkyl|Lyase, S-Hydroxyalkyl Glutathione|S Hydroxyalkyl Glutathione Lyase|Glutathione Transferases|Transferases, Glutathione|Heme Transfer Protein|Protein, Heme Transfer|Transfer Protein, Heme|Ligandin|Ligandins|Glutathione Organic Nitrate Ester Reductase|Glutathione S-Transferase|Glutathione S Transferase|S-Transferase, Glutathione
-D005983	Glutens	Gluten Proteins|Proteins, Gluten
+D005983	Glutens	Gluten Proteins|Gluten
 D005984	Glutethimide	
 D005985	Glyceraldehyde	
 D005986	Glyceraldehyde 3-Phosphate	Glyceraldehyde 3 Phosphate|3-Phosphoglyceraldehyde|3 Phosphoglyceraldehyde
@@ -7394,7 +7813,7 @@ D006127	Group Structure	Group Structures|Structure, Group|Structures, Group
 D006128	Growth	
 D006130	Growth Disorders	Disorder, Growth|Growth Disorder|Stunted Growth|Growth, Stunted|Stunting|Stuntings
 D006131	Growth Inhibitors	Inhibitors, Growth|Cell Growth Inhibitors|Growth Inhibitors, Cell|Inhibitors, Cell Growth
-D006132	Growth Plate	Growth Plates|Plate, Growth|Plates, Growth|Epiphyseal Cartilage|Cartilage, Epiphyseal|Cartilages, Epiphyseal|Epiphyseal Cartilages|Epiphyseal Plate|Epiphyseal Plates|Plate, Epiphyseal|Plates, Epiphyseal
+D006132	Growth Plate	Growth Plates|Plate, Growth|Plates, Growth|Cartilage, Epiphyseal|Cartilages, Epiphyseal|Epiphyseal Cartilages|Epiphyseal Cartilage|Epiphyseal Plate|Epiphyseal Plates|Plate, Epiphyseal|Plates, Epiphyseal
 D006133	Growth Substances	
 D006135	Gryllidae	Crickets|Cricket
 D006136	GTP Cyclohydrolase	Cyclohydrolase, GTP|GTP 8-Formylhydrolase|8-Formylhydrolase, GTP|GTP 8 Formylhydrolase|GTP Ring-Opening Enzyme|GTP Ring Opening Enzyme|Ring-Opening Enzyme, GTP|GTP Dihydrolase|Dihydrolase, GTP|7,8-Dihydroneopterintriphosphate Synthetase|7,8 Dihydroneopterintriphosphate Synthetase|Synthetase, 7,8-Dihydroneopterintriphosphate
@@ -7435,7 +7854,7 @@ D006175	Gynatresia	Gynatresias
 D006176	Gynecology	
 D006177	Gynecomastia	Male Breast Enlargement|Breast Enlargement, Male|Enlargement, Male Breast
 D006178	Roma	Romany|Gipsies|Gipsy|Romanies|Romani|Gypsies|Gypsy
-D006179	Gyrus Cinguli	Cingulate Area|Area, Cingulate|Areas, Cingulate|Cingulate Areas|Gyrus, Cingulate|Cingulate Gyrus|Cingulate Region|Cingulate Regions|Region, Cingulate|Regions, Cingulate|Cingular Gyrus|Gyrus, Cingular|Cingulate Body|Bodies, Cingulate|Body, Cingulate|Cingulate Bodies
+D006179	Gyrus Cinguli	Cingulate Gyrus|Cingulate Body|Bodies, Cingulate|Body, Cingulate|Cingulate Bodies|Cingulate Area|Area, Cingulate|Areas, Cingulate|Cingulate Areas|Cingulate Region|Cingulate Regions|Region, Cingulate|Regions, Cingulate|Gyrus, Cingulate|Cingular Gyrus|Gyrus, Cingular
 D006180	Proton-Translocating ATPases	Proton-Translocating ATPase Complex|ATPase Complex, Proton-Translocating|Proton Translocating ATPase Complex|ATPase, F(1)F(0)|F(1)F(0)-ATPase|ATPase, F0F1|F0F1 ATPase|F(0)F(1)-ATP Synthase|H+ ATPase|ATPase, H+|ATPase, H(+)|Proton-Translocating ATPase Complexes|ATPase Complexes, Proton-Translocating|Complexes, Proton-Translocating ATPase|Proton Translocating ATPase Complexes|ATP Dependent Proton Translocase|F1F0 ATPase Complex|H(+)-Transporting ATPase|H(+)-ATPase|H+-Translocating ATPase|ATPase, H+-Translocating|H+ Translocating ATPase|Proton-Translocating ATPase|ATPase, Proton-Translocating|Proton Translocating ATPase|H+ Transporting ATP Synthase|H(+)-Transporting ATP Synthase|Adenosine Triphosphatase Complex|Complex, Adenosine Triphosphatase|Triphosphatase Complex, Adenosine|H(+)ATPase Complex
 D006181	H-Reflex	H Reflex|Reflex, H|H-Reflexes|H Reflexes
 D006182	H-Y Antigen	Antigen, H-Y|H Y Antigen|HY Antigen|Antigen, HY|GA-1 Germ Cell Antigen|GA 1 Germ Cell Antigen
@@ -7452,8 +7871,8 @@ D006194	Gardnerella vaginalis	Hemophilus vaginalis|Corynebacterium vaginale|Haem
 D006195	Hafnium	
 D006196	Hagfishes	Hagfishe|Hagfish|Hagfishs
 D006197	Hair	Hairs
-D006198	Hair Cells, Auditory	Auditory Hair Cell|Hair Cell, Auditory|Cochlear Hair Cells|Cell, Cochlear Hair|Cells, Cochlear Hair|Cochlear Hair Cell|Hair Cell, Cochlear|Hair Cells, Cochlear|Auditory Hair Cells
-D006199	Hair Cells, Auditory, Inner	Inner Hair Cells|Cell, Inner Hair|Cells, Inner Hair|Hair Cell, Inner|Hair Cells, Inner|Inner Hair Cell|Cochlear Inner Hair Cells|Inner Auditory Hair Cells|Auditory Hair Cells, Inner|Hair Cell, Auditory, Inner|Inner Auditory Hair Cell|Cochlear Inner Hair Cell|Auditory Hair Cell, Inner
+D006198	Hair Cells, Auditory	Auditory Hair Cell|Hair Cell, Auditory|Auditory Hair Cells|Cochlear Hair Cells|Cell, Cochlear Hair|Cells, Cochlear Hair|Cochlear Hair Cell|Hair Cell, Cochlear|Hair Cells, Cochlear
+D006199	Hair Cells, Auditory, Inner	Cochlear Inner Hair Cells|Cochlear Inner Hair Cell|Inner Auditory Hair Cells|Inner Auditory Hair Cell|Auditory Hair Cells, Inner|Hair Cell, Auditory, Inner|Auditory Hair Cell, Inner|Inner Hair Cells|Cell, Inner Hair|Cells, Inner Hair|Hair Cell, Inner|Hair Cells, Inner|Inner Hair Cell
 D006200	Hair Color	Color, Hair|Colors, Hair|Hair Colors
 D006201	Hair Diseases	Hair Disease
 D006202	Hair Dyes	Dyes, Hair|Hair Colorants|Colorants, Hair|Coloring Agents, Hair|Agents, Hair Coloring|Hair Coloring Agents
@@ -7489,7 +7908,7 @@ D006232	Hand, Foot and Mouth Disease	Hand, Foot, Mouth Disease
 D006233	Disabled Persons	Disabled Person|Person, Disabled|Persons, Disabled|Persons with Disabilities|Disabilities, Persons with|Disability, Persons with|Persons with Disability|Handicapped|People with Disabilities|Disabilities, People with|People with Disability
 D006234	Handling (Psychology)	Handlings (Psychology)|Handling
 D006235	Hand Disinfection	Disinfection, Hand
-D006236	Handwriting	Handwritings
+D006236	Handwriting	
 D006238	Haploidy	Haploidies|Haploid|Haploids
 D006239	Haplotypes	Haplotype
 D006240	Happiness	Happinesses
@@ -7531,8 +7950,8 @@ D006276	Health Facility Size	Facility Size, Health|Facility Sizes, Health|Health
 D006277	Health Fairs	Fair, Health|Fairs, Health|Health Fair
 D006278	Medicare	Health Insurance for Aged, Disabled, Title 18|Health Insurance for Aged, Title 18|Health Insurance for Aged and Disabled, Title 18
 D006279	Health Maintenance Organizations	Prepaid Group Health Organizations|HMO|Organizations, Health Maintenance|Group Health Organizations, Prepaid|Health Maintenance Organization|Organization, Health Maintenance
-D006280	Health Manpower	Manpower, Health|Health Workforce|Workforce, Health|Manpower, Health Occupations|Health Occupations Manpower
-D006281	Health Occupations	Health Occupation|Occupation, Health|Occupations, Health|Health Professions|Health Profession|Profession, Health|Professions, Health
+D006280	Health Workforce	Workforce, Health|Health Manpower|Health Occupations Manpower|Manpower, Health|Manpower, Health Occupations
+D006281	Health Occupations	Health Occupation|Health Professions|Health Profession|Profession, Health|Professions, Health
 D006282	Health Personnel	Personnel, Health|Health Care Providers|Health Care Provider|Provider, Health Care|Providers, Health Care|Healthcare Providers|Healthcare Provider|Provider, Healthcare|Providers, Healthcare|Healthcare Workers|Healthcare Worker
 D006283	Health Physics	Physics, Health|Radiologic Physics|Physics, Radiologic
 D006284	Health Plan Implementation	Health Plan Implementations|Implementation, Health Plan|Implementations, Health Plan|Plan Implementation, Health|Plan Implementations, Health
@@ -7547,13 +7966,13 @@ D006292	Health Priorities	Priorities, Health|Health Priority|Priority, Health
 D006293	Health Promotion	Promotion, Health|Promotions, Health|Promotion of Health|Health Promotions
 D006294	Health Resorts	Health Resort|Resort, Health|Resorts, Health
 D006295	Health Resources	Health Resource|Resource, Health|Resources, Health
-D006296	Health Services	Services, Health|Health Service|Service, Health
+D006296	Health Services	Health Service|Services, Health
 D006297	Health Services Accessibility	Availability of Health Services|Health Services Availability|Accessibility, Health Services|Access to Health Care|Accessibility of Health Services
 D006298	Health Services Administration	Administration, Health Services
 D006299	Health Services for the Aged	Geriatric Health Services|Health Services for the Elderly|Health Services, Geriatric|Geriatric Health Service|Health Service, Geriatric|Service, Geriatric Health|Services, Geriatric Health|Health Services for Aged
 D006300	Health Services Misuse	Health Services Misuses|Misuses, Health Services|Misuse, Health Services|Misuse of Health Services
 D006301	Health Services Needs and Demand	Needs and Demand, Health Services
-D006302	Health Services Research	Health Services Evaluation|Evaluation, Health Services|Evaluations, Health Services|Health Services Evaluations|Healthcare Research|Research, Healthcare|Research, Health Services|Research, Medical Care|Health Care Research|Research, Health Care|Medical Care Research
+D006302	Health Services Research	Health Services Evaluation|Evaluation, Health Services|Evaluations, Health Services|Health Services Evaluations|Research, Medical Care|Medical Care Research|Research, Health Services|Health Care Research|Research, Health Care|Healthcare Research|Research, Healthcare
 D006303	Health Services, Indigenous	Indigenous Services, Health|Health Indigenous Service|Health Indigenous Services|Indigenous Service, Health|Service, Health Indigenous|Services, Health Indigenous|Indigenous Health Services|Health Service, Indigenous|Indigenous Health Service|Service, Indigenous Health|Services, Indigenous Health
 D006304	Health Status	Status, Health|Level of Health|Health Level|Health Levels
 D006305	Health Status Indicators	Health Status Indicator|Indicator, Health Status|Indicators, Health Status|Health Status Index|Health Status Indices|Index, Health Status|Indices, Health Status|Health Status Indexes|Indexes, Health Status
@@ -7661,7 +8080,7 @@ D006408	Hematoma, Subdural	Hematomas, Subdural|Subdural Hematomas|Subdural Hemat
 D006409	Hematometra	Hematometras
 D006410	Hematopoiesis	Haematopoiesis
 D006411	Hematopoiesis, Extramedullary	Extramedullary Hematopoieses|Extramedullary Hematopoiesis|Hematopoieses, Extramedullary
-D006412	Hematopoietic Stem Cells	Progenitor Cells, Hematopoietic|Hematopoietic Progenitor Cells|Cell, Hematopoietic Progenitor|Cells, Hematopoietic Progenitor|Hematopoietic Progenitor Cell|Progenitor Cell, Hematopoietic|Stem Cells, Hematopoietic|Cell, Hematopoietic Stem|Cells, Hematopoietic Stem|Hematopoietic Stem Cell|Stem Cell, Hematopoietic
+D006412	Hematopoietic Stem Cells	Cell, Hematopoietic Stem|Cells, Hematopoietic Stem|Hematopoietic Stem Cell|Stem Cell, Hematopoietic|Hematopoietic Progenitor Cells|Cell, Hematopoietic Progenitor|Cells, Hematopoietic Progenitor|Hematopoietic Progenitor Cell|Progenitor Cell, Hematopoietic|Progenitor Cells, Hematopoietic|Stem Cells, Hematopoietic
 D006413	Hematopoietic System	Hematopoietic Systems|System, Hematopoietic
 D006414	Hematoporphyrin Photoradiation	Photochemotherapy, Hematoporphyrin|Hematoporphyrin Photochemotherapy|Photoradiation, Hematoporphyrin
 D006415	Hematoporphyrins	
@@ -7725,7 +8144,7 @@ D006473	Postpartum Hemorrhage	Hemorrhage, Postpartum
 D006474	Hemorrhagic Disorders	Disorder, Hemorrhagic|Disorders, Hemorrhagic|Hemorrhagic Disorder|Hemorrhagic Diathesis|Diatheses, Hemorrhagic|Diathesis, Hemorrhagic|Hemorrhagic Diatheses
 D006475	Vitamin K Deficiency Bleeding	
 D006476	Hantavirus	Hantaviruses
-D006477	Arenaviruses, New World	Tacaribe Complex Viruses|New World Arenaviruses|American Hemorrhagic Fever Virus|Hemorrhagic Fever Viruses, American
+D006477	Arenaviruses, New World	Hemorrhagic Fever Viruses, American|New World Arenaviruses|American Hemorrhagic Fever Virus|Tacaribe Complex Viruses
 D006478	Hemorrhagic Fever, American	American Hemorrhagic Fever|Fever, American Hemorrhagic
 D006479	Hemorrhagic Fever, Crimean	Crimean Hemorrhagic Fever|Crimean Hemorrhagic Fevers|Fever, Crimean Hemorrhagic|Congo Virus Infection|Crimean-Congo Hemorrhagic Fever|Crimean Congo Hemorrhagic Fever|Crimean-Congo Hemorrhagic Fevers|Fever, Crimean-Congo Hemorrhagic|Hemorrhagic Fever, Crimean-Congo|Infection, Congo Virus|Congo Virus Infections
 D006480	Hemorrhagic Fever with Renal Syndrome	Hemorrhagic Fever, Korean|Korean Hemorrhagic Fever|HFRS|Hemorrhagic Fever, Epidemic|Epidemic Hemorrhagic Fever|Epidemic Hemorrhagic Fevers|Hemorrhagic Fevers, Epidemic|Hemorrhagic Nephroso-Nephritis|Hemorrhagic Nephroso Nephritis|Hemorrhagic Nephroso-Nephritides|Nephroso-Nephritides, Hemorrhagic|Nephroso-Nephritis, Hemorrhagic
@@ -7796,7 +8215,7 @@ D006552	Hernia, Inguinal	Hernias, Inguinal|Inguinal Hernias|Inguinal Hernia
 D006553	Hernia, Obturator	Obturator Hernia|Hernias, Obturator|Obturator Hernias
 D006554	Hernia, Umbilical	Exomphalos|Umbilical Hernia|Hernias, Umbilical|Umbilical Hernias
 D006555	Hernia, Ventral	Hernias, Ventral|Ventral Hernias|Ventral Hernia
-D006556	Heroin Dependence	Dependence, Heroin|Heroin Abuse|Abuse, Heroin|Heroin Addiction|Addiction, Heroin
+D006556	Heroin Dependence	Dependence, Heroin|Heroin Addiction|Addiction, Heroin
 D006557	Herpangina	Herpanginas
 D006558	Herpes Genitalis	Genital Herpes|Herpes, Genital|Herpes Simplex Virus Genital Infection|Herpes Simplex, Genital|Genital Herpes Simplex
 D006559	Pemphigoid Gestationis	Gestationi, Pemphigoid|Gestationis, Pemphigoid|Pemphigoid Gestationi|Herpes Gestationis|Gestational Pemphigoid|Gestational Pemphigoids|Pemphigoid, Gestational|Pemphigoids, Gestational
@@ -7807,7 +8226,7 @@ D006563	Herpes Zoster Ophthalmicus	Herpes Zoster, Ocular|Ocular Herpes Zoster
 D006564	Herpesviridae	Herpesviruses
 D006566	Herpesviridae Infections	Infections, Herpesviridae|Herpesviridae Infection|Infection, Herpesviridae|Infections, Herpesvirus|Herpesvirus Infection|Infection, Herpesvirus|Herpesvirus Infections
 D006567	Herpesvirus 2, Saimiriine	Saimiriine Herpesvirus 2|Saimirine Herpesvirus 2|Herpesvirus 2, Saimirine|Herpesvirus Saimiri|Herpesvirus Saimirus|Saimiri, Herpesvirus|Saimirus, Herpesvirus|Herpesvirus 2 (gamma), Saimirine
-D006568	Herpesvirus 1, Cercopithecine	Herpesvirus Simiae|Simiae, Herpesvirus|B Virus|B Viruses|Herpesvirus 1 (alpha), Cercopithecine|Monkey B Virus|Monkey B Viruses|Simian Herpesvirus|Herpesvirus, Simian|Herpesviruses, Simian|Simian Herpesviruses|Herpes B Virus|Herpes B Viruses|Herpes Virus B|Cercopithecine Herpesvirus 1|Herpesvirus B
+D006568	Herpesvirus 1, Cercopithecine	Herpesvirus Simiae|Simiae, Herpesvirus|B Virus|B Viruses|Herpesvirus 1 (alpha), Cercopithecine|Macacine Herpesvirus 1|Herpesvirus 1, Macacine|Simian Herpesvirus|Herpesvirus, Simian|Herpesviruses, Simian|Simian Herpesviruses|Herpes B Virus|Herpes B Viruses|Herpes Virus B|Monkey B Virus|Monkey B Viruses|Macacine alphaherpesvirus 1|alphaherpesvirus 1, Macacine|Cercopithecine Herpesvirus 1|Herpesvirus B
 D006569	Hesperidin	Hesperetin 7-Rhamnoglucoside|7-Rhamnoglucoside, Hesperetin|Hesperetin 7 Rhamnoglucoside|Hesperetin-7-Rutinoside|Hesperetin 7 Rutinoside
 D006570	Heterochromatin	Heterochromatins
 D006571	Heterocyclic Compounds	Compounds, Heterocyclic
@@ -7837,7 +8256,7 @@ D006595	Hexosamines
 D006596	Hexosaminidases	Hexosaminidase
 D006597	Fructose-Bisphosphatase	Fructose Bisphosphatase|D-Fructose-1,6-Bisphosphate 1-Phosphohydrolase|1-Phosphohydrolase, D-Fructose-1,6-Bisphosphate|D Fructose 1,6 Bisphosphate 1 Phosphohydrolase|FDPase|Fructosediphosphatase|Fructose-1,6-Bisphosphatase|Fructose 1,6 Bisphosphatase|Fructose-1,6-Diphosphatase|Fructose 1,6 Diphosphatase|Hexosediphosphatase|Fructose-1,6-Biphosphatase|Fructose 1,6 Biphosphatase
 D006598	Hexosediphosphates	
-D006599	UDPglucose-Hexose-1-Phosphate Uridylyltransferase	Uridylyltransferase, UDPglucose-Hexose-1-Phosphate|Hexosephosphate Uridylyltransferase|Uridylyltransferase, Hexosephosphate|Phosphogalactose Uridyl Transferase|Transferase, Phosphogalactose Uridyl|Uridyl Transferase, Phosphogalactose|Galactose-1-P-Uridyltransferase|Galactose 1 P Uridyltransferase|Uridyl Transferase|Transferase, Uridyl
+D006599	UDPglucose-Hexose-1-Phosphate Uridylyltransferase	Uridylyltransferase, UDPglucose-Hexose-1-Phosphate|Phosphogalactose Uridyl Transferase|Transferase, Phosphogalactose Uridyl|Uridyl Transferase, Phosphogalactose|Uridyl Transferase|Transferase, Uridyl|Galactose-1-P-Uridyltransferase|Galactose 1 P Uridyltransferase|Hexosephosphate Uridylyltransferase|Uridylyltransferase, Hexosephosphate
 D006600	Hexosephosphates	
 D006601	Hexoses	
 D006602	Hexosyltransferases	
@@ -7861,15 +8280,15 @@ D006619	Hip Dysplasia, Canine	Canine Hip Dysplasia|Dysplasia, Canine Hip
 D006620	Hip Fractures	Fractures, Hip
 D006621	Hip Joint	Hip Joints|Joint, Hip|Joints, Hip|Acetabulofemoral Joint|Acetabulofemoral Joints|Joint, Acetabulofemoral|Joints, Acetabulofemoral
 D006622	Hip Prosthesis	Hip Prostheses|Prostheses, Hip|Prosthesis, Hip
-D006623	von Hippel-Lindau Disease	von Hippel Lindau Disease|Familial Cerebello-Retinal Angiomatosis|Angiomatoses, Familial Cerebello-Retinal|Angiomatosis, Familial Cerebello-Retinal|Cerebello-Retinal Angiomatoses, Familial|Cerebello-Retinal Angiomatosis, Familial|Familial Cerebello Retinal Angiomatosis|Familial Cerebello-Retinal Angiomatoses|Hippel-Lindau Disease|Hippel Lindau Disease|Lindau Disease|von Hippel-Lindau Syndrome|Syndrome, von Hippel-Lindau|von Hippel Lindau Syndrome|Angiomatosis Retinae|Retinae, Angiomatosis|VHL Syndrome|Syndrome, VHL|Syndromes, VHL|VHL Syndromes|Cerebelloretinal Angiomatosis, Familial|Angiomatoses, Familial Cerebelloretinal|Angiomatosis, Familial Cerebelloretinal|Cerebelloretinal Angiomatoses, Familial|Familial Cerebelloretinal Angiomatoses|Familial Cerebelloretinal Angiomatosis|Lindau's Disease|Lindau's Diseases|Lindaus Disease
-D006624	Hippocampus	Hippocampus Proper|Hippocampus Propers|Proper, Hippocampus|Propers, Hippocampus|Cornu Ammonis|Ammon Horn|Horn, Ammon|Ammon's Horn|Ammons Horn|Horn, Ammon's
+D006623	von Hippel-Lindau Disease	von Hippel Lindau Disease|Familial Cerebello-Retinal Angiomatosis|Angiomatoses, Familial Cerebello-Retinal|Angiomatosis, Familial Cerebello-Retinal|Cerebello-Retinal Angiomatoses, Familial|Cerebello-Retinal Angiomatosis, Familial|Familial Cerebello Retinal Angiomatosis|Familial Cerebello-Retinal Angiomatoses|Hippel-Lindau Disease|Hippel Lindau Disease|VHL Syndrome|VHL Syndromes|Lindau's Disease|Lindau's Diseases|Lindaus Disease|von Hippel-Lindau Syndrome|von Hippel Lindau Syndrome|Angiomatosis Retinae|Cerebelloretinal Angiomatosis, Familial|Angiomatoses, Familial Cerebelloretinal|Angiomatosis, Familial Cerebelloretinal|Cerebelloretinal Angiomatoses, Familial|Familial Cerebelloretinal Angiomatoses|Familial Cerebelloretinal Angiomatosis|Lindau Disease
+D006624	Hippocampus	Hippocampus Proper|Hippocampus Propers|Proper, Hippocampus|Propers, Hippocampus|Ammon Horn|Horn, Ammon|Ammon's Horn|Ammons Horn|Horn, Ammon's|Cornu Ammonis
 D006625	Hippocratic Oath	Oath, Hippocratic
 D006626	Hippurates	
 D006627	Hirschsprung Disease	Disease, Hirschsprung|Megacolon, Congenital|Hirschsprung's Disease|Disease, Hirschsprung's|Hirschsprungs Disease|Megacolon, Aganglionic|Aganglionic Megacolon|Congenital Megacolon
 D006628	Hirsutism	
 D006629	Hirudins	
 D006630	Hispanic Americans	American, Hispanic|Americans, Hispanic|Hispanic American|Spanish Americans|Americans, Spanish|Spanish American
-D006631	Amine Oxidase (Copper-Containing)	Copper Amine Oxidase|Amine Oxidase, Copper|Oxidase, Copper Amine|Semicarbazide-Sensitive Amine Oxidase|Amine Oxidase, Semicarbazide-Sensitive|Oxidase, Semicarbazide-Sensitive Amine|Semicarbazide Sensitive Amine Oxidase|Amine Oxidase, Copper-Containing|Amine Oxidase, Copper Containing|Copper-Containing Amine Oxidase|Oxidase, Copper-Containing Amine
+D006631	Amine Oxidase (Copper-Containing)	Histaminase|Copper Amine Oxidase|Amine Oxidase, Copper|Oxidase, Copper Amine|Amine Oxidase, Copper-Containing|Amine Oxidase, Copper Containing|Copper-Containing Amine Oxidase|Oxidase, Copper-Containing Amine|Diamine Oxidase|Oxidase, Diamine|Semicarbazide-Sensitive Amine Oxidase|Amine Oxidase, Semicarbazide-Sensitive|Oxidase, Semicarbazide-Sensitive Amine|Semicarbazide Sensitive Amine Oxidase
 D006632	Histamine	
 D006633	Histamine Antagonists	Antagonists, Histamine|Antihistamines
 D006634	Histamine H1 Antagonists	H1 Antagonists, Histamine|Antagonists, Histamine H1 Receptor|Antihistaminics, H1|H1 Antihistaminics|Receptor Blockaders, H1|H1 Receptor Blockaders|Histamine H1 Blockers|Histamine H1 Receptor Antagonists|Histamine H1 Receptor Blockaders|Antagonists, Histamine H1|Blockaders, Histamine H1 Receptor
@@ -7899,9 +8318,9 @@ D006659	Histoplasmin
 D006660	Histoplasmosis	Histoplasmoses|Histoplasma Infection|Histoplasma Infections|Infection, Histoplasma|Infections, Histoplasma
 D006663	Historiography	Historiographies
 D006664	History	Histories
-D006665	History of Dentistry	Dentistry Histories|Dentistry History|Dentistry, History|Dentistries, History|History Dentistries|History Dentistry
-D006666	History of Medicine	Medicine, History
-D006676	History of Nursing	Nursing Histories|Nursing History|Nursing, History|History Nursing|History Nursings|Nursings, History
+D006665	History of Dentistry	Dentistry Histories|Dentistry, History
+D006666	History of Medicine	Medicine Histories|Medicine, History|History Medicines|Medicines, History
+D006676	History of Nursing	Nursing History|Nursing, History|History Nursing
 D006677	Histrionic Personality Disorder	Personality, Hysterical|Hysterical Personality|Hysterical Personalities|Personalities, Hysterical|Personality Disorder, Histrionic|Disorder, Histrionic Personality|Disorders, Histrionic Personality|Histrionic Personality Disorders|Personality Disorders, Histrionic
 D006678	HIV	Human Immunodeficiency Virus|Immunodeficiency Virus, Human|Immunodeficiency Viruses, Human|Virus, Human Immunodeficiency|Viruses, Human Immunodeficiency|Human Immunodeficiency Viruses|Human T Cell Lymphotropic Virus Type III|Human T-Cell Lymphotropic Virus Type III|Human T-Cell Leukemia Virus Type III|Human T Cell Leukemia Virus Type III|LAV-HTLV-III|Lymphadenopathy-Associated Virus|Lymphadenopathy Associated Virus|Lymphadenopathy-Associated Viruses|Virus, Lymphadenopathy-Associated|Viruses, Lymphadenopathy-Associated|Human T Lymphotropic Virus Type III|Human T-Lymphotropic Virus Type III|AIDS Virus|AIDS Viruses|Virus, AIDS|Viruses, AIDS|Acquired Immune Deficiency Syndrome Virus|Acquired Immunodeficiency Syndrome Virus|HTLV-III
 D006679	HIV Seropositivity	HIV Seropositivities|Seropositivities, HIV|Seropositivity, HIV|AIDS Seropositivity|AIDS Seropositivities|Seropositivities, AIDS|Seropositivity, AIDS|Anti-HIV Positivity|Anti HIV Positivity|Anti-HIV Positivities|Positivities, Anti-HIV|Positivity, Anti-HIV|HTLV-III Seropositivity|HTLV III Seropositivity|HTLV-III Seropositivities|Seropositivities, HTLV-III|Seropositivity, HTLV-III|HIV Seroconversion|HIV Seroconversions|Seroconversion, HIV|Seroconversions, HIV|HTLV-III Seroconversion|HTLV III Seroconversion|HTLV-III Seroconversions|Seroconversion, HTLV-III|Seroconversions, HTLV-III|AIDS Seroconversion|AIDS Seroconversions|Seroconversion, AIDS|Seroconversions, AIDS|HIV Antibody Positivity|Antibody Positivities, HIV|Antibody Positivity, HIV|HIV Antibody Positivities|Positivities, HIV Antibody|Positivity, HIV Antibody
@@ -7915,8 +8334,8 @@ D006686	Hobbies	Hobby
 D006688	Hockey	Hockeys
 D006689	Hodgkin Disease	Disease, Hodgkin|Granuloma, Hodgkin's|Hodgkin's Granuloma|Granuloma, Hodgkins|Hodgkins Granuloma|Lymphogranuloma, Malignant|Lymphogranulomas, Malignant|Malignant Lymphogranuloma|Malignant Lymphogranulomas|Hodgkin Lymphoma|Lymphoma, Hodgkin|Hodgkin's Disease|Disease, Hodgkin's|Hodgkin's Lymphoma|Hodgkins Lymphoma|Lymphoma, Hodgkin's|Hodgkins Disease|Disease, Hodgkins|Granuloma, Hodgkin|Hodgkin Granuloma|Granuloma, Malignant|Malignant Granuloma|Malignant Granulomas
 D006690	Bisbenzimidazole	Pibenzimol
-D006691	Classical Swine Fever	Swine Fever, Classical|Hog Cholera|Cholera, Hog|Swine Fever
-D006692	Classical swine fever virus	Swine Fever Virus|Swine Fever Virus, Classical|Hog Cholera Virus|Cholera Virus, Hog
+D006691	Classical Swine Fever	Swine Fever|Swine Fever, Classical|Hog Cholera|Cholera, Hog
+D006692	Classical Swine Fever Virus	Swine Fever Virus|Hog Cholera Virus|Cholera Virus, Hog|Swine Fever Virus, Classical
 D006693	Holidays	Holiday
 D006694	Holistic Health	Health, Holistic|Wholistic Health|Health, Wholistic|Wholistic Health Care|Care, Wholistic Health|Health Care, Wholistic
 D006695	Holmium	
@@ -7924,7 +8343,7 @@ D006696	Holography
 D006697	Holothurin	
 D006698	Holtzman Inkblot Test	Inkblot Test, Holtzman|Test, Holtzman Inkblot
 D006699	Home Care Services	Home Care Service|Service, Home Care|Care Services, Home|Domiciliary Care|Care, Domiciliary|Services, Home Care
-D006700	Home Childbirth	Childbirth, Home|Childbirths, Home|Home Childbirths|Childbirth at Home|Childbirths at Home
+D006700	Home Childbirth	Childbirth, Home|Childbirths, Home|Childbirth at Home|Home Birth|Birth, Home|Births, Home|Home Births|Childbirths at Home
 D006701	Home Nursing	Home Care, Nonprofessional|Care, Nonprofessional Home|Nonprofessional Home Care|Home Care, Non-Professional|Care, Non-Professional Home|Home Care, Non Professional|Non-Professional Home Care|Nursing, Home
 D006702	Homing Behavior	Behavior, Homing|Behaviors, Homing|Homing Behaviors
 D006703	Homeless Persons	Homeless Person|Person, Homeless|Persons, Homeless
@@ -7962,8 +8381,8 @@ D006736	Horses	Horse|Horse, Domestic|Domestic Horse|Domestic Horses|Horses, Dome
 D006737	Horseshoe Crabs	Xiphosura|Xiphosuras|Crabs, Horseshoe|Crab, Horseshoe|Horseshoe Crab
 D006738	Hospices	Hospice
 D006739	Hospital Administration	Administration, Hospital
-D006740	Hospital Administrators	Hospital Administrator|Administrator, Hospital|Administrators, Hospital
-D006741	Hospital Auxiliaries	Hospital Auxiliary|Auxiliaries, Hospital|Auxiliary, Hospital
+D006740	Hospital Administrators	Administrators, Hospital|Hospital Administrator|Administrator, Hospital
+D006741	Hospital Auxiliaries	Auxiliary, Hospital|Hospital Auxiliary|Auxiliaries, Hospital
 D006742	Hospital Bed Capacity	Bed Size, Hospital|Bed Capacities, Hospital|Hospital Bed Capacities|Capacities, Hospital Bed|Capacity, Hospital Bed|Size, Hospital Bed|Bed Sizes, Hospital|Hospital Bed Size|Hospital Bed Sizes|Sizes, Hospital Bed|Bed Capacity, Hospital
 D006743	Hospital Bed Capacity, under 100	
 D006744	Hospital Bed Capacity, 100 to 299	
@@ -7980,11 +8399,11 @@ D006754	Hospital Restructuring	Hospital Reorganization|Restructuring, Hospital|H
 D006755	Hospital Shared Services	Shared Hospital Services|Hospital Services, Shared|Hospital Service, Shared|Service, Shared Hospital|Shared Hospital Service|Services, Shared Hospital|Services, Hospital Shared|Hospital Shared Service|Service, Hospital Shared|Shared Service, Hospital|Shared Services, Hospital
 D006756	Hospital Shops	Shop, Hospital|Shops, Hospital|Hospital Shop
 D006757	Hospital Units	Hospital Unit|Unit, Hospital|Units, Hospital
-D006758	Hospital Volunteers	Volunteers, Hospital|Hospital Volunteer|Volunteer, Hospital
+D006758	Hospital Volunteers	Volunteer, Hospital|Volunteers, Hospital|Hospital Volunteer
 D006759	Hospital-Physician Joint Ventures	Hospital Physician Joint Ventures|Joint Venture, Hospital-Physician|Joint Venture, Hospital Physician|Joint Ventures, Hospital-Physician|Joint Ventures, Hospital Physician|Hospital-Physician Joint Venture|Hospital Physician Joint Venture|Venture, Hospital-Physician Joint|Ventures, Hospital-Physician Joint
 D006760	Hospitalization	Hospitalizations
 D006761	Hospitals	Hospital
-D006762	Hospitals, Animal	Animal Hospital|Hospital, Animal|Veterinary Hospitals|Hospitals, Veterinary|Hospital, Veterinary|Veterinary Hospital|Animal Hospitals
+D006762	Hospitals, Animal	Animal Hospital|Hospital, Animal|Hospitals, Veterinary|Hospital, Veterinary|Veterinary Hospital|Veterinary Hospitals|Animal Hospitals
 D006763	Hospitals, Chronic Disease	Chronic Disease Hospital|Hospital, Chronic Disease|Chronic Disease Hospitals
 D006764	Hospitals, Community	Community Hospital|Community Hospitals|Hospital, Community
 D006765	Hospitals, Convalescent	Convalescent Hospital|Convalescent Hospitals|Hospital, Convalescent
@@ -8023,7 +8442,7 @@ D006797	Housekeeping, Hospital	Hospital Housekeeping|Hospital Housekeepings|Hous
 D006798	Housing	
 D006799	Housing, Animal	Animal Housing
 D006800	Deltaretrovirus Infections	Deltaretrovirus Infection|Infection, Deltaretrovirus|Infections, Deltaretrovirus|HTLV-BLV Infections|HTLV BLV Infections|HTLV-BLV Infection
-D006801	Humans	Man (Taxonomy)|Man, Modern|Modern Man|Human|Homo sapiens
+D006801	Humans	Homo sapiens|Man (Taxonomy)|Man, Modern|Modern Man|Human
 D006802	Human Activities	Activities, Human|Activity, Human|Human Activity
 D006803	Human Development	Development, Human
 D006804	Ergonomics	Ergonomic|Human Factors and Ergonomics|Human Engineering|Human Factors Engineering|Human Factors Engineerings
@@ -8115,7 +8534,7 @@ D006897	Hydroxyindoleacetic Acid	Acid, Hydroxyindoleacetic|5-Hydroxyindolamine A
 D006898	Hydroxylamines	
 D006899	Mixed Function Oxygenases	Oxygenases, Mixed Function|Monooxygenases|Hydroxylases|Mixed Function Oxidases|Oxidases, Mixed Function
 D006900	Hydroxylation	Hydroxylations
-D006901	Hydroxylysine	Lysine, 5-Hydroxy-|Lysine, 5 Hydroxy|5-Hydroxylysine|5 Hydroxylysine|(2S,5R)-2,6-Diamino-5-hydroxyhexanoic Acid|2,6-Diamino-5-hydroxyhexanoic Acid|2,6 Diamino 5 hydroxyhexanoic Acid
+D006901	Hydroxylysine	
 D006902	Hydroxymercuribenzoates	
 D006903	Hydroxymethylglutaryl CoA Reductases	Hydroxymethylglutaryl CoA Reductase|HMG CoA Reductases|3-Hydroxy-3-methylglutaryl CoA Reductase|3 Hydroxy 3 methylglutaryl CoA Reductase|CoA Reductase, 3-Hydroxy-3-methylglutaryl|Reductase, 3-Hydroxy-3-methylglutaryl CoA|HMG CoA Reductase
 D006904	Hydroxymethylglutaryl-CoA Synthase	Hydroxymethylglutaryl CoA Synthase|Synthase, Hydroxymethylglutaryl-CoA|3-hydroxy-3-methylglutaryl-coenzyme A synthase|HMG-CoA synthase
@@ -8237,8 +8656,8 @@ D007021	Hypospadias	Hypospadia
 D007022	Hypotension	Vascular Hypotension|Low Blood Pressure|Blood Pressure, Low|Hypotension, Vascular
 D007023	Hypotension, Controlled	Hypotension, Induced|Controlled Hypotension|Induced Hypotension
 D007024	Hypotension, Orthostatic	Hypotension, Postural|Postural Hypotension|Orthostatic Hypotension
-D007025	Anterior Hypothalamic Nucleus	Hypothalamic Nucleus, Anterior|Nucleus, Anterior Hypothalamic|Hypothalamic Area, Anterior|Nucleus Anterior Hypothalami|Anterior Hypothalami, Nucleus|Anterior Hypothalamus, Nucleus|Hypothalami, Nucleus Anterior|Hypothalamus, Nucleus Anterior|Nucleus Anterior Hypothalamus|Anterior Hypothalamic Area|Anterior Hypothalamic Areas|Area, Anterior Hypothalamic|Areas, Anterior Hypothalamic|Hypothalamic Areas, Anterior
-D007026	Hypothalamic Area, Lateral	Area, Lateral Hypothalamic|Areas, Lateral Hypothalamic|Hypothalamic Areas, Lateral|Lateral Hypothalamic Areas|Lateral Hypothalamus|Hypothalamus, Lateral|Lateral Hypothalamic Area|Area Hypothalamica Lateralis|Area Hypothalamica Laterali|Hypothalamica Laterali, Area|Hypothalamica Lateralis, Area|Laterali, Area Hypothalamica|Lateralis, Area Hypothalamica|Area Lateralis Hypothalami|Area Lateralis Hypothalamus|Hypothalami, Area Lateralis|Hypothalamus, Area Lateralis|Lateralis Hypothalami, Area|Lateralis Hypothalamus, Area
+D007025	Anterior Hypothalamic Nucleus	Hypothalamic Nucleus, Anterior|Nucleus, Anterior Hypothalamic|Nucleus Anterior Hypothalami|Anterior Hypothalami, Nucleus|Anterior Hypothalamus, Nucleus|Hypothalami, Nucleus Anterior|Hypothalamus, Nucleus Anterior|Nucleus Anterior Hypothalamus|Anterior Hypothalamic Area|Anterior Hypothalamic Areas|Area, Anterior Hypothalamic|Areas, Anterior Hypothalamic|Hypothalamic Areas, Anterior|Hypothalamic Area, Anterior
+D007026	Hypothalamic Area, Lateral	Area, Lateral Hypothalamic|Areas, Lateral Hypothalamic|Hypothalamic Areas, Lateral|Lateral Hypothalamic Areas|Lateral Hypothalamic Area|Area Hypothalamica Lateralis|Area Hypothalamica Laterali|Hypothalamica Laterali, Area|Hypothalamica Lateralis, Area|Laterali, Area Hypothalamica|Lateralis, Area Hypothalamica|Area Lateralis Hypothalami|Area Lateralis Hypothalamus|Hypothalami, Area Lateralis|Hypothalamus, Area Lateralis|Lateralis Hypothalami, Area|Lateralis Hypothalamus, Area|Lateral Hypothalamus|Hypothalamus, Lateral
 D007027	Hypothalamic Diseases	Disease, Hypothalamic|Diseases, Hypothalamic|Hypothalamic Disease
 D007028	Hypothalamic Hormones	Hormones, Hypothalamic|Hypothalamic Pituitary-Regulating Peptides|Hypothalamic Pituitary Regulating Peptides|Peptides, Hypothalamic Pituitary-Regulating|Pituitary-Regulating Peptides, Hypothalamic|Hypothalamic Pituitary-Regulating Hormones|Hormones, Hypothalamic Pituitary-Regulating|Hypothalamic Pituitary Regulating Hormones|Pituitary-Regulating Hormones, Hypothalamic
 D007029	Hypothalamic Neoplasms	Hypothalamus Neoplasms|Hypothalamus Neoplasm|Neoplasm, Hypothalamus|Tumors, Hypothalamus|Hypothalamus Tumor|Hypothalamus Tumors|Tumor, Hypothalamus|Neoplasms, Hypothalamus|Hypothalamic Tumors|Hypothalamic Tumor|Tumor, Hypothalamic|Tumors, Hypothalamic|Neoplasms, Hypothalamic|Hypothalamic Neoplasm|Neoplasm, Hypothalamic
@@ -8246,7 +8665,7 @@ D007030	Hypothalamo-Hypophyseal System	Hypothalamo Hypophyseal System|Hypothalam
 D007031	Hypothalamus	Preoptico-Hypothalamic Area|Area, Preoptico-Hypothalamic|Areas, Preoptico-Hypothalamic|Preoptico Hypothalamic Area|Preoptico-Hypothalamic Areas
 D007032	Hypothalamus, Anterior	Anterior Hypothalamus
 D007033	Hypothalamus, Middle	Middle Hypothalamus|Intermediate Hypothalamic Region|Hypothalamic Region, Intermediate|Hypothalamic Regions, Intermediate|Intermediate Hypothalamic Regions|Region, Intermediate Hypothalamic|Regions, Intermediate Hypothalamic|Hypothalamus, Medial|Medial Hypothalamus
-D007034	Hypothalamus, Posterior	Hypothalamic Region, Posterior|Hypothalamic Regions, Posterior|Posterior Hypothalamic Regions|Region, Posterior Hypothalamic|Regions, Posterior Hypothalamic|Posterior Hypothalamus|Mammillary Region|Mammillary Regions|Region, Mammillary|Regions, Mammillary|Posterior Hypothalamic Region|Area Hypothalamica Posterior|Area Hypothalamica Posteriors|Hypothalamica Posterior, Area|Hypothalamica Posteriors, Area|Posterior, Area Hypothalamica|Posteriors, Area Hypothalamica|Hypothalamus Posterior|Hypothalamus Posteriors|Posterior, Hypothalamus|Posteriors, Hypothalamus
+D007034	Hypothalamus, Posterior	Posterior Hypothalamic Region|Posterior Hypothalamus|Hypothalamus Posterior|Hypothalamus Posteriors|Posterior, Hypothalamus|Posteriors, Hypothalamus|Mammillary Region|Mammillary Regions|Region, Mammillary|Regions, Mammillary|Hypothalamic Region, Posterior|Hypothalamic Regions, Posterior|Posterior Hypothalamic Regions|Region, Posterior Hypothalamic|Regions, Posterior Hypothalamic|Area Hypothalamica Posterior|Area Hypothalamica Posteriors|Hypothalamica Posterior, Area|Hypothalamica Posteriors, Area|Posterior, Area Hypothalamica|Posteriors, Area Hypothalamica
 D007035	Hypothermia	Hypothermias
 D007036	Hypothermia, Induced	Therapeutic Hypothermia|Hypothermia, Therapeutic|Targeted Temperature Management|Targeted Temperature Managements|Induced Hypothermia
 D007037	Hypothyroidism	Hypothyroidisms
@@ -8294,7 +8713,7 @@ D007080	Ileocecal Valve	Ileocecal Valves|Valve, Ileocecal|Valves, Ileocecal
 D007081	Ileostomy	Ileostomies
 D007082	Ileum	
 D007083	Iliac Artery	Arteries, Iliac|Artery, Iliac|Iliac Arteries|Deep Circumflex Iliac Artery
-D007084	Iliac Vein	Iliac Veins|Vein, Iliac|Veins, Iliac|Deep Circumflex Iliac Vein
+D007084	Iliac Vein	Iliac Veins|Vein, Iliac|Veins, Iliac
 D007085	Ilium	Iliums
 D007086	Illegitimacy	
 D007087	Illinois	
@@ -8420,7 +8839,7 @@ D007210	Indoleacetic Acids	Acids, Indoleacetic|Indolylacetic Acids|Acids, Indoly
 D007211	Indoles	
 D007212	Indolizines	
 D007213	Indomethacin	Indometacin
-D007214	Indonesia	Bali|Netherlands East Indies|Malay Archipelago|East Indies
+D007214	Indonesia	Netherlands East Indies|East Indies
 D007215	Indophenol	
 D007216	Indoprofen	
 D007217	Indoramin	
@@ -8446,7 +8865,7 @@ D007236	Infant, Small for Gestational Age
 D007237	Infanticide	Infanticides
 D007238	Infarction	Infarctions
 D007239	Infection	Infections
-D007240	Arteritis Virus, Equine	Infectious Arteritis Virus of Horses|Infectious Arteritis Virus, Equine|Equine Infectious Arteritis Virus|Equine Arteritis Virus|Arteritis Viruses, Equine|Equine Arteritis Viruses|Virus, Equine Arteritis|Viruses, Equine Arteritis
+D007240	Equartevirus	Equarteviruses
 D007241	Infectious Bovine Rhinotracheitis	Bovine Rhinotracheitides, Infectious|Bovine Rhinotracheitis, Infectious|Infectious Bovine Rhinotracheitides|Rhinotracheitides, Infectious Bovine|Rhinotracheitis, Infectious Bovine
 D007242	Herpesvirus 1, Bovine	IBR-IPV Virus|IBR IPV Virus|IBR-IPV Viruses|Virus, IBR-IPV|Viruses, IBR-IPV|Herpesvirus 1 (alpha), Bovine|Infectious Bovine Rhinotracheitis Virus|Pustular Vulvovaginitis Virus, Infectious|Infectious Pustular Vulvovaginitis Virus|Bovine Herpesvirus 1|Bovine Rhinotracheitis Virus, Infectious
 D007243	Infectious bursal disease virus	Bursal Agent, Infectious|Bursal Agents, Infectious|Infectious Bursal Agents|Infectious Bursal Agent|Gumboro Disease Virus|IBDV|Avian Nephrosis Virus|Avian Nephrosis Viruses|Nephrosis Virus, Avian|Nephrosis Viruses, Avian|Bursal Disease Virus, Infectious
@@ -8542,7 +8961,7 @@ D007341	Insurance
 D007342	Insurance Benefits	Benefit, Insurance|Benefits, Insurance|Insurance Benefit
 D007343	Insurance Carriers	Carrier, Insurance|Carriers, Insurance|Insurance Carrier|Insurers|Insurer
 D007344	Insurance Claim Reporting	Claim Reporting, Insurance|Reporting, Insurance Claim
-D007345	Insurance Claim Review	Review, Insurance Claim|Claims Review|Claims Analysis|Review, Claims|Claims Reviews|Reviews, Claims|Claim Review, Insurance|Claim Reviews, Insurance|Insurance Claim Reviews|Reviews, Insurance Claim|Analysis, Claims|Analyses, Claims|Claims Analyses
+D007345	Insurance Claim Review	Claim Reviews, Insurance|Insurance Claim Reviews|Reviews, Insurance Claim|Review, Insurance Claim|Insurance Claims Analysis|Analyses, Insurance Claims|Analysis, Insurance Claims|Claims Analyses, Insurance|Claims Analysis, Insurance|Insurance Claims Analyses|Claims Analysis|Review, Claims|Claims Reviews|Reviews, Claims|Claims Review|Claim Review, Insurance|Analysis, Claims|Analyses, Claims|Claims Analyses
 D007346	Insurance, Accident	Accident Insurance|Accident Insurances|Insurances, Accident
 D007347	Insurance, Dental	Dental Insurance
 D007348	Insurance, Health	Health Insurance
@@ -8585,7 +9004,7 @@ D007384	Intermittent Positive-Pressure Breathing	Breathing, Intermittent Positiv
 D007385	Intermittent Positive-Pressure Ventilation	Intermittent Positive Pressure Ventilation|Positive-Pressure Ventilation, Intermittent|IPPV|Ventilation, Intermittent Positive-Pressure|Ventilation, Intermittent Positive Pressure|Inspiratory Positive-Pressure Ventilation|Inspiratory Positive Pressure Ventilation|Positive-Pressure Ventilation, Inspiratory|Ventilation, Inspiratory Positive-Pressure
 D007387	Internal Mammary-Coronary Artery Anastomosis	Anastomosis, Internal Mammary-Coronary Artery|Anastomosis, Internal Mammary Coronary Artery|Coronary-Internal Mammary Artery Anastomosis|Coronary Internal Mammary Artery Anastomosis|Internal Mammary Coronary Artery Anastomosis
 D007388	Internal Medicine	Medicine, Internal
-D007389	Internal-External Control	Control, Internal-External|Controls, Internal-External|Internal External Control|Internal-External Controls
+D007389	Internal-External Control	Controls, Internal-External|Internal-External Controls|Sense of Control|External-Internal Control|Control, External-Internal|Controls, External-Internal
 D007390	International Agencies	Agencies, International|Agency, International|International Agency
 D007391	International Cooperation	Cooperation, International
 D007392	International Council of Nurses	Nurses International Council|Nurses International Councils
@@ -8599,7 +9018,7 @@ D007399	Interphase	Interphases
 D007400	Interprofessional Relations	Relations, Interprofessional
 D007401	Interrenal Gland	Gland, Interrenal|Glands, Interrenal|Interrenal Glands
 D007402	Intertrigo	
-D007403	Intervertebral Disc	Disc, Intervertebral|Discs, Intervertebral|Intervertebral Discs|Disk, Intervertebral|Disks, Intervertebral|Intervertebral Disks|Intervertebral Disk
+D007403	Intervertebral Disc	Intervertebral Disk|Disc, Intervertebral|Discs, Intervertebral|Intervertebral Discs|Disk, Intervertebral|Disks, Intervertebral|Intervertebral Disks
 D007404	Intervertebral Disc Chemolysis	Chemolyses, Intervertebral Disc|Intervertebral Disc Chemolyses|Discolysis|Discolyses|Chemolysis, Intervertebral Disk|Chemolyses, Intervertebral Disk|Intervertebral Disk Chemolyses|Nucleolysis, Intervertebral Disc|Intervertebral Disc Nucleolyses|Intervertebral Disc Nucleolysis|Nucleolyses, Intervertebral Disc|Nucleolysis, Intervertebral Disk|Intervertebral Disk Nucleolyses|Intervertebral Disk Nucleolysis|Nucleolyses, Intervertebral Disk|Chemolysis, Intervertebral Disc|Chemonucleolysis|Chemonucleolyses|Intervertebral Disk Chemolysis
 D007405	Intervertebral Disc Displacement	Disc Displacement, Intervertebral|Disc Displacements, Intervertebral|Intervertebral Disc Displacements|Disk, Herniated|Disks, Herniated|Herniated Disks|Slipped Disk|Disk, Slipped|Disks, Slipped|Slipped Disks|Disk Prolapse|Disk Prolapses|Prolapse, Disk|Prolapses, Disk|Prolapsed Disc|Disc, Prolapsed|Discs, Prolapsed|Prolapsed Discs|Herniated Disc|Discs, Herniated|Herniated Discs|Disc, Herniated|Herniated Disk|Slipped Disc|Disc, Slipped|Discs, Slipped|Slipped Discs|Intervertebral Disk Displacement|Disk Displacement, Intervertebral|Disk Displacements, Intervertebral|Intervertebral Disk Displacements|Prolapsed Disk|Disk, Prolapsed|Disks, Prolapsed|Prolapsed Disks
 D007406	Interview, Psychological	Psychological Interview|Interview, Psychologic|Interviews, Psychologic|Psychologic Interview|Psychologic Interviews|Interviews, Psychological|Psychological Interviews
@@ -8682,7 +9101,7 @@ D007483	Iothalamic Acid	Acid, Iothalamic|Methalamic Acid|Acid, Methalamic|Iotala
 D007484	Iowa	
 D007485	Ioxaglic Acid	
 D007486	Ipecac	Syrup of Ipecac|Ipecac Syrup|Ipecac (Syrup)
-D007487	Ipodate	Iopodate
+D007487	Ipodate	
 D007488	Iprindole	
 D007490	Iproniazid	Iprazid
 D007491	Ipronidazole	
@@ -8709,7 +9128,7 @@ D007511	Ischemia	Ischemias
 D007512	Ischium	
 D007513	Isethionic Acid	Acid, Isethionic|Hydroxyethylsulfonic Acid|Acid, Hydroxyethylsulfonic
 D007514	Islam	Mohammedanism
-D007515	Islets of Langerhans	Langerhans Islets|Pancreatic Islets|Islet, Pancreatic|Islets, Pancreatic|Pancreatic Islet|Nesidioblasts|Nesidioblast|Pancreas, Endocrine|Endocrine Pancreas|Islands of Langerhans|Langerhans Islands|Islet Cells|Cell, Islet|Cells, Islet|Islet Cell
+D007515	Islets of Langerhans	Langerhans Islets|Pancreatic Islets|Islet, Pancreatic|Islets, Pancreatic|Pancreatic Islet|Pancreas, Endocrine|Endocrine Pancreas|Islet Cells|Cell, Islet|Cells, Islet|Islet Cell|Islands of Langerhans|Langerhans Islands|Nesidioblasts|Nesidioblast
 D007516	Adenoma, Islet Cell	Adenomas, Islet Cell|Islet Cell Adenoma|Islet Cell Adenomas
 D007517	Isoamylase	
 D007518	Isoantibodies	Alloantibodies
@@ -8738,7 +9157,7 @@ D007540	Isonipecotic Acids	Acids, Isonipecotic
 D007541	Isopentenyladenosine	N(6)-(delta(2)-Isopentenyl)Adenosine
 D007542	Inosine Pranobex	Pranobex, Inosine|Metisoprinol|Methysoprinol|Inosiplex|Methisoprinol
 D007544	Isopropyl Thiogalactoside	Thiogalactoside, Isopropyl|IPTG|Isopropyl 1-Thio-beta-D-galactopyranoside|1-Thio-beta-D-galactopyranoside, Isopropyl|Isopropyl 1 Thio beta D galactopyranoside
-D007545	Isoproterenol	Isoprenaline|Isopropylnorepinephrine|Isopropylarterenol|Isopropylnoradrenaline|4-(1-Hydroxy-2-((1-methylethyl)amino)ethyl)-1,2-benzenediol|Isopropyl Noradrenaline|Noradrenaline, Isopropyl
+D007545	Isoproterenol	Isopropylarterenol|Isopropylnoradrenaline|Isopropylnorepinephrine|4-(1-Hydroxy-2-((1-methylethyl)amino)ethyl)-1,2-benzenediol|Isopropyl Noradrenaline|Noradrenaline, Isopropyl|Isoprenaline
 D007546	Isoquinolines	
 D007547	Isosorbide	
 D007548	Isosorbide Dinitrate	Dinitrate, Isosorbide
@@ -8769,7 +9188,7 @@ D007573	Jaw Neoplasms	Jaw Neoplasm|Neoplasm, Jaw|Neoplasms, Jaw
 D007574	Jaw Relation Record	Record, Jaw Relation|Jaw Relation Records|Records, Jaw Relation
 D007575	Jaw, Edentulous	Edentulous Jaw|Edentulous Jaws|Jaws, Edentulous
 D007576	Jaw, Edentulous, Partially	
-D007577	JC Virus	Polyomavirus, JC|JC polyomavirus|Polyomavirus hominis 2|John Cunningham Virus|Virus, John Cunningham|Human Polyomavirus JC|Polyomavirus JC, Human
+D007577	JC Virus	Human Polyomavirus JC|Polyomavirus JC, Human|JC polyomavirus|Polyomavirus, JC|John Cunningham Virus|Virus, John Cunningham|Polyomavirus hominis 2
 D007578	Jealousy	Jealousies
 D007579	Jejunal Diseases	Disease, Jejunal|Diseases, Jejunal|Jejunal Disease
 D007580	Jejunal Neoplasms	Jejunal Neoplasm|Neoplasm, Jejunal|Neoplasms, Jejunal
@@ -8809,7 +9228,7 @@ D007615	Kansas
 D007616	Kaolin	
 D007617	Kaposi Varicelliform Eruption	Eruption, Kaposi Varicelliform|Varicelliform Eruption, Kaposi|Kaposi's Varicelliform Eruption|Eruption, Kaposi's Varicelliform|Kaposis Varicelliform Eruption|Varicelliform Eruption, Kaposi's
 D007618	Karaya Gum	Gum, Karaya|Tragacanth, Indian|Indian Tragacanth|Gum Karaya|Karaya, Gum
-D007619	Kartagener Syndrome	Syndrome, Kartagener|Kartagener's Syndrome|Kartageners Syndrome|Syndrome, Kartagener's|Dextrocardia, Bronchiectasis, and Sinusitis|Kartagener Triad|Siewert Syndrome|Syndrome, Siewert|Ciliary Dyskinesia, Primary|Dyskinesia, Primary Ciliary|Kartagener's Triad|Kartageners Triad
+D007619	Kartagener Syndrome	Syndrome, Kartagener|Dextrocardia, Bronchiectasis, and Sinusitis|Kartagener Triad|Siewert Syndrome|Syndrome, Siewert|Kartagener's Syndrome|Kartageners Syndrome|Syndrome, Kartagener's|Kartagener's Triad|Kartageners Triad
 D007620	Karyometry	Karyometric Analysis|Analyses, Karyometric|Analysis, Karyometric|Karyometric Analyses
 D007621	Karyotyping	Karyotypings|Karyotype Analysis Methods|Analysis Method, Karyotype|Analysis Methods, Karyotype|Karyotype Analysis Method|Method, Karyotype Analysis|Methods, Karyotype Analysis
 D007623	Kazakhstan	Kazakh SSR|Kazakh S.S.R.
@@ -8843,7 +9262,7 @@ D007652	Oxo-Acid-Lyases	Oxo Acid Lyases|Ketoacid-Lyases|Ketoacid Lyases
 D007653	Ketocholesterols	Oxocholesterols
 D007654	Ketoconazole	
 D007655	Ketoglutarate Dehydrogenase Complex	Complex, Ketoglutarate Dehydrogenase|Dehydrogenase Complex, Ketoglutarate|2-Oxoglutarate Dehydrogenase|2 Oxoglutarate Dehydrogenase|Dehydrogenase, 2-Oxoglutarate|2-Oxoglutarate Dehydrogenase Complex|2 Oxoglutarate Dehydrogenase Complex|Complex, 2-Oxoglutarate Dehydrogenase|Dehydrogenase Complex, 2-Oxoglutarate|Oxoglutarate Dehydrogenase|Dehydrogenase, Oxoglutarate|alpha-Ketoglutarate Dehydrogenase Complex|Complex, alpha-Ketoglutarate Dehydrogenase|Dehydrogenase Complex, alpha-Ketoglutarate|alpha Ketoglutarate Dehydrogenase Complex|2-Keto-4-Hydroxyglutarate Dehydrogenase|2 Keto 4 Hydroxyglutarate Dehydrogenase|Dehydrogenase, 2-Keto-4-Hydroxyglutarate|alpha-Ketoglutarate Dehydrogenase|Dehydrogenase, alpha-Ketoglutarate|alpha Ketoglutarate Dehydrogenase
-D007656	Ketoglutaric Acids	Acids, Ketoglutaric|Oxoglutarates
+D007656	Ketoglutaric Acids	Oxoglutarates
 D007657	Ketone Bodies	Bodies, Ketone
 D007658	Ketone Oxidoreductases	Oxidoreductases, Ketone
 D007659	Ketones	
@@ -8940,7 +9359,7 @@ D007754	Laboratories, Dental	Dental Laboratory|Laboratory, Dental|Dental Laborat
 D007755	Laboratories, Hospital	Hospital Laboratories|Hospital Laboratory|Laboratory, Hospital
 D007756	Laboratory Animal Science	Animal Science, Laboratory|Animal Sciences, Laboratory|Laboratory Animal Sciences|Science, Laboratory Animal|Sciences, Laboratory Animal
 D007757	Laboratory Infection	Infection, Laboratory|Infections, Laboratory|Laboratory Infections
-D007758	Ear, Inner	Ears, Inner|Inner Ears|Inner Ear|Labyrinth|Labyrinths|Ear, Internal|Ears, Internal|Internal Ear|Internal Ears
+D007758	Ear, Inner	Ears, Inner|Inner Ears|Inner Ear|Ear, Internal|Ears, Internal|Internal Ear|Internal Ears|Labyrinth|Labyrinths
 D007759	Labyrinth Diseases	Labyrinth Disease|Inner Ear Disease|Ear Disease, Inner|Ear Diseases, Inner|Inner Ear Diseases
 D007760	Labyrinth Supporting Cells	Supporting Cells, Labyrinth|Cell, Labyrinth Supporting|Cells, Labyrinth Supporting|Labyrinth Supporting Cell|Supporting Cell, Labyrinth
 D007761	Labyrinthine Fluids	Fluid, Labyrinthine|Fluids, Labyrinthine|Labyrinthine Fluid
@@ -8955,7 +9374,7 @@ D007769	Lactams
 D007770	L-Lactate Dehydrogenase	Dehydrogenase, L-Lactate|L Lactate Dehydrogenase|Lactate Dehydrogenase|Dehydrogenase, Lactate
 D007772	Lactate dehydrogenase-elevating virus	Lactate dehydrogenase elevating virus|Lactate dehydrogenase-elevating viruses|Lactic Dehydrogenase Virus|Lactic Dehydrogenase Viruses|Riley Virus|Lactate Dehydrogenase Virus|Lactate Dehydrogenase Viruses
 D007773	Lactates	
-D007774	Lactation	
+D007774	Lactation	Milk Secretion|Milk Secretions
 D007775	Lactation Disorders	Disorder, Lactation|Disorders, Lactation|Lactation Disorder
 D007777	Lactobacillaceae	
 D007778	Lactobacillus	
@@ -8980,7 +9399,7 @@ D007796	Laminectomy	Laminectomies
 D007797	Laminin	Glycoprotein GP-2|Glycoprotein GP 2
 D007798	Lampreys	Lamprey|Eels, Lamprey|Eel, Lamprey|Lamprey Eel|Lamprey Eels|Petromyzontidae
 D007799	Lanatosides	Digilanides
-D007801	Langerhans Cells	Cells, Langerhans|Epidermal Dendritic Cells|Dendritic Cells, Epidermal|Cell, Epidermal Dendritic|Cells, Epidermal Dendritic|Dendritic Cell, Epidermal|Epidermal Dendritic Cell
+D007801	Langerhans Cells	Cells, Langerhans|Dendritic Cells, Epidermal|Cell, Epidermal Dendritic|Cells, Epidermal Dendritic|Dendritic Cell, Epidermal|Epidermal Dendritic Cell|Epidermal Dendritic Cells
 D007802	Language	Languages
 D007803	Language Arts	Art, Language|Arts, Language|Language Art
 D007804	Language Development	Development, Language|Developments, Language|Language Developments
@@ -9021,7 +9440,7 @@ D007841	Latex Fixation Tests	Fixation Test, Latex|Fixation Tests, Latex|Latex Fi
 D007842	Lathyrism	
 D007843	Latin America	
 D007844	Latvia	Republic of Latvia
-D007845	Laughter	Laughters
+D007845	Laughter	
 D007846	Laundering	
 D007847	Laundry Service, Hospital	Hospital Laundry Service|Service, Hospital Laundry|Hospital Laundry Services|Laundry Services, Hospital|Services, Hospital Laundry
 D007848	Laurates	Dodecanoates
@@ -9097,7 +9516,7 @@ D007919	Leptospira
 D007921	Leptospira interrogans	
 D007922	Leptospirosis	Leptospiroses|Stuttgart Disease|Leptospira Infection|Infection, Leptospira|Infections, Leptospira|Leptospira Infections
 D007925	Leriche Syndrome	Syndrome, Leriche|Leriche's Syndrome|Leriches Syndrome|Syndrome, Leriche's
-D007926	Lesch-Nyhan Syndrome	Lesch Nyhan Syndrome|Complete HGPRT Deficiency Disease|Deficiency Disease, Complete HGPRT|Deficiency Disease, Hypoxanthine-Phosphoribosyl-Transferase|Deficiency Disease, Hypoxanthine Phosphoribosyl Transferase|Deficiency Diseases, Hypoxanthine-Phosphoribosyl-Transferase|Hypoxanthine-Phosphoribosyl-Transferase Deficiency Diseases|HGPRT Deficiency Disease, Complete|Hypoxanthine Guanine Phosphoribosyltransferase 1 Deficiency|Hypoxanthine-Phosphoribosyl-Transferase Deficiency Disease|Hypoxanthine Phosphoribosyl Transferase Deficiency Disease|Lesch-Nyhan Disease|Lesch Nyhan Disease|Choreoathetosis Self-Mutilation Syndrome|Choreoathetosis Self Mutilation Syndrome|Choreoathetosis Self-Mutilation Syndromes|Self-Mutilation Syndrome, Choreoathetosis|Self-Mutilation Syndromes, Choreoathetosis|Syndrome, Choreoathetosis Self-Mutilation|Syndromes, Choreoathetosis Self-Mutilation|Complete Hypoxanthine-Guanine Phosphoribosyltransferase Deficiency|Complete Hypoxanthine Guanine Phosphoribosyltransferase Deficiency|Deficiency of Guanine Phosphoribosyltransferase|Guanine Phosphoribosyltransferase Deficiencies|Guanine Phosphoribosyltransferase Deficiency|Phosphoribosyltransferase Deficiencies, Guanine|Phosphoribosyltransferase Deficiency, Guanine|Deficiency of Hypoxanthine Phosphoribosyltransferase|Hypoxanthine Phosphoribosyltransferase Deficiencies|Phosphoribosyltransferase Deficiencies, Hypoxanthine|Phosphoribosyltransferase Deficiency, Hypoxanthine|Hypoxanthine Guanine Phosphoribosyltransferase Deficiency|Hypoxanthine Phosphoribosyltransferase Deficiency|Deficiencies, Hypoxanthine Phosphoribosyltransferase|Deficiency, Hypoxanthine Phosphoribosyltransferase|Juvenile Gout, Choreoathetosis, Mental Retardation Syndrome|Juvenile Hyperuricemia Syndrome|Hyperuricemia Syndrome, Juvenile|Hyperuricemia Syndromes, Juvenile|Juvenile Hyperuricemia Syndromes|Syndrome, Juvenile Hyperuricemia|Syndromes, Juvenile Hyperuricemia|Primary Hyperuricemia Syndrome|Hyperuricemia Syndrome, Primary|Hyperuricemia Syndromes, Primary|Primary Hyperuricemia Syndromes|Syndrome, Primary Hyperuricemia|Syndromes, Primary Hyperuricemia|Total Hypoxanthine-Guanine Phosphoribosyl Transferase Deficiency|Total Hypoxanthine Guanine Phosphoribosyl Transferase Deficiency|X-Linked Hyperuricemia|Hyperuricemia, X-Linked|Hyperuricemias, X-Linked|X Linked Hyperuricemia|X-Linked Hyperuricemias|X-Linked Primary Hyperuricemia|Hyperuricemia, X-Linked Primary|Hyperuricemias, X-Linked Primary|Primary Hyperuricemia, X-Linked|Primary Hyperuricemias, X-Linked|X Linked Primary Hyperuricemia|X-Linked Primary Hyperuricemias|HGPRT Deficiency|Deficiencies, HGPRT|Deficiency, HGPRT|HGPRT Deficiencies|Total HPRT Deficiency|Deficiencies, Total HPRT|Deficiency, Total HPRT|HPRT Deficiencies, Total|HPRT Deficiency, Total|Total HPRT Deficiencies|Complete HPRT Deficiency|Complete HPRT Deficiencies|Deficiencies, Complete HPRT|Deficiency, Complete HPRT|HPRT Deficiencies, Complete|HPRT Deficiency, Complete|Choreoathetosis Self-Mutilation Hyperuricemia Syndrome|Choreoathetosis Self Mutilation Hyperuricemia Syndrome
+D007926	Lesch-Nyhan Syndrome	Lesch Nyhan Syndrome|Complete Hypoxanthine-Guanine Phosphoribosyltransferase Deficiency|Complete Hypoxanthine Guanine Phosphoribosyltransferase Deficiency|X-Linked Hyperuricemia|Hyperuricemia, X-Linked|Hyperuricemias, X-Linked|X Linked Hyperuricemia|X-Linked Hyperuricemias|X-Linked Primary Hyperuricemia|Hyperuricemia, X-Linked Primary|Hyperuricemias, X-Linked Primary|Primary Hyperuricemia, X-Linked|Primary Hyperuricemias, X-Linked|X Linked Primary Hyperuricemia|X-Linked Primary Hyperuricemias|HGPRT Deficiency|Deficiencies, HGPRT|Deficiency, HGPRT|HGPRT Deficiencies|Total HPRT Deficiency|Deficiencies, Total HPRT|Deficiency, Total HPRT|HPRT Deficiencies, Total|HPRT Deficiency, Total|Total HPRT Deficiencies|Complete HPRT Deficiency|Complete HPRT Deficiencies|Deficiencies, Complete HPRT|Deficiency, Complete HPRT|HPRT Deficiencies, Complete|HPRT Deficiency, Complete|Deficiency of Guanine Phosphoribosyltransferase|Guanine Phosphoribosyltransferase Deficiencies|Guanine Phosphoribosyltransferase Deficiency|Phosphoribosyltransferase Deficiencies, Guanine|Phosphoribosyltransferase Deficiency, Guanine|Hypoxanthine Guanine Phosphoribosyltransferase Deficiency|Hypoxanthine Phosphoribosyltransferase Deficiency|Deficiencies, Hypoxanthine Phosphoribosyltransferase|Deficiency, Hypoxanthine Phosphoribosyltransferase|Juvenile Gout, Choreoathetosis, Mental Retardation Syndrome|Juvenile Hyperuricemia Syndrome|Hyperuricemia Syndrome, Juvenile|Hyperuricemia Syndromes, Juvenile|Juvenile Hyperuricemia Syndromes|Syndrome, Juvenile Hyperuricemia|Syndromes, Juvenile Hyperuricemia|Deficiency of Hypoxanthine Phosphoribosyltransferase|Hypoxanthine Phosphoribosyltransferase Deficiencies|Phosphoribosyltransferase Deficiencies, Hypoxanthine|Phosphoribosyltransferase Deficiency, Hypoxanthine|Choreoathetosis Self-Mutilation Hyperuricemia Syndrome|Choreoathetosis Self Mutilation Hyperuricemia Syndrome|Hypoxanthine-Phosphoribosyl-Transferase Deficiency Disease|Hypoxanthine Phosphoribosyl Transferase Deficiency Disease|Complete HGPRT Deficiency Disease|Deficiency Disease, Complete HGPRT|Deficiency Disease, Hypoxanthine-Phosphoribosyl-Transferase|Deficiency Disease, Hypoxanthine Phosphoribosyl Transferase|Deficiency Diseases, Hypoxanthine-Phosphoribosyl-Transferase|Hypoxanthine-Phosphoribosyl-Transferase Deficiency Diseases|HGPRT Deficiency Disease, Complete|Lesch-Nyhan Disease|Lesch Nyhan Disease|Hypoxanthine Guanine Phosphoribosyltransferase 1 Deficiency|Choreoathetosis Self-Mutilation Syndrome|Choreoathetosis Self Mutilation Syndrome|Choreoathetosis Self-Mutilation Syndromes|Self-Mutilation Syndrome, Choreoathetosis|Self-Mutilation Syndromes, Choreoathetosis|Syndrome, Choreoathetosis Self-Mutilation|Syndromes, Choreoathetosis Self-Mutilation|Primary Hyperuricemia Syndrome|Hyperuricemia Syndrome, Primary|Hyperuricemia Syndromes, Primary|Primary Hyperuricemia Syndromes|Syndrome, Primary Hyperuricemia|Syndromes, Primary Hyperuricemia|Total Hypoxanthine-Guanine Phosphoribosyl Transferase Deficiency|Total Hypoxanthine Guanine Phosphoribosyl Transferase Deficiency
 D007927	Lesotho	Basutoland|Kingdom of Lesotho
 D007928	Lethal Dose 50	Dose 50, Lethal|LD50
 D007930	Leucine	L-Leucine|Leucine, L-Isomer|L-Isomer Leucine|Leucine, L Isomer
@@ -9137,7 +9556,7 @@ D007968	Leukoencephalopathy, Progressive Multifocal	Leukoencephalopathies, Progr
 D007969	Leukomalacia, Periventricular	Periventricular Leukomalacia|Leukomalacias, Periventricular|Periventricular Leukomalacias|Encephalomalacia, Periventricular|Encephalomalacias, Periventricular|Periventricular Encephalomalacia|Periventricular Encephalomalacias|Leucomalacia, Periventricular|Leucomalacias, Periventricular|Periventricular Leucomalacia|Periventricular Leucomalacias
 D007970	Leukopenia	Leukopenias|Leukocytopenia|Leukocytopenias
 D007971	Leukoplakia	Leukoplakias|Leukoplakic Lesions|Lesion, Leukoplakic|Lesions, Leukoplakic|Leukoplakic Lesion
-D007972	Leukoplakia, Oral	Leukoplakias, Oral|Oral Leukoplakia|Oral Leukoplakias
+D007972	Leukoplakia, Oral	Leukoplakias, Oral|Oral Leukoplakia|Oral Leukoplakias|Leukokeratosis, Oral|Leukokeratoses, Oral|Oral Leukokeratoses|Oral Leukokeratosis|Keratosis, Oral|Keratoses, Oral|Oral Keratoses|Oral Keratosis
 D007973	Leukorrhea	Leukorrheas
 D007975	Leukotriene B4	Leukotriene B-4|B-4, Leukotriene|Leukotriene B 4|LTB4
 D007976	Leupeptins	
@@ -9157,10 +9576,10 @@ D007989	Libido
 D007990	Libraries	Library
 D007991	Libraries, Dental	Library, Dental|Dental Libraries|Dental Library
 D007992	Libraries, Hospital	Hospital Libraries|Hospital Library|Library, Hospital
-D007993	Libraries, Medical	Medical Library|Library, Medical|Medical Libraries
+D007993	Libraries, Medical	Medical Libraries|Libraries, Biomedical|Biomedical Libraries|Biomedical Library|Library, Biomedical|Library, Medical|Medical Library
 D007994	Libraries, Nursing	Nursing Libraries|Library, Nursing|Nursing Library
 D007995	Library Administration	Administration, Library|Administrations, Library|Library Administrations
-D007996	Library Associations	Associations, Library|Association, Library|Library Association
+D007996	Library Associations	Library Association|Associations, Library
 D007997	Library Schools	Schools, Library|Library School|School, Library
 D007998	Library Science	Library Sciences|Science, Library|Sciences, Library
 D007999	Library Services	Services, Library|Library Service|Service, Library
@@ -9254,7 +9673,7 @@ D008088	Listeriosis	Listerioses|Listeria Infections|Infection, Listeria|Listeria
 D008089	Listeria monocytogenes	
 D008090	Lisuride	Lysurid|Methylergol Carbamide|Carbamide, Methylergol
 D008091	Literature	Literatures
-D008092	Literature, Medieval	Medieval Literature
+D008092	Literature, Medieval	Literatures, Medieval|Medieval Literatures|Medieval Literature
 D008093	Literature, Modern	Modern Literature
 D008094	Lithium	Lithium-7|Lithium 7
 D008095	Lithocholic Acid	Acid, Lithocholic|Isolithocholic Acid|Acid, Isolithocholic
@@ -9383,7 +9802,7 @@ D008220	Lymphography	Lymphographies
 D008221	Lymphoid Tissue	Lymphoid Tissues|Tissue, Lymphoid|Tissues, Lymphoid|Lymphatic Tissue|Lymphatic Tissues|Tissue, Lymphatic|Tissues, Lymphatic
 D008222	Lymphokines	Lymphocyte Mediators|Mediators, Lymphocyte
 D008223	Lymphoma	Lymphomas|Sarcoma, Germinoblastic|Germinoblastic Sarcoma|Germinoblastic Sarcomas|Sarcomas, Germinoblastic|Reticulolymphosarcoma|Reticulolymphosarcomas|Germinoblastoma|Germinoblastomas|Lymphoma, Malignant|Lymphomas, Malignant|Malignant Lymphoma|Malignant Lymphomas
-D008224	Lymphoma, Follicular	Follicular Lymphomas|Lymphomas, Follicular|Follicular Lymphoma|Lymphoma, Nodular|Lymphomas, Nodular|Nodular Lymphoma|Nodular Lymphomas|Giant Follicular Lymphoma|Lymphoma, Giant Follicular|Brill-Symmers Disease|Brill Symmers Disease|Disease, Brill-Symmers|Follicular Lymphoma, Giant|Follicular Lymphomas, Giant|Giant Follicular Lymphomas|Lymphomas, Giant Follicular
+D008224	Lymphoma, Follicular	Follicular Lymphomas|Lymphomas, Follicular|Follicular Lymphoma|Follicular Lymphoma, Giant|Follicular Lymphomas, Giant|Giant Follicular Lymphomas|Lymphomas, Giant Follicular|Lymphoma, Giant Follicular|Lymphoma, Nodular|Lymphomas, Nodular|Nodular Lymphoma|Nodular Lymphomas|Brill-Symmers Disease|Brill Symmers Disease|Disease, Brill-Symmers|Giant Follicular Lymphoma
 D008228	Lymphoma, Non-Hodgkin	Lymphoma, Non Hodgkin|Lymphoma, Atypical Diffuse Small Lymphoid|Lymphoma, Non-Hodgkin's|Lymphoma, Non Hodgkin's|Lymphoma, Non-Hodgkin, Familial|Lymphoma, Non-Hodgkins|Lymphoma, Non Hodgkins|Non-Hodgkins Lymphoma|Small Cleaved-Cell Lymphoma, Diffuse|Small Cleaved Cell Lymphoma, Diffuse|Lymphoma, Nonhodgkins|Nonhodgkins Lymphoma|Lymphoma, Small Cleaved Cell, Diffuse|Lymphoma, Small Cleaved-Cell, Diffuse|Non-Hodgkin Lymphoma|Non Hodgkin Lymphoma|Non-Hodgkin's Lymphoma|Non Hodgkin's Lymphoma|Diffuse Small Cleaved-Cell Lymphoma|Diffuse Small Cleaved Cell Lymphoma|Lymphoma, Nonhodgkin's|Lymphoma, Nonhodgkin|Nonhodgkin's Lymphoma
 D008230	Lymphomatoid Granulomatosis	Granulomatoses, Lymphomatoid|Lymphomatoid Granulomatoses|Granulomatosis, Lymphomatoid
 D008231	Lymphopenia	Lymphopenias|Lymphocytopenia|Lymphocytopenias
@@ -9426,7 +9845,7 @@ D008268	Macular Degeneration	Degeneration, Macular|Degenerations, Macular|Macula
 D008269	Macular Edema	Edema, Macular
 D008270	Madagascar	Malagasy Republic
 D008271	Mycetoma	Mycetomas
-D008272	Mafenide	Bensulfamide|Sulfabenzamine|Maphenid|4-Homosulfanilamide|4 Homosulfanilamide
+D008272	Mafenide	Maphenid
 D008273	Magic	Magics
 D008274	Magnesium	
 D008275	Magnesium Deficiency	Deficiency, Magnesium|Deficiencies, Magnesium|Magnesium Deficiencies
@@ -9495,7 +9914,7 @@ D008338	Mandibular Injuries	Injuries, Mandibular|Injury, Mandibular|Mandibular I
 D008339	Mandibular Neoplasms	Mandibular Neoplasm|Neoplasm, Mandibular|Neoplasms, Mandibular
 D008340	Mandibular Nerve	Mandibular Nerves|Nerve, Mandibular|Nerves, Mandibular
 D008341	Mandibular Prosthesis	Mandibular Prostheses|Prostheses, Mandibular|Prosthesis, Mandibular
-D008342	Mandibulofacial Dysostosis	Dysostoses, Mandibulofacial|Dysostosis, Mandibulofacial|Mandibulofacial Dysostoses|Treacher Collins-Franceschetti Syndrome|Mandibulofacial Dysostosis (MFD1)|Treacher Collins Syndrome|Collins Syndrome, Treacher|Syndrome, Treacher Collins|Franceschetti-Zwahlen-Klein Syndrome
+D008342	Mandibulofacial Dysostosis	Dysostoses, Mandibulofacial|Dysostosis, Mandibulofacial|Mandibulofacial Dysostoses|Mandibulofacial Dysostosis (MFD1)|Dysostoses, Mandibulofacial (MFD1)|Dysostosis, Mandibulofacial (MFD1)|Mandibulofacial Dysostoses (MFD1)|Franceschetti-Zwahlen-Klein Syndrome|Franceschetti Zwahlen Klein Syndrome|Franceschetti-Zwahlen-Klein Syndromes|Syndrome, Franceschetti-Zwahlen-Klein|Syndromes, Franceschetti-Zwahlen-Klein|Treacher Collins Syndrome|Syndrome, Treacher Collins|Treacher Collins-Franceschetti Syndrome|Syndrome, Treacher Collins-Franceschetti|Syndromes, Treacher Collins-Franceschetti|Treacher Collins Franceschetti Syndrome|Treacher Collins-Franceschetti Syndromes
 D008344	Maneb	
 D008345	Manganese	
 D008347	Manifest Anxiety Scale	Anxiety Scale, Manifest|Anxiety Scales, Manifest|Manifest Anxiety Scales|Scale, Manifest Anxiety|Scales, Manifest Anxiety
@@ -9524,19 +9943,19 @@ D008370	Manuals as Topic
 D008371	Manubrium	
 D008372	Manure	
 D008373	Manuscripts as Topic	
-D008374	Manuscripts, Medical as Topic	Manuscripts, Medical|Medical Manuscripts|Manuscript, Medical|Medical Manuscript
+D008374	Manuscripts, Medical as Topic	
 D008375	Maple Syrup Urine Disease	BCKD Deficiency|Keto Acid Decarboxylase Deficiency|MSUD (Maple Syrup Urine Disease)|Branched-Chain alpha-Keto Acid Dehydrogenase Deficiency|Branched Chain alpha Keto Acid Dehydrogenase Deficiency|Branched-Chain Ketoaciduria|Branched Chain Ketoaciduria|Branched-Chain Ketoacidurias|Ketoaciduria, Branched-Chain|Ketoacidurias, Branched-Chain
 D008376	Maprotiline	Maprotilin|N-Methyl-9,10-ethanoanthracene-9(10H)-propylamine|Dibencycladine
 D008377	Maps as Topic	Maps as Topics
 D008379	Marburg Virus Disease	Marburg Disease|Disease, Marburg|Marburg Hemorrhagic Fever|Fever, Marburg Hemorrhagic|Hemorrhagic Fever, Marburg
-D008380	Marek Disease	Marek's Disease|Mareks Disease|Neurolymphomatosis|Neurolymphomatoses|Fowl Paralysis|Fowl Paralyses|Paralyses, Fowl|Paralysis, Fowl
+D008380	Marek Disease	Marek's Disease|Mareks Disease|Fowl Paralysis|Fowl Paralyses|Paralyses, Fowl|Paralysis, Fowl
 D008381	Herpesvirus 2, Gallid	Gallid Herpesvirus 2|Neurolymphomatosis Virus|Neurolymphomatosis Viruses|Marek's Disease Virus Serotype 1|Marek Disease Herpesvirus 1|Marek's Disease Herpesvirus 1|Fowl Paralysis Virus|Fowl Paralysis Viruses|Paralysis Virus, Fowl|Paralysis Viruses, Fowl|Herpesvirus 2 (gamma), Gallid
 D008382	Marfan Syndrome	Syndrome, Marfan|Marfan Syndrome, Type I|Marfan's Syndrome|Marfans Syndrome|Syndrome, Marfan's
 D008383	Margarine	
 D008385	Marijuana Smoking	Smoking, Marijuana|Marihuana Smoking|Smoking, Marihuana
 D008386	Marine Biology	Biology, Marine
 D008387	Marine Toxins	Toxins, Marine
-D008388	Marital Therapy	Marriage Therapy|Therapy, Marriage|Marriage Therapies|Therapies, Marriage|Therapy, Marital|Marital Therapies|Therapies, Marital
+D008388	Marital Therapy	Marital Therapies|Therapies, Marital|Therapy, Marriage|Marriage Therapies|Therapies, Marriage|Marriage Therapy|Therapy, Marital
 D008389	Marketing of Health Services	Services, Health Marketing|Marketing, Health Services|Health Services Marketing|Marketing Services, Health|Health Marketing Service|Health Marketing Services|Marketing Service, Health
 D008390	Markov Chains	Chains, Markov|Markov Process|Markov Processes|Process, Markov|Processes, Markov|Markov Chain|Chain, Markov
 D008392	Marmota	Marmotas|Marmots|Marmot
@@ -9631,28 +10050,28 @@ D008482	Mediastinum
 D008483	Medical Assistance	Assistance, Medical
 D008484	Medicaid	
 D008485	Medical Audit	Medical Audits|Audit, Medical|Audits, Medical
-D008486	Physician Executives	Executive, Physician|Executives, Physician|Physician Executive|Directors, Medical|Medical Directors|Director, Medical|Medical Director
+D008486	Physician Executives	Executive, Physician|Executives, Physician|Physician Executive|Medical Directors|Medical Director|Director, Medical|Directors, Medical
 D008487	Medical History Taking	History Taking, Medical
 D008488	Medical Illustration	Illustration, Medical|Illustrations, Medical|Medical Illustrations
 D008489	Medical Indigency	Indigency, Medical|Indigencies, Medical|Medical Indigencies
 D008490	Medical Informatics	Health Informatics|Informatics, Health|Informatics, Medical
 D008491	Medical Informatics Applications	Applications, Medical Informatics|Informatics Applications, Medical|Application, Medical Informatics|Informatics Application, Medical|Medical Informatics Application
 D008492	Medical Informatics Computing	Computing, Medical Informatics|Informatics Computing, Medical
-D008493	Medical Missions, Official	Medical Mission, Official|Mission, Official Medical|Official Medical Mission|Official Medical Missions|Missions, Official Medical
+D008493	Medical Missions	Medical Mission|Mission, Medical|Missions, Medical
 D008494	Medical Office Buildings	Office Buildings, Medical|Building, Medical Office|Buildings, Medical Office|Medical Office Building|Office Building, Medical
 D008495	Medical Oncology	Oncology, Medical
-D008496	Medical Receptionists	Receptionists, Medical|Medical Receptionist|Receptionist, Medical
+D008496	Medical Receptionists	Receptionist, Medical|Receptionists, Medical|Medical Receptionist
 D008497	Medical Record Administrators	Administrator, Medical Record|Administrators, Medical Record|Medical Record Administrator|Record Administrator, Medical|Record Administrators, Medical|Medical Record Librarians|Librarians, Medical Record|Librarian, Medical Record|Medical Record Librarian|Record Librarian, Medical|Record Librarians, Medical
 D008498	Medical Record Linkage	Record Linkage, Medical|Linkage, Medical Record|Linkages, Medical Record|Medical Record Linkages|Record Linkages, Medical
 D008499	Medical Records	Records, Medical|Medical Record|Record, Medical
 D008500	Medical Records Department, Hospital	Medical Records Department|Department, Medical Records|Departments, Medical Records|Medical Records Departments|Records Department, Medical|Records Departments, Medical|Hospital Medical Records Department
-D008501	Medical Records, Problem-Oriented	Medical Records, Problem Oriented|Records, Problem-Oriented Medical|Records, Problem Oriented Medical|Problem-Oriented Medical Records|Problem Oriented Medical Records|Medical Record, Problem-Oriented|Medical Record, Problem Oriented|Problem-Oriented Medical Record|Record, Problem-Oriented Medical|Record, Problem Oriented Medical
+D008501	Medical Records, Problem-Oriented	Problem-Oriented Medical Records|Problem Oriented Medical Records|Record, Problem-Oriented Medical|Record, Problem Oriented Medical|Records, Problem-Oriented Medical|Records, Problem Oriented Medical|Medical Record, Problem-Oriented|Medical Record, Problem Oriented|Problem-Oriented Medical Record|Medical Records, Problem Oriented
 D008502	Medical Secretaries	Medical Secretary|Secretaries, Medical|Secretary, Medical
-D008503	Medical Staff	Staffs, Medical|Medical Staffs|Staff, Medical
+D008503	Medical Staff	Staff, Medical|Staffs, Medical|Medical Staffs
 D008504	Medical Staff Privileges	Staff Privileges, Medical|Medical Staff Privilege|Privilege, Medical Staff|Privileges, Medical Staff|Staff Privilege, Medical
 D008505	Medical Staff, Hospital	Hospital Medical Staff|Hospital Medical Staffs|Staff, Hospital Medical|Staffs, Hospital Medical|Medical Staffs, Hospital
 D008506	Medical Waste	Waste, Medical|Medical Wastes|Wastes, Medical
-D008507	Medically Underserved Area	Area, Medically Underserved|Areas, Medically Underserved|Medically Underserved Areas|Underserved Area, Medically|Underserved Areas, Medically
+D008507	Medically Underserved Area	Areas, Medically Underserved|Medically Underserved Areas|Underserved Area, Medically|Underserved Areas, Medically|Area, Medically Underserved
 D008508	Medication Errors	Errors, Medication|Error, Medication|Medication Error
 D008509	Medication Systems	Medication System|System, Medication|Systems, Medication
 D008510	Medication Systems, Hospital	Drug Distribution Systems, Hospital|Hospital Drug Distribution Systems|Hospital Medication System|System, Hospital Medication|Systems, Hospital Medication|Systems, Medication Hospital|Hospital System, Medication|Hospital Systems, Medication|Medication Hospital System|Medication Hospital Systems|System, Medication Hospital|Hospital Unit Dose Drug Distribution System|Hospital Unit Dose Drug Distribution Systems|Medication System, Hospital|System Hospital Medication|Hospital Medication, System|Hospital Medications, System|Medication, System Hospital|Medications, System Hospital|System Hospital Medications|Drug Distribution System, Hospital|Hospital Medication Systems
@@ -9663,7 +10082,7 @@ D008514	Medicine, Arabic	Arabic Medicine
 D008515	Medicine, Ayurvedic	Ayurvedic Medicine
 D008516	Medicine, Chinese Traditional	Traditional Chinese Medicine|Chung I Hsueh|Hsueh, Chung I|Traditional Medicine, Chinese|Zhong Yi Xue|Chinese Traditional Medicine|Chinese Medicine, Traditional
 D008517	Phytotherapy	Herbal Therapy|Herb Therapy
-D008518	Medicine, East Asian Traditional	Oriental Medicine, Traditional|Medicine, Traditional Oriental|Traditional Oriental Medicine|Traditional Oriental Medicines|Traditional Medicine, Oriental|Medicine, Oriental Traditional|Traditional Medicine, East Asia|Traditional Far Eastern Medicine|East Asian Traditional Medicine|Traditional East Asian Medicine|Oriental Traditional Medicine|Medicine, Traditional, East Asia
+D008518	Medicine, East Asian Traditional	Oriental Medicine, Traditional|Medicine, Traditional Oriental|Traditional Oriental Medicine|Traditional Oriental Medicines|Traditional Medicine, Oriental|Traditional East Asian Medicine|Medicine, Traditional, East Asia|Traditional Medicine, East Asia|Traditional Far Eastern Medicine|East Asian Traditional Medicine|Oriental Traditional Medicine|Medicine, Oriental Traditional
 D008519	Medicine, Traditional	Traditional Medicine
 D008520	Medigoxin	4'''-O-Methyldigoxin|4''' O Methyldigoxin|Metildigoxin|beta-Methyldigoxin|beta Methyldigoxin
 D008521	Mediterranean Islands	
@@ -9673,7 +10092,7 @@ D008524	Medrogestone
 D008525	Medroxyprogesterone	Methylhydroxyprogesterone|17 alpha-Hydroxy-6 alpha-Methylprogesterone|17 alpha Hydroxy 6 alpha Methylprogesterone
 D008526	Medulla Oblongata	Medulla Oblongatas
 D008527	Medulloblastoma	Medulloblastomas
-D008528	Mefenamic Acid	Acid, Mefenamic|Mefenaminic Acid|Acid, Mefenaminic
+D008528	Mefenamic Acid	Acid, Mefenamic|Mefenaminic Acid
 D008529	Mefruside	
 D008530	Megacins	
 D008531	Megacolon	Megacolons
@@ -9740,10 +10159,10 @@ D008591	Meningomyelocele	Meningomyeloceles|Myelomeningocele|Myelomeningoceles
 D008592	Menisci, Tibial	Tibial Meniscus|Semilunar Cartilages|Cartilage, Semilunar|Cartilages, Semilunar|Semilunar Cartilage|Meniscus, Tibial|Tibial Menisci
 D008593	Menopause	Change of Life, Female
 D008594	Menopause, Premature	Premature Menopause
-D008595	Menorrhagia	Hypermenorrhea
+D008595	Menorrhagia	Hypermenorrhea|Heavy Periods|Heavy Period|Heavy Menstrual Bleeding|Menstrual Bleeding, Heavy
 D008596	Menotropins	Menotrophin|Gonadotropins, Human Menopausal|Human Menopausal Gonadotropins
 D008597	Menstrual Cycle	Cycle, Menstrual|Cycles, Menstrual|Menstrual Cycles
-D008598	Menstruation	Menstruations
+D008598	Menstruation	
 D008599	Menstruation Disturbances	Disturbance, Menstruation|Disturbances, Menstruation|Menstruation Disturbance|Menstruation Disorders|Disorder, Menstruation|Disorders, Menstruation|Menstruation Disorder
 D008600	Menstruation-Inducing Agents	Agents, Menstruation-Inducing|Menstruation Inducing Agents|Emmenagogues
 D008602	Mental Healing	Healing, Mental
@@ -9751,7 +10170,7 @@ D008603	Mental Health	Health, Mental|Mental Hygiene|Hygiene, Mental
 D008604	Mental Health Associations	Health Associations, Mental|Associations, Mental Health|Association, Mental Health|Health Association, Mental|Mental Health Association
 D008605	Mental Health Services	Health Services, Mental|Health Service, Mental|Mental Health Service|Service, Mental Health|Services, Mental Hygiene|Hygiene Service, Mental|Hygiene Services, Mental|Mental Hygiene Service|Service, Mental Hygiene|Mental Hygiene Services|Services, Mental Health
 D008606	Mental Processes	Human Information Processing|Information Processing, Human
-D008607	Intellectual Disability	Disabilities, Intellectual|Intellectual Disabilities|Retardation, Mental|Mental Retardation|Disability, Intellectual|Intellectual Development Disorder|Development Disorder, Intellectual|Development Disorders, Intellectual|Disorder, Intellectual Development|Disorders, Intellectual Development|Intellectual Development Disorders
+D008607	Intellectual Disability	Disabilities, Intellectual|Intellectual Disabilities|Retardation, Mental|Intellectual Development Disorder|Development Disorder, Intellectual|Development Disorders, Intellectual|Disorder, Intellectual Development|Disorders, Intellectual Development|Intellectual Development Disorders|Mental Retardation|Disability, Intellectual
 D008609	Mental Status Schedule	
 D008610	Menthol	
 D008611	Mentors	Mentor
@@ -9801,7 +10220,7 @@ D008655	Mesterolone
 D008656	Mestranol	Ethinyl Estradiol 3-Methyl Ether|Ethinyl Estradiol 3 Methyl Ether
 D008657	Metabolic Clearance Rate	Clearance Rate, Metabolic|Clearance Rates, Metabolic|Metabolic Clearance Rates|Rate, Metabolic Clearance|Rates, Metabolic Clearance
 D008658	Inactivation, Metabolic	Metabolic Inactivation
-D008659	Metabolic Diseases	Thesaurismosis|Thesaurismoses|Diseases, Metabolic|Disease, Metabolic|Metabolic Disease
+D008659	Metabolic Diseases	Disease, Metabolic|Metabolic Disease|Thesaurismosis|Thesaurismoses|Diseases, Metabolic
 D008660	Metabolism	Metabolic Processes|Processes, Metabolic|Metabolic Process|Process, Metabolic
 D008661	Metabolism, Inborn Errors	Errors Metabolism, Inborn|Errors Metabolisms, Inborn|Inborn Errors Metabolism|Inborn Errors Metabolisms|Metabolisms, Inborn Errors|Metabolism Errors, Inborn|Error, Inborn Metabolism|Errors, Inborn Metabolism|Inborn Metabolism Error|Inborn Metabolism Errors|Metabolism Error, Inborn|Inborn Errors of Metabolism|Metabolism Inborn Error|Metabolism Inborn Errors
 D008662	Metacarpophalangeal Joint	Joint, Metacarpophalangeal|Joints, Metacarpophalangeal|Metacarpophalangeal Joints
@@ -9887,8 +10306,8 @@ D008746	Methylazoxymethanol Acetate	Acetate, Methylazoxymethanol|(Methyl-ONN-azo
 D008747	Methylcellulose	Methyl Cellulose|Cellulose, Methyl
 D008748	Methylcholanthrene	
 D008749	Methyldimethylaminoazobenzene	Dimethyl-p-(m-tolylazo)aniline|MeDAB|3'-Methyl-4-dimethylaminoazobenzene|3' Methyl 4 dimethylaminoazobenzene
-D008750	Methyldopa	alpha-Methyl-L-Dopa|alpha Methyl L Dopa|alpha-Methyldopa|alpha Methyldopa|Alphamethyldopa
-D008751	Methylene Blue	Blue, Methylene|Methylthioninium Chloride|Swiss Blue|Blue, Swiss|Methylene Blue N|Blue N, Methylene|Methylthionine Chloride
+D008750	Methyldopa	alpha-Methyldopa|alpha Methyldopa|alpha-Methyl-L-Dopa|alpha Methyl L Dopa|Alphamethyldopa
+D008751	Methylene Blue	Blue, Methylene|Methylthioninium Chloride|Methylthionine Chloride|Swiss Blue|Blue, Swiss|Basic Blue 9|Blue 9, Basic|Methylene Blue N|Blue N, Methylene
 D008752	Methylene Chloride	Chloride, Methylene|Methylene Bichloride|Bichloride, Methylene|Methylene Dichloride|Dichloride, Methylene|Dichloromethane
 D008753	Methylenebis(chloroaniline)	3,3'-Dichloro-4,4'-Diaminodiphenylmethane|Methylene Bis(chloroaniline)|MBOCA|4,4'-Methylenebis(2-chloroaniline)
 D008754	Methylenetetrahydrofolate Dehydrogenase (NADP)	Methylenetetrahydrofolate Dehydrogenase (NADP+)|Methylenetetrahydrofolate Dehydrogenase|Dehydrogenase, Methylenetetrahydrofolate
@@ -9913,7 +10332,7 @@ D008773	Methylphenazonium Methosulfate	Methosulfate, Methylphenazonium|Phenazine
 D008774	Methylphenidate	
 D008775	Methylprednisolone	Metipred|6-Methylprednisolone|6 Methylprednisolone
 D008776	Methylprednisolone Hemisuccinate	Hemisuccinate, Methylprednisolone|Methylprednisolone Succinate|Succinate, Methylprednisolone
-D008777	Methyltestosterone	17beta-Methyltestosterone|17beta Methyltestosterone|17-Epimethyltestosterone|17 Epimethyltestosterone|17 beta Methyltestosterone|17 beta-Hydroxy-17-methyl-4-androsten-3-one|17 beta Hydroxy 17 methyl 4 androsten 3 one|17 beta-Methyltestosterone|17beta-Hydroxy-17-methyl-4-androsten-3-one|17beta Hydroxy 17 methyl 4 androsten 3 one
+D008777	Methyltestosterone	17beta-Methyltestosterone|17beta Methyltestosterone|17 beta Methyltestosterone|17 beta-Hydroxy-17-methyl-4-androsten-3-one|17 beta Hydroxy 17 methyl 4 androsten 3 one|17 beta-Methyltestosterone|17beta-Hydroxy-17-methyl-4-androsten-3-one|17beta Hydroxy 17 methyl 4 androsten 3 one|17-Epimethyltestosterone|17 Epimethyltestosterone
 D008778	Methylthioinosine	6-Methylmercaptopurine Riboside|6 Methylmercaptopurine Riboside|Riboside, 6-Methylmercaptopurine|6-Methylthiopurine Riboside|6 Methylthiopurine Riboside|Riboside, 6-Methylthiopurine
 D008779	Methylthiouracil	Alkiron|4-Methyl-2-thiouracil
 D008780	Methyltransferases	
@@ -10022,7 +10441,7 @@ D008885	Military Dentistry	Dentistry, Military|Dentistries, Military|Military De
 D008886	Military Hygiene	Hygiene, Military
 D008887	Military Medicine	Medicine, Military
 D008888	Military Nursing	Nursing, Military|Military Nursings|Nursings, Military
-D008889	Military Personnel	Personnel, Military|Military|Armed Forces Personnel|Personnel, Armed Forces
+D008889	Military Personnel	Personnel, Military|Armed Forces Personnel|Personnel, Armed Forces|Military
 D008890	Military Psychiatry	Psychiatry, Military
 D008891	Military Science	Military Sciences|Science, Military|Sciences, Military
 D008892	Milk	
@@ -10055,7 +10474,7 @@ D008922	Mississippi
 D008923	Missouri	
 D008924	Mite Infestations	Infestation, Mite|Infestations, Mite|Mite Infestation|Acariasis
 D008925	Mites	Mite
-D008926	Plicamycin	Mitramycin|Aureolic Acid|Acid, Aureolic|Mithramycin
+D008926	Plicamycin	Mithramycin|Mitramycin|Aureolic Acid
 D008927	Mitobronitol	Dibromomannitol
 D008928	Mitochondria	Mitochondrion
 D008929	Mitochondria, Heart	Myocardial Mitochondria|Mitochondria, Myocardial|Mitochondrion, Heart|Heart Mitochondrion|Heart Mitochondria
@@ -10165,7 +10584,7 @@ D009038	Motion	Motions
 D009039	Motion Perception	Perception, Motion
 D009040	Motion Pictures	Motion Picture|Picture, Motion|Pictures, Motion
 D009041	Motion Sickness	Sickness, Motion
-D009042	Motivation	
+D009042	Motivation	Motivations
 D009043	Motor Activity	Activities, Motor|Activity, Motor|Motor Activities
 D009044	Motor Cortex	Cortex, Motor|Somatic Motor Areas|Area, Somatic Motor|Areas, Somatic Motor|Motor Area, Somatic|Motor Areas, Somatic|Somatic Motor Area|Somatomotor Areas|Area, Somatomotor|Areas, Somatomotor|Somatomotor Area|Motor Area|Area, Motor|Areas, Motor|Motor Areas
 D009045	Motor Endplate	Endplate, Motor|Endplates, Motor|Motor Endplates|Motor End-Plate|End-Plate, Motor|End-Plates, Motor|Motor End Plate|Motor End-Plates
@@ -10214,7 +10633,7 @@ D009091	Mucormycosis	Mucormycoses
 D009092	Mucous Membrane	Membrane, Mucous|Membranes, Mucous|Mucous Membranes|Mucosa|Mucosal Tissue|Mucosal Tissues|Tissue, Mucosal|Tissues, Mucosal
 D009093	Mucus	
 D009094	Mud Therapy	Pelotherapy|Peloid Therapy|Therapy, Mud|Therapy, Peloid
-D009095	Mullerian Ducts	Ducts, Mullerian
+D009095	Mullerian Ducts	Ducts, Mullerian|Muellerian Ducts|Ducts, Muellerian
 D009096	Multi-Institutional Systems	Multi Institutional Systems|System, Multi-Institutional|System, Multi Institutional|Systems, Multi-Institutional|Systems, Multi Institutional|Multi-Institutional System|Multi Institutional System
 D009097	Multienzyme Complexes	Complexes, Multienzyme
 D009098	Multiphasic Screening	Multiphasic Screenings|Screening, Multiphasic|Screenings, Multiphasic
@@ -10224,7 +10643,7 @@ D009101	Multiple Myeloma	Multiple Myelomas|Myelomas, Multiple|Myeloma, Multiple|
 D009102	Multiple Organ Failure	Multiple Organ Dysfunction Syndrome|Organ Failure, Multiple|Failure, Multiple Organ|Multiple Organ Failures|MODS|Organ Dysfunction Syndrome, Multiple
 D009103	Multiple Sclerosis	Sclerosis, Multiple|Sclerosis, Disseminated|Disseminated Sclerosis|MS (Multiple Sclerosis)
 D009104	Multiple Trauma	Multiple Traumas|Traumas, Multiple|Wounds, Multiple|Multiple Wound|Multiple Wounds|Wound, Multiple|Polytrauma|Polytraumas|Trauma, Multiple|Injuries, Multiple|Injury, Multiple|Multiple Injury|Multiple Injuries
-D009105	Multiple Personality Disorder	Disorder, Multiple Personality|Multiple Personality Disorders|Personality Disorder, Multiple|Personality Disorders, Multiple|Multiple Identity Disorder|Disorder, Multiple Identity|Identity Disorder, Multiple|Multiple Identity Disorders|Dissociative Identity Disorder|Disorder, Dissociative Identity|Identity Disorder, Dissociative|Multiple Personalities|Multiple Personality|Personalities, Multiple|Personality, Multiple
+D009105	Dissociative Identity Disorder	Disorder, Dissociative Identity|Identity Disorder, Dissociative|Multiple Personality Disorder|Disorder, Multiple Personality|Multiple Personality Disorders|Personality Disorder, Multiple|Personality Disorders, Multiple|Multiple Identity Disorder|Disorder, Multiple Identity|Identity Disorder, Multiple|Multiple Identity Disorders|Multiple Personalities|Multiple Personality|Personalities, Multiple|Personality, Multiple
 D009106	Mummies	Mummy
 D009107	Mumps	Parotitis, Epidemic|Epidemic Parotitides|Epidemic Parotitis|Parotitides, Epidemic
 D009108	Mumps Vaccine	Vaccine, Mumps
@@ -10406,11 +10825,11 @@ D009289	Narcissism	Narcissisms
 D009290	Narcolepsy	Paroxysmal Sleep|Sleep, Paroxysmal|Narcoleptic Syndrome|Narcoleptic Syndromes|Syndrome, Narcoleptic|Syndromes, Narcoleptic|Gelineau Syndrome|Syndrome, Gelineau|Gelineau's Syndrome|Gelineau's Syndromes|Gelineaus Syndrome|Syndrome, Gelineau's|Syndromes, Gelineau's
 D009291	Narcotherapy	Narcotherapies
 D009292	Narcotic Antagonists	Antagonists, Narcotic|Opioid Receptor Antagonists|Antagonists, Opioid Receptor|Receptor Antagonists, Opioid|Opioid Antagonists|Antagonists, Opioid
-D009293	Opioid-Related Disorders	Disorder, Opioid-Related|Opioid Abuse|Abuse, Opioid|Abuses, Opioid|Opioid Abuses|Opiate Abuse|Abuse, Opiate|Abuses, Opiate|Opiate Abuses
+D009293	Opioid-Related Disorders	Opioid Related Disorders|Opioid-Related Disorder|Addiction, Opioid|Opioid Addiction|Addictions, Opioid|Opioid Addictions|Opioid Dependence|Dependences, Opioid|Opioid Dependences|Dependence, Opioid
 D009294	Narcotics	Narcotic
 D009295	Nasal Bone	Bone, Nasal|Bones, Nasal|Nasal Bones
 D009296	Nasal Cavity	Cavities, Nasal|Cavity, Nasal|Nasal Cavities
-D009297	Nasal Mucosa	Mucosa, Nasal|Schneiderian Membrane|Membrane, Schneiderian|Membranes, Schneiderian|Schneiderian Membranes
+D009297	Nasal Mucosa	Mucosa, Nasal
 D009298	Nasal Polyps	Nasal Polyp|Polyp, Nasal|Polyps, Nasal
 D009299	Nasal Provocation Tests	Provocation Tests, Nasal|Nasal Provocation Test|Provocation Test, Nasal|Test, Nasal Provocation|Tests, Nasal Provocation
 D009300	Nasal Septum	Nasal Septums|Septum, Nasal|Septums, Nasal
@@ -10423,7 +10842,7 @@ D009306	Natal Teeth	Teeth, Natal|Teeth Present At Birth|Tooth, Natal|Natal Tooth
 D009307	National Academy of Sciences (U.S.)	Sciences National Academies (U.S.)|Sciences National Academy (U.S.)|United States National Academy of Sciences|National Academy of Sciences
 D009308	National Center for Health Care Technology (U.S.)	NCHCT|National Center for Health Care Technology|United States Nat'l Center for Health Care Technology
 D009309	National Center for Health Statistics (U.S.)	United States National Center for Health Statistics|National Center for Health Statistics
-D009310	National Health Insurance, United States	Federal Health Insurance Plans, United States|United States National Health Insurance
+D009310	National Health Insurance, United States	United States National Health Insurance|Federal Health Insurance Plans, United States
 D009312	National Health Planning Information Center (U.S.)	United States National Health Planning Information Center|NHPIC|National Health Planning Information Center
 D009313	National Health Programs	Health Program, National|Health Programs, National|National Health Program|Program, National Health|Programs, National Health
 D009314	National Institute for Occupational Safety and Health (U.S.)	NIOSH|National Institute for Occupational Safety and Health
@@ -10467,7 +10886,7 @@ D009356	Neon
 D009357	Neonatal Abstinence Syndrome	Substance Withdrawal, Neonatal|Neonatal Withdrawal Syndrome|Neonatal Withdrawal Syndromes|Syndrome, Neonatal Withdrawal|Syndromes, Neonatal Withdrawal|Withdrawal Syndrome, Neonatal|Withdrawal Syndromes, Neonatal|Abstinence Syndrome, Neonatal|Abstinence Syndromes, Neonatal|Neonatal Abstinence Syndromes|Syndrome, Neonatal Abstinence|Syndromes, Neonatal Abstinence|Neonatal Substance Withdrawal|Neonatal Substance Withdrawals|Substance Withdrawals, Neonatal|Withdrawal, Neonatal Substance
 D009358	Congenital, Hereditary, and Neonatal Diseases and Abnormalities	
 D009359	Neonatology	
-D009360	Neoplastic Cells, Circulating	Circulating Cells, Neoplasm|Neoplasm Circulating Cells|Circulating Tumor Cells|Cell, Circulating Tumor|Cells, Circulating Tumor|Circulating Tumor Cell|Tumor Cell, Circulating|Tumor Cells, Circulating|Cells, Neoplasm Circulating|Cell, Neoplasm Circulating|Neoplasm Circulating Cell|Circulating Neoplastic Cells|Cell, Circulating Neoplastic|Cells, Circulating Neoplastic|Circulating Neoplastic Cell|Neoplastic Cell, Circulating
+D009360	Neoplastic Cells, Circulating	Neoplasm Circulating Cells|Circulating Neoplastic Cells|Cell, Circulating Neoplastic|Cells, Circulating Neoplastic|Circulating Neoplastic Cell|Neoplastic Cell, Circulating|Circulating Tumor Cells|Cell, Circulating Tumor|Cells, Circulating Tumor|Circulating Tumor Cell|Tumor Cell, Circulating|Tumor Cells, Circulating|Cells, Neoplasm Circulating|Cell, Neoplasm Circulating|Neoplasm Circulating Cell|Circulating Cells, Neoplasm
 D009361	Neoplasm Invasiveness	Neoplasm Invasion|Invasion, Neoplasm|Invasiveness, Neoplasm
 D009362	Neoplasm Metastasis	Metastases, Neoplasm|Neoplasm Metastases|Metastasis|Metastases|Metastasis, Neoplasm
 D009363	Neoplasm Proteins	Proteins, Neoplasm
@@ -10493,7 +10912,7 @@ D009382	Neoplasms, Unknown Primary	Occult Primary Neoplasms|Neoplasms, Occult Pr
 D009383	Neoplasms, Vascular Tissue	Blood Vessel Tumors|Blood Vessel Tumor|Tumor, Blood Vessel|Tumors, Blood Vessel|Vascular Tissue Neoplasms|Neoplasm, Vascular Tissue|Vascular Tissue Neoplasm
 D009384	Paraneoplastic Endocrine Syndromes	Endocrine Syndrome, Paraneoplastic|Paraneoplastic Endocrine Syndrome|Syndrome, Paraneoplastic Endocrine|Syndromes, Paraneoplastic Endocrine|Ectopic Hormone Syndromes|Ectopic Hormone Syndrome|Syndrome, Ectopic Hormone|Syndromes, Ectopic Hormone
 D009385	Neoplastic Processes	Processes, Neoplastic
-D009386	Neoplastic Syndromes, Hereditary	Hereditary Neoplastic Syndromes|Hereditary Neoplastic Syndrome|Neoplastic Syndrome, Hereditary|Syndrome, Hereditary Neoplastic|Syndromes, Hereditary Neoplastic|Hereditary Cancer Syndromes|Cancer Syndrome, Hereditary|Hereditary Cancer Syndrome|Syndrome, Hereditary Cancer|Syndromes, Hereditary Cancer|Cancer Syndromes, Hereditary
+D009386	Neoplastic Syndromes, Hereditary	Cancer Syndromes, Hereditary|Hereditary Neoplastic Syndromes|Hereditary Neoplastic Syndrome|Neoplastic Syndrome, Hereditary|Syndrome, Hereditary Neoplastic|Syndromes, Hereditary Neoplastic|Hereditary Cancer Syndromes|Cancer Syndrome, Hereditary|Hereditary Cancer Syndrome|Syndrome, Hereditary Cancer|Syndromes, Hereditary Cancer
 D009387	Neoprene	Polychloroprene|Polychloroprenes|Chloroprene Polymer|Chloroprene Polymers|Duprene
 D009388	Neostigmine	Synstigmin|Proserine|Prozerin
 D009389	Neovascularization, Pathologic	Pathologic Neovascularization|Neovascularization, Pathological|Pathological Neovascularization|Pathologic Angiogenesis|Angiogenesis, Pathologic|Angiogenesis, Pathological|Pathological Angiogenesis
@@ -10503,7 +10922,7 @@ D009392	Nephrectomy	Nephrectomies
 D009393	Nephritis	Nephritides
 D009394	Nephritis, Hereditary	Hereditary Nephritis|Nephritis, Familial|Familial Nephritis|Hereditary Interstitial Pyelonephritis|Pyelonephritis, Hereditary Interstitial
 D009395	Nephritis, Interstitial	Interstitial Nephritis|Interstitial Nephritides|Nephritides, Interstitial
-D009396	Wilms Tumor	Tumor, Wilms|Wilms' Tumor|Tumor, Wilms'|Wilm Tumor|Wilm's Tumor|Wilms Tumor 1|Nephroblastoma|Nephroblastomas
+D009396	Wilms Tumor	Tumor, Wilms|Wilms Tumor 1|Nephroblastoma|Nephroblastomas|Wilms' Tumor|Tumor, Wilms'|Wilm Tumor|Wilm's Tumor
 D009397	Nephrocalcinosis	Nephrocalcinoses
 D009398	Nephrology	
 D009399	Nephrons	Nephron
@@ -10561,7 +10980,7 @@ D009451	Neuroeffector Junction	Junction, Neuroeffector|Junctions, Neuroeffector|
 D009452	Neuroendocrinology	
 D009454	Neurofibrils	Neurofibril
 D009455	Neurofibroma	Neurofibromas
-D009456	Neurofibromatosis 1	Recklinghausen Disease, Nerve|Recklinghausens Disease of Nerve|Recklinghausen's Disease of Nerve|von Recklinghausen Disease|von Recklinghausen's Disease|von Recklinghausens Disease|Neurofibromatosis, Peripheral, NF 1|Peripheral Neurofibromatosis|Neurofibromatoses, Peripheral|Neurofibromatosis, Peripheral|Peripheral Neurofibromatoses|Neurofibromatosis I|Neurofibromatosis Type I|Type I, Neurofibromatosis|Neurofibromatosis Type 1|Type 1, Neurofibromatosis|Neurofibromatosis, Type 1|Type 1 Neurofibromatosis|Neurofibromatosis, Type I|Neurofibromatoses, Type I|Type I Neurofibromatoses|NF1 (Neurofibromatosis 1)|Neurofibromatosis, Peripheral Type|Molluscum Fibrosum|Neurofibromatosis, Peripheral, NF1|Recklinghausen Disease of Nerve
+D009456	Neurofibromatosis 1	Recklinghausen Disease of Nerve|Recklinghausens Disease of Nerve|Recklinghausen's Disease of Nerve|von Recklinghausen Disease|von Recklinghausen's Disease|von Recklinghausens Disease|Neurofibromatosis, Peripheral, NF 1|Peripheral Neurofibromatosis|Neurofibromatoses, Peripheral|Neurofibromatosis, Peripheral|Peripheral Neurofibromatoses|Neurofibromatosis I|Neurofibromatosis Type I|Type I, Neurofibromatosis|Neurofibromatosis Type 1|Type 1, Neurofibromatosis|Neurofibromatosis, Type 1|Type 1 Neurofibromatosis|Neurofibromatosis, Type I|Neurofibromatoses, Type I|Type I Neurofibromatoses|NF1 (Neurofibromatosis 1)|Neurofibromatosis, Peripheral Type|Molluscum Fibrosum|Recklinghausen Disease, Nerve|Neurofibromatosis, Peripheral, NF1
 D009457	Neuroglia	Glial Cells|Cell, Glial|Cells, Glial|Glial Cell|Neuroglial Cells|Cell, Neuroglial|Cells, Neuroglial|Neuroglial Cell|Glia
 D009458	Neuroleptanalgesia	Neuroleptoanalgesia
 D009459	Neuroleptic Malignant Syndrome	Neuroleptic Malignant Syndromes|Syndrome, Neuroleptic Malignant|Syndromes, Neuroleptic Malignant|NMS (Neuroleptic Malignant Syndrome)|NMSs (Neuroleptic Malignant Syndrome)
@@ -10577,12 +10996,12 @@ D009468	Neuromuscular Diseases	Neuromuscular Disease
 D009469	Neuromuscular Junction	Junction, Neuromuscular|Junctions, Neuromuscular|Neuromuscular Junctions|Myoneural Junction|Junction, Myoneural|Junctions, Myoneural|Myoneural Junctions
 D009470	Muscle Spindles	Muscle Spindle|Spindle, Muscle|Spindles, Muscle|Stretch Receptors, Muscle|Receptors, Stretch, Muscle|Muscle Stretch Receptors|Muscle Stretch Receptor|Receptor, Muscle Stretch|Receptors, Muscle Stretch|Stretch Receptor, Muscle|Neuromuscular Spindles|Neuromuscular Spindle|Spindle, Neuromuscular|Spindles, Neuromuscular
 D009471	Neuromyelitis Optica	NMO Spectrum Disorder|NMO Spectrum Disorders|Neuromyelitis Optica (NMO) Spectrum Disorder|Neuromyelitis Optica Spectrum Disorders|Neuromyelitis Optica (NMO) Spectrum Disorders|Devic Neuromyelitis Optica|Devic Neuromyelitis Opticas|Neuromyelitis Optica, Devic|Neuromyelitis Opticas, Devic|Devic Disease|Disease, Devic|Devic Syndrome|Syndrome, Devic|Devic's Syndrome|Devics Syndrome|Syndrome, Devic's|Devic's Neuromyelitis Optica|Devics Neuromyelitis Optica|Neuromyelitis Optica, Devic's|Neuromyelitis Optica Spectrum Disorder|Devic's Disease|Devics Disease|Disease, Devic's
-D009472	Neuronal Ceroid-Lipofuscinoses	Neuronal Ceroid Lipofuscinoses|Ceroid-Lipofuscinosis, Neuronal|Ceroid Lipofuscinosis, Neuronal|Neuronal Ceroid-Lipofuscinosis|Lipofuscinosis, Neuronal Ceroid|Neuronal Ceroid Lipofuscinosis|Ceroid Storage Disease|Ceroid Storage Diseases|Disease, Ceroid Storage|Diseases, Ceroid Storage|Storage Disease, Ceroid|Storage Diseases, Ceroid|Lipofuscin Storage Disease|Disease, Lipofuscin Storage|Diseases, Lipofuscin Storage|Lipofuscin Storage Diseases|Storage Disease, Lipofuscin|Storage Diseases, Lipofuscin
+D009472	Neuronal Ceroid-Lipofuscinoses	Ceroid-Lipofuscinosis, Neuronal|Lipofuscinosis, Neuronal Ceroid|Lipofuscin Storage Disease|Disease, Lipofuscin Storage|Diseases, Lipofuscin Storage|Lipofuscin Storage Diseases|Storage Disease, Lipofuscin|Storage Diseases, Lipofuscin|Ceroid Storage Disease|Ceroid Storage Diseases|Disease, Ceroid Storage|Diseases, Ceroid Storage|Storage Disease, Ceroid|Storage Diseases, Ceroid|Neuronal Ceroid Lipofuscinosis|Ceroid Lipofuscinosis, Neuronal|Neuronal Ceroid Lipofuscinoses|Neuronal Ceroid-Lipofuscinosis
 D009473	Neuronal Plasticity	Plasticity, Neuronal|Neuronal Plasticities|Plasticities, Neuronal|Synaptic Plasticity|Plasticities, Synaptic|Plasticity, Synaptic|Synaptic Plasticities|Neuroplasticity|Neuroplasticities|Neural Plasticity|Neural Plasticities|Plasticities, Neural|Plasticity, Neural
 D009474	Neurons	Neuron|Nerve Cells|Cell, Nerve|Cells, Nerve|Nerve Cell
 D009475	Neurons, Afferent	Afferent Neurons|Afferent Neuron|Neuron, Afferent
 D009476	Neurons, Efferent	Efferent Neuron|Neuron, Efferent|Efferent Neurons
-D009477	Hereditary Sensory and Autonomic Neuropathies	Sensory and Autonomic Neuropathies, Hereditary|Neuropathies, Hereditary Sensory and Autonomic|HSAN|HSAN (Hereditary Sensory Autonomic Neuropathy)|HSANs (Hereditary Sensory Autonomic Neuropathy)
+D009477	Hereditary Sensory and Autonomic Neuropathies	HSAN (Hereditary Sensory Autonomic Neuropathy)|HSANs (Hereditary Sensory Autonomic Neuropathy)|Neuropathies, Hereditary Sensory and Autonomic|HSAN|Sensory and Autonomic Neuropathies, Hereditary
 D009478	Neuropeptide Y	Neuropeptide Tyrosine|Tyrosine, Neuropeptide
 D009479	Neuropeptides	Neuropeptide
 D009480	Neuropharmacology	Neuropharmacologies
@@ -10728,7 +11147,7 @@ D009625	Noma	Nomas|Stomatitis, Gangrenous|Gangrenous Stomatitides|Gangrenous Sto
 D009626	Terminology as Topic	
 D009627	Nomifensine	Nomifensin|Linamiphen
 D009628	Nonachlazine	Nonakhlazin|Azaclorzine|Nonachlazin
-D009629	Person-Centered Therapy	Person Centered Therapy|Person-Centered Therapies|Therapies, Person-Centered|Therapy, Person-Centered
+D009629	Person-Centered Psychotherapy	Person Centered Psychotherapy|Person-Centered Psychotherapies|Psychotherapies, Person-Centered|Psychotherapy, Person-Centered
 D009630	Nondisjunction, Genetic	Genetic Nondisjunctions|Nondisjunctions, Genetic|Genetic Nondisjunction|Genetic Non-Disjunction|Genetic Non Disjunction|Genetic Non-Disjunctions|Non-Disjunctions, Genetic|Non-Disjunction, Genetic|Non Disjunction, Genetic
 D009631	Nonodontogenic Cysts	Cyst, Nonodontogenic|Cysts, Nonodontogenic|Nonodontogenic Cyst
 D009632	Nonsuppressible Insulin-Like Activity	Activity, Nonsuppressible Insulin-Like|Insulin-Like Activity, Nonsuppressible|Nonsuppressible Insulin Like Activity|Nonsuppressible Insulinlike Activity|Activity, Nonsuppressible Insulinlike|Insulinlike Activity, Nonsuppressible|NSILA
@@ -10737,7 +11156,7 @@ D009634	Noonan Syndrome	Syndrome, Noonan|Noonan Syndrome 1|Noonan-Ehmke Syndrome
 D009635	Norandrostanes	
 D009636	Norbornanes	Norcamphanes
 D009637	Masoprocol	(R*,S*)-4,4'-(2,3-Dimethylbutane-1,4-diyl)bispyrocatechol|Nordihydroguaiaretic Acid|Nordihydroguaiaretic Acid, (R*,S*)-Isomer|Dihydronorguaiaretic Acid|meso-Nordihydroguaiaretic Acid|Acid, meso-Nordihydroguaiaretic|meso Nordihydroguaiaretic Acid
-D009638	Norepinephrine	Noradrenaline|Levarterenol|Levonorepinephrine
+D009638	Norepinephrine	Levonorepinephrine|Noradrenaline|Levarterenol
 D009639	Norethandrolone	Ethylestrenolone|Ethylnortestosterone
 D009640	Norethindrone	Norpregneninolone|Norethisterone|Ethinylnortestosterone
 D009641	Norethynodrel	
@@ -10746,7 +11165,7 @@ D009643	Norfloxacin
 D009644	Norgestrel	DL-Norgestrel|DL Norgestrel
 D009645	Norgestrienone	
 D009646	Norleucine	
-D009647	Normetanephrine	Normetadrenaline|3-Methoxynoradrenaline|3 Methoxynoradrenaline
+D009647	Normetanephrine	3-Methoxynoradrenaline|3 Methoxynoradrenaline|Normetadrenaline
 D009649	Norpregnadienes	
 D009650	Norpregnanes	
 D009651	Norpregnatrienes	
@@ -10812,21 +11231,21 @@ D009710	Nucleotide Mapping	Mapping, Nucleotide|Mappings, Nucleotide|Nucleotide M
 D009711	Nucleotides	
 D009712	Nucleotides, Cyclic	Cyclic Nucleotides
 D009713	Nucleotidyltransferases	
-D009714	Nucleus Accumbens	Accumbens, Nucleus|Nucleus Accumbens Septi|Accumbens Septi, Nucleus|Accumbens Septus, Nucleus|Nucleus Accumbens Septus|Septi, Nucleus Accumbens|Septus, Nucleus Accumbens|Accumbens Nucleus|Nucleus, Accumbens
+D009714	Nucleus Accumbens	Accumbens, Nucleus|Accumbens Nucleus|Nucleus, Accumbens|Nucleus Accumbens Septi|Accumbens Septi, Nucleus|Accumbens Septus, Nucleus|Nucleus Accumbens Septus|Septi, Nucleus Accumbens|Septus, Nucleus Accumbens
 D009715	Nudism	Nudisms
 D009716	Numerical Analysis, Computer-Assisted	Numerical Analysis, Computer Assisted|Computer-Assisted Numerical Analysis|Computer Assisted Numerical Analysis|Analysis, Computer-Assisted Numerical|Analyses, Computer-Assisted Numerical|Analysis, Computer Assisted Numerical|Computer-Assisted Numerical Analyses|Numerical Analyses, Computer-Assisted
 D009717	Numismatics	
 D009718	Nurse Administrators	Administrator, Nurse|Administrators, Nurse|Nurse Administrator
 D009719	Nurse Anesthetists	Anesthetist, Nurse|Anesthetists, Nurse|Nurse Anesthetist
-D009720	Nurse Clinicians	Clinician, Nurse|Clinicians, Nurse|Nurse Clinician|Nurse Specialist, Clinical|Nurse Specialists, Clinical|Specialists, Clinical Nurse|Clinical Nurse Specialists|Clinical Nurse Specialist|Specialist, Clinical Nurse
-D009721	Nurse Midwives	Nurse-Midwife|Nurse Midwife|Nurse-Midwives
+D009720	Nurse Clinicians	Clinician, Nurse|Clinicians, Nurse|Nurse Clinician|Nurse Specialist, Clinical|Clinical Nurse Specialists|Specialist, Clinical Nurse|Specialists, Clinical Nurse|Clinical Nurse Specialist|Nurse Specialists, Clinical
+D009721	Nurse Midwives	Nurse-Midwives|Nurse-Midwife|Nurse Midwife
 D009722	Nurse Practitioners	Nurse Practitioner|Practitioner, Nurse|Practitioners, Nurse
 D009723	Nurse-Patient Relations	Nurse-Patient Relation|Relations, Nurse-Patient|Nurse Patient Relations|Patient Relations, Nurse|Relations, Nurse Patient|Nurse Patient Relationship|Nurse Patient Relationships|Patient Relationship, Nurse|Patient Relationships, Nurse|Relationship, Nurse Patient|Relationships, Nurse Patient
 D009724	Nurseries	Nursery
 D009725	Nurseries, Hospital	Hospital Nurseries|Hospital Nursery|Nursery, Hospital
 D009726	Nurses	Nurse|Personnel, Nursing|Nursing Personnel
 D009727	Nurses, Male	Male Nurse|Male Nurses|Nurse, Male
-D009728	Nurses' Aides	Aide, Nurses'|Aides, Nurses'|Nurse Aides|Nurse's Aides|Nurses Aides|Nurses' Aide|Nursing Auxiliaries|Auxiliaries, Nursing|Auxiliary, Nursing|Nursing Auxiliary
+D009728	Nursing Assistants	Assistant, Nursing|Assistants, Nursing|Nursing Assistant
 D009729	Nursing	Nursings
 D009730	Nursing Assessment	Assessment, Nursing|Assessments, Nursing|Nursing Assessments
 D009731	Nursing Audit	Audit, Nursing|Audits, Nursing|Nursing Audits
@@ -10838,8 +11257,8 @@ D009736	Nursing Process	Process, Nursing|Nursing Processes|Processes, Nursing
 D009737	Nursing Records	Records, Nursing|Nursing Record|Record, Nursing
 D009738	Nursing Service, Hospital	Hospital Nursing Service|Service, Hospital Nursing|Hospital Nursing Services|Nursing Services, Hospital|Services, Hospital Nursing
 D009739	Nursing Services	Services, Nursing|Nursing Service|Service, Nursing
-D009740	Nursing Staff	Staffs, Nursing|Nursing Staffs|Staff, Nursing
-D009741	Nursing Staff, Hospital	Nursing Staffs, Hospital|Staffs, Hospital Nursing|Hospital Nursing Staff|Hospital Nursing Staffs|Staff, Hospital Nursing
+D009740	Nursing Staff	Staff, Nursing|Staffs, Nursing|Nursing Staffs
+D009741	Nursing Staff, Hospital	Hospital Nursing Staff|Staff, Hospital Nursing|Staffs, Hospital Nursing|Hospital Nursing Staffs|Nursing Staffs, Hospital
 D009742	Nursing Theory	Theory, Nursing|Nursing Theories|Theories, Nursing
 D009743	Nursing, Practical	Practical Nursing|Nursings, Practical|Practical Nursings
 D009744	Nursing, Private Duty	Private Practice Nursing|Nursing, Private Practice|Private Duty Nursing
@@ -10855,7 +11274,7 @@ D009753	Nutritive Value	Nutritive Values|Value, Nutritive|Values, Nutritive|Avai
 D009754	Nuts	Nut
 D009755	Night Blindness	Blindness, Night|Nyctalopia
 D009756	Nylidrin	Buphenin|Bufenine|Buphenine
-D009757	Nylons	Polyamide|Polyamides|Nylon
+D009757	Nylons	Polyamides|Polyamide|Nylon
 D009758	Nymph	
 D009759	Nystagmus, Pathologic	Pathologic Nystagmus
 D009760	Nystagmus, Physiologic	Nystagmus, Physiological|Physiological Nystagmus|Physiologic Nystagmus
@@ -10990,7 +11409,7 @@ D009893	Opossums	Opossum|Didelphidae
 D009894	Opportunistic Infections	Infection, Opportunistic|Infections, Opportunistic|Opportunistic Infection
 D009895	Opsonin Proteins	Proteins, Opsonin|Opsonins
 D009896	Optic Atrophy	Atrophy, Optic
-D009897	Optic Chiasm	Chiasm, Optic|Chiasms, Optic|Optic Chiasms|Optic Chiasma|Chiasma, Optic|Chiasmas, Optic|Optic Chiasmas|Optic Decussation|Decussation, Optic|Decussations, Optic|Optic Decussations|Chiasma Opticum|Chiasma Opticums|Opticum, Chiasma|Opticums, Chiasma
+D009897	Optic Chiasm	Chiasm, Optic|Chiasms, Optic|Optic Chiasms|Chiasma Opticum|Chiasma Opticums|Opticum, Chiasma|Opticums, Chiasma|Optic Chiasma|Chiasma, Optic|Chiasmas, Optic|Optic Chiasmas|Optic Decussation|Decussation, Optic|Decussations, Optic|Optic Decussations
 D009898	Optic Disk	Disk, Optic|Disks, Optic|Optic Disks|Optic Papilla|Optic Papillas|Papilla, Optic|Papillas, Optic|Optic Nerve Head|Head, Optic Nerve|Heads, Optic Nerve|Nerve Head, Optic|Nerve Heads, Optic|Optic Nerve Heads
 D009899	Optic Lobe, Nonmammalian	Nonmammalian Optic Lobe|Nonmammalian Optic Lobes|Optic Lobes, Nonmammalian|Optic Lobe, Non-Mammalian|Non-Mammalian Optic Lobe|Non-Mammalian Optic Lobes|Optic Lobe, Non Mammalian|Optic Lobes, Non-Mammalian|Corpora Bigemina|Bigemina, Corpora
 D009900	Optic Nerve	Nerve, Optic|Nerves, Optic|Optic Nerves|Nervus Opticus|Opticus, Nervus|Second Cranial Nerve|Cranial Nerve, Second|Cranial Nerves, Second|Nerve, Second Cranial|Nerves, Second Cranial|Second Cranial Nerves|Cranial Nerve II|Cranial Nerve IIs|Nerve II, Cranial|Nerve IIs, Cranial
@@ -11040,7 +11459,7 @@ D009948	Orgasm	Orgasms
 D009949	Orientation	Orientations|Cognitive Orientation|Cognitive Orientations|Orientation, Cognitive|Orientations, Cognitive|Psychological Orientation|Orientation, Psychological|Orientations, Psychological|Psychological Orientations|Mental Orientation|Mental Orientations|Orientation, Mental|Orientations, Mental
 D009950	Ornidazole	
 D009951	Ornipressin	Orpressin|Ornithine-8-Vasopressin|Ornithine 8 Vasopressin|Ornithine Vasopressin|Vasopressin, Ornithine
-D009952	Ornithine	Ornithine, (L)-Isomer|2,5-Diaminopentanoic Acid|2,5 Diaminopentanoic Acid
+D009952	Ornithine	
 D009953	Ornithine-Oxo-Acid Transaminase	Ornithine Oxo Acid Transaminase|Transaminase, Ornithine-Oxo-Acid|L-Ornithine-2-Oxoglutarate Aminotransferase|Aminotransferase, L-Ornithine-2-Oxoglutarate|L Ornithine 2 Oxoglutarate Aminotransferase|Ornithine Aminotransferase|Aminotransferase, Ornithine|Ornithine-Keto-Acid-Transaminase|Ornithine Keto Acid Transaminase|Ornithine Transaminase|Transaminase, Ornithine|Ornithine-2-Ketoglutarate Aminotransferase|Aminotransferase, Ornithine-2-Ketoglutarate|Ornithine 2 Ketoglutarate Aminotransferase|Ornithine-Ketoacid-Transaminase|Ornithine Ketoacid Transaminase|Pyrroline-5-Carboxylate Synthase|Pyrroline 5 Carboxylate Synthase|Synthase, Pyrroline-5-Carboxylate|L-Ornithine-2-Oxo-Acid Aminotransferase|Aminotransferase, L-Ornithine-2-Oxo-Acid|L Ornithine 2 Oxo Acid Aminotransferase|Ornithine Ketoacid Aminotransferase|Aminotransferase, Ornithine Ketoacid|Ketoacid Aminotransferase, Ornithine
 D009954	Ornithine Carbamoyltransferase	Carbamoyltransferase, Ornithine|Ornithine Transcarbamylase|Transcarbamylase, Ornithine|Ornithine Carbamylphosphate Transferase|Carbamylphosphate Transferase, Ornithine|Transferase, Ornithine Carbamylphosphate
 D009955	Ornithine Decarboxylase	Decarboxylase, Ornithine|Ornithine Carboxy-lyase|Carboxy-lyase, Ornithine|Ornithine Carboxy lyase
@@ -11056,7 +11475,7 @@ D009964	Orotidine-5'-Phosphate Decarboxylase	Decarboxylase, Orotidine-5'-Phospha
 D009965	Orphan Drug Production	Drug Production, Orphan|Production, Orphan Drug
 D009966	Orphenadrine	Methyldiphenylhydramine
 D009967	Orthodontic Appliances	Appliance, Orthodontic|Appliances, Orthodontic|Orthodontic Appliance
-D009968	Orthodontic Appliances, Removable	Appliance, Removable Orthodontic|Appliances, Removable Orthodontic|Orthodontic Appliance, Removable|Removable Orthodontic Appliance|Removable Orthodontic Appliances
+D009968	Orthodontic Appliances, Removable	Appliance, Removable Orthodontic|Appliances, Removable Orthodontic|Orthodontic Appliance, Removable|Removable Orthodontic Appliance|Removable Orthodontic Appliances|Clear Dental Braces|Brace, Clear Dental|Braces, Clear Dental|Clear Dental Brace|Dental Brace, Clear|Dental Braces, Clear
 D009969	Orthodontic Wires	Orthodontic Wire|Wire, Orthodontic|Wires, Orthodontic
 D009970	Orthodontics	
 D009971	Orthodontics, Corrective	Corrective Orthodontics
@@ -11100,7 +11519,7 @@ D010011	Osteocytes	Osteocyte
 D010012	Osteogenesis	Bone Formation|Ossification|Ossifications
 D010013	Osteogenesis Imperfecta	Brittle Bone Disease|Fragilitas Ossium|Ossiums, Fragilitas
 D010014	Osteolysis	Osteolyses
-D010015	Osteolysis, Essential	Essential Osteolyses|Essential Osteolysis|Osteolyses, Essential|Disappearing Bone Disease|Bone Disease, Disappearing
+D010015	Osteolysis, Essential	Essential Osteolyses|Essential Osteolysis|Osteolyses, Essential|Disappearing Bone Disease
 D010016	Osteoma	Osteomas
 D010017	Osteoma, Osteoid	Osteoid Osteomas|Osteomas, Osteoid|Osteoid Osteoma
 D010018	Osteomalacia	Adult Rickets|Rickets, Adult
@@ -11200,7 +11619,7 @@ D010113	Oxyphenbutazone	Oxyphenylbutazone|Hydroxyphenylbutazone
 D010114	Oxyphenisatin Acetate	Acetate, Oxyphenisatin|Acetfenolisatin|Diasatine
 D010115	Oxyphenonium	Metacin|2-((Cyclohexylhydroxyphenylacetyl)oxy)-N,N-diethyl-N-methylethanaminium|Oxyphenon|Methacin
 D010117	Oxypurinol	Alloxanthine|Oxipurinol
-D010118	Oxytetracycline	Oxytetracycline Dihydrate|Dihydrate, Oxytetracycline|Hydroxytetracycline
+D010118	Oxytetracycline	Hydroxytetracycline
 D010119	Oxythiamine	Hydroxythiamine
 D010120	Oxytocics	Oxytocic Drugs|Drugs, Oxytocic|Uterine Stimulants|Stimulants, Uterine|Oxytocic Agents|Agents, Oxytocic
 D010121	Oxytocin	Ocytocin
@@ -11248,7 +11667,7 @@ D010162	Paleography
 D010163	Paleontology	
 D010164	Paleopathology	
 D010165	Palladium	
-D010166	Palliative Care	Care, Palliative|Therapy, Palliative|Palliative Therapy|Palliative Treatment|Palliative Treatments|Treatment, Palliative|Treatments, Palliative
+D010166	Palliative Care	Care, Palliative|Palliative Treatment|Palliative Treatments|Treatment, Palliative|Treatments, Palliative|Therapy, Palliative|Palliative Therapy|Palliative Supportive Care|Supportive Care, Palliative
 D010167	Pallor	Pallors
 D010168	Palmitates	Hexadecanoates
 D010169	Palmitic Acids	Acids, Palmitic
@@ -11356,7 +11775,7 @@ D010277	Parasympathomimetics	Parasympathomimetic Drugs|Drugs, Parasympathomimeti
 D010278	Parathion	Phosphostigmine|Ethyl Parathion|Parathion, Ethyl
 D010279	Parathyroid Diseases	Disease, Parathyroid|Diseases, Parathyroid|Parathyroid Disease|Parathyroid Disorders|Disorder, Parathyroid|Disorders, Parathyroid|Parathyroid Disorder
 D010280	Parathyroid Glands	Gland, Parathyroid|Glands, Parathyroid|Parathyroid Gland
-D010281	Parathyroid Hormone	Hormone, Parathyroid|PTH (1-84)|Parathyroid Hormone (1-84)|Parathormone|Parathyrin
+D010281	Parathyroid Hormone	Hormone, Parathyroid|Parathyrin|PTH (1-84)|Parathormone|Parathyroid Hormone (1-84)
 D010282	Parathyroid Neoplasms	Neoplasm, Parathyroid|Parathyroid Neoplasm|Neoplasms, Parathyroid
 D010283	Paratuberculosis	Paratuberculoses|Johne Disease|Disease, Johne|Johne's Disease|Disease, Johne's|Johnes Disease
 D010284	Paratyphoid Fever	Fever, Paratyphoid|Fevers, Paratyphoid|Paratyphoid Fevers
@@ -11378,7 +11797,7 @@ D010299	Parking Facilities	Facilities, Parking|Facility, Parking|Parking Facilit
 D010300	Parkinson Disease	Idiopathic Parkinson's Disease|Lewy Body Parkinson Disease|Lewy Body Parkinson's Disease|Primary Parkinsonism|Parkinsonism, Primary|Parkinson Disease, Idiopathic|Parkinson's Disease|Parkinson's Disease, Idiopathic|Parkinson's Disease, Lewy Body|Idiopathic Parkinson Disease|Paralysis Agitans
 D010301	Parkinson Disease, Postencephalitic	Parkinson Disease, Post-Encephalitic|Parkinson Disease, Post Encephalitic|Parkinsonian Syndrome, Postencephalitis|Postencephalitis Parkinsonian Syndrome|von Economo Encephalitis Type Parkinsonism|Post-Encephalitic Parkinson Disease|Post Encephalitic Parkinson Disease|Postencephalitic Economo-Type Parkinsonism|Economo-Type Parkinsonism, Postencephalitic|Parkinsonism, Postencephalitic Economo-Type|Postencephalitic Economo Type Parkinsonism|Postencephalitic Parkinson Disease|Postencephalitic Parkinsonism|Encephalitis Lethargica Type Parkinsonism|Parkinsonism, Postencephalitic
 D010302	Parkinson Disease, Secondary	Secondary Parkinson Disease|Symptomatic Parkinson Disease|Parkinsonism, Symptomatic|Symptomatic Parkinsonism|Secondary Parkinsonism|Parkinson Disease, Symptomatic|Parkinsonism, Secondary
-D010303	Paromomycin	Estomycin|Hydroxymycin|Aminosidine|Paramomycin|Paromomycin I|Catenulin|Neomycin E
+D010303	Paromomycin	Estomycin|Aminosidine|Neomycin E|Paramomycin|Paromomycin I|Catenulin|Hydroxymycin
 D010304	Paronychia	Paronychias
 D010305	Parotid Diseases	Disease, Parotid|Diseases, Parotid|Parotid Disease
 D010306	Parotid Gland	Gland, Parotid|Glands, Parotid|Parotid Glands
@@ -11441,7 +11860,7 @@ D010364	Pattern Recognition, Visual	Recognition, Visual Pattern|Visual Pattern R
 D010365	Patulin	
 D010366	Peak Expiratory Flow Rate	PEFR|Flow Rate, Peak Expiratory|Expiratory Peak Flow Rate
 D010367	Arachis	
-D010368	Pectins	
+D010368	Pectins	Pectin
 D010369	Pectoralis Muscles	Muscle, Pectoralis|Muscles, Pectoralis|Pectoralis Muscle|Pectoral Muscle|Muscle, Pectoral|Muscles, Pectoral|Pectoral Muscles
 D010370	Pediatric Assistants	Assistant, Pediatric|Assistants, Pediatric|Pediatric Assistant
 D010371	Pediatric Nursing	Nursing, Pediatric|Nursings, Pediatric|Pediatric Nursings
@@ -11529,7 +11948,7 @@ D010452	Peptide Biosynthesis	Biosynthesis, Peptide
 D010453	Peptide Synthases	Synthases, Peptide|Acid-Amino-Acid Ligases|Acid Amino Acid Ligases|Ligases, Acid-Amino-Acid|Peptide Synthetases|Synthetases, Peptide
 D010454	Peptide Termination Factors	Factors, Peptide Termination|Termination Factors, Peptide
 D010455	Peptides	
-D010456	Peptides, Cyclic	Cyclic Peptides|Cyclopeptides
+D010456	Peptides, Cyclic	Cyclic Peptides|Cyclopeptides|Circular Peptides|Peptides, Circular
 D010457	Peptidoglycan	Murein
 D010458	Peptidyl Transferases	Transferases, Peptidyl|Transpeptidases|Peptidyltransferases|Peptidyl Translocases|Translocases, Peptidyl|Peptidyltransferase
 D010459	Peptococcaceae	
@@ -11620,7 +12039,7 @@ D010546	Perphenazine	Perfenazine|Chlorpiprazine
 D010547	Persistent Fetal Circulation Syndrome	Pulmonary Hypertension, Familial Persistent, of the Newborn|ACD-MPV|ACD MPV|ACDMPV|Alveolar Capillary Dysplasia With Misalignment Of Pulmonary Veins|Persistent Fetal Circulation|Circulation, Persistent Fetal|Familial Persistent Pulmonary Hypertension of the Newborn|Fetal Circulation, Persistent|Hypertension, Pulmonary, of Newborn, Persistent|Misalignment of the Pulmonary Vessels|Persistent Pulmonary Hypertension of Newborn|Alveolar Capillary Dysplasia With Misalignment Of Pulmonary Veins And Other Congenital Anomalies
 D010548	Personal Health Services	Health Services, Personal|Health Service, Personal|Personal Health Service|Service, Personal Health|Services, Personal Health
 D010549	Personal Satisfaction	Satisfaction, Personal
-D010550	Personal Space	Personal Spaces|Space, Personal|Spaces, Personal|Privacy of Space|Space Privacy|Body Buffer Zone|Body Buffer Zones|Buffer Zone, Body|Buffer Zones, Body|Zone, Body Buffer|Zones, Body Buffer
+D010550	Personal Space	Personal Spaces|Space, Personal|Spaces, Personal|Body Buffer Zone|Body Buffer Zones|Buffer Zone, Body|Buffer Zones, Body|Zone, Body Buffer|Zones, Body Buffer|Privacy of Space|Space Privacy|Peripersonal Space|Peripersonal Spaces|Space, Peripersonal|Spaces, Peripersonal
 D010551	Personality	Personalities
 D010552	Personality Assessment	Assessment, Personality|Assessments, Personality|Personality Assessments
 D010553	Personality Development	Development, Personality
@@ -11672,7 +12091,7 @@ D010599	Pharmacokinetics	Drug Kinetics|Kinetics, Drug
 D010600	Pharmacology	Pharmacologies
 D010601	Pharmacology, Clinical	Clinical Pharmacology
 D010602	Pharmacopoeias as Topic	
-D010603	Pharmacopoeias, Homeopathic	Homeopathic Pharmacopoeias|Homeopathic Pharmacopoeia|Pharmacopoeia, Homeopathic
+D010603	Pharmacopoeias, Homeopathic as Topic	Homeopathic Pharmacopoeias as Topic
 D010604	Pharmacy	
 D010605	Pharmacy Administration	Pharmacy Administrations|Administration, Pharmacy|Administrations, Pharmacy
 D010606	Pharmacy and Therapeutics Committee	
@@ -11752,16 +12171,16 @@ D010681	Philology, Classical	Classical Philology
 D010682	Philology, Oriental	Oriental Philology
 D010683	Philology, Romance	Romance Philology
 D010684	Philosophy	Philosophies
-D010685	Philosophy, Dental	Philosophies, Dental|Dental Philosophies|Dental Philosophy
+D010685	Philosophy, Dental	Dental Philosophy|Philosophies, Dental|Dental Philosophies
 D010686	Philosophy, Medical	Medical Philosophy
-D010687	Philosophy, Nursing	Nursing Philosophy|Nursing Philosophies|Philosophies, Nursing
+D010687	Philosophy, Nursing	Nursing Philosophies|Philosophies, Nursing|Nursing Philosophy
 D010688	Phimosis	Phimoses
 D010689	Phlebitis	Phlebitides
 D010690	Phlebography	Phlebographies|Venography|Venographies
 D010691	Phlebotomus	
 D010692	Phleomycins	Phleomycin
 D010693	Phloretin	
-D010694	Lactase-Phlorizin Hydrolase	Hydrolase, Lactase-Phlorizin|Lactase Phlorizin Hydrolase|Glycosylceramidase|Phloretin-Glucosidase|Phloretin Glucosidase|Phlorizin Hydrolase|Hydrolase, Phlorizin|Glycosyl Ceramidase|Ceramidase, Glycosyl|Lactase-Glycosylceramidase|Lactase Glycosylceramidase
+D010694	Lactase-Phlorizin Hydrolase	Hydrolase, Lactase-Phlorizin|Lactase Phlorizin Hydrolase|Lactase-Glycosylceramidase|Lactase Glycosylceramidase
 D010695	Phlorhizin	Phlorizin|Phloridzin
 D010696	Phloroglucinol	Benzene-1,3,5-triol|1,3,5-Benzenetriol
 D010697	Eosine I Bluish	Bluish, Eosine I|Phloxine B|Eosin B|Eosine B|Phloxin B|Eosine Bluish|Bluish, Eosine
@@ -11776,7 +12195,7 @@ D010705	Phosgene
 D010706	Phosmet	N-(Mercaptomethyl)phthalimide S-(O,O-dimethyl phosphorothionate)|Phthalophos
 D010707	Phosphamidon	
 D010709	Phosphate Acetyltransferase	Acetyltransferase, Phosphate|Phosphotransbutyrylase|Phosphoacylase|Phosphotransacetylase|Phosphotransacylase
-D010710	Phosphates	Inorganic Phosphates|Phosphates, Inorganic
+D010710	Phosphates	Phosphates, Inorganic|Phosphate|Inorganic Phosphates
 D010711	Phosphatidate Phosphatase	Phosphatase, Phosphatidate|Phosphatidic Acid Phosphohydrolase|Phosphohydrolase, Phosphatidic Acid|Phosphatidic Acid Phosphatase|Phosphatase, Phosphatidic Acid|Phosphatidate Phosphohydrolase|Phosphohydrolase, Phosphatidate
 D010712	Phosphatidic Acids	Acids, Phosphatidic
 D010713	Phosphatidylcholines	Phosphatidyl Choline|Choline, Phosphatidyl|Choline Phosphoglycerides|Phosphoglycerides, Choline|Phosphatidylcholine|Phosphatidyl Cholines|Cholines, Phosphatidyl|Choline Glycerophospholipids|Glycerophospholipids, Choline
@@ -11860,12 +12279,12 @@ D010797	Phthalimides
 D010798	Phycocyanin	
 D010799	Phycoerythrin	
 D010800	Phycomyces	Phycomyce
-D010802	Phylogeny	Phylogenies
+D010802	Phylogeny	Phylogenies|Phylogenomics|Phylogenomic
 D010803	Physalaemin	Physalemin
 D010804	Physarum	Physarums
 D010805	Physical Conditioning, Animal	Animal Physical Conditioning|Animal Physical Conditionings|Conditioning, Animal Physical|Conditionings, Animal Physical|Physical Conditionings, Animal
 D010806	Physical Education and Training	Physical Education, Training
-D010807	Physical Endurance	Endurance, Physical|Endurances, Physical|Physical Endurances
+D010807	Physical Endurance	Stamina, Physical|Physical Stamina|Endurance, Physical
 D010808	Physical Examination	Examination, Physical|Examinations, Physical|Physical Examinations
 D010809	Physical Fitness	Fitness, Physical
 D010810	Physical and Rehabilitation Medicine	Physical Medicine|Physiatrics|Physiatry|Physical Medicine and Rehabilitation|Medicine, Physical
@@ -11879,8 +12298,8 @@ D010818	Practice Patterns, Physicians'	Physicians' Practice Pattern|Physicians' 
 D010819	Physician's Role	Physician Role|Physician's Roles|Physicians Role|Role, Physician's|Roles, Physician's|Physicians' Role|Physicians' Roles|Role, Physicians'|Roles, Physicians'
 D010820	Physicians	Physician
 D010821	Physicians, Family	Family Physician|Family Physicians|Physician, Family
-D010822	Physicians, Women	Physician, Woman|Physicians, Woman|Woman Physician|Woman Physicians|Women Physicians
-D010823	Physician Assistants	Assistants, Physician|Physician Assistant|Physicians' Extenders|Extender, Physicians'|Extenders, Physicians'|Physician Extenders|Physician's Extenders|Physicians' Extender|Doctor's Assistants|Assistant, Doctor's|Assistants, Doctor's|Doctor Assistants|Doctor's Assistant|Physicians' Assistants|Assistant, Physicians'|Assistants, Physicians'|Physician's Assistants|Physicians Assistants|Physicians' Assistant
+D010822	Physicians, Women	Women Physicians|Physician, Woman|Physicians, Woman|Woman Physician|Woman Physicians
+D010823	Physician Assistants	Assistants, Physician|Physician Assistant|Physicians' Assistants|Assistant, Physicians'|Assistants, Physicians'|Physician's Assistants|Physicians Assistants|Physicians' Assistant|Physicians' Extenders|Extender, Physicians'|Extenders, Physicians'|Physician Extenders|Physician's Extenders|Physicians' Extender|Doctor's Assistants|Assistant, Doctor's|Assistants, Doctor's|Doctor Assistants|Doctor's Assistant
 D010824	Physicians' Offices	Office, Physicians'|Offices, Physicians'|Physician Offices|Physicians Offices|Physicians' Office|Physician's Office|Office, Physician's|Offices, Physician's|Physician Office|Physician's Offices|Physicians Office
 D010825	Physics	Physic
 D010826	Physiognomy	Physiognomies
@@ -11927,8 +12346,8 @@ D010866	Natamycin	Tennecetin|Pimaricin
 D010867	Pimelic Acids	Acids, Pimelic
 D010868	Pimozide	
 D010869	Pindolol	Prindolol
-D010870	Pineal Gland	Gland, Pineal|Pineal Glands|Pineal Body|Pineal Bodies|Corpus Pineale|Corpus Pineales|Epiphysis Cerebri|Cerebri, Epiphysis
-D010871	Pinealoma	Pinealomas|Pineal Tumors|Pineal Tumor|Tumor, Pineal|Tumors, Pineal|Pineal Neoplasms|Pineal Parenchymal Tumors|Pineal Parenchymal Tumor|Tumor, Pineal Parenchymal|Tumors, Pineal Parenchymal|Neoplasms, Pineal|Neoplasm, Pineal|Pineal Neoplasm|Pineal Gland Tumor|Pineal Gland Tumors|Tumor, Pineal Gland|Tumors, Pineal Gland
+D010870	Pineal Gland	Gland, Pineal|Pineal Glands|Corpus Pineale|Epiphysis Cerebri|Pineal Body|Pineal Bodies
+D010871	Pinealoma	Pinealomas|Pineal Gland Tumor|Pineal Gland Tumors|Tumor, Pineal Gland|Tumors, Pineal Gland|Pineal Parenchymal Tumors|Pineal Parenchymal Tumor|Tumor, Pineal Parenchymal|Tumors, Pineal Parenchymal|Pineal Tumors|Pineal Tumor|Tumor, Pineal|Tumors, Pineal|Neoplasms, Pineal|Neoplasm, Pineal|Pineal Neoplasm|Pineal Neoplasms
 D010872	Caniformia	Pinnipeds|Pinnipedia
 D010873	Pinocytosis	Pinocytoses
 D010874	Pinta	
@@ -11956,8 +12375,8 @@ D010899	Pituitary Apoplexy	Apoplexy, Pituitary
 D010900	Pituitary Diseases	Disease, Pituitary|Diseases, Pituitary|Pituitary Disease|Pituitary Gland Diseases|Disease, Pituitary Gland|Diseases, Pituitary Gland|Pituitary Gland Disease|Hypophyseal Disorders|Disorder, Hypophyseal|Disorders, Hypophyseal|Hypophyseal Disorder|Pituitary Disorders|Disorder, Pituitary|Disorders, Pituitary|Pituitary Disorder
 D010901	Pituitary Function Tests	Function Test, Pituitary|Function Tests, Pituitary|Pituitary Function Test|Test, Pituitary Function|Tests, Pituitary Function|Pituitary Gland Function Tests
 D010902	Pituitary Gland	Gland, Pituitary|Glands, Pituitary|Pituitary Glands|Hypophysis Cerebri|Cerebri, Hypophysis|Cerebrus, Hypophysis|Hypophysis Cerebrus|Hypophysis|Hypophyses
-D010903	Pituitary Gland, Anterior	Anterior Pituitary Glands|Pituitary Glands, Anterior|Lobus Anterior|Anterior, Lobus|Anteriors, Lobus|Lobus Anteriors|Anterior Lobe of Pituitary|Pituitary Anterior Lobe|Anterior Pituitary Gland|Pars Distalis of Pituitary|Pituitary Pars Distalis|Adenohypophysis|Adenohypophyses
-D010904	Pituitary Gland, Posterior	Gland, Posterior Pituitary|Posterior Pituitary Gland|Posterior Pituitary Glands|Infundibular Process|Infundibular Processes|Process, Infundibular|Processes, Infundibular|Pars Nervosa of Pituitary|Pituitary Pars Nervosa|Neural Lobe|Lobe, Neural|Lobes, Neural|Neural Lobes|Neurohypophysis|Posterior Lobe of Pituitary|Pituitary Posterior Lobe|Lobus Nervosus|Nervosus, Lobus
+D010903	Pituitary Gland, Anterior	Anterior Pituitary Glands|Pituitary Glands, Anterior|Lobus Anterior|Anterior, Lobus|Anteriors, Lobus|Lobus Anteriors|Pars Distalis of Pituitary|Pituitary Pars Distalis|Anterior Lobe of Pituitary|Pituitary Anterior Lobe|Adenohypophysis|Adenohypophyses|Anterior Pituitary Gland
+D010904	Pituitary Gland, Posterior	Gland, Posterior Pituitary|Posterior Pituitary Gland|Posterior Pituitary Glands|Pars Nervosa of Pituitary|Pituitary Pars Nervosa|Neural Lobe|Lobe, Neural|Lobes, Neural|Neural Lobes|Infundibular Process|Infundibular Processes|Process, Infundibular|Processes, Infundibular|Lobus Nervosus|Nervosus, Lobus|Neurohypophysis|Posterior Lobe of Pituitary|Pituitary Posterior Lobe
 D010905	Pituitary Hormone Release Inhibiting Hormones	Pituitary Hormone-Release Inhibiting Hormones
 D010906	Pituitary Hormone-Releasing Hormones	Pituitary Hormone Releasing Hormones|Hypophysiotropic Hormones|Hormones, Hypophysiotropic|Hormones, Pituitary Hormone Releasing
 D010907	Pituitary Hormones	Hormones, Pituitary
@@ -12139,7 +12558,7 @@ D011088	DNA Ligases	Ligases, DNA|Polydeoxyribonucleotide Ligases|Ligases, Polyde
 D011089	Polydeoxyribonucleotides	
 D011090	Polyenes	
 D011091	Polyesters	Polyester
-D011092	Polyethylene Glycols	Macrogols|Macrogol|Polyethylene Glycol|Glycol, Polyethylene|Glycols, Polyethylene|Polyethylene Oxide|Oxide, Polyethylene|Oxides, Polyethylene|Polyethylene Oxides|Polyethyleneoxide|Polyethyleneoxides|Polyoxyethylenes|Polyoxyethylene|Tritons
+D011092	Polyethylene Glycols	Macrogol|Macrogols|Polyethylene Oxide|Oxide, Polyethylene|Oxides, Polyethylene|Polyethylene Oxides|Polyethyleneoxide|Polyethyleneoxides|Polyoxyethylenes|Polyoxyethylene|Polyglycol|Polyglycols|Polyethylene Glycol|Glycol, Polyethylene|Glycols, Polyethylene
 D011093	Polyethylene Terephthalates	Polyethylene Terephthalate|Terephthalate, Polyethylene|Terephthalates, Polyethylene|Poly(Ethylene Terephtalate)|PET Polymer|PET Polymers
 D011094	Polyethyleneimine	Polyethyleneimines|Polyethylenimine|Polyethylenimines|Polyaziridine|Polyaziridines
 D011095	Polyethylenes	Ethene Homopolymers|Homopolymers, Ethene|Ethylene Polymers|Polymers, Ethylene
@@ -12249,7 +12668,7 @@ D011201	Poultry Diseases	Disease, Poultry|Diseases, Poultry|Poultry Disease
 D011202	Poultry Products	Poultry Product|Product, Poultry|Products, Poultry
 D011203	Poverty	
 D011204	Poverty Areas	Area, Poverty|Areas, Poverty|Poverty Area
-D011205	Povidone	Povidones|Polyvidon|Polyvidons|Polvidone|Polvidones|Povidone, Unspecified|Povidones, Unspecified|Unspecified Povidone|Unspecified Povidones|Polyvinylpyrrolidone|Polyvinylpyrrolidones
+D011205	Povidone	Polvidone|Polyvinylpyrrolidone|Povidone, Unspecified|Unspecified Povidone|Polyvidon|Polyvidons
 D011206	Povidone-Iodine	Povidone Iodine|Povidone-Iodines|PVP-I|PVP-Iodine|PVP Iodine|PVP-Iodines|Polyvinylpyrrolidone Iodine|Polyvinylpyrrolidone Iodines
 D011208	Powders	
 D011209	Power (Psychology)	Powers (Psychology)|Power
@@ -12261,7 +12680,7 @@ D011214	Practice (Psychology)	Practices (Psychology)
 D011215	Practice Management, Dental	Dental Practice Management|Management, Dental Practice
 D011216	Practice Management, Medical	Medical Practice Management|Management, Medical Practice|Managements, Medical Practice|Medical Practice Managements|Practice Managements, Medical
 D011217	Practolol	
-D011218	Prader-Willi Syndrome	Prader Willi Syndrome|Syndrome, Prader-Willi|Willi-Prader Syndrome|Syndrome, Willi-Prader|Willi Prader Syndrome|Prader Labhart Willi Syndrome|Prader-Labhart-Willi Syndrome|Syndrome, Prader-Labhart-Willi|Labhart-Willi Syndrome|Labhart Willi Syndrome|Syndrome, Labhart-Willi|Labhart-Willi-Prader-Fanconi Syndrome|Labhart Willi Prader Fanconi Syndrome|Syndrome, Labhart-Willi-Prader-Fanconi
+D011218	Prader-Willi Syndrome	Prader Willi Syndrome|Syndrome, Prader-Willi|Prader Labhart Willi Syndrome|Prader-Labhart-Willi Syndrome|Syndrome, Prader-Labhart-Willi|Labhart-Willi Syndrome|Labhart Willi Syndrome|Syndrome, Labhart-Willi|Labhart-Willi-Prader-Fanconi Syndrome|Labhart Willi Prader Fanconi Syndrome|Syndrome, Labhart-Willi-Prader-Fanconi|Willi-Prader Syndrome|Syndrome, Willi-Prader|Willi Prader Syndrome
 D011219	Prajmaline	Prajmalium|N-Propylajmaline
 D011220	Pralidoxime Compounds	Compounds, Pralidoxime|Pyridine Aldoxime Methyl Compounds|2-PAM Compounds|2 PAM Compounds|Compounds, 2-PAM
 D011221	Praseodymium	
@@ -12292,8 +12711,8 @@ D011247	Pregnancy	Pregnancies|Gestation
 D011248	Pregnancy Complications	Complication, Pregnancy|Pregnancy Complication|Complications, Pregnancy
 D011249	Pregnancy Complications, Cardiovascular	Complications, Cardiovascular Pregnancy|Pregnancy, Cardiovascular Complications|Pregnancies, Cardiovascular Complications|Cardiovascular Pregnancy Complications|Cardiovascular Pregnancy Complication|Complication, Cardiovascular Pregnancy|Pregnancy Complication, Cardiovascular
 D011250	Pregnancy Complications, Hematologic	Pregnancy Complications, Hematological|Complication, Hematological Pregnancy|Complications, Hematological Pregnancy|Hematological Pregnancy Complication|Hematological Pregnancy Complications|Pregnancy Complication, Hematological|Hematologic Pregnancy Complications|Pregnancy, Hematologic Complications|Pregnancies, Hematologic Complications|Complications, Hematologic Pregnancy|Complication, Hematologic Pregnancy|Hematologic Pregnancy Complication|Pregnancy Complication, Hematologic
-D011251	Pregnancy Complications, Infectious	Infectious Pregnancy Complications|Pregnancy, Infectious Complications|Pregnancies, Infectious Complications|Complications, Infectious Pregnancy|Complication, Infectious Pregnancy|Infectious Pregnancy Complication|Pregnancy Complication, Infectious
-D011252	Pregnancy Complications, Neoplastic	Pregnancy, Neoplastic Complications|Pregnancies, Neoplastic Complications|Complications, Neoplastic Pregnancy|Complication, Neoplastic Pregnancy|Neoplastic Pregnancy Complication|Pregnancy Complication, Neoplastic|Neoplastic Pregnancy Complications
+D011251	Pregnancy Complications, Infectious	Pregnancy, Infectious Complications|Complications, Infectious Pregnancy|Infectious Pregnancy Complication|Pregnancy Complication, Infectious|Infectious Pregnancy Complications
+D011252	Pregnancy Complications, Neoplastic	Neoplastic Pregnancy Complications|Pregnancy, Neoplastic Complications|Pregnancies, Neoplastic Complications|Complications, Neoplastic Pregnancy|Complication, Neoplastic Pregnancy|Neoplastic Pregnancy Complication|Pregnancy Complication, Neoplastic
 D011253	Pregnancy in Adolescence	Adolescence, Pregnancy in|Teen Pregnancy|Pregnancies, Teen|Pregnancy, Teen|Teen Pregnancies|Adolescent Pregnancy|Adolescent Pregnancies|Pregnancies, Adolescent|Pregnancy, Adolescent|Pregnancy, Teenage|Pregnancies, Teenage|Teenage Pregnancies|Teenage Pregnancy
 D011254	Pregnancy in Diabetics	Pregnancy in Diabetic|Pregnancy in Diabetes|Pregnancy in Diabete
 D011255	Pregnancy Maintenance	Maintenance, Pregnancy|Maintenances, Pregnancy|Pregnancy Maintenances
@@ -12342,7 +12761,7 @@ D011302	Prephenate Dehydratase	Dehydratase, Prephenate|Prephenate Hydro-lyase|Hy
 D011303	Prephenate Dehydrogenase	Dehydrogenase, Prephenate
 D011304	Presbycusis	Presbycuses
 D011305	Presbyopia	Presbyopias
-D011306	Prescription Fees	Dispensing Fees|Dispensing Fee|Fee, Dispensing|Fees, Dispensing|Fees, Prescription|Fee, Prescription|Prescription Fee
+D011306	Prescription Fees	Fees, Prescription|Fee, Prescription|Prescription Fee|Dispensing Fees|Dispensing Fee|Fee, Dispensing|Fees, Dispensing
 D011307	Drug Prescriptions	Drug Prescription
 D011309	Preservation, Biological	Preservation, Biologic|Biologic Preservation|Biological Preservation
 D011310	Preservatives, Pharmaceutical	Pharmaceutical Preservative|Preservative, Pharmaceutical|Pharmaceutic Aids (Preservatives)|Preservatives, Pharmaceutic|Pharmaceutic Preservative|Preservative, Pharmaceutic|Pharmaceutical Preservatives|Pharmaceutic Preservatives
@@ -12359,7 +12778,7 @@ D011320	Primary Health Care	Care, Primary Health|Health Care, Primary|Primary He
 D011321	Primary Nursing	Nursing, Primary|Primary Nursing Care|Care, Primary Nursing|Nursing Care, Primary
 D011322	Primary Prevention	Disease Prevention, Primary|Disease Preventions, Primary|Primary Disease Prevention|Primary Disease Preventions|Prevention, Primary
 D011323	Primates	Primate
-D011324	Primidone	Desoxyphenobarbital
+D011324	Primidone	
 D011325	Prince Edward Island	
 D011326	Printers' Marks	Marks, Printers'|Printer's Marks|Printers Marks|Printers' Mark
 D011327	Printing	
@@ -12490,7 +12909,7 @@ D011460	Prostaglandins F	PGF
 D011461	Prostaglandins F, Synthetic	PGF Synthetic|Synthetic, PGF|Prostaglandin F Analogues|Analogues, Prostaglandin F|Prostaglandin F Analogs|Analogs, Prostaglandin F|Synthetic Prostaglandins F
 D011462	Prostaglandins G	PGG
 D011463	Prostaglandins H	
-D011464	Epoprostenol	PGI2|Prostaglandin I2|Prostacyclin|Prostaglandin I(2)|Epoprostanol|PGX
+D011464	Epoprostenol	Epoprostanol|Prostaglandin I2|Prostacyclin|Prostaglandin I(2)
 D011465	Prostaglandins, Synthetic	PG Analogs|Analogs, PG|Prostaglandin Analogues|Analogues, Prostaglandin|Prostaglandin Analogs|Analogs, Prostaglandin|Synthetic Prostaglandins
 D011466	Prostanoic Acids	Acids, Prostanoic
 D011467	Prostate	Prostates
@@ -12509,7 +12928,7 @@ D011480	Protease Inhibitors	Inhibitors, Protease|Endopeptidase Inhibitors|Inhibi
 D011481	Protective Clothing	Clothing, Protective
 D011482	Protective Devices	Device, Protective|Devices, Protective|Protective Device|Safety Devices|Device, Safety|Devices, Safety|Safety Device
 D011483	Proteidae	
-D011484	Protein-Arginine N-Methyltransferases	N-Methyltransferases, Protein-Arginine|Protein Arginine N Methyltransferases|Protein Arginine Methyltransferase|Arginine Methyltransferase, Protein|Methyltransferase, Protein Arginine|Protein Methyltransferase I|Protein-Arginine N-Methyltransferase|N-Methyltransferase, Protein-Arginine|Protein Arginine N Methyltransferase|Arginine Methylase|Protein Methylase I
+D011484	Protein-Arginine N-Methyltransferases	Protein Arginine N Methyltransferases|Protein Methylase I|Arginine Methylase|Protein-Arginine N-Methyltransferase|Protein Arginine N Methyltransferase|Protein Arginine Methyltransferase|Arginine Methyltransferase, Protein|Methyltransferase, Protein Arginine|Protein Methyltransferase I
 D011485	Protein Binding	Binding, Protein
 D011486	Protein C	
 D011487	Protein Conformation	Conformation, Protein|Conformations, Protein|Protein Conformations
@@ -12612,7 +13031,7 @@ D011589	Psychology, Experimental	Experimental Psychology|Experimental Psychologi
 D011590	Psychology, Industrial	Industrial Psychology|Industrial Psychologies|Psychologies, Industrial
 D011591	Psychology, Medical	Medical Psychology
 D011592	Psychology, Military	Military Psychology
-D011593	Psychology, Social	Social Psychology|Psychologies, Social|Social Psychologies
+D011593	Psychology, Social	Social Psychology
 D011594	Psychometrics	Psychometric
 D011595	Psychomotor Agitation	Restlessness|Psychomotor Hyperactivity|Hyperactivity, Psychomotor|Psychomotor Restlessness|Restlessness, Psychomotor|Agitation, Psychomotor|Excitement, Psychomotor|Psychomotor Excitement
 D011596	Psychomotor Disorders	
@@ -12631,7 +13050,7 @@ D011610	Psychosocial Deprivation	Deprivation, Psychosocial|Deprivations, Psychos
 D011611	Psychosomatic Medicine	Medicine, Psychosomatic
 D011612	Psychosurgery	Psychosurgeries
 D011613	Psychotherapy	Psychotherapies
-D011614	Psychotherapy, Brief	Psychotherapy, Short-Term|Psychotherapies, Short-Term|Psychotherapy, Short Term|Short-Term Psychotherapies|Short-Term Psychotherapy|Short Term Psychotherapy|Brief Psychotherapy|Brief Psychotherapies|Psychotherapies, Brief
+D011614	Psychotherapy, Brief	Brief Psychotherapies|Psychotherapies, Brief|Psychotherapy, Short-Term|Psychotherapies, Short-Term|Psychotherapy, Short Term|Short-Term Psychotherapies|Short-Term Psychotherapy|Short Term Psychotherapy|Brief Psychotherapy
 D011615	Psychotherapy, Group	Group Psychotherapy
 D011616	Psychotherapy, Multiple	Multiple Psychotherapy|Multiple Psychotherapies|Psychotherapies, Multiple
 D011617	Psychotherapy, Rational-Emotive	Psychotherapies, Rational-Emotive|Psychotherapy, Rational Emotive|Rational-Emotive Psychotherapies|Rational Psychotherapy|Rational-Emotive Psychotherapy|Rational Emotive Psychotherapy|Psychotherapy, Rational|Psychotherapies, Rational|Rational Psychotherapies
@@ -12646,7 +13065,7 @@ D011625	Pterygium	Pterygiums
 D011626	Pterygoid Muscles	Muscle, Pterygoid|Muscles, Pterygoid|Pterygoid Muscle
 D011627	Puberty	Puberties
 D011628	Puberty, Delayed	Delayed Puberty
-D011629	Puberty, Precocious	Precocious Puberty
+D011629	Puberty, Precocious	Precocious Puberties|Puberties, Precocious|Pubertas Praecox|Praecox, Pubertas|Precocious Puberty
 D011630	Pubic Bone	Bone, Pubic|Bones, Pubic|Pubic Bones|Pubis
 D011631	Pubic Symphysis	Pubic Symphyses|Symphyses, Pubic|Symphysis, Pubic
 D011632	Public Assistance	Assistance, Public
@@ -12668,7 +13087,7 @@ D011648	Pulmonary Adenomatosis, Ovine	Adenomatosis, Ovine Pulmonary|Adenomatoses
 D011649	Pulmonary Alveolar Proteinosis	Alveolar Proteinosis, Pulmonary|Proteinosis, Pulmonary Alveolar|Pulmonary Alveolar Proteinoses|Alveolar Proteinoses, Pulmonary|Proteinoses, Pulmonary Alveolar
 D011650	Pulmonary Alveoli	Pulmonary Alveolus|Alveoli, Pulmonary|Alveolus, Pulmonary
 D011651	Pulmonary Artery	Pulmonary Arteries|Arteries, Pulmonary|Artery, Pulmonary
-D011652	Pulmonary Circulation	Circulation, Respiratory|Respiratory Circulation|Circulation, Pulmonary
+D011652	Pulmonary Circulation	Respiratory Circulation|Circulation, Respiratory|Circulation, Pulmonary
 D011653	Pulmonary Diffusing Capacity	Capacity, Pulmonary Diffusing|Diffusing Capacity, Pulmonary
 D011654	Pulmonary Edema	Wet Lung|Lung, Wet|Lungs, Wet|Wet Lungs|Pulmonary Edemas|Edema, Pulmonary|Edemas, Pulmonary
 D011655	Pulmonary Embolism	Pulmonary Embolisms|Embolism, Pulmonary|Embolisms, Pulmonary
@@ -12713,7 +13132,7 @@ D011693	Purpura	Purpuras
 D011694	Purpura, Hyperglobulinemic	Hyperglobulinemic Purpuras|Purpuras, Hyperglobulinemic|Waldenstrom Hyperglobulinemic Purpura|Hyperglobulinemic Purpura, Waldenstrom|Purpura, Waldenstrom Hyperglobulinemic|Hyperglobulinemic Purpura of Waldenström|Waldenström Hyperglobulinemic Purpura|Benign Hyperglobulinemic Purpura of Waldenström|Hyperglobulinemic Purpura
 D011695	Purpura, Schoenlein-Henoch	Purpura, Schoenlein Henoch|Anaphylactoid Purpura|Purpura, Anaphylactoid|Henoch Purpura|Purpura, Henoch|Purpura, Schonlein-Henoch|Purpura, Schonlein Henoch|Purpuras, Schonlein-Henoch|Schonlein-Henoch Purpura|Schonlein-Henoch Purpuras|Schoenlein-Henoch Purpura|Schoenlein Henoch Purpura|Henoch-Schonlein Purpura|Henoch-Schonlein Purpuras|Purpura, Henoch-Schonlein|Purpuras, Henoch-Schonlein|Henoch Schonlein Purpura|Henoch Schonlein Purpuras|Purpura, Henoch Schonlein|Purpuras, Henoch Schonlein|Schonlein Purpura, Henoch|Schonlein Purpuras, Henoch|Allergic Purpura|Purpura, Allergic|Henoch-Schoenlein Purpura|Henoch Schoenlein Purpura|Purpura, Henoch-Schoenlein
 D011696	Purpura, Thrombocytopenic	Purpuras, Thrombocytopenic|Thrombocytopenic Purpura|Thrombocytopenic Purpuras|Purpura, Thrombopenic|Purpuras, Thrombopenic|Thrombopenic Purpura|Thrombopenic Purpuras
-D011697	Purpura, Thrombotic Thrombocytopenic	Thrombocytopenic Purpura, Thrombotic|Moschkowitz Disease|Disease, Moschkowitz|Thrombotic Thrombocytopenic Purpura|Moschcowitz Disease|Disease, Moschcowitz|Purpura, Thrombotic Thrombopenic|Thrombopenic Purpura, Thrombotic|Thrombotic Thrombopenic Purpura
+D011697	Purpura, Thrombotic Thrombocytopenic	Thrombocytopenic Purpura, Thrombotic|Thrombotic Thrombocytopenic Purpura|Purpura, Thrombotic Thrombopenic|Thrombopenic Purpura, Thrombotic|Thrombotic Thrombopenic Purpura|Moschcowitz Disease|Moschkowitz Disease
 D011698	Pursuit, Smooth	Pursuits, Smooth|Smooth Pursuit|Smooth Pursuits
 D011699	Putamen	Putamens|Nucleus Putamen|Nucleus Putamens|Putamen, Nucleus|Putamens, Nucleus
 D011700	Putrescine	1,4-Diaminobutane|1,4 Diaminobutane|Tetramethylenediamine|1,4-Butanediamine|1,4 Butanediamine
@@ -12799,7 +13218,7 @@ D011783	Quadruplets	Quadruplet
 D011784	Quail	Quails
 D011785	Quality Assurance, Health Care	Healthcare Quality Assurance|Assurance, Healthcare Quality|Assurances, Healthcare Quality|Healthcare Quality Assurances|Quality Assurances, Healthcare|Quality Assurance, Healthcare|Health Care Quality Assurance
 D011786	Quality Control	Control, Quality|Controls, Quality|Quality Controls
-D011787	Quality of Health Care	Health Care Quality|Quality of Healthcare|Healthcare Quality|Quality of Care|Care Qualities|Care Quality
+D011787	Quality of Health Care	Health Care Quality|Quality of Healthcare|Healthcare Quality|Quality of Care|Care Quality
 D011788	Quality of Life	Life Quality
 D011789	Quantum Theory	Quantum Theories|Theories, Quantum|Theory, Quantum
 D011790	Quarantine	Quarantines
@@ -12833,7 +13252,7 @@ D011818	Rabies	Hydrophobia|Lyssa|Lyssas
 D011819	Rabies Vaccines	Vaccines, Rabies|Rabies Vaccine|Vaccine, Rabies
 D011820	Rabies virus	Rabies viruses
 D011821	Raccoons	Raccoon|Procyon|Procyons
-D011822	Race Relations	Relations, Race
+D011822	Race Relations	Relations, Race|Racial Relations|Relations, Racial
 D011825	Radar	
 D011826	Radial Nerve	Nerve, Radial|Nerves, Radial|Radial Nerves
 D011827	Radiation	Radiations
@@ -12865,7 +13284,7 @@ D011853	Radiobiology	Biology, Radiation|Radiation Biology
 D011854	Radiochemistry	Radiochemistries
 D011855	Radiodermatitis	Radiodermatitides|Radiation-Induced Dermatitis|Radiation Induced Dermatitis|Dermatitis, Radiation-Induced|Dermatitides, Radiation-Induced|Dermatitis, Radiation Induced|Radiation-Induced Dermatitides
 D011856	Radiographic Image Enhancement	Image Enhancement, Radiographic|Enhancement, Radiographic Image|Enhancements, Radiographic Image|Image Enhancements, Radiographic|Radiographic Image Enhancements
-D011857	Radiographic Image Interpretation, Computer-Assisted	Radiographic Image Interpretation, Computer Assisted|Computer Assisted Radiographic Image Interpretation|Computer-Assisted Radiographic Image Interpretation
+D011857	Radiographic Image Interpretation, Computer-Assisted	Computer-Assisted Radiographic Image Interpretation|Radiographic Image Interpretation, Computer Assisted|Computer Assisted Radiographic Image Interpretation
 D011858	Radiographic Magnification	Magnification, Radiographic|Magnifications, Radiographic|Radiographic Magnifications
 D011859	Radiography	
 D011860	Radiography, Abdominal	Abdominal Radiography|Abdominal Radiographies|Radiographies, Abdominal
@@ -12886,7 +13305,7 @@ D011874	Radiometry	Dosimetry, Radiation|Dosimetries, Radiation|Radiation Dosimet
 D011875	Radionuclide Angiography	Angiography, Radionuclide|Angiographies, Radionuclide|Radionuclide Angiographies|Angiography, Radioisotope|Angiographies, Radioisotope|Radioisotope Angiographies|Radioisotope Angiography
 D011876	Radionuclide Generators	Generator, Radionuclide|Generators, Radionuclide|Radionuclide Generator|Radioisotope Generators|Generator, Radioisotope|Generators, Radioisotope|Radioisotope Generator
 D011877	Radionuclide Imaging	Imaging, Radionuclide|Radioisotope Scanning|Scintigraphy|Gamma Camera Imaging|Imaging, Gamma Camera|Scanning, Radioisotope
-D011878	Radiotherapy	Radiotherapies|Radiation Therapy|Radiation Therapies|Therapies, Radiation|Therapy, Radiation
+D011878	Radiotherapy	Radiotherapies|Radiation Therapy|Radiation Therapies|Therapies, Radiation|Therapy, Radiation|Radiation Treatment|Radiation Treatments|Treatment, Radiation
 D011879	Radiotherapy Dosage	Dosage, Radiotherapy|Dosages, Radiotherapy|Radiotherapy Dosages
 D011880	Radiotherapy Planning, Computer-Assisted	Radiotherapy Planning, Computer Assisted|Planning, Computer-Assisted Radiotherapy|Planning, Computer Assisted Radiotherapy|Computer-Assisted Radiotherapy Planning|Computer Assisted Radiotherapy Planning|Dosimetry Calculations, Computer-Assisted|Calculation, Computer-Assisted Dosimetry|Calculations, Computer-Assisted Dosimetry|Computer-Assisted Dosimetry Calculation|Computer-Assisted Dosimetry Calculations|Dosimetry Calculation, Computer-Assisted|Dosimetry Calculations, Computer Assisted
 D011881	Radiotherapy, Computer-Assisted	Radiotherapy, Computer Assisted|Radiation Therapy, Computer-Assisted|Radiation Therapy, Computer Assisted|Computer-Assisted Radiotherapy|Computer Assisted Radiotherapy|Computer-Assisted Radiotherapies|Radiotherapies, Computer-Assisted|Computer-Assisted Radiation Therapy|Computer Assisted Radiation Therapy|Computer-Assisted Radiation Therapies|Radiation Therapies, Computer-Assisted|Therapies, Computer-Assisted Radiation|Therapy, Computer-Assisted Radiation
@@ -12912,7 +13331,7 @@ D011900	Ranula	Ranulas
 D011901	Ranvier's Nodes	Nodes, Ranvier's|Ranviers Nodes|Nodes of Ranvier|Ranvier Nodes
 D011902	Rape	
 D011903	Raphe Nuclei	Nuclei, Raphe|Nucleus, Raphe|Raphe Nucleus
-D011904	Rare Books	Book, Rare|Books, Rare|Rare Book
+D011904	Rare Books	Rare Book
 D011905	Genes, ras	ras Genes|ras Gene
 D011906	Rat-Bite Fever	Fever, Rat-Bite|Fevers, Rat-Bite|Rat Bite Fever|Rat-Bite Fevers|Streptobacillus moniliformis Infection|Infection, Streptobacillus moniliformis|Infections, Streptobacillus moniliformis|Streptobacillus moniliformis Infections|Ratbite Fever|Fever, Ratbite|Fevers, Ratbite|Ratbite Fevers|Haverhill Fever|Fever, Haverhill
 D011907	Rate Setting and Review	Review and Rate Setting|Rate Setting, Review|Rate Settings, Review|Review Rate Setting|Review Rate Settings|Setting, Review Rate|Settings, Review Rate
@@ -12938,7 +13357,7 @@ D011928	Raynaud Disease	Cold Fingers, Hereditary|Raynaud's Disease|Raynauds Dise
 D011929	Razoxane	
 D011930	Reaction Time	Reaction Times|Response Time|Response Times
 D011931	Reactive Inhibition	Inhibition, Reactive|Inhibitions, Reactive|Reactive Inhibitions
-D011932	Reading	Readings
+D011932	Reading	
 D011933	Reagent Kits, Diagnostic	Diagnostic Reagent Kits|Diagnostic Reagents and Test Kits|Diagnostic Test Kits|Diagnostic Test Kit|Kit, Diagnostic Test|Kits, Diagnostic Test|Test Kit, Diagnostic|Test Kits, Diagnostic|Kits, Diagnostic Reagent|Diagnostic Reagent Kit|Kit, Diagnostic Reagent|Reagent Kit, Diagnostic
 D011934	Reagent Strips	Reagent Strip|Strip, Reagent|Strips, Reagent
 D011935	Reagins	
@@ -12958,13 +13377,12 @@ D011948	Receptors, Antigen, T-Cell	T-Cell Antigen Receptor|Antigen Receptor, T-C
 D011949	Receptors, Cholecystokinin	Receptors, Pancreozymin|Cholecystokinin Receptor|Receptor, Cholecystokinin|Receptors, CCK|CCK Receptor|Receptor, CCK|CCK Receptors|Pancreozymin Receptors|Cholecystokinin Receptors
 D011950	Receptors, Cholinergic	Receptors, Acetylcholine|Cholinoceptive Sites|Sites, Cholinoceptive|Receptors, ACh|Cholinergic Receptors|ACh Receptors|Acetylcholine Receptors|Cholinoceptors
 D011951	Receptors, Complement	Complement Receptor|Receptor, Complement|Complement Receptors
-D011952	Receptors, Concanavalin A	Concanavalin A Receptor|Concanavalin A Receptors|Concanavalin A Binding Sites|Receptor, Concanavalin A
+D011952	Receptors, Concanavalin A	Receptor, Concanavalin A|Concanavalin A Binding Sites|Concanavalin A Receptor|Concanavalin A Receptors
 D011953	Receptors, Cyclic AMP	Cyclic AMP Receptors|cAMP Receptors|Receptors, cAMP|cAMP Receptor|Receptor, cAMP|Cyclic AMP Receptor|Receptor, Cyclic AMP
 D011954	Receptors, Dopamine	Dopamine Receptor|Receptor, Dopamine|Dopamine Receptors
 D011955	Receptors, Drug	Drug Receptor|Receptor, Drug|Drug Receptors
 D011956	Receptors, Cell Surface	Cell Surface Receptors
 D011957	Receptors, Opioid	Opiate Receptors|Opioid Receptor|Receptor, Opioid|Opioid Receptors|Opiate Receptor|Receptor, Opiate|Receptors, Opiate
-D011958	Receptor, Epidermal Growth Factor	Receptor Tyrosine-protein Kinase erbB-1|Receptor Tyrosine protein Kinase erbB 1|Transforming Growth Factor alpha Receptor|Urogastrone Receptor|TGF-alpha Receptor|Epidermal Growth Factor Receptor Kinase|Epidermal Growth Factor Receptor Protein-Tyrosine Kinase|Epidermal Growth Factor Receptor Protein Tyrosine Kinase|erbB-1 Proto-Oncogene Protein|Proto-Oncogene Protein, erbB-1|erbB 1 Proto Oncogene Protein|Receptor, EGF|Receptor, Urogastrone|Receptor, Transforming-Growth Factor alpha|Receptor, Transforming Growth Factor alpha|Receptor, TGF-alpha|Receptor, TGF alpha|c-erbB-1 Protein|c erbB 1 Protein|Receptor, ErbB-1|ErbB-1 Receptor|Receptor, ErbB 1|Proto-oncogene c-ErbB-1 Protein|Proto oncogene c ErbB 1 Protein|c-ErbB-1 Protein, Proto-oncogene|EGF Receptor|Epidermal Growth Factor Receptor
 D011959	Receptors, Estradiol	Estradiol Receptors|Estradiol Receptor|Receptor, Estradiol
 D011960	Receptors, Estrogen	Estrogen Receptors
 D011961	Receptors, Fc	Fc Receptor|Receptor, Fc|Fc Receptors
@@ -13001,7 +13419,7 @@ D011992	Endosomes	Endosome|Receptosomes|Receptosome
 D011993	Recombinant Fusion Proteins	Proteins, Recombinant Fusion|Fusion Proteins, Recombinant
 D011994	Recombinant Proteins	Proteins, Recombinant|Proteins, Biosynthetic|Biosynthetic Proteins
 D011995	Recombination, Genetic	Recombination|Recombinations|Genetic Recombination|Genetic Recombinations|Recombinations, Genetic
-D011996	Records as Topic	Records as Topics
+D011996	Records	Record|Records as Topic|Records as Topics
 D011997	Recovery Room	Recovery Rooms, Hospital|Room, Hospital Recovery|Rooms, Hospital Recovery|Hospital Recovery Rooms|Recovery Rooms|Room, Recovery|Rooms, Recovery|Recovery Room, Hospital|Hospital Recovery Room
 D011998	Recreation	Recreations
 D011999	Recruitment, Neurophysiological	Neurophysiological Recruitment
@@ -13046,7 +13464,7 @@ D012037	Refuse Disposal	Disposal, Refuse|Disposals, Refuse|Refuse Disposals
 D012038	Regeneration	Regenerations
 D012039	Regional Blood Flow	Blood Flow, Regional|Blood Flows, Regional|Flow, Regional Blood|Flows, Regional Blood|Regional Blood Flows
 D012040	Regional Health Planning	Health Planning, Regional|Planning, Regional Health
-D012041	Regional Medical Programs	Medical Programs, Regional|Programs, Regional Medical|Medical Program, Regional|Program, Regional Medical
+D012041	Regional Medical Programs	Programs, Regional Medical|Program, Regional Medical|Medical Program, Regional|Medical Programs, Regional
 D012042	Registries	Registry
 D012043	Regression (Psychology)	Regressions (Psychology)|Regression
 D012044	Regression Analysis	Analysis, Regression|Analyses, Regression|Regression Analyses|Regression Diagnostics|Diagnostics, Regression|Statistical Regression|Regression, Statistical|Regressions, Statistical|Statistical Regressions
@@ -13172,8 +13590,8 @@ D012170	Retinal Vein Occlusion	Occlusion, Retinal Vein|Occlusions, Retinal Vein|
 D012171	Retinal Vessels	Retinal Vessel|Vessel, Retinal|Vessels, Retinal|Retinal Blood Vessels|Blood Vessel, Retinal|Blood Vessels, Retinal|Retinal Blood Vessel|Vessel, Retinal Blood|Vessels, Retinal Blood
 D012172	Retinaldehyde	Vitamin A Aldehyde|Aldehyde, Vitamin A|Retinene|Axerophthal|Retinal
 D012173	Retinitis	
-D012174	Retinitis Pigmentosa	Rod-Cone Dystrophy|Rod-Cone Dystrophies|Rod Cone Dystrophies|Rod Cone Dystrophy|Pigmentary Retinopathy|Pigmentary Retinopathies|Retinopathies, Pigmentary|Retinopathy, Pigmentary|Tapetoretinal Degeneration|Tapetoretinal Degenerations
-D012175	Retinoblastoma	Retinoblastomas|Neuroblastoma, Retinal|Neuroblastomas, Retinal|Retinal Neuroblastoma|Retinal Neuroblastomas|Glioma, Retinal|Gliomas, Retinal|Retinal Glioma|Retinal Gliomas|Eye Cancer, Retinoblastoma|Glioblastoma, Retinal|Glioblastomas, Retinal|Retinal Glioblastoma|Retinal Glioblastomas
+D012174	Retinitis Pigmentosa	Tapetoretinal Degeneration|Tapetoretinal Degenerations|Pigmentary Retinopathy|Pigmentary Retinopathies|Retinopathies, Pigmentary|Retinopathy, Pigmentary
+D012175	Retinoblastoma	Retinoblastomas|Neuroblastoma, Retinal|Neuroblastomas, Retinal|Retinal Neuroblastoma|Retinal Neuroblastomas|Glioma, Retinal|Gliomas, Retinal|Retinal Glioma|Retinal Gliomas|Eye Cancer, Retinoblastoma|Cancer, Retinoblastoma Eye|Cancers, Retinoblastoma Eye|Eye Cancers, Retinoblastoma|Retinoblastoma Eye Cancer|Retinoblastoma Eye Cancers|Glioblastoma, Retinal|Glioblastomas, Retinal|Retinal Glioblastoma|Retinal Glioblastomas
 D012176	Retinoids	
 D012177	Retinol-Binding Proteins	Retinol Binding Proteins|Binding Proteins, Retinol|Retinoid Binding Proteins|Binding Proteins, Retinoid
 D012178	Retinopathy of Prematurity	Prematurity Retinopathies|Prematurity Retinopathy|Retrolental Fibroplasia|Fibroplasia, Retrolental|Fibroplasias, Retrolental|Retrolental Fibroplasias
@@ -13322,11 +13740,11 @@ D012333	RNA, Messenger	mRNA|Messenger RNA
 D012334	RNA, Neoplasm	Neoplasm RNA
 D012335	RNA, Ribosomal	Ribosomal RNA
 D012336	RNA, Ribosomal, 16S	16S Ribosomal RNA|RNA, 16S Ribosomal|Ribosomal RNA, 16S
-D012337	RNA, Ribosomal, 18S	18S Ribosomal RNA|RNA, 18S Ribosomal|Ribosomal RNA, 18S
-D012338	RNA, Ribosomal, 23S	23S Ribosomal RNA|RNA, 23S Ribosomal|Ribosomal RNA, 23S
-D012339	RNA, Ribosomal, 28S	28S Ribosomal RNA|RNA, 28S Ribosomal|Ribosomal RNA, 28S
-D012340	RNA, Ribosomal, 5.8S	5.8S Ribosomal RNA|RNA, 5.8S Ribosomal|Ribosomal RNA, 5.8S
-D012341	RNA, Ribosomal, 5S	5S Ribosomal RNA|RNA, 5S Ribosomal|Ribosomal RNA, 5S
+D012337	RNA, Ribosomal, 18S	18S RRNA|18S Ribosomal RNA|RNA, 18S Ribosomal|Ribosomal RNA, 18S
+D012338	RNA, Ribosomal, 23S	23S RRNA|23S Ribosomal RNA|RNA, 23S Ribosomal|Ribosomal RNA, 23S
+D012339	RNA, Ribosomal, 28S	28S RRNA|28S Ribosomal RNA|RNA, 28S Ribosomal|Ribosomal RNA, 28S
+D012340	RNA, Ribosomal, 5.8S	5.8S RRNA|5.8S Ribosomal RNA|RNA, 5.8S Ribosomal|Ribosomal RNA, 5.8S
+D012341	RNA, Ribosomal, 5S	5S RRNA|5S Ribosomal RNA|RNA, 5S Ribosomal|Ribosomal RNA, 5S
 D012342	RNA, Small Nuclear	snRNA|Small Nuclear RNA|Low Molecular Weight Nuclear RNA|Small Molecular Weight RNA
 D012343	RNA, Transfer	tRNA|Transfer RNA
 D012344	RNA, Transfer, Ala	Transfer RNA, Ala|Ala Transfer RNA|RNA, Ala Transfer|tRNA(Ala)|tRNAAla|Alanine-Specific tRNA|Alanine Specific tRNA|tRNA, Alanine-Specific
@@ -13388,7 +13806,7 @@ D012401	Rotavirus	Rotaviruses
 D012402	Rotenone	
 D012403	Rotifera	Rotiferas
 D012404	Round Ligament of Uterus	Uterus Round Ligament|Uterus Round Ligaments|Ligamentum Teres Uteri|Ligamentum Teres Uterus
-D012405	Round Window, Ear	Ear Round Window|Round Windows, Ear|Fenestra Cochleae|Round Window of Ear|Cochlear Round Window|Cochlear Round Windows|Round Window, Cochlear|Round Windows, Cochlear
+D012405	Round Window, Ear	Ear Round Window|Round Windows, Ear|Round Window of Ear|Cochlear Round Window|Cochlear Round Windows|Round Window, Cochlear|Round Windows, Cochlear|Fenestra Cochleae
 D012406	Roxarsone	3-Nitro-4-Hydroxyphenylarsonic Acid|3 Nitro 4 Hydroxyphenylarsonic Acid|Acid, 3-Nitro-4-Hydroxyphenylarsonic
 D012407	rRNA Operon	Operon, rRNA|Operons, rRNA|rRNA Operons
 D012408	Rubber	Natural Rubber|Natural Rubbers|Rubber, Natural|Rubbers, Natural|Plant Rubber|Plant Rubbers|Rubber, Plant|Rubbers, Plant|Latex Rubber
@@ -13398,7 +13816,7 @@ D012411	Rubella Vaccine	Vaccine, Rubella
 D012412	Rubella virus	Measles Virus, German|German Measles Virus
 D012413	Rubidium	
 D012414	Rubidium Radioisotopes	Radioisotopes, Rubidium
-D012415	Rubinstein-Taybi Syndrome	Rubinstein Taybi Syndrome|Syndrome, Rubinstein-Taybi|Rubinstein Syndrome|Syndrome, Rubinstein|Broad Thumbs and Great Toes, Characteristic Facies, and Mental Retardation|Broad Thumb-Hallux Syndrome|Broad Thumb Hallux Syndrome|Broad Thumb-Hallux Syndromes|Syndrome, Broad Thumb-Hallux|Syndromes, Broad Thumb-Hallux
+D012415	Rubinstein-Taybi Syndrome	Rubinstein Taybi Syndrome|Syndrome, Rubinstein-Taybi|Broad Thumb-Hallux Syndrome|Broad Thumb Hallux Syndrome|Broad Thumb-Hallux Syndromes|Syndrome, Broad Thumb-Hallux|Syndromes, Broad Thumb-Hallux|Broad Thumbs and Great Toes, Characteristic Facies, and Mental Retardation|Rubinstein Syndrome|Syndrome, Rubinstein
 D012416	Rubredoxins	
 D012417	Rumen	Rumens
 D012418	Ruminants	Ruminant|Ruminantia
@@ -13437,13 +13855,13 @@ D012450	Safflower Oil	Oil, Safflower|Oils, Safflower|Safflower Oils
 D012451	Safrole	Safroles|4-Allyl-1,2-methylenedioxybenzene|4 Allyl 1,2 methylenedioxybenzene|4-Allyl-1,2-methylenedioxybenzenes|Safrol|Safrols
 D012452	Saguinus	Tamarins, Long-tusked|Long-tusked Tamarin|Long-tusked Tamarins|Tamarin, Long-tusked|Tamarins, Long tusked|Marmoset, Long-Tusked|Long-Tusked Marmoset|Long-Tusked Marmosets|Marmoset, Long Tusked|Marmosets, Long-Tusked
 D012453	Saimiri	Saimirus|Monkey, Squirrel|Monkeys, Squirrel|Squirrel Monkeys|Squirrel Monkey
-D012454	Salamandra	Salamandras
+D012454	Salamandra	
 D012455	Salamandridae	
 D012456	Salaries and Fringe Benefits	
 D012457	Salicylamides	
 D012458	Salicylanilides	N-Phenylsalicylamides|N Phenylsalicylamides
 D012459	Salicylates	
-D012460	Sulfasalazine	Sulphasalazine|Salazosulfapyridine|Salicylazosulfapyridine
+D012460	Sulfasalazine	Salicylazosulfapyridine|Sulphasalazine|Salazosulfapyridine
 D012462	Saline Solution, Hypertonic	Hypertonic Solutions, Saline|Saline Hypertonic Solutions|Solutions, Saline Hypertonic|Saline Solutions, Hypertonic|Sodium Chloride Solution, Hypertonic|Hypertonic Solution, Saline|Saline Hypertonic Solution|Solution, Saline Hypertonic|Sodium Chloride Solutions, Hypertonic|Hypertonic Saline Solutions|Solutions, Hypertonic Saline|Hypertonic Saline Solution|Solution, Hypertonic Saline
 D012463	Saliva	Salivas
 D012464	Saliva, Artificial	Artificial Saliva
@@ -13546,13 +13964,13 @@ D012562	Schizophrenia, Disorganized	Disorganized Schizophrenia|Disorganized Schi
 D012563	Schizophrenia, Paranoid	Paranoid Schizophrenias|Schizophrenias, Paranoid|Paranoid Schizophrenia
 D012564	Schizophrenic Language	Language, Schizophrenic
 D012565	Schizophrenic Psychology	Psychology, Schizophrenic
-D012566	Sizofiran	Sonifilan|Schizophyllan|Sizofilan
+D012566	Sizofiran	
 D012567	Schizophyllum	Schizophyllums
 D012568	Schizosaccharomyces	Schizosaccharomyce
 D012569	Schizotypal Personality Disorder	Personality Disorder, Schizotypal|Disorder, Schizotypal Personality|Disorders, Schizotypal Personality|Personality Disorders, Schizotypal|Schizotypal Personality Disorders
 D012570	School Admission Criteria	Admission Criteria, School|Criteria, School Admission
 D012571	School Dentistry	Dentistries, School|Dentistry, School|School Dentistries
-D012572	School Health Services	Health Service, School|School Health Service|Service, School Health|School-Based Services|School Based Services|School-Based Service|Service, School-Based|Services, School-Based|Services, School Health|Health Services, School
+D012572	School Health Services	Health Services, School|Health Service, School|School Health Service|Service, School Health|School-Based Services|School Based Services|School-Based Service|Service, School-Based|Services, School-Based|School-Based Health Services|Health Service, School-Based|Health Services, School-Based|School Based Health Services|School-Based Health Service|Service, School-Based Health|Services, School-Based Health|Services, School Health
 D012573	School Nursing	Nursing, School|Nursings, School|School Nursings
 D012574	Schools	School
 D012575	Schools, Dental	Dental Schools|Dental School|School, Dental
@@ -13581,7 +13999,7 @@ D012597	Sclerosing Solutions	Solutions, Sclerosing
 D012598	Sclerosis	Scleroses
 D012599	Sclerostomy	Sclerostomies
 D012600	Scoliosis	Scolioses
-D012601	Scopolamine Hydrobromide	Hydrobromide, Scopolamine
+D012601	Scopolamine	Hyoscine
 D012602	Scopolamine Derivatives	Derivatives, Scopolamine|Scopolamines
 D012603	Scopoletin	Methylesculetin|Chrysotropic Acid|Acid, Chrysotropic|Gelseminic Acid|Acid, Gelseminic
 D012604	Scorpion Venoms	Venoms, Scorpion|Scorpion Venom|Venom, Scorpion
@@ -13617,14 +14035,14 @@ D012637	Security Measures	Measure, Security|Measures, Security|Security Measure
 D012639	Seeds	Seed|Zygotes, Plant|Plant Zygotes|Plant Zygote|Zygote, Plant|Embryos, Plant|Embryo, Plant|Plant Embryo|Plant Embryos
 D012640	Seizures	Seizure
 D012641	Selection, Genetic	Genetic Selection
-D012642	Selegiline	Selegiline, (R)-Isomer|Selegyline|L-Deprenyl
+D012642	Selegiline	Selegyline|Selegiline, (R)-Isomer|L-Deprenyl
 D012643	Selenium	Selenium-80|Selenium 80
 D012644	Selenium Radioisotopes	Radioisotopes, Selenium
 D012645	Selenomethionine	
 D012646	Self Administration	Administration, Self|Administrations, Self|Self Administrations
 D012647	Self-Assessment	Self-Assessments|Self Assessment|Self Assessment (Psychology)|Assessment, Self (Psychology)|Assessments, Self (Psychology)|Self Assessments (Psychology)|Assessment, Self|Assessments, Self|Self Assessments
 D012648	Self Care	Care, Self|Self-Care
-D012649	Self Concept	Concept, Self|Concepts, Self|Self Concepts
+D012649	Self Concept	Concept, Self
 D012650	Self Disclosure	Disclosure, Self|Disclosures, Self|Self Disclosures
 D012651	Self Medication	Medication, Self|Medications, Self|Self Medications
 D012652	Self Mutilation	Mutilation, Self
@@ -13642,7 +14060,7 @@ D012663	Semicarbazides
 D012664	Semicarbazones	
 D012665	Semicircular Canals	Canal, Semicircular|Canals, Semicircular|Semicircular Canal
 D012666	Semiconductors	Semiconductor
-D012667	Lunate Bone	Bone, Lunate|Bones, Lunate|Lunate Bones|Os Lunatum|Semilunar Bone|Bone, Semilunar|Bones, Semilunar|Semilunar Bones
+D012667	Lunate Bone	Bone, Lunate|Bones, Lunate|Lunate Bones|Semilunar Bone|Bone, Semilunar|Bones, Semilunar|Semilunar Bones|Os Lunatum
 D012668	Trigeminal Ganglion	Ganglion, Trigeminal|Trigeminal Ganglions|Gasserian Ganglion|Ganglion, Gasserian|Trigeminal Ganglia|Ganglia, Trigeminal|Trigeminal Ganglias|Gasser's Ganglion|Ganglion, Gasser's|Gasser Ganglion|Gassers Ganglion|Semilunar Ganglion|Ganglion, Semilunar|Semilunar Ganglions
 D012669	Seminal Vesicles	Seminal Vesicle|Vesicle, Seminal|Vesicles, Seminal
 D012670	Seminiferous Epithelium	Epithelium, Seminiferous|Epitheliums, Seminiferous|Seminiferous Epitheliums
@@ -13751,8 +14169,8 @@ D012776	Fibroma Virus, Rabbit	Fibroma Viruses, Rabbit|Rabbit Fibroma Viruses|Rab
 D012777	Cottontail rabbit papillomavirus	Cottontail rabbit papillomaviruses|papillomaviruses, Cottontail rabbit|Papillomavirus sylvilagi|Papilloma Virus, Shope|Shope Papilloma Virus
 D012778	Short Bowel Syndrome	Bowel Syndrome, Short|Bowel Syndromes, Short|Short Bowel Syndromes|Syndrome, Short Bowel|Syndromes, Short Bowel
 D012779	Short Rib-Polydactyly Syndrome	Short Rib Polydactyly Syndrome|Short Rib-Polydactyly Syndromes
-D012780	Short-Wave Therapy	Therapy, Shortwave|Shortwave Therapy|Shortwave Therapies|Therapies, Shortwave|Short Wave Therapy|Short Wave Therapies|Therapies, Short Wave|Therapy, Short Wave|Wave Therapies, Short|Wave Therapy, Short|Therapy, Short-Wave|Short-Wave Therapies|Therapies, Short-Wave
-D012781	Shorthand	Shorthands
+D012780	Short-Wave Therapy	Therapy, Short-Wave|Short-Wave Therapies|Therapies, Short-Wave|Therapy, Shortwave|Shortwave Therapy|Shortwave Therapies|Therapies, Shortwave|Short Wave Therapy|Short Wave Therapies|Therapies, Short Wave|Therapy, Short Wave
+D012781	Shorthand	
 D012782	Shoulder	Shoulders
 D012783	Shoulder Dislocation	Dislocation, Shoulder|Dislocations, Shoulder|Shoulder Dislocations|Glenohumeral Dislocation|Dislocation, Glenohumeral|Dislocations, Glenohumeral|Glenohumeral Dislocations
 D012784	Shoulder Fractures	Fracture, Shoulder|Fractures, Shoulder|Shoulder Fracture|Humeral Fractures, Proximal|Fracture, Proximal Humeral|Fractures, Proximal Humeral|Humeral Fracture, Proximal|Proximal Humeral Fracture|Proximal Humeral Fractures
@@ -13965,7 +14383,7 @@ D012996	Solutions
 D012997	Solvents	
 D012998	Somalia	
 D012999	Soman	Pinacolyl Methylphosphonofluoridate|Methylphosphonofluoridate, Pinacolyl
-D013000	Psychiatric Somatic Therapies	Therapies, Psychiatric Somatic|Somatic Therapies, Psychiatric|Somatic Therapy, Psychiatric|Therapy, Psychiatric Somatic|Psychiatric Somatic Therapy
+D013000	Psychiatric Somatic Therapies	Psychiatric Somatic Therapy|Therapies, Psychiatric Somatic|Somatic Therapies, Psychiatric|Somatic Therapy, Psychiatric|Therapy, Psychiatric Somatic
 D013001	Somatoform Disorders	Disorder, Somatoform|Disorders, Somatoform|Somatoform Disorder|Medically Unexplained Syndrome|Syndrome, Medically Unexplained|Syndromes, Medically Unexplained|Unexplained Syndrome, Medically|Unexplained Syndromes, Medically|Medically Unexplained Syndromes
 D013002	Somatomedins	Sulfation Factor|Factor, Sulfation|Somatomedin|Insulin Like Growth Factors|Insulin-Like Growth Factors|Factors, Insulin-Like Growth|Growth Factors, Insulin-Like
 D013003	Somatosensory Cortex	Cortex, Somatosensory
@@ -13978,7 +14396,7 @@ D013009	Somnambulism	Sleepwalking|Sleep Walking Disorder|Sleep Walking Disorders
 D013010	Sonication	Sonications
 D013011	Sorbic Acid	Acid, Sorbic|Propenylacrylic Acid|Acid, Propenylacrylic|Hexadienoic Acid|Acid, Hexadienoic
 D013012	Sorbitol	Glucitol
-D013013	Sorbose	L-Sorbose|L Sorbose
+D013013	Sorbose	
 D013014	SOS Response (Genetics)	Response, SOS (Genetics)|Responses, SOS (Genetics)|SOS Responses (Genetics)|SOS Induction|Induction, SOS|Inductions, SOS|SOS Inductions|SOS System|SOS Systems|System, SOS|Systems, SOS|SOS Response|Response, SOS|Responses, SOS|SOS Responses|SOS Function|Function, SOS|Functions, SOS|SOS Functions|SOS Repair|Repair, SOS|Repairs, SOS|SOS Repairs
 D013015	Sotalol	
 D013016	Sound	Sounds|Sonic Radiation|Radiation, Sonic|Radiations, Sonic|Sonic Radiations
@@ -14079,7 +14497,7 @@ D013115	Spinal Canal	Canal, Spinal|Spinal Canals
 D013116	Spinal Cord	Cord, Spinal|Cords, Spinal|Spinal Cords|Medulla Spinalis|Medulla Spinali|Spinali, Medulla|Spinalis, Medulla|Myelon|Myelons
 D013117	Spinal Cord Compression	Compression, Spinal Cord|Compressions, Spinal Cord|Spinal Cord Compressions|Myelopathy, Compressive|Compressive Myelopathy|Spinal Cord Compression, Extramedullary|Extramedullary Spinal Cord Compression
 D013118	Spinal Cord Diseases	Spinal Cord Disease|Spinal Cord Disorders|Spinal Cord Disorder|Myelopathy|Myelopathies
-D013119	Spinal Cord Injuries	Spinal Cord Trauma|Cord Trauma, Spinal|Cord Traumas, Spinal|Spinal Cord Traumas|Trauma, Spinal Cord|Traumas, Spinal Cord|Injuries, Spinal Cord|Cord Injuries, Spinal|Cord Injury, Spinal|Injury, Spinal Cord|Spinal Cord Injury|Myelopathy, Traumatic|Myelopathies, Traumatic|Traumatic Myelopathies|Traumatic Myelopathy
+D013119	Spinal Cord Injuries	Spinal Cord Trauma|Cord Trauma, Spinal|Cord Traumas, Spinal|Spinal Cord Traumas|Trauma, Spinal Cord|Traumas, Spinal Cord|Myelopathy, Traumatic|Myelopathies, Traumatic|Traumatic Myelopathies|Traumatic Myelopathy|Injuries, Spinal Cord|Cord Injuries, Spinal|Cord Injury, Spinal|Injury, Spinal Cord|Spinal Cord Injury
 D013120	Spinal Cord Neoplasms	Tumors, Spinal Cord|Spinal Cord Tumor|Spinal Cord Tumors|Tumor, Spinal Cord|Neoplasms, Spinal Cord|Neoplasm, Spinal Cord|Spinal Cord Neoplasm
 D013121	Spinal Curvatures	Curvature, Spinal|Curvatures, Spinal|Spinal Curvature
 D013122	Spinal Diseases	Disease, Spinal|Diseases, Spinal|Spinal Disease
@@ -14095,7 +14513,7 @@ D013131	Spine	Vertebral Column|Column, Vertebral|Columns, Vertebral|Vertebral Co
 D013132	Spinocerebellar Degenerations	Degeneration, Spinocerebellar|Degenerations, Spinocerebellar|Spinocerebellar Diseases|Spinocerebellar Disease|Spinocerebellar Degeneration|Spino Cerebellar Degenerations|Degeneration, Spino Cerebellar|Degenerations, Spino Cerebellar|Spino Cerebellar Degeneration|Spino-Cerebellar Degenerations|Degeneration, Spino-Cerebellar|Spino-Cerebellar Degeneration
 D013133	Spinothalamic Tracts	Spinothalamic Tract|Tract, Spinothalamic|Tracts, Spinothalamic
 D013134	Spiperone	Spiroperone|Spiroperidol
-D013136	Spiral Ganglion	Ganglion, Spiral|Spiral Ganglia|Ganglia, Spiral|Auditory Ganglion|Auditory Ganglions|Ganglion, Auditory|Ganglions, Auditory|Ganglion of Corti
+D013136	Spiral Ganglion	Ganglion, Spiral|Auditory Ganglion|Auditory Ganglions|Ganglion, Auditory|Ganglions, Auditory|Ganglion of Corti|Spiral Ganglia|Ganglia, Spiral
 D013137	Spiral Lamina	Lamina, Spiral|Laminas, Spiral|Spiral Laminas
 D013139	Spirillum	
 D013140	Spiritualism	
@@ -14268,7 +14686,7 @@ D013311	Streptozocin	Streptozotocine|2-Deoxy-2-((methylnitrosoamino)carbonyl)ami
 D013312	Stress, Physiological	Physiological Stresses|Stresses, Physiological|Physiological Stress
 D013313	Stress Disorders, Post-Traumatic	PTSD|Stress Disorder, Post Traumatic|Neuroses, Posttraumatic|Posttraumatic Neuroses|Posttraumatic Stress Disorders|Posttraumatic Stress Disorder|Stress Disorder, Posttraumatic|Stress Disorders, Posttraumatic|Neuroses, Post-Traumatic|Neuroses, Post Traumatic|Post-Traumatic Neuroses|Post-Traumatic Stress Disorders|Post Traumatic Stress Disorders|Post-Traumatic Stress Disorder|Stress Disorder, Post-Traumatic
 D013314	Stress, Mechanical	Mechanical Stress|Mechanical Stresses|Stresses, Mechanical
-D013315	Stress, Psychological	Psychological Stresses|Stresses, Psychological|Life Stress|Life Stresses|Stress, Life|Stresses, Life|Stress, Psychologic|Psychologic Stress|Psychological Stress
+D013315	Stress, Psychological	Psychological Stress|Psychological Stresses|Stresses, Psychological|Life Stress|Life Stresses|Stress, Life|Stresses, Life|Stress, Psychologic|Psychologic Stress|Stressor, Psychological|Psychological Stressor|Psychological Stressors|Stressors, Psychological
 D013316	Stria Vascularis	Vascularis, Stria
 D013317	Strikes, Employee	Strikes|Strike|Employee Strikes|Employee Strike|Strike, Employee
 D013318	Stroke Volume	Stroke Volumes|Volume, Stroke|Volumes, Stroke
@@ -14340,7 +14758,7 @@ D013386	Succinates
 D013387	Succinic Anhydrides	Anhydrides, Succinic
 D013388	Succinimides	Pyrrolidinediones|Butanimides
 D013389	Succinate-CoA Ligases	Ligases, Succinate-CoA|Succinate CoA Ligases|Succinyl Coenzyme A Synthetases|Succinic Thiokinases|Thiokinases, Succinic|Succinyl CoA Synthetases|CoA Synthetases, Succinyl|Synthetases, Succinyl CoA
-D013390	Succinylcholine	Succinyldicholine|Suxamethonium
+D013390	Succinylcholine	Succinyldicholine|Suxamethonium|Dicholine Succinate|Succinate, Dicholine
 D013391	Sucking Behavior	Behavior, Sucking|Behaviors, Sucking|Sucking Behaviors
 D013392	Sucralfate	Aluminum Sucrose Sulfate|Sulfate, Aluminum Sucrose|Basic Aluminum Sucrose Sulfate
 D013393	Sucrase	Sucrose alpha-D-Glucohydrolase|Sucrose alpha D Glucohydrolase|alpha-D-Glucohydrolase, Sucrose
@@ -14405,7 +14823,7 @@ D013454	Sulfoxides
 D013455	Sulfur	Sulfur-16|Sulfur 16
 D013456	Sulfur Acids	Acids, Sulfur
 D013457	Sulfur Compounds	Compounds, Sulfur
-D013458	Sulfur Dioxide	Dioxide, Sulfur|Sulfurous Anhydride|Anhydride, Sulfurous
+D013458	Sulfur Dioxide	Sulfurous Anhydride
 D013459	Sulfur Hexafluoride	Hexafluoride, Sulfur
 D013460	Sulfur Isotopes	Isotopes, Sulfur
 D013461	Sulfur Oxides	Oxides, Sulfur
@@ -14437,9 +14855,9 @@ D013488	Suppositories
 D013489	Suppression, Genetic	Genetic Suppression|Genetic Suppressions|Suppressions, Genetic
 D013491	Suppressor Factors, Immunologic	Immunologic Suppressor Factors|Suppressor T-Cell Factors|Factors, Suppressor T-Cell|Suppressor T Cell Factors|T-Cell Factors, Suppressor|Factors, T Suppressor|Suppressor Factors, T|T Suppressor Factors|T-Suppressor Factors|Factors, T-Suppressor|T Cell Suppressor Factors|Factors, Immunologic Suppressor|T-Cell Suppressive Factors|Factors, T-Cell Suppressive|Suppressive Factors, T-Cell|T Cell Suppressive Factors
 D013492	Suppuration	
-D013493	Suprachiasmatic Nucleus	Hypothalamic Suprachiasmatic Nuclei|Suprachiasmatic Nuclei, Hypothalamic|Hypothalamic Suprachiasmatic Nucleus|Suprachiasmatic Nucleus, Hypothalamic|Suprachiasmatic Nuclei
+D013493	Suprachiasmatic Nucleus	Hypothalamic Suprachiasmatic Nuclei|Suprachiasmatic Nuclei, Hypothalamic|Suprachiasmatic Nuclei|Hypothalamic Suprachiasmatic Nucleus|Suprachiasmatic Nucleus, Hypothalamic
 D013494	Supranuclear Palsy, Progressive	Progressive Supranuclear Palsies|Supranuclear Palsies, Progressive|Palsy, Progressive Supranuclear|Progressive Supranuclear Ophthalmoplegia|Progressive Supranuclear Palsy|Steele-Richardson-Olszewski Disease|Steele Richardson Olszewski Disease|Steele-Richardson-Olszewski Syndrome|Steele Richardson Olszewski Syndrome|Syndrome, Steele-Richardson-Olszewski|Supranuclear Palsy, Progressive, 1|Ophthalmoplegia, Progressive Supranuclear|Supranuclear Ophthalmoplegia, Progressive|Richardson's Syndrome|Richardson Syndrome|Syndrome, Richardson's
-D013495	Supraoptic Nucleus	Nucleus, Supraoptic|Supraoptic Nucleus of Hypothalamus|Hypothalamus Supraoptic Nucleus|Nucleus Supraopticus|Supraopticus, Nucleus
+D013495	Supraoptic Nucleus	Nucleus, Supraoptic|Nucleus Supraopticus|Supraopticus, Nucleus|Supraoptic Nucleus of Hypothalamus|Hypothalamus Supraoptic Nucleus
 D013496	Suprofen	
 D013497	Sural Nerve	Nerve, Sural|Nerves, Sural|Sural Nerves
 D013498	Suramin	
@@ -14457,8 +14875,8 @@ D013509	Gynecologic Surgical Procedures	Gynecologic Surgical Procedure|Procedure
 D013510	Pulmonary Surgical Procedures	Procedures, Pulmonary Surgical|Surgical Procedure, Pulmonary|Surgical Procedures, Pulmonary|Procedure, Pulmonary Surgical|Pulmonary Surgical Procedure
 D013511	Minor Surgical Procedures	Minor Surgical Procedure|Surgical Procedures, Minor|Procedures, Minor Surgical|Surgery, Minor|Surgical Procedure, Minor|Minor Surgery|Minor Surgeries|Surgeries, Minor|Procedure, Minor Surgical
 D013513	Obstetric Surgical Procedures	Obstetric Surgical Procedure|Procedure, Obstetric Surgical|Procedures, Obstetric Surgical|Obstetrical Surgical Procedures|Obstetrical Surgical Procedure|Procedure, Obstetrical Surgical|Procedures, Obstetrical Surgical|Surgical Procedure, Obstetrical|Surgical Procedures, Obstetrical|Surgical Procedures, Obstetric|Surgery, Obstetric|Obstetric Surgeries|Obstetric Surgery|Surgeries, Obstetric|Obstetrical Surgery|Obstetrical Surgeries|Surgeries, Obstetrical|Surgery, Obstetrical|Surgical Procedure, Obstetric
-D013514	Surgical Procedures, Operative	Operative Surgical Procedure|Operative Surgical Procedures|Procedures, Operative Surgical|Surgical Procedure, Operative|Operative Procedures|Operative Procedure|Procedure, Operative|Procedures, Operative|Procedure, Operative Surgical
-D013515	Surgery, Oral	Surgery, Maxillofacial|Maxillofacial Surgery|Oral Surgery
+D013514	Surgical Procedures, Operative	Operative Surgical Procedure|Surgical Procedure, Operative|Procedure, Operative Surgical|Procedures, Operative Surgical|Operative Procedures|Operative Procedure|Procedure, Operative|Procedures, Operative|Operative Surgical Procedures
+D013515	Surgery, Oral	Maxillofacial Surgery|Surgery, Maxillofacial|Oral Surgery
 D013516	Oral Surgical Procedures, Preprosthetic	Preprosthetic Oral Surgical Procedure|Surgical Procedures, Oral, Preprosthetic|Preprosthetic Oral Surgical Procedures|Oral Surgical Procedure, Preprosthetic|Surgical Procedure, Oral, Preprosthetic
 D013517	Otorhinolaryngologic Surgical Procedures	Procedure, Otorhinolaryngologic Surgical|Procedures, Otorhinolaryngologic Surgical|Otorhinolaryngological Surgical Procedures|Otorhinolaryngological Surgical Procedure|Procedure, Otorhinolaryngological Surgical|Procedures, Otorhinolaryngological Surgical|Surgical Procedure, Otorhinolaryngological|Surgical Procedures, Otorhinolaryngological|Surgical Procedures, Otorhinolaryngologic|Otorhinolaryngologic Surgical Procedure|Surgical Procedure, Otorhinolaryngologic
 D013518	Surgery, Plastic	Plastic Surgery
@@ -14557,11 +14975,11 @@ D013616	Tachycardia, Sinus	Sinus Tachycardia|Sinus Tachycardias|Tachycardias, Si
 D013617	Tachycardia, Supraventricular	Supraventricular Tachycardia|Supraventricular Tachycardias|Tachycardias, Supraventricular
 D013618	Tachyphylaxis	
 D013619	Tacrine	9-Amino-1,2,3,4-Tetrahydroacridine|1,2,3,4-Tetrahydro-9-acridinamine|Tetrahydroaminoacridine|1,2,3,4-Tetrahydroaminoacridine
-D013620	Tajikistan	Tadzhikistan|Tadjikistan|Tadzhik S.S.R.|Tadzhik SSR
+D013620	Tajikistan	Tadjikistan|Tadzhik S.S.R.|Tadzhik SSR|Tadzhikistan
 D013621	Taenia	Taenias|Taeniarhynchus
 D013622	Taeniasis	Taeniases|Taenia Infections|Infections, Taenia|Infection, Taenia|Taenia Infection
 D013623	Tail	Tails
-D013624	Taiwan	Republic of China|Formosa
+D013624	Taiwan	Formosa|Republic of China
 D013625	Takayasu Arteritis	Arteritis, Takayasu|Pulseless Disease|Young Female Arteritis|Arteritides, Young Female|Arteritis, Young Female|Female Arteritides, Young|Female Arteritis, Young|Young Female Arteritides|Takayasu Syndrome|Takayasu's Arteritis|Takayasus Arteritis|Arteritis, Takayasu's|Arteritis, Takayasus|Takayasu Disease|Disease, Takayasu
 D013626	Talampicillin	Phthalidyl Ampicillin|Ampicillin, Phthalidyl
 D013627	Talc	Talcum Powder
@@ -14637,7 +15055,7 @@ D013698	Templates, Genetic	Genetic Template|Genetic Templates|Template, Genetic
 D013699	Temporal Arteries	Arteries, Temporal|Artery, Temporal|Temporal Artery
 D013700	Giant Cell Arteritis	Arteritides, Giant Cell|Arteritis, Giant Cell|Giant Cell Arteritides|Arteritis, Giant Cell, Horton's|Horton's Giant Cell Arteritis|Horton Disease|Horton Giant Cell Arteritis|Horton's Disease|Hortons Disease|Arteritis, Giant Cell, Horton|Giant Cell Arteritis, Horton
 D013701	Temporal Bone	Bone, Temporal|Bones, Temporal|Temporal Bones
-D013702	Temporal Lobe	Lobe, Temporal|Lobes, Temporal|Temporal Lobes|Temporal Cortex|Cortex, Temporal|Cortices, Temporal|Temporal Cortices|Temporal Region|Region, Temporal|Regions, Temporal|Temporal Regions
+D013702	Temporal Lobe	Lobe, Temporal|Lobes, Temporal|Temporal Lobes|Temporal Region|Region, Temporal|Regions, Temporal|Temporal Regions|Temporal Cortex|Cortex, Temporal|Cortices, Temporal|Temporal Cortices
 D013703	Temporal Muscle	Muscle, Temporal|Muscles, Temporal|Temporal Muscles
 D013704	Temporomandibular Joint	Joint, Temporomandibular|Joints, Temporomandibular|Temporomandibular Joints|TMJ
 D013705	Temporomandibular Joint Disorders	Disorder, Temporomandibular Joint|Disorders, Temporomandibular Joint|Joint Disorder, Temporomandibular|Joint Disorders, Temporomandibular|Temporomandibular Joint Disorder|TMJ Disorders|Disorder, TMJ|Disorders, TMJ|TMJ Disorder|Temporomandibular Disorders|Disorder, Temporomandibular|Disorders, Temporomandibular|Temporomandibular Disorder|Temporomandibular Joint Diseases|Disease, Temporomandibular Joint|Diseases, Temporomandibular Joint|Joint Disease, Temporomandibular|Joint Diseases, Temporomandibular|Temporomandibular Joint Disease|TMJ Diseases|Disease, TMJ|Diseases, TMJ|TMJ Disease
@@ -14831,7 +15249,7 @@ D013905	Thoracoplasty	Thoracoplasties
 D013906	Thoracoscopy	Thoracoscopies|Pleural Endoscopy|Pleuroscopy|Pleuroscopies|Endoscopy, Pleural|Endoscopies, Pleural|Pleural Endoscopies
 D013907	Thoracostomy	Thoracostomies
 D013908	Thoracotomy	Thoracotomies
-D013909	Thorax	Chest|Chests|Thoraces|Thorace
+D013909	Thorax	Thoraces|Thorace|Chest|Chests
 D013910	Thorium	
 D013911	Thorium Dioxide	Dioxide, Thorium|Thorium Oxide|Oxide, Thorium
 D013912	Threonine	L-Threonine|L Threonine
@@ -14896,7 +15314,7 @@ D013970	Thyronines
 D013971	Thyrotoxicosis	Thyrotoxicoses
 D013972	Thyrotropin	TSH (Thyroid Stimulating Hormone)|Thyrotrophin|Thyroid-Stimulating Hormone|Hormone, Thyroid-Stimulating|Thyroid Stimulating Hormone|Thyreotropin
 D013973	Thyrotropin-Releasing Hormone	Thyrotropin Releasing Hormone|Thyrotropin-Releasing Factor|Thyrotropin Releasing Factor|Protirelin
-D013974	Thyroxine	T4 Thyroid Hormone|Thyroid Hormone, T4|Thyroxin|O-(4-Hydroxy-3,5-diiodophenyl) 3,5-diiodo-L-tyrosine|L-3,5,3',5'-Tetraiodothyronine|Levothyroxine|L-Thyroxine|L Thyroxine|3,5,3',5'-Tetraiodothyronine|O-(4-Hydroxy-3,5-diiodophenyl)-3,5-diiodotyrosine
+D013974	Thyroxine	O-(4-Hydroxy-3,5-diiodophenyl)-3,5-diiodotyrosine|Thyroxin|3,5,3',5'-Tetraiodothyronine|T4 Thyroid Hormone|Thyroid Hormone, T4
 D013975	Thyroxine-Binding Proteins	Thyroxine Binding Proteins|Thyroxine-Binding Protein|Thyroxine Binding Protein|Thyroxine Transport Protein
 D013976	Tiapamil Hydrochloride	Hydrochloride, Tiapamil|N-(3,4-dimethoxyphenethyl)-2-(3,4-dimethoxyphenyl)-N-methyl-m-dithian-2-propylamin-1,1,3,3-tetroxide hydrochloride
 D013977	Tibia	Tibias
@@ -14920,7 +15338,7 @@ D013995	Time
 D013996	Time and Motion Studies	
 D013997	Time Factors	Factor, Time|Factors, Time|Time Factor
 D013998	Time Perception	Perception, Time|Perceptions, Time|Time Perceptions
-D013999	Timolol	(S)-1-((1,1-Dimethylethyl)amino)-3-((4-(4-morpholinyl)-1,2,5-thiadazol-3-yl)oxy)-2-propanol|Timolol Hemihydrate|Hemihydrate, Timolol
+D013999	Timolol	
 D014001	Tin	Stannum
 D014002	Tin Fluorides	Fluoride, Tin|Fluorides, Tin|Tin Fluoride
 D014003	Tin Polyphosphates	Polyphosphates, Tin
@@ -14936,7 +15354,7 @@ D014012	Tinnitus	Ringing-Buzzing-Tinnitus|Ringing Buzzing Tinnitus
 D014013	1,2-Dihydroxybenzene-3,5-Disulfonic Acid Disodium Salt	
 D014014	Tissue Adhesives	Adhesive, Tissue|Adhesives, Tissue|Tissue Adhesive
 D014015	Tissue Banks	Bank, Tissue|Banks, Tissue|Tissue Bank
-D014016	Tissue Conditioning (Dental)	Conditioning, Tissue (Dental)|Conditionings, Tissue (Dental)|Tissue Conditionings (Dental)|Conditioning, Dental Tissue|Dental Tissue Conditioning|Tissue Conditioning, Dental
+D014016	Tissue Conditioning, Dental	Conditioning, Dental Tissue|Tissue Conditioning (Dental)|Conditioning, Tissue (Dental)|Dental Tissue Conditioning
 D014018	Tissue Distribution	Distribution, Tissue|Distributions, Tissue|Tissue Distributions
 D014019	Tissue Donors	Donor, Tissue|Donors, Tissue|Tissue Donor
 D014020	Tissue Extracts	Extracts, Tissue
@@ -14957,7 +15375,7 @@ D014034	Toes	Toe
 D014035	Togaviridae	Togaviruses|Togavirus
 D014036	Togaviridae Infections	Infection, Togaviridae|Togaviridae Infection|Togaviridae Disease|Disease, Togaviridae|Diseases, Togaviridae|Togaviridae Diseases|Togavirus Infections|Infections, Togaviridae|Infections, Togavirus|Infection, Togavirus|Togavirus Infection
 D014037	Togo	Togolese Republic
-D014038	Toilet Facilities	Facilities, Toilet|Facility, Toilet|Toilet Facility|Bathrooms|Bathroom
+D014038	Toilet Facilities	Facilities, Toilet|Facility, Toilet|Toilet Facility|Lavatories|Lavatory|Restrooms|Restroom|Bathrooms|Bathroom
 D014039	Toilet Training	Toilet Trainings|Training, Toilet|Trainings, Toilet
 D014040	Token Economy	Token Reinforcement|Reinforcement, Token|Reinforcements, Token|Token Reinforcements|Economy, Token|Economies, Token|Token Economies
 D014041	Tokyo	
@@ -15101,7 +15519,7 @@ D014180	Transplantation	Transplantations
 D014181	Transplantation Immunology	Immunology, Transplantation
 D014182	Transplantation, Autologous	Autotransplantation|Autotransplantations|Autografting|Autograftings|Autologous Transplantation|Autologous Transplantations|Transplantations, Autologous
 D014183	Transplantation, Heterologous	Heterografting|Xenotransplantation|Xenograft Transplantation|Transplantation, Xenograft|Xenografting|Heterograft Transplantation|Transplantation, Heterograft|Heterologous Transplantation
-D014184	Transplantation, Homologous	Transplantation, Allogeneic|Homografting|Homologous Transplantation|Allogeneic Transplantation|Allografting
+D014184	Transplantation, Homologous	Allogeneic Transplantation|Transplantation, Allogeneic|Homografting|Homologous Transplantation|Allogeneic Grafting|Grafting, Allogeneic|Allografting
 D014185	Transplantation, Isogeneic	Isograft Transplantation|Transplantation, Isograft|Syngeneic Transplantation|Transplantation, Syngeneic|Isogeneic Transplantation|Isografting
 D014186	Transportation	
 D014187	Transportation of Patients	Patients Transportation|Patients Transportations|Transport, Wounded and Sick|Transport of Wounded and Sick
@@ -15172,7 +15590,7 @@ D014253	Trichostrongylosis	Trichostrongyloses
 D014254	Trichostrongylus	
 D014255	Trichothecenes	
 D014256	Trichotillomania	Trichotillomanias
-D014257	Trichuriasis	Trichuriases|Whipworm Infection|Infection, Whipworm|Infections, Whipworm|Whipworm Infections|Trichuris Infection|Infection, Trichuris|Infections, Trichuris|Trichuris Infections|Trichocephaliasis|Trichocephaliases
+D014257	Trichuriasis	Trichuriases|Whipworm Infection|Infection, Whipworm|Infections, Whipworm|Whipworm Infections|Trichocephaliasis|Trichocephaliases|Trichuris Infection|Infection, Trichuris|Infections, Trichuris|Trichuris Infections|Trichuris trichiura Infection|Infection, Trichuris trichiura|Infections, Trichuris trichiura|Trichuris trichiura Infections
 D014258	Trichuris	Trichuri|Trichocephalus
 D014259	Trichuroidea	Trichuroideas
 D014260	Triclosan	2,4,4'-Trichloro-2'-Hydroxydiphenyl Ether|2-Hydroxy-2',4,4'-trichlorodiphenyl Ether
@@ -15199,7 +15617,7 @@ D014280	Triglycerides	Triacylglycerol|Triacylglycerols
 D014281	Trihexosylceramides	Trihexosyl Ceramides|Ceramides, Trihexosyl|Ceramide Trihexosides|Trihexosides, Ceramide
 D014282	Trihexyphenidyl	Benzhexol
 D014283	Triiodobenzoic Acids	Acids, Triiodobenzoic
-D014284	Triiodothyronine	T3 Thyroid Hormone|Thyroid Hormone, T3|Liothyronine
+D014284	Triiodothyronine	T3 Thyroid Hormone|Thyroid Hormone, T3
 D014285	Triiodothyronine, Reverse	Reverse Triiodothyronine|3,3,5-Triiodothyronine|Reverse T3 Thyroid hormone|3,3',5'-Triiodothyronine|3,3,5 Triiodothyronine
 D014286	Trilogy of Fallot	Fallot Trilogy|Fallot's Trilogy|Fallots Trilogy|Trilogy, Fallot's
 D014287	Trimebutine	
@@ -15251,7 +15669,7 @@ D014332	Tropocollagen
 D014333	Tropoelastin	
 D014334	Tropolone	
 D014335	Tropomyosin	
-D014336	Troponin	Troponins|Troponin Complex
+D014336	Troponin	Troponin Complex|Troponins
 D014337	Trout	
 D014338	Truncus Arteriosus	Arteriosus, Truncus
 D014339	Truncus Arteriosus, Persistent	Persistent Truncus Arteriosus
@@ -15315,7 +15733,7 @@ D014398	Tuberculosis, Renal	Renal Tuberculoses|Renal Tuberculosis|Tuberculoses, 
 D014399	Tuberculosis, Spinal	Spinal Tuberculoses|Spinal Tuberculosis|Tuberculoses, Spinal|Pott Disease|Disease, Pott|Pott's Disease|Disease, Pott's|Potts Disease
 D014400	Tuberculosis, Splenic	Splenic Tuberculoses|Splenic Tuberculosis|Tuberculoses, Splenic
 D014401	Tuberculosis, Urogenital	Tuberculoses, Urogenital|Urogenital Tuberculoses|Urogenital Tuberculosis
-D014402	Tuberous Sclerosis	Sclerosis, Tuberous|Tuberous Sclerosis Complex|Bourneville Syndrome|Syndrome, Bourneville|Bourneville's Disease|Bourneville's Syndrome|Syndrome, Bourneville's|Bourneville-Pringle Disease|Bourneville Pringle Disease|Disease, Bourneville-Pringle|Bourneville-Pringle's Disease|Bourneville Pringle's Disease|Bourneville-Pringles Disease|Disease, Bourneville-Pringle's|Cerebral Sclerosis|Cerebral Scleroses|Sclerosis, Cerebral|Epiloia|Phacomatosis, Bourneville|Bourneville Phacomatosis|Phakomatosis, Bourneville|Sclerosis Tuberosa|Tuberose Sclerosis|Sclerosis, Tuberose|Bourneville Disease|Bourneville Phakomatosis
+D014402	Tuberous Sclerosis	Sclerosis, Tuberous|Bourneville Phakomatosis|Bourneville Syndrome|Syndrome, Bourneville|Bourneville's Disease|Bourneville's Syndrome|Syndrome, Bourneville's|Bourneville-Pringle Disease|Bourneville Pringle Disease|Disease, Bourneville-Pringle|Bourneville-Pringle's Disease|Bourneville Pringle's Disease|Bourneville-Pringles Disease|Disease, Bourneville-Pringle's|Cerebral Sclerosis|Cerebral Scleroses|Sclerosis, Cerebral|Epiloia|Phacomatosis, Bourneville|Bourneville Phacomatosis|Phakomatosis, Bourneville|Sclerosis Tuberosa|Tuberose Sclerosis|Sclerosis, Tuberose|Tuberous Sclerosis Complex|Bourneville Disease
 D014403	Tubocurarine	Tubocurare|d-Tubocurare|d-Tubocurarine
 D014404	Tubulin	
 D014405	Tuftsin	L-Threonyl-L-Lysyl-L-Prolyl-L-Arginine|Taftsin|L-Thr-L-Lys-L-Pro-L-Arg
@@ -15474,13 +15892,13 @@ D014557	Urobilin
 D014558	Urobilinogen	
 D014559	Urocanate Hydratase	Hydratase, Urocanate|Urocanase|Urocaninase
 D014560	Urocanic Acid	Acid, Urocanic|Glyoxalinylacrylic Acid|Acid, Glyoxalinylacrylic
-D014561	Urochordata	Urochordatas|Urochordates|Urochordate|Tunicata|Tunicatas|Tunicates|Tunicate
+D014561	Urochordata	Tunicates|Tunicate|Urochordates|Urochordate|Tunicata
 D014562	Urodela	Caudata
 D014563	Urodynamics	Urodynamic
 D014564	Urogenital Abnormalities	Abnormality, Urogenital|Urogenital Abnormality|Genitourinary Abnormalities|Abnormalities, Genitourinary|Abnormality, Genitourinary|Genitourinary Abnormality|Abnormalities, Urogenital
 D014565	Urogenital Neoplasms	Neoplasm, Urogenital|Urogenital Neoplasm|Neoplasms, Urogenital|Genito-urinary Neoplasm|Genito-urinary Neoplasms|Neoplasm, Genito-urinary|Neoplasms, Genito-urinary|Genitourinary Neoplasms|Genitourinary Neoplasm|Neoplasm, Genitourinary|Neoplasms, Genitourinary
 D014566	Urogenital System	System, Urogenital|Systems, Urogenital|Urogenital Systems|Genitourinary System|Genitourinary Systems|System, Genitourinary|Systems, Genitourinary
-D014567	Urography	Urographies
+D014567	Urography	Urographies|Urogram|Urograms
 D014568	Urokinase-Type Plasminogen Activator	Urokinase Type Plasminogen Activator|Plasminogen Activator, Urokinase-Type|U-Plasminogen Activator|U Plasminogen Activator|U-PA|Urinary Plasminogen Activator|Urokinase
 D014570	Urologic Diseases	Disease, Urologic|Diseases, Urologic|Urologic Disease|Urological Diseases|Disease, Urological|Diseases, Urological|Urological Disease|Urinary Tract Diseases|Disease, Urinary Tract|Diseases, Urinary Tract|Urinary Tract Disease
 D014571	Urologic Neoplasms	Urological Neoplasms|Neoplasm, Urological|Neoplasms, Urological|Urological Neoplasm|Urinary Tract Neoplasms|Neoplasm, Urinary Tract|Neoplasms, Urinary Tract|Tract Neoplasm, Urinary|Tract Neoplasms, Urinary|Urinary Tract Neoplasm|Neoplasms, Urologic|Neoplasm, Urologic|Urologic Neoplasm
@@ -15510,7 +15928,7 @@ D014595	Uterine Perforation	Perforation, Uterine|Perforations, Uterine|Uterine P
 D014596	Uterine Prolapse	Prolapse, Uterine|Prolapses, Uterine|Uterine Prolapses
 D014597	Uterine Rupture	Rupture, Uterine|Ruptures, Uterine|Uterine Ruptures
 D014598	Uteroglobin	Clara Cell Secretory Protein|Secretoglobin, Family 1A, Member 1|Blastokinin|Clara Cell-Specific Protein|Clara Cell Specific Protein
-D014599	Uterus	Uteri
+D014599	Uterus	Uteri|Womb|Wombs
 D014600	Utilization Review	Review, Utilization|Reviews, Utilization|Utilization Reviews
 D014601	Utopias	Utopia
 D014602	Uvea	Uveas
@@ -15546,7 +15964,7 @@ D014631	Valerates	Pentanoates
 D014632	Valerian	Valerians|Valeriana|Valerianas
 D014633	Valine	L-Valine|L Valine
 D014634	Valinomycin	
-D014635	Valproic Acid	Propylisopropylacetic Acid|2-Propylpentanoic Acid|2 Propylpentanoic Acid|Divalproex
+D014635	Valproic Acid	2-Propylpentanoic Acid|2 Propylpentanoic Acid|Divalproex
 D014636	Valsalva Maneuver	Maneuver, Valsalva|Maneuvers, Valsalva|Valsalva Maneuvers|Valsalva's Maneuver|Maneuver, Valsalva's
 D014637	Valine-tRNA Ligase	Ligase, Valine-tRNA|Valine tRNA Ligase|Val-tRNA Ligase|Ligase, Val-tRNA|Val tRNA Ligase|Valyl T RNA Synthetase|Valyl-tRNA Synthetase|Synthetase, Valyl-tRNA|Valyl tRNA Synthetase
 D014638	Vanadates	Vanadate
@@ -15584,7 +16002,7 @@ D014670	Ampulla of Vater	Vater Ampulla|Hepatopancreatic Ampulla|Ampulla, Hepatop
 D014671	Vatican City	Holy See
 D014672	Vectorcardiography	Vectorcardiographies|Vectercardiography|Vectercardiographies|Electrocardiography, Vector|Electrocardiographies, Vector|Vector Electrocardiographies|Vector Electrocardiography
 D014673	Vecuronium Bromide	Bromide, Vecuronium|Vecuronium Hydrobromide|Hydrobromide, Vecuronium
-D014674	Vegetable Proteins	Protein, Vegetable|Proteins, Vegetable|Vegetable Protein|Plant Proteins, Dietary|Dietary Plant Proteins|Dietary Plant Protein|Plant Protein, Dietary|Protein, Dietary Plant|Proteins, Dietary Plant
+D014674	Plant Proteins, Dietary	Dietary Plant Proteins|Dietary Plant Protein|Plant Protein, Dietary|Protein, Dietary Plant|Proteins, Dietary Plant
 D014675	Vegetables	Vegetable
 D014676	Diet, Vegetarian	Diets, Vegetarian|Vegetarian Diets|Vegetarian Diet
 D014677	Pharmaceutical Vehicles	Pharmaceutical Vehicle|Vehicle, Pharmaceutical|Vehicles, Pharmaceutical
@@ -15611,7 +16029,7 @@ D014698	Venturicidins
 D014699	Venules	Venule
 D014700	Verapamil	Iproveratril
 D014701	Veratridine	
-D014702	Veratrine	Cevadine
+D014702	Veratrine	
 D014703	Veratrum	Hellebore, False|False Hellebore|False Hellebores|Hellebores, False
 D014704	Veratrum Alkaloids	Alkaloids, Veratrum
 D014705	Verbal Behavior	Behavior, Verbal|Behaviors, Verbal|Verbal Behaviors
@@ -15630,7 +16048,7 @@ D014718	Vesico-Ureteral Reflux	Reflux, Vesico-Ureteral|Vesico Ureteral Reflux|Ve
 D014719	Vesicovaginal Fistula	Fistula, Vesicovaginal|Fistulas, Vesicovaginal|Vesicovaginal Fistulas|Vesico-Vaginal Fistulae|Fistulae, Vesico-Vaginal|Vesico Vaginal Fistulae|Vesicovaginal Fistulae|Fistulae, Vesicovaginal|Vesico-Vaginal Fistula|Fistula, Vesico-Vaginal|Fistulas, Vesico-Vaginal|Vesico Vaginal Fistula|Vesico-Vaginal Fistulas
 D014720	Vesicular Exanthema of Swine	Swine Vesicular Exanthema|Swine Vesicular Exanthemas
 D014721	Vesicular stomatitis Indiana virus	Vesicular stomatitis-Indiana virus
-D014722	Vestibule, Labyrinth	Labyrinth Vestibule|Labyrinth Vestibules|Vestibules, Labyrinth|Vestibular Labyrinth|Labyrinth, Vestibular|Labyrinths, Vestibular|Vestibular Labyrinths|Vestibulum Auris|Ear Vestibule|Vestibule, Ear|Vestibules, Ear|Vestibular Apparatus|Apparatus, Vestibular|Vestibule of Ear|Ear Vestibules
+D014722	Vestibule, Labyrinth	Labyrinth Vestibule|Labyrinth Vestibules|Vestibules, Labyrinth|Ear Vestibule|Vestibule, Ear|Vestibules, Ear|Vestibule of Ear|Ear Vestibules|Vestibulum Auris|Vestibular Apparatus|Apparatus, Vestibular|Vestibular Labyrinth|Labyrinth, Vestibular|Labyrinths, Vestibular|Vestibular Labyrinths
 D014723	Vestibular Aqueduct	Aqueduct, Vestibular|Aqueducts, Vestibular|Vestibular Aqueducts|Aqueduct of Vestibule|Vestibule Aqueduct|Vestibule Aqueducts
 D014724	Vestibular Function Tests	Function Test, Vestibular|Function Tests, Vestibular|Test, Vestibular Function|Tests, Vestibular Function|Vestibular Function Test
 D014725	Vestibular Nerve	Nerve, Vestibular|Nerves, Vestibular|Vestibular Nerves
@@ -15671,7 +16089,7 @@ D014759	Viral Envelope Proteins	Proteins, Viral Envelope|Virus Envelope Proteins
 D014760	Viral Fusion Proteins	Virus Fusion Proteins|Fusion Proteins, Virus|Proteins, Virus Fusion|Fusion Proteins, Viral
 D014761	Viral Hepatitis Vaccines	Hepatitis Vaccines, Viral|Vaccines, Viral Hepatitis|Hepatitis, Viral, Vaccines
 D014762	Viral Interference	Interference, Viral|Interferences, Viral|Viral Interferences
-D014763	Viral Matrix Proteins	Matrix Proteins, Viral|Proteins, Viral Matrix|Membrane Proteins, Viral|Viral M Proteins|M Proteins, Viral|Proteins, Viral M|Viral Membrane Proteins|Proteins, Viral Membrane
+D014763	Viral Matrix Proteins	
 D014764	Viral Proteins	Proteins, Viral|Viral Gene Proteins|Gene Products, Viral|Viral Gene Products
 D014765	Viral Vaccines	Vaccines, Viral
 D014766	Viremia	Viremias
@@ -15685,7 +16103,7 @@ D014773	Virology
 D014774	Virulence	
 D014775	Virus Activation	Activation, Virus|Activations, Virus|Virus Activations|Viral Activation|Activation, Viral|Activations, Viral|Viral Activations|Virus Induction|Induction, Virus|Inductions, Virus|Virus Inductions
 D014776	Virus Cultivation	Cultivation, Virus|Cultivations, Virus|Virus Cultivations|Viral Cultivation|Cultivation, Viral|Cultivations, Viral|Viral Cultivations
-D014777	Virus Diseases	Disease, Virus|Diseases, Virus|Virus Disease|Viral Diseases|Disease, Viral|Diseases, Viral|Viral Disease|Viral Infections|Infection, Viral|Infections, Viral|Viral Infection|Virus Infections|Infection, Virus|Infections, Virus|Virus Infection
+D014777	Virus Diseases	Disease, Virus|Diseases, Virus|Virus Disease|Virus Infections|Infection, Virus|Infections, Virus|Virus Infection|Viral Diseases|Disease, Viral|Diseases, Viral|Viral Disease|Viral Infections|Infection, Viral|Infections, Viral|Viral Infection
 D014779	Virus Replication	Replication, Virus|Replications, Virus|Virus Replications
 D014780	Viruses	Virus
 D014781	Viscera	
@@ -15709,7 +16127,7 @@ D014799	Vitalism	Vitalisms
 D014800	Vitallium	
 D014801	Vitamin A	
 D014802	Vitamin A Deficiency	Deficiency, Vitamin A|Deficiencies, Vitamin A|Vitamin A Deficiencies
-D014803	Vitamin B Complex	B Vitamins|Neurobion
+D014803	Vitamin B Complex	
 D014804	Vitamin B Deficiency	Deficiency, Vitamin B|Deficiencies, Vitamin B|Vitamin B Deficiencies
 D014805	Vitamin B 12	B 12, Vitamin|Vitamin B12|B12, Vitamin|Cyanocobalamin
 D014806	Vitamin B 12 Deficiency	Vitamin B12 Deficiency|Deficiency, Vitamin B12|Deficiencies, Vitamin B12|Vitamin B12 Deficiencies|Deficiency, Vitamin B 12
@@ -15948,7 +16366,7 @@ D015046	Zoology
 D015047	Zoonoses	Zoonotic Infectious Diseases|Disease, Zoonotic Infectious|Diseases, Zoonotic Infectious|Infectious Disease, Zoonotic|Infectious Diseases, Zoonotic|Zoonotic Infectious Disease|Zoonotic Diseases|Disease, Zoonotic|Diseases, Zoonotic|Zoonotic Disease|Zoonotic Infections|Infection, Zoonotic|Infections, Zoonotic|Zoonotic Infection
 D015048	Zooplankton	
 D015049	Zoxazolamine	
-D015050	Zygoma	Zygomas|Malar Bone|Bone, Malar|Bones, Malar|Malar Bones|Cheek Bone|Bone, Cheek|Bones, Cheek|Cheek Bones|Jugal Bone|Bone, Jugal|Bones, Jugal|Jugal Bones
+D015050	Zygoma	Zygomas|Jugal Bone|Bone, Jugal|Bones, Jugal|Jugal Bones|Malar Bone|Bone, Malar|Bones, Malar|Malar Bones|Cheek Bone|Bone, Cheek|Bones, Cheek|Cheek Bones
 D015051	Zygomatic Fractures	Fracture, Zygomatic|Fractures, Zygomatic|Zygomatic Fracture
 D015053	Zygote	Zygotes|Fertilized Ovum|Ovum, Fertilized|Fertilized Egg|Egg, Fertilized|Eggs, Fertilized|Fertilized Eggs
 D015054	Zymosan	
@@ -16016,12 +16434,12 @@ D015118	Eicosapentaenoic Acid	Eicosapentanoic Acid|Acid, Eicosapentanoic|omega-3
 D015119	Aminocaproic Acid	6-Aminohexanoic Acid|6 Aminohexanoic Acid|epsilon-Aminocaproic Acid|epsilon Aminocaproic Acid|6-Aminocaproic Acid|6 Aminocaproic Acid
 D015120	6-Aminonicotinamide	6 Aminonicotinamide
 D015121	6-Ketoprostaglandin F1 alpha	F1 alpha, 6-Ketoprostaglandin|alpha, 6-Ketoprostaglandin F1|6-Oxoprostaglandin F1 alpha|6 Oxoprostaglandin F1 alpha|F1 alpha, 6-Oxoprostaglandin|alpha, 6-Oxoprostaglandin F1|6-Oxo-PGF1 alpha|6 Oxo PGF1 alpha|alpha, 6-Oxo-PGF1|6 Ketoprostaglandin F1 alpha|6-Keto-PGF1 alpha|6 Keto PGF1 alpha|alpha, 6-Keto-PGF1
-D015122	Mercaptopurine	6-Thiopurine|6 Thiopurine|6-Mercaptopurine Monohydrate|6 Mercaptopurine Monohydrate|1,7-Dihydro-6H-purine-6-thione|6-Thiohypoxanthine|6 Thiohypoxanthine
+D015122	Mercaptopurine	6H-Purine-6-thione, 1,7-dihydro-|6-Mercaptopurine Monohydrate|6 Mercaptopurine Monohydrate|6-Thiopurine|6 Thiopurine|1,7-Dihydro-6H-purine-6-thione|6-Mercaptopurine|6 Mercaptopurine|6-Thiohypoxanthine|6 Thiohypoxanthine
 D015123	7,8-Dihydro-7,8-dihydroxybenzo(a)pyrene 9,10-oxide	7,8-Dihydroxy-9,10-Epoxy-7,8,9,10-Tetrahydrobenzo(a)pyrene|BPDE|Benzo(a)pyrene 7,8-Dihydrodiol 9,10-Epoxide|Benzo(a)pyrene-7,8-diol 9,10-Epoxide|7,8-BaP-9,10-Diol Epoxide|Anti-BaPDE|Anti BaPDE
 D015124	8-Bromo Cyclic Adenosine Monophosphate	8 Bromo Cyclic Adenosine Monophosphate|Br Cycl AMP|AMP, Br Cycl|8-Bromo-cAMP|8 Bromo cAMP|8-Bromoadenosine 3',5'-Cyclic Monophosphate|8 Bromoadenosine 3',5' Cyclic Monophosphate|8-Br Cyclic AMP|8 Br Cyclic AMP|Cyclic AMP, 8-Br|8-Bromo Cyclic AMP|8 Bromo Cyclic AMP|Cyclic AMP, 8-Bromo
 D015125	Oxyquinoline	Oxyquinol|8-Quinolinol|8 Quinolinol|Oxine|8-Hydroxyquinoline|8 Hydroxyquinoline|8-Oxyquinoline|8 Oxyquinoline
-D015126	8,11,14-Eicosatrienoic Acid	Dihomo-gamma-Linolenic Acid|Acid, Dihomo-gamma-Linolenic|Dihomo gamma Linolenic Acid|Dihomogammalinolenic Acid|Acid, Dihomogammalinolenic|8,11,14 Eicosatrienoic Acid|DHLA
-D015127	9,10-Dimethyl-1,2-benzanthracene	DMBA|7,12-Dimethylbenzanthracene|7,12 Dimethylbenzanthracene
+D015126	8,11,14-Eicosatrienoic Acid	Homo-gamma Linolenic Acid|Homo gamma Linolenic Acid|Linolenic Acid, Homo-gamma|Dihomo-gamma-Linolenic Acid|Dihomo gamma Linolenic Acid|8,11,14 Eicosatrienoic Acid|Dihomogammalinolenic Acid
+D015127	9,10-Dimethyl-1,2-benzanthracene	7,12-Dimethylbenz(a)anthracene|7,12-Dimethylbenzanthracene|7,12 Dimethylbenzanthracene
 D015138	RNA, Nuclear	Nuclear RNA
 D015139	Blotting, Southern	Southern Blotting
 D015140	Dementia, Vascular	Dementias, Vascular|Vascular Dementias|Vascular Dementia
@@ -16181,7 +16599,7 @@ D015321	Gene Rearrangement	Gene Rearrangements|Rearrangement, Gene|Rearrangement
 D015322	Gene Rearrangement, B-Lymphocyte	Gene Rearrangement, B Lymphocyte|B-Lymphocyte Gene Rearrangement|B Lymphocyte Gene Rearrangement|B-Lymphocyte Gene Rearrangements|Gene Rearrangements, B-Lymphocyte|Rearrangement, B-Lymphocyte Gene|Rearrangements, B-Lymphocyte Gene|Gene Rearrangement, B-Cell|B-Cell Gene Rearrangements|Gene Rearrangement, B Cell|Gene Rearrangements, B-Cell|Rearrangement, B-Cell Gene|Rearrangements, B-Cell Gene|B-Cell Gene Rearrangement|B Cell Gene Rearrangement
 D015323	Pyruvate Metabolism, Inborn Errors	
 D015324	Pyruvate Carboxylase Deficiency Disease	Ataxia with Lactic Acidosis II|Ataxia with Lactic Acidosis, Type II|Lactic Acidosis with Ataxia, Type II|Pyruvate Carboxylase Deficiency|Deficiency, Pyruvate Carboxylase|Type II Ataxia with Lactic Acidosis|Ataxia with Lactic Acidosis 2|Deficiency Disease, Pyruvate Carboxylase
-D015325	Pyruvate Dehydrogenase Complex Deficiency Disease	Ataxia, Intermittent, with Pyruvate Dehydrogenase, or Decarboxylase, Deficiency|Intermittent Ataxia with Pyruvate Dehydrogenase Deficiency|PDH Deficiency|Deficiency, PDH|PDHC Deficiency Disease|Pyruvate Decarboxylase Deficiency|Deficiency, Pyruvate Decarboxylase|Pyruvate Dehydrogenase Complex Deficiency|Pyruvate Dehydrogenase Deficiency|Deficiency, Pyruvate Dehydrogenase|Ataxia, Intermittent, with Abnormal Pyruvate Metabolism|PDHC Deficiency|Deficiency, PDHC
+D015325	Pyruvate Dehydrogenase Complex Deficiency Disease	PDH Deficiency|Deficiency, PDH|Ataxia, Intermittent, with Abnormal Pyruvate Metabolism|Ataxia, Intermittent, with Pyruvate Dehydrogenase, or Decarboxylase, Deficiency|PDHC Deficiency Disease|Pyruvate Dehydrogenase Deficiency|Deficiency, Pyruvate Dehydrogenase|Intermittent Ataxia with Pyruvate Dehydrogenase Deficiency|PDHC Deficiency|Deficiency, PDHC|Pyruvate Decarboxylase Deficiency|Deficiency, Pyruvate Decarboxylase|Pyruvate Dehydrogenase Complex Deficiency
 D015326	Gene Rearrangement, B-Lymphocyte, Heavy Chain	B-Cell Heavy Chain Gene Rearrangement|B-Lymphocyte Heavy Chain Gene Rearrangement|B Cell Heavy Chain Gene Rearrangement|B Lymphocyte Heavy Chain Gene Rearrangement
 D015328	Gene Rearrangement, B-Lymphocyte, Light Chain	B-Cell Light Chain Gene Rearrangement|B-Lymphocyte Light Chain Gene Rearrangement|B Cell Light Chain Gene Rearrangement|B Lymphocyte Light Chain Gene Rearrangement
 D015329	Gene Rearrangement, T-Lymphocyte	Gene Rearrangement, T Lymphocyte|T-Lymphocyte Gene Rearrangement|Gene Rearrangements, T-Lymphocyte|Rearrangement, T-Lymphocyte Gene|Rearrangements, T-Lymphocyte Gene|T Lymphocyte Gene Rearrangement|T-Lymphocyte Gene Rearrangements|T-Cell Gene Rearrangement|T Cell Gene Rearrangement|Gene Rearrangement, T-Cell|Gene Rearrangement, T Cell|Gene Rearrangements, T-Cell|Rearrangement, T-Cell Gene|Rearrangements, T-Cell Gene|T-Cell Gene Rearrangements|Gene Rearrangement, T-Cell Antigen Receptor|Gene Rearrangement, T Cell Antigen Receptor
@@ -16192,7 +16610,7 @@ D015334	Gene Rearrangement, gamma-Chain T-Cell Antigen Receptor	T-Cell Antigen R
 D015335	Molecular Probes	Probe, Molecular|Probes, Molecular|Molecular Probe
 D015336	Molecular Probe Techniques	Technique, Molecular Probe|Techniques, Molecular Probe|Technics, Molecular Probe|Molecular Probe Technic|Probe Technic, Molecular|Probe Technics, Molecular|Molecular Probe Technics|Technic, Molecular Probe|Molecular Probe Technique|Probe Technique, Molecular|Probe Techniques, Molecular
 D015337	Multicenter Studies as Topic	Multicentre Studies as Topic
-D015340	Epidemiologic Research Design	Design, Epidemiologic Research|Designs, Epidemiologic Research|Research Design, Epidemiologic|Research Designs, Epidemiologic|Epidemiological Research Design|Design, Epidemiological Research|Designs, Epidemiological Research|Epidemiological Research Designs|Research Design, Epidemiological|Research Designs, Epidemiological|Epidemiologic Research Designs
+D015340	Epidemiologic Research Design	Epidemiological Research Design|Design, Epidemiological Research|Designs, Epidemiological Research|Epidemiological Research Designs|Research Design, Epidemiological|Research Designs, Epidemiological|Research Design, Epidemiologic|Designs, Epidemiologic Research|Epidemiologic Research Designs|Research Designs, Epidemiologic|Design, Epidemiologic Research
 D015341	Nucleic Acid Probes	Acid Probes, Nucleic|Probes, Nucleic Acid
 D015342	DNA Probes	Probes, DNA|DNA Hybridization Probes|Hybridization Probes, DNA|Probes, DNA Hybridization
 D015343	DNA Probes, HLA	Probes, HLA DNA|Human Leukocyte Antigen DNA Probes|HLA DNA Probes|DNA Probes, Histocompatibility Antigen|Histocompatibility Antigen DNA Probes
@@ -16236,7 +16654,7 @@ D015391	Gastroplasty	Gastroplasties
 D015392	Chemistry, Inorganic	Inorganic Chemistry|Chemistries, Inorganic|Inorganic Chemistries
 D015393	Chemistry, Bioinorganic	Bioinorganic Chemistry|Bioinorganic Chemistries|Chemistries, Bioinorganic|Biological Inorganic Chemistry|Biological Inorganic Chemistries|Chemistries, Biological Inorganic|Chemistry, Biological Inorganic|Inorganic Chemistries, Biological|Inorganic Chemistry, Biological|Biochemistry, Inorganic|Biochemistries, Inorganic|Inorganic Biochemistries|Inorganic Biochemistry
 D015394	Molecular Structure	Structure, Molecular|Molecular Structures|Structures, Molecular
-D015395	Histocompatibility Antigens Class I	Class I Histocompatibility Antigens|Class I Antigens|Antigens, Class I|I Antigens, Class|Class I Major Histocompatibility Antigens
+D015395	Histocompatibility Antigens Class I	Class I Antigens|Antigens, Class I|Class I Major Histocompatibility Antigens|Class I Histocompatibility Antigens|Class I MHC Proteins|Class I Major Histocompatibility Molecules|MHC-I Molecules|MHC I Molecules|Molecules, MHC-I|MHC-I Peptides|MHC I Peptides|Peptides, MHC-I|MHC Class I Molecules
 D015397	Program Evaluation	Evaluation, Program|Evaluations, Program|Program Evaluations
 D015398	Signal Transduction	Signal Transductions|Transduction, Signal|Transductions, Signal|Signal Transduction Systems|Signal Transduction System|System, Signal Transduction|Systems, Signal Transduction
 D015399	Nursing Research	Research, Nursing
@@ -16326,7 +16744,7 @@ D015510	Clinical Medicine	Medicine, Clinical
 D015511	Goat Diseases	Disease, Goat|Diseases, Goat|Goat Disease|Caprine Diseases|Caprine Disease|Disease, Caprine|Diseases, Caprine
 D015513	Oncogene Proteins	Proteins, Oncogene|Oncogene Products|Products, Oncogene|Oncoproteins|Oncogene Product|Product, Oncogene|Oncogene Protein|Protein, Oncogene
 D015514	Oncogene Proteins, Fusion	Fusion Oncogene Proteins|Proteins, Fusion Oncogene|Oncogene Proteins, Chimeric|Fusion Proteins, Oncogene|Oncogene Fusion Proteins|Proteins, Oncogene Fusion|Chimeric Oncogene Proteins|Proteins, Chimeric Oncogene|Chimeric Proteins, Oncogene|Oncogene Chimeric Proteins|Proteins, Oncogene Chimeric
-D015518	Rett Syndrome	Syndrome, Rett|Cerebroatrophic Hyperammonemia|Cerebroatrophic Hyperammonemias|Hyperammonemia, Cerebroatrophic|Hyperammonemias, Cerebroatrophic|Autism, Dementia, Ataxia, and Loss of Purposeful Hand Use|Rett's Disorder|Rett's Syndrome|Retts Syndrome|Syndrome, Rett's|Autism-Dementia-Ataxia-Loss of Purposeful Hand Use Syndrome|Autism Dementia Ataxia Loss of Purposeful Hand Use Syndrome|Rett Disorder
+D015518	Rett Syndrome	Syndrome, Rett|Autism-Dementia-Ataxia-Loss of Purposeful Hand Use Syndrome|Autism Dementia Ataxia Loss of Purposeful Hand Use Syndrome|Autism, Dementia, Ataxia, and Loss of Purposeful Hand Use|Rett Disorder|Rett's Disorder|Rett's Syndrome|Retts Syndrome|Syndrome, Rett's|Cerebroatrophic Hyperammonemia|Cerebroatrophic Hyperammonemias|Hyperammonemia, Cerebroatrophic|Hyperammonemias, Cerebroatrophic
 D015519	Bone Density	Bone Densities|Density, Bone|Bone Mineral Density|Bone Mineral Densities|Density, Bone Mineral
 D015521	Ethmoid Sinusitis	Sinusitis, Ethmoid|Ethmoid Sinusitides|Sinusitides, Ethmoid|Ethmoidal Sinusitis|Ethmoidal Sinusitides|Sinusitides, Ethmoidal|Sinusitis, Ethmoidal
 D015522	Frontal Sinusitis	Sinusitis, Frontal|Frontal Sinusitides|Sinusitides, Frontal
@@ -16404,8 +16822,8 @@ D015644	Miocamycin	9,3''-Diacetylmidecamycin|9,3'' Diacetylmidecamycin|Myocamici
 D015645	Tylosin	Tylosine|Fradizine
 D015646	Ventriculography, First-Pass	Ventriculography, First Pass|First-Pass Ventriculography|First Pass Ventriculography|First-Pass Ventriculographies|Radionuclide Ventriculography, First-Pass|First-Pass Radionuclide Ventriculographies|First-Pass Radionuclide Ventriculography|Radionuclide Ventriculographies, First-Pass|Radionuclide Ventriculography, First Pass|Ventriculographies, First-Pass Radionuclide|Ventriculography, First-Pass Radionuclide|First-Pass Radionuclide Angiography|Angiographies, First-Pass Radionuclide|Angiography, First-Pass Radionuclide|First Pass Radionuclide Angiography|First-Pass Radionuclide Angiographies|Radionuclide Angiographies, First-Pass|Radionuclide Angiography, First-Pass|Radionuclide Angiography, First Pass
 D015647	2,3,4,5-Tetrahydro-7,8-dihydroxy-1-phenyl-1H-3-benzazepine	1H-3-Benzazepine-7,8-diol, 2,3,4,5-tetrahydro-1-phenyl-
-D015649	Pentostatin	Deoxycoformycin|Co-Vidarabine|2'-Deoxycoformycin|2' Deoxycoformycin
-D015650	24,25-Dihydroxyvitamin D 3	24,25 Dihydroxyvitamin D 3|24,25-Dihydroxycholecalciferol|24,25 Dihydroxycholecalciferol|24,25 Dihydroxyvitamin D3|Dihydroxyvitamin D3, 24,25|24,25-Dihydroxyvitamin D3
+D015649	Pentostatin	
+D015650	24,25-Dihydroxyvitamin D 3	24,25 Dihydroxyvitamin D 3|24,25-Dihydroxyvitamin D3|24,25-Dihydroxycholecalciferol|24,25 Dihydroxycholecalciferol|24,25 Dihydroxyvitamin D3|Dihydroxyvitamin D3, 24,25
 D015651	Mycotoxicosis	Mycotoxicoses|Fungus Poisoning|Poisoning, Fungus|Fungus Poisonings|Poisonings, Fungus
 D015652	25-Hydroxyvitamin D 2	25 Hydroxyvitamin D 2|25-Hydroxyergocalciferol|25 Hydroxyergocalciferol|25-Hydroxyvitamin D2|25 Hydroxyvitamin D2|9,10-Secoergosta-5,7,10(19),22-tetraene-3 beta,25-diol|Ercalcidiol|25-Hydroxycalciferol|25 Hydroxycalciferol
 D015653	Cystectomy	Cystectomies
@@ -16468,10 +16886,10 @@ D015736	Felodipine
 D015737	Nisoldipine	
 D015738	Famotidine	
 D015739	Nocodazole	Oncodazole
-D015740	Calcitonin Gene-Related Peptide	Calcitonin Gene Related Peptide|Gene-Related Peptide, Calcitonin|Peptide, Calcitonin Gene-Related
+D015740	Calcitonin Gene-Related Peptide	Calcitonin Gene Related Peptide|Gene-Related Peptide, Calcitonin
 D015741	Metribolone	17 beta-Hydroxy-17 alpha-methylestra-4,9,11-trien-3-one|Methyltrienolone
 D015742	Propofol	2,6-Diisopropylphenol|2,6 Diisopropylphenol|2,6-Bis(1-methylethyl)phenol|Disoprofol
-D015743	Giant Cells, Foreign-Body	Cell, Foreign-Body Giant|Cells, Foreign-Body Giant|Foreign-Body Giant Cell|Foreign-Body Giant Cells|Giant Cell, Foreign-Body|Giant Cells, Foreign Body|Foreign Body Giant Cell|Foreign Body Giant Cells|Foreign Body-Type Giant Cells|Foreign Body Type Giant Cells
+D015743	Giant Cells, Foreign-Body	Cell, Foreign-Body Giant|Cells, Foreign-Body Giant|Foreign-Body Giant Cell|Foreign-Body Giant Cells|Giant Cell, Foreign-Body|Giant Cells, Foreign Body|Foreign Body Giant Cells|Foreign Body-Type Giant Cells|Foreign Body Type Giant Cells|Foreign Body Giant Cell
 D015744	Giant Cells, Langhans	Langhans-Type Giant Cells|Cells, Langhans-Type Giant|Giant Cells, Langhans-Type|Langhans Type Giant Cells|Langhans Giant Cells|Cells, Langhans Giant
 D015745	Granuloma, Foreign-Body	Granuloma, Foreign Body|Foreign-Body Granuloma|Foreign Body Granuloma|Foreign-Body Granulomas|Granulomas, Foreign-Body
 D015746	Abdominal Pain	Abdominal Pains|Pain, Abdominal|Pains, Abdominal
@@ -16495,7 +16913,7 @@ D015769	Granuloma, Respiratory Tract	Granulomas, Respiratory Tract|Respiratory T
 D015772	4,5-Dihydro-1-(3-(trifluoromethyl)phenyl)-1H-pyrazol-3-amine	
 D015773	Enalaprilat	
 D015774	Ganciclovir	Gancyclovir
-D015775	Fractures, Stress	Fractures, Fatigue|Stress Fractures|Fracture, Stress|Stress Fracture|Fatigue Fractures|Fatigue Fracture|Fracture, Fatigue|Fractures, March|Fracture, March|March Fracture|March Fractures
+D015775	Fractures, Stress	Fracture, Stress|Stress Fracture|Stress Fractures|Fractures, March|Fracture, March|March Fracture|March Fractures|Fatigue Fractures|Fatigue Fracture|Fracture, Fatigue|Fractures, Fatigue
 D015776	Keratoderma, Palmoplantar, Diffuse	Unna-Thost Syndrome|Syndrome, Unna-Thost|Unna Thost Syndrome|Tylosis|Thost-Unna Syndrome|Syndrome, Thost-Unna|Thost Unna Syndrome
 D015777	Eicosanoids	Icosanoids
 D015778	Minor Histocompatibility Antigens	Histocompatibility Antigens, Minor|Minor Histocompatibility Peptides|Histocompatibility Peptides, Minor
@@ -16589,7 +17007,7 @@ D015882	Retinal Necrosis Syndrome, Acute	Acute Retinal Necrosis|Acute Retinal Ne
 D015891	Cystatins	Cystatin Superfamily
 D015894	Genome, Human	Human Genome|Genomes, Human|Human Genomes
 D015895	Relative Value Scales	Relative Value Scale|Scale, Relative Value|Scales, Relative Value|Relative-Value Schedules|Relative Value Schedules|Relative-Value Schedule|Schedule, Relative-Value|Schedules, Relative-Value
-D015897	Comorbidity	Comorbidities
+D015897	Comorbidity	
 D015898	Tomography Scanners, X-Ray Computed	Tomography Scanners, X Ray Computed|CAT Scanners, X-Ray|CAT Scanners, X Ray|Computed Tomography Scanner, X-Ray|Computed Tomography Scanner, X Ray|X-Ray Computed Tomography Scanners|X Ray Computed Tomography Scanners|CT Scanner, X-Ray|CT Scanner, X Ray|CT Scanners, X-Ray|Scanner, X-Ray CT|Scanners, X-Ray CT|X-Ray CT Scanner|X-Ray CT Scanners|Tomography, X-Ray Computed, Scanner|Tomography, X-Ray Computed, Scanners|X-Ray Computed Tomography Scanner|X Ray Computed Tomography Scanner|CAT Scanner, X-Ray|CAT Scanner, X Ray|Scanner, X-Ray CAT|Scanners, X-Ray CAT|X-Ray CAT Scanner|X-Ray CAT Scanners|Computed Tomography Scanners, X-Ray|Computed Tomography Scanners, X Ray
 D015899	Tomography, Emission-Computed, Single-Photon	CT Scan, Single-Photon Emission|CT Scan, Single Photon Emission|Radionuclide Tomography, Single-Photon Emission-Computed|Radionuclide Tomography, Single Photon Emission Computed|Tomography, Single-Photon, Emission-Computed|Single-Photon Emission Computerized Tomography|Single Photon Emission Computerized Tomography|Single-Photon Emission CT Scan|Single Photon Emission CT Scan|Single-Photon Emission-Computed Tomography|Emission-Computed Tomography, Single-Photon|Single Photon Emission Computed Tomography|Tomography, Single-Photon Emission-Computed|SPECT|CAT Scan, Single-Photon Emission|CAT Scan, Single Photon Emission|Single-Photon Emission Computer-Assisted Tomography|Single Photon Emission Computer Assisted Tomography
 D015900	Radiography, Dual-Energy Scanned Projection	Digital Scanned Projection Radiography, Dual Energy|Dual-Energy Scanned Projection Radiography|Digital Scan Projection Radiography, Dual-Energy|Dual Energy Scanned Projection Radiography|Radiography, Dual Energy Scanned Projection|Digital Scan Projection Radiography, Dual Energy|Digital Scanned Projection Radiography, Dual-Energy
@@ -16618,7 +17036,7 @@ D015924	Blood Pressure Monitors	Sphygmomanometers, Continuous|Continuous Sphygmo
 D015925	Cryopreservation	Cryofixation
 D015926	Complement C3a	C3a, Complement|Complement 3a|Complement Component 3a|Component 3a, Complement|C3a Complement|Complement, C3a
 D015927	Skin Test End-Point Titration	Skin Test End Point Titration|Titration Skin Test, End-Point|Titration Skin Test, End Point|Titration Skin Test, Endpoint|Skin End-Point Titration|End-Point Titration, Skin|End-Point Titrations, Skin|Skin End Point Titration|Skin End-Point Titrations|Titration, Skin End-Point|Titrations, Skin End-Point|Serial Dilution End-Point Titration|Serial Dilution End Point Titration|Serial Dilution Endpoint Titration|Skin Test Endpoint Titration
-D015928	Cognitive Therapy	Cognitive Therapies|Therapies, Cognitive|Cognition Therapy|Cognition Therapies|Therapies, Cognition|Cognitive Behavior Therapy|Therapy, Cognitive Behavior|Cognitive Psychotherapy|Cognitive Psychotherapies|Psychotherapies, Cognitive|Psychotherapy, Cognitive|Therapy, Cognition|Therapy, Cognitive|Behavior Therapy, Cognitive|Behavior Therapies, Cognitive|Cognitive Behavior Therapies|Therapies, Cognitive Behavior|Cognitive Behavioral Therapy|Behavioral Therapies, Cognitive|Behavioral Therapy, Cognitive|Cognitive Behavioral Therapies|Therapies, Cognitive Behavioral|Therapy, Cognitive Behavioral
+D015928	Cognitive Behavioral Therapy	Behavioral Therapies, Cognitive|Behavioral Therapy, Cognitive|Cognitive Behavioral Therapies|Therapies, Cognitive Behavioral|Therapy, Cognitive Behavioral|Therapy, Cognition|Therapy, Cognitive Behavior|Cognition Therapy|Cognition Therapies|Therapies, Cognition|Cognitive Psychotherapy|Cognitive Psychotherapies|Psychotherapies, Cognitive|Psychotherapy, Cognitive|Therapy, Cognitive|Cognitive Therapies|Therapies, Cognitive|Cognitive Therapy|Cognitive Behavior Therapy|Behavior Therapies, Cognitive|Cognitive Behavior Therapies|Therapies, Cognitive Behavior|Behavior Therapy, Cognitive
 D015930	Diet Records	Diet Record|Record, Diet|Records, Diet|Food Diaries|Diaries, Food|Diary, Food|Food Diary|Dietary Records|Dietary Record|Record, Dietary|Records, Dietary
 D015931	Intensive Care, Neonatal	Care, Neonatal Intensive|Neonatal Intensive Care|Infant, Newborn, Intensive Care
 D015932	Complement C3c	C3c, Complement|Complement 3c|Complement Component 3c|Component 3c, Complement|C3c Complement|Complement, C3c|Complement C3c Fragment|C3c Fragment, Complement|Fragment, Complement C3c
@@ -16645,7 +17063,7 @@ D015967	Gene Expression Regulation, Viral	Viral Gene Expression Regulation|Regul
 D015969	National Academies of Science, Engineering, and Medicine (U.S.) Health and Medicine Division	Institute of Medicine|Institute of Medicine (U.S.)|Medicine Institute (U.S.)|Medicine Institutes (U.S.)|National Academies of Science, Engineering, and Medicine (US) Health and Medicine Division
 D015971	Gene Expression Regulation, Enzymologic	Regulation of Gene Expression, Enzymologic|Regulation, Gene Expression, Enzymologic|Enzymologic Gene Expression Regulation
 D015972	Gene Expression Regulation, Neoplastic	Regulation of Gene Expression, Neoplastic|Regulation, Gene Expression, Neoplastic|Neoplastic Gene Expression Regulation
-D015973	Gene Expression Regulation, Leukemic	Regulation of Gene Expression, Leukemic|Regulation, Gene Expression, Leukemic|Leukemic Gene Expression Regulation
+D015973	Gene Expression Regulation, Leukemic	Leukemic Gene Expression Regulation|Regulation of Gene Expression, Leukemic|Regulation, Gene Expression, Leukemic
 D015974	Wrongful Life	Life, Wrongful|Wrongful Lives|Lives, Wrongful
 D015975	Consensus Development Conferences, NIH as Topic	NIH Consensus Development Conferences as Topic
 D015977	Eukaryotic Initiation Factor-1	Eukaryotic Initiation Factor 1|Eukaryotic Peptide Initiation Factor-1|Eukaryotic Peptide Initiation Factor 1|Peptide Initiation Factor EIF-1|Peptide Initiation Factor EIF 1|EIF-1
@@ -16770,7 +17188,7 @@ D016130	Immunophenotyping	Immunophenotypings|Subtypings, Immunologic|Subtyping, 
 D016131	Lymphocyte Subsets	Lymphocyte Subset|Subset, Lymphocyte|Subsets, Lymphocyte|Lymphocyte Subpopulations|Lymphocyte Subpopulation|Subpopulation, Lymphocyte|Subpopulations, Lymphocyte
 D016133	Polymerase Chain Reaction	Polymerase Chain Reactions|Reaction, Polymerase Chain|Reactions, Polymerase Chain|PCR
 D016134	Organizational Policy	Policies, Organizational|Policy, Organizational|Organizational Policies
-D016135	Spinal Dysraphism	Dysraphism, Spinal|Dysraphisms, Spinal|Spinal Dysraphisms|Open Spine|Open Spines|Spine, Open|Cleft Spine|Cleft Spines|Spine, Cleft|Spina Bifida|Bifida, Spina|Spina Bifidas|Schistorrhachis
+D016135	Spinal Dysraphism	Dysraphism, Spinal|Dysraphisms, Spinal|Spinal Dysraphisms|Open Spine|Open Spines|Spine, Open|Schistorrhachis|Cleft Spine|Cleft Spines|Spine, Cleft|Spinal Dysraphia|Dysraphia, Spinal|Spinal Dysraphias|Spina Bifida|Bifida, Spina|Spina Bifidas
 D016136	Spina Bifida Occulta	Spinal Bifida, Closed|Closed Spinal Bifida|Occult Spina Bifida|Spina Bifida, Occult
 D016137	Spina Bifida Cystica	Spina Bifida Manifesta|Spina Bifida Aperta
 D016138	Walking	
@@ -16884,7 +17302,7 @@ D016267	External Fixators	External Fixator|Fixator, External|Fixators, External|
 D016268	Internal Fixators	Fixator, Internal|Fixators, Internal|Internal Fixator|Fixation Devices, Internal|Device, Internal Fixation|Devices, Internal Fixation|Fixation Device, Internal|Internal Fixation Device|Internal Fixation Devices
 D016269	Milk Hypersensitivity	Hypersensitivities, Milk|Milk Hypersensitivities|Hypersensitivity, Milk|Milk Allergy|Allergies, Milk|Milk Allergies|Allergy, Milk
 D016270	United States Agency for Healthcare Research and Quality	Agency for Healthcare Research and Quality (U.S.)|Agency for Health Care Policy and Research|United States Agency for Health Care Policy and Research
-D016271	Proto-Oncogene Proteins c-myc	Proto Oncogene Proteins c myc|myc Proto-Oncogene Product p62|myc Proto Oncogene Product p62|Proto-Oncogene Proteins myc|Proteins myc, Proto-Oncogene|Proto Oncogene Proteins myc|myc, Proto-Oncogene Proteins|p62 c-myc|p62 c myc|p62(c-myc)|Proto-Oncogene Products c-myc|Proto Oncogene Products c myc|c-myc Proteins|c myc Proteins|myc Proto-Oncogene Proteins|Proto-Oncogene Proteins, myc|myc Proto Oncogene Proteins
+D016271	Proto-Oncogene Proteins c-myc	Proto Oncogene Proteins c myc|Proto-Oncogene Proteins myc|Proteins myc, Proto-Oncogene|Proto Oncogene Proteins myc|myc, Proto-Oncogene Proteins|myc Proto-Oncogene Proteins|Proto-Oncogene Proteins, myc|myc Proto Oncogene Proteins|c-myc Proteins|c myc Proteins|p62(c-myc)|Proto-Oncogene Products c-myc|Proto Oncogene Products c myc|myc Proto-Oncogene Product p62|myc Proto Oncogene Product p62|p62 c-myc|p62 c myc
 D016272	Occupational Health	Health, Occupational
 D016273	Occupational Exposure	Exposure, Occupational|Exposures, Occupational|Occupational Exposures
 D016274	Oncogene Protein p55(v-myc)	myc Oncogene Protein p55|Oncogene Product p55(v-myc)|v-myc Protein p55|Protein p55, v-myc|v myc Protein p55|p55 v-myc|p55 v myc|p55(v-myc)|myc Oncogene Product p55
@@ -16931,7 +17349,7 @@ D016322	HIV Enhancer	Enhancer, HIV|Enhancers, HIV|HIV Enhancers
 D016324	Sequence Tagged Sites	Sequence Tagged Site|Site, Sequence Tagged|Sites, Sequence Tagged|Tagged Site, Sequence|Tagged Sites, Sequence|Sequence-Tagged Sites|Sequence-Tagged Site|Site, Sequence-Tagged|Sites, Sequence-Tagged
 D016325	HIV Long Terminal Repeat	LTR, Human Immunodeficiency Virus|Human Immunodeficiency Virus LTR|Long Terminal Repeat, HIV|Human Immunodeficiency Virus Long Terminal Repeat
 D016326	Extracellular Matrix Proteins	Matrix Proteins, Extracellular|Proteins, Extracellular Matrix
-D016328	NF-kappa B	kappa B Enhancer Binding Protein|NF-kappaB|NF kappaB|Transcription Factor NF-kB|Factor NF-kB, Transcription|NF-kB, Transcription Factor|Transcription Factor NF kB|NF-kB|NF kB|Immunoglobulin Enhancer-Binding Protein|Enhancer-Binding Protein, Immunoglobulin|Immunoglobulin Enhancer Binding Protein|Nuclear Factor kappa B
+D016328	NF-kappa B	kappa B Enhancer Binding Protein|Nuclear Factor-Kappab|Factor-Kappab, Nuclear|Nuclear Factor Kappab|Transcription Factor NF-kB|Factor NF-kB, Transcription|NF-kB, Transcription Factor|Transcription Factor NF kB|NF-kB|NF kB|NF-kappaB|NF kappaB|Immunoglobulin Enhancer-Binding Protein|Enhancer-Binding Protein, Immunoglobulin|Immunoglobulin Enhancer Binding Protein|Nuclear Factor kappa B
 D016329	Sp1 Transcription Factor	Transcription Factor, Sp1|Specificity Protein 1 Transcription Factor
 D016330	Frail Elderly	Elderly, Frail|Frail Elders|Elder, Frail|Elders, Frail|Frail Elder
 D016331	Parenteral Nutrition, Home	Home Parenteral Nutrition|Nutrition, Home Parenteral
@@ -16957,7 +17375,7 @@ D016353	Self-Examination	Self-Examinations|Examination, Self|Examinations, Self|
 D016354	Rhodobacter capsulatus	Rhodopseudomonas capsulatus|Rhodopseudomonas capsulata
 D016355	Genes, pX	pX Genes|Gene, pX|pX Gene|Genes, lor|Gene, lor|lor Gene|lor Genes
 D016356	Gene Products, tax	p40 tax|p40(tax)|tax Gene Products|tax Protein|Transforming Antigen p40x|Antigen p40x, Transforming|p40x, Transforming Antigen|Trans-Activator Protein p40(tax)|Trans-Activator Protein p40(x)|Trans-Activator Protein p40x|Trans Activator Protein p40x|p40x, Trans-Activator Protein|Trans-Activator Protein pX|Trans Activator Protein pX|pX, Trans-Activator Protein|Transactivator p40(tax)|Transactivator Protein p40(x)|Gene Product, tax|tax Gene Product|Trans-Activator Protein p40(lor)
-D016357	Infection Control Practitioners	Practitioners, Infection Control|Infection Control Practitioner|Practitioner, Infection Control
+D016357	Infection Control Practitioners	Practitioner, Infection Control|Practitioners, Infection Control|Infection Control Practitioner
 D016358	Contact Tracing	Tracing, Contact|Infectious Disease Contact Tracing|Communicable Disease Contact Tracing
 D016360	Clostridium difficile	
 D016361	Bankruptcy	Bankruptcies|Financial Insolvency|Financial Insolvencies|Insolvencies, Financial|Insolvency, Financial
@@ -16978,7 +17396,7 @@ D016375	Antisense Elements (Genetics)	Anti-Sense Elements|Anti Sense Elements|El
 D016376	Oligonucleotides, Antisense	Antisense Oligonucleotides|Anti-Sense Oligonucleotides|Anti Sense Oligonucleotides|Oligonucleotides, Anti-Sense
 D016377	Organ Transplantation	Transplantation, Organ|Organ Transplantations|Transplantations, Organ|Grafting, Organ|Graftings, Organ|Organ Grafting|Organ Graftings
 D016378	Tissue Transplantation	Grafting, Tissue|Tissue Grafting|Transplantation, Tissue
-D016379	Denture, Partial, Fixed, Resin-Bonded	Resin-Bonded Bridge|Bridge, Resin-Bonded|Bridges, Resin-Bonded|Resin Bonded Bridge|Resin-Bonded Bridges|Resin-Bonded Acid-Etched Fixed Partial Denture|Resin Bonded Acid Etched Fixed Partial Denture|Resin-Bonded Fixed Partial Denture|Resin Bonded Fixed Partial Denture|Maryland Bridge|Bridge, Maryland
+D016379	Denture, Partial, Fixed, Resin-Bonded	Resin-Bonded Bridge|Bridge, Resin-Bonded|Bridges, Resin-Bonded|Resin Bonded Bridge|Resin-Bonded Bridges|Resin-Bonded Acid-Etched Fixed Partial Denture|Resin Bonded Acid Etched Fixed Partial Denture|Maryland Bridge|Bridge, Maryland|Resin-Bonded Fixed Partial Denture|Resin Bonded Fixed Partial Denture
 D016380	Brain Tissue Transplantation	Grafting, Brain Tissue|Brain Tissue Grafting|Brain Tissue Graftings|Graftings, Brain Tissue|Tissue Grafting, Brain|Tissue Graftings, Brain|Transplantation, Brain Tissue|Brain Tissue Transplantations|Tissue Transplantation, Brain|Tissue Transplantations, Brain|Transplantations, Brain Tissue
 D016381	Islets of Langerhans Transplantation	Islands of Langerhans Transplantation|Transplantation, Islands of Langerhans|Islands of Pancreas Transplantation|Transplantation, Islands of Pancreas|Transplantation, Islet|Pancreatic Islets Transplantation|Islets Transplantation, Pancreatic|Transplantation, Pancreatic Islets|Islet Transplantation|Islet Transplantations|Transplantations, Islet|Grafting, Islets of Langerhans|Transplantation, Islets of Langerhans
 D016382	Orthodontic Appliance Design	Appliance Design, Orthodontic|Appliance Designs, Orthodontic|Design, Orthodontic Appliance|Designs, Orthodontic Appliance|Orthodontic Appliance Designs
@@ -16993,20 +17411,20 @@ D016391	Genes, src	src Gene|Gene, src|src Genes
 D016392	Proto-Oncogene Proteins pp60(c-src)	Phosphoprotein pp60(c-src)|pp60 c-src|c-src, pp60|pp60 c src|pp60(c-src)|Proto-Oncogene Protein src|Protein src, Proto-Oncogene|Proto Oncogene Protein src|src Proto-Oncogene Product|Proto-Oncogene Product, src|src Proto Oncogene Product|src Proto-Oncogene Protein pp60|src Proto Oncogene Protein pp60|c-src Protein pp60|Protein pp60, c-src|c src Protein pp60|pp60, c-src Protein|Proto-Oncogene Protein pp60(c-src)
 D016393	Lymphoma, B-Cell	Lymphoma, B Cell|B-Cell Lymphoma|B Cell Lymphoma|B-Cell Lymphomas|Lymphomas, B-Cell
 D016399	Lymphoma, T-Cell	Lymphoma, T Cell|T-Cell Lymphoma|Lymphomas, T-Cell|T Cell Lymphoma|T-Cell Lymphomas
-D016400	Lymphoma, Large-Cell, Immunoblastic	Sarcoma, Immunoblastic|Immunoblastic Sarcoma|Immunoblastic Sarcomas|Sarcomas, Immunoblastic|Immunoblastic Lymphosarcoma, Diffuse|Diffuse Immunoblastic Lymphosarcoma|Diffuse Immunoblastic Lymphosarcomas|Immunoblastic Lymphosarcomas, Diffuse|Lymphosarcoma, Diffuse Immunoblastic|Lymphosarcomas, Diffuse Immunoblastic|Large-Cell Immunoblastic Lymphoma|Immunoblastic Lymphoma, Large-Cell|Immunoblastic Lymphomas, Large-Cell|Large Cell Immunoblastic Lymphoma|Large-Cell Immunoblastic Lymphomas|Lymphoma, Large-Cell Immunoblastic|Lymphomas, Large-Cell Immunoblastic|Lymphoma, Large Cell, Immunoblastic|Immunoblastic Large-Cell Lymphoma|Immunoblastic Large Cell Lymphoma|Immunoblastic Large-Cell Lymphomas|Large-Cell Lymphoma, Immunoblastic|Large-Cell Lymphomas, Immunoblastic|Lymphoma, Immunoblastic Large-Cell|Lymphomas, Immunoblastic Large-Cell|Lymphoma, Immunoblastic, Large-Cell|Immunoblastoma|Immunoblastomas|Lymphoma, Immunoblastic, Large Cell
-D016403	Lymphoma, Large B-Cell, Diffuse	Diffuse, Large B-Cell, Lymphoma|Histiocytic Lymphoma|Histiocytic Lymphomas|Lymphomas, Histiocytic|Histiocytic Lymphoma, Diffuse|Diffuse Histiocytic Lymphoma|Diffuse Histiocytic Lymphomas|Histiocytic Lymphomas, Diffuse|Lymphoma, Diffuse Histiocytic|Lymphomas, Diffuse Histiocytic|Large Lymphoid Lymphoma, Diffuse|Lymphoma, Large-Cell, Diffuse|Lymphoma, Diffuse Large-Cell|Lymphoma, Diffuse Large Cell|Lymphoma, Histiocytic|Lymphoma, Large Lymphoid, Diffuse|Lymphoma, Histiocytic, Diffuse|Lymphoma, Large Cell, Diffuse|Diffuse Large-Cell Lymphoma|Diffuse Large Cell Lymphoma|Diffuse Large-Cell Lymphomas|Large-Cell Lymphomas, Diffuse|Lymphomas, Diffuse Large-Cell|Large-Cell Lymphoma, Diffuse|Large Cell Lymphoma, Diffuse
-D016410	Lymphoma, T-Cell, Cutaneous	T-Cell Lymphoma, Cutaneous|T Cell Lymphoma, Cutaneous|Cutaneous T-Cell Lymphoma|Cutaneous T Cell Lymphoma|Cutaneous T-Cell Lymphomas|Lymphoma, Cutaneous T-Cell|Lymphomas, Cutaneous T-Cell|T-Cell Lymphomas, Cutaneous|Lymphoma, T Cell, Cutaneous
-D016411	Lymphoma, T-Cell, Peripheral	T-Cell Lymphoma, Peripheral|T Cell Lymphoma, Peripheral|Lymphoma, T Cell, Peripheral|Peripheral T-Cell Lymphoma|Lymphoma, Peripheral T-Cell|Lymphomas, Peripheral T-Cell|Peripheral T Cell Lymphoma|Peripheral T-Cell Lymphomas|T-Cell Lymphomas, Peripheral
+D016400	Lymphoma, Large-Cell, Immunoblastic	Sarcoma, Immunoblastic|Immunoblastic Sarcoma|Immunoblastic Sarcomas|Sarcomas, Immunoblastic|Immunoblastic Lymphosarcoma, Diffuse|Diffuse Immunoblastic Lymphosarcoma|Diffuse Immunoblastic Lymphosarcomas|Immunoblastic Lymphosarcomas, Diffuse|Lymphosarcoma, Diffuse Immunoblastic|Lymphosarcomas, Diffuse Immunoblastic|Lymphoma, Immunoblastic, Large-Cell|Lymphoma, Immunoblastic, Large Cell|Lymphoma, Large Cell, Immunoblastic|Immunoblastic Large-Cell Lymphoma|Immunoblastic Large Cell Lymphoma|Immunoblastic Large-Cell Lymphomas|Large-Cell Lymphoma, Immunoblastic|Large-Cell Lymphomas, Immunoblastic|Lymphoma, Immunoblastic Large-Cell|Lymphomas, Immunoblastic Large-Cell|Immunoblastoma|Immunoblastomas|Large-Cell Immunoblastic Lymphoma|Immunoblastic Lymphoma, Large-Cell|Immunoblastic Lymphomas, Large-Cell|Large Cell Immunoblastic Lymphoma|Large-Cell Immunoblastic Lymphomas|Lymphoma, Large-Cell Immunoblastic|Lymphomas, Large-Cell Immunoblastic
+D016403	Lymphoma, Large B-Cell, Diffuse	Lymphoma, Large Lymphoid, Diffuse|Lymphoma, Histiocytic, Diffuse|Lymphoma, Large Cell, Diffuse|Lymphoma, Large-Cell, Diffuse|Lymphoma, Diffuse Large-Cell|Lymphoma, Diffuse Large Cell|Diffuse, Large B-Cell, Lymphoma|Histiocytic Lymphoma|Histiocytic Lymphomas|Lymphomas, Histiocytic|Histiocytic Lymphoma, Diffuse|Diffuse Histiocytic Lymphoma|Diffuse Histiocytic Lymphomas|Histiocytic Lymphomas, Diffuse|Lymphoma, Diffuse Histiocytic|Lymphomas, Diffuse Histiocytic|Large Lymphoid Lymphoma, Diffuse|Large-Cell Lymphoma, Diffuse|Large Cell Lymphoma, Diffuse|Lymphoma, Histiocytic|Diffuse Large-Cell Lymphoma|Diffuse Large Cell Lymphoma|Diffuse Large-Cell Lymphomas|Large-Cell Lymphomas, Diffuse|Lymphomas, Diffuse Large-Cell
+D016410	Lymphoma, T-Cell, Cutaneous	Lymphoma, T Cell, Cutaneous|T-Cell Lymphoma, Cutaneous|T Cell Lymphoma, Cutaneous|Cutaneous T-Cell Lymphoma|Cutaneous T Cell Lymphoma|Cutaneous T-Cell Lymphomas|Lymphoma, Cutaneous T-Cell|Lymphomas, Cutaneous T-Cell|T-Cell Lymphomas, Cutaneous
+D016411	Lymphoma, T-Cell, Peripheral	Peripheral T-Cell Lymphoma|Lymphoma, Peripheral T-Cell|Lymphomas, Peripheral T-Cell|Peripheral T Cell Lymphoma|Peripheral T-Cell Lymphomas|T-Cell Lymphomas, Peripheral|T-Cell Lymphoma, Peripheral|T Cell Lymphoma, Peripheral|Lymphoma, T Cell, Peripheral
 D016414	Resuscitation Orders	Order, Resuscitation|Orders, Resuscitation|Resuscitation Order
 D016415	Sequence Alignment	Alignment, Sequence|Alignments, Sequence|Sequence Alignments
-D016416	Meeting Abstracts	
+D016416	Meeting Abstract	Meeting Abstracts
 D016417	Bibliography	
-D016418	Legal Cases	
+D016418	Legal Case	Legal Cases
 D016419	Classical Article	
 D016420	Comment	Viewpoint|Editorial Comment|Commentary
 D016421	Editorial	
 D016422	Letter	
-D016423	Congresses	Meeting Reports
+D016423	Congress	Meeting Reports|Congresses
 D016424	Overall	
 D016425	Published Erratum	Corrigenda|Errata
 D016426	Scientific Integrity Review	
@@ -17055,7 +17473,7 @@ D016483	Lymphoma, AIDS-Related	Lymphoma, AIDS Related|Lymphoma, HIV-Related|Lymp
 D016485	Needle Sharing	Sharing, Needle|Needlesharing|Syringe Sharing|Sharing, Syringe|Needle-Sharing
 D016487	Parenting	
 D016488	Medicine, African Traditional	Traditional Medicine, African|Medicine, Traditional African|Traditional African Medicine|African Medicine, Traditional|African Traditional Medicine
-D016489	Head Injuries, Closed	Injuries, Closed Head|Head Injury, Nonpenetrating|Head Injuries, Nonpenetrating|Nonpenetrating Head Injuries|Nonpenetrating Head Injury|Head Trauma, Closed|Closed Head Trauma|Closed Head Traumas|Head Traumas, Closed|Closed Head Injuries|Closed Head Injury|Head Injury, Closed
+D016489	Head Injuries, Closed	Closed Head Injury|Head Injury, Closed|Head Injury, Nonpenetrating|Head Injuries, Nonpenetrating|Nonpenetrating Head Injuries|Nonpenetrating Head Injury|Head Trauma, Closed|Closed Head Trauma|Closed Head Traumas|Head Traumas, Closed|Closed Head Injuries|Injuries, Closed Head
 D016490	Integrated Advanced Information Management Systems	IAIMS
 D016491	Peripheral Vascular Diseases	Disease, Peripheral Vascular|Peripheral Vascular Disease|Vascular Disease, Peripheral|Peripheral Angiopathies|Angiopathies, Peripheral|Angiopathy, Peripheral|Peripheral Angiopathy|Vascular Diseases, Peripheral|Diseases, Peripheral Vascular
 D016494	Computer Security	Security, Computer|Cybersecurity|Cyber Security|Security, Cyber
@@ -17090,7 +17508,7 @@ D016527	Drug Costs	Cost, Drug|Costs, Drug|Drug Cost
 D016528	Postanesthesia Nursing	Nursing, Post-Surgical|Nursing, Post Surgical|Post-Anesthesia Nursing|Post Anesthesia Nursing|Nursing, Recovery Room|Recovery Room Nursing|Nursing, Post-Anesthesia|Nursing, Post Anesthesia|Nursing, Postanesthesia|Post-Surgical Nursing|Post Surgical Nursing
 D016529	Emergency Nursing	Nursing, Emergency Room|Emergency Room Nursing|Nursing, Emergency
 D016530	Orthopedic Nursing	Nursing, Orthopedic
-D016532	Mucopolysaccharidosis II	Hunter Syndrome Gargoylism|Hunter's Syndrome|Hunters Syndrome|Syndrome, Hunter's|Mucopolysaccharidosis Type 2|Mucopolysaccharidosis Type II|Hunter Syndrome|Syndrome, Hunter|Gargoylism, Hunter Syndrome|Mucopolysaccharidosis 2
+D016532	Mucopolysaccharidosis II	Mucopolysaccharidosis 2|Hunter Syndrome|Syndrome, Hunter|Hunter Syndrome Gargoylism|Mucopolysaccharidosis Type 2|Mucopolysaccharidosis Type II|Hunter's Syndrome|Hunters Syndrome|Syndrome, Hunter's|Gargoylism, Hunter Syndrome
 D016533	Mycological Typing Techniques	Mycological Typing Technics|Technic, Mycological Typing|Technics, Mycological Typing|Typing Technic, Mycological|Fungal Typing Technics|Fungal Typing Technic|Technic, Fungal Typing|Technics, Fungal Typing|Typing Technic, Fungal|Typing Technics, Fungal|Fungal Typing Techniques|Fungal Typing Technique|Technique, Fungal Typing|Techniques, Fungal Typing|Typing Technique, Fungal|Typing Techniques, Fungal|Mycological Typing Technique|Technique, Mycological Typing|Techniques, Mycological Typing|Typing Technique, Mycological|Typing Techniques, Mycological|Mycological Typing Technic|Typing Technics, Mycological
 D016534	Cardiac Output, High	Cardiac Outputs, High|High Cardiac Outputs|High Cardiac Output
 D016535	Bronchial Hyperreactivity	Bronchial Hyperreactivities|Hyperreactivities, Bronchial|Hyperreactivity, Bronchial
@@ -17099,7 +17517,7 @@ D016537	Gangliosidosis, GM1	Beta-Galactosidosis|Beta Galactosidosis|GM1 Ganglios
 D016538	Mucopolysaccharidosis VII	Mucopolysaccharidosis VIIs|VIIs, Mucopolysaccharidosis|Sly Disease|Disease, Sly|beta-Glucuronidase Deficiency|Deficiencies, beta-Glucuronidase|Deficiency, beta-Glucuronidase|beta Glucuronidase Deficiency|beta-Glucuronidase Deficiencies|GUSB Deficiency|Deficiencies, GUSB|Deficiency, GUSB|GUSB Deficiencies|Mucopolysaccharidosis Type VII|Mucopolysaccharidosis Type VIIs|Type VII, Mucopolysaccharidosis|Type VIIs, Mucopolysaccharidosis|Mucopolysaccharidosis 7|Sly Syndrome|Syndrome, Sly
 D016539	Reed-Sternberg Cells	Cells, Reed-Sternberg|Reed Sternberg Cells|Sternberg-Reed Cells|Cells, Sternberg-Reed|Sternberg Reed Cells
 D016540	Smoking Cessation	Cessation, Smoking|Smoking Cessations|Stopping Smoking|Smoking, Stopping|Giving Up Smoking|Smoking, Giving Up|Smokings, Giving Up|Up Smoking, Giving|Quitting Smoking|Smoking, Quitting
-D016542	Chief Executive Officers, Hospital	Hospital CEO|Hospital Chief Executive Officer|Hospital Chief Executive Officers|CEO, Hospital|Chief Executive Officer, Hospital
+D016542	Chief Executive Officers, Hospital	Hospital Chief Executive Officer|Hospital CEO|CEO, Hospital|Chief Executive Officer, Hospital|Hospital Chief Executive Officers
 D016543	Central Nervous System Neoplasms	Neoplasms, Central Nervous System|Tumors, Central Nervous System|Central Nervous System Tumors
 D016544	Patient Simulation	Patient Simulations|Simulation, Patient|Simulations, Patient
 D016545	Choroid Plexus Neoplasms	Choroid Plexus Tumors|Choroid Plexus Tumor|Neoplasms, Choroid Plexus|Choroid Plexus Neoplasm|Neoplasm, Choroid Plexus
@@ -17115,7 +17533,7 @@ D016557	Guided Tissue Regeneration, Periodontal	Regeneration, Periodontal Guided
 D016558	Hemostasis, Endoscopic	Endoscopic Hemostasis|Endoscopic Hemostases|Hemostases, Endoscopic
 D016559	Tacrolimus	
 D016562	Parenteral Nutrition, Home Total	Home Total Parenteral Nutrition|Total Parenteral Nutrition, Home|Home Parenteral Nutrition, Total|Nutrition, Home Total Parenteral
-D016563	Filoviridae	
+D016563	Filoviridae	Filovirus|Filoviruses
 D016564	Amyloid beta-Protein Precursor	Amyloid beta Protein Precursor|beta-Protein Precursor, Amyloid|Amyloid beta Precursor Protein|Protease Nexin II|Nexin II, Protease|beta-Amyloid Protein Precursor|beta Amyloid Protein Precursor|Protease Nexin 2|Nexin 2, Protease|Amyloid A4 Protein Precursor|Amyloid Protein Precursor
 D016565	Cheirogaleidae	
 D016566	Organoselenium Compounds	Compounds, Organoselenium
@@ -17170,7 +17588,7 @@ D016630	Rioprostil
 D016631	Lewy Bodies	Lewy Body|Bodies, Lewy|Body, Lewy
 D016632	Apolipoprotein A-I	Apolipoprotein A I|Apo A-I|Apo A1|Apolipoprotein AI|ApoA-1|ApoA-I|Apolipoprotein A-1|Apolipoprotein A 1|Apolipoprotein A1|Apo A-1|Apo AI
 D016633	Apolipoprotein A-II	Apolipoprotein A II|Apo A-II|Apo A2|Apo AII|ApoA-II|Apolipoprotein A-2|Apolipoprotein A 2|Apolipoprotein A2|Apolipoprotein AII|Apo A-2|ApoA-2
-D016634	Radiosurgery	Radiosurgeries|Stereotactic Radiation Therapy|Radiation Therapy, Stereotactic|Stereotactic Radiation Therapies|Therapy, Stereotactic Radiation|Stereotactic Radiation|Radiation, Stereotactic|Stereotactic Radiations|Radiosurgery, Stereotactic|Stereotactic Radiosurgeries|Stereotactic Radiosurgery
+D016634	Radiosurgery	
 D016635	Universal Precautions	Precautions, Universal|Precaution, Universal|Universal Precaution
 D016636	Telefacsimile	Telefacsimiles|Telefax|Fax
 D016638	Critical Illness	Critical Illnesses|Illness, Critical|Illnesses, Critical|Critically Ill
@@ -17183,7 +17601,7 @@ D016645	Aotidae	Monkey, Owl|Monkeys, Owl|Owl Monkeys|Owl Monkey|Night Monkey|Aot
 D016646	Cebinae	
 D016647	Callimico	Callimicos|Marmosets, Goeldi's|Goeldi's Marmosets|Marmosets, Goeldi|Marmosets, Goeldis
 D016648	Saimirinae	
-D016649	Primary Ovarian Insufficiency	Insufficiency, Primary Ovarian|Ovarian Insufficiency, Primary|Premature Ovarian Failure|Ovarian Failure, Premature
+D016649	Primary Ovarian Insufficiency	Ovarian Insufficiency, Primary|Ovarian Failure, Premature|Premature Ovarian Failure
 D016650	Fluorescein-5-isothiocyanate	Fluorescein 5 isothiocyanate|5-Isothiocyanatofluorescein|5 Isothiocyanatofluorescein|FITC
 D016651	Lithium Carbonate	Carbonate, Lithium|Dilithium Carbonate|Carbonate, Dilithium
 D016654	Genes, RAG-1	Genes, RAG 1|Recombination-Activating Genes-1|Recombination Activating Genes 1|Recombination-Activating Gene-1|Recombination Activating Gene 1|RAG-1 Genes|Gene, RAG-1|RAG 1 Genes|RAG-1 Gene
@@ -17222,7 +17640,7 @@ D016687	Polydioxanone	Polydioxanones
 D016688	Mice, Inbred NOD	Inbred NOD Mice|NOD Mice, Inbred|Mouse, NOD|NOD Mouse|Nonobese Diabetic Mice|Diabetic Mice, Nonobese|Mice, Nonobese Diabetic|Non-Obese Diabetic Mouse|Diabetic Mouse, Non-Obese|Mouse, Non-Obese Diabetic|Non Obese Diabetic Mouse|Non-Obese Diabetic Mice|Diabetic Mice, Non-Obese|Mice, Non-Obese Diabetic|Non Obese Diabetic Mice|Mouse, Inbred NOD|Inbred NOD Mouse|NOD Mouse, Inbred|Mice, NOD|NOD Mice|Nonobese Diabetic Mouse|Diabetic Mouse, Nonobese|Mouse, Nonobese Diabetic
 D016689	Trypanosoma vivax	Trypanosoma vivaxs|vivax, Trypanosoma
 D016692	Receptors, Antigen, T-Cell, gamma-delta	Antigen Receptors, T-Cell, gamma-delta|TcR gamma-delta|TcR gamma delta|gamma-delta, TcR|T-Cell Receptor, gamma-delta|T Cell Receptor, gamma delta|gamma-delta T-Cell Receptor|T-Cell Receptors, gamma-delta|gamma-delta T-Cell Receptors|Receptors, Antigen, T Cell, gamma delta|T Cell Receptors, gamma delta
-D016693	Receptors, Antigen, T-Cell, alpha-beta	Antigen Receptors, T-Cell, alpha-beta|TcR alpha-beta|TcR alpha beta|alpha-beta, TcR|T-Cell Receptor, alpha-beta|T Cell Receptor, alpha beta|alpha-beta T-Cell Receptor|T-Cell Receptors, alpha-beta|alpha-beta T-Cell Receptors|Receptors, Antigen, T Cell, alpha beta|T Cell Receptors, alpha beta
+D016693	Receptors, Antigen, T-Cell, alpha-beta	Receptors, Antigen, T Cell, alpha beta|TcR alpha-beta|TcR alpha beta|alpha-beta, TcR|T-Cell Receptor, alpha-beta|T Cell Receptor, alpha beta|alpha-beta T-Cell Receptor|T-Cell Receptors, alpha-beta|alpha-beta T-Cell Receptors|T Cell Receptors, alpha beta|Antigen Receptors, T-Cell, alpha-beta
 D016694	Gene Rearrangement, delta-Chain T-Cell Antigen Receptor	T-Cell Antigen Receptor delta-Chain Gene Rearrangement|T Cell Antigen Receptor delta Chain Gene Rearrangement|T-Lymphocyte Antigen Receptor delta-Chain Gene Rearrangement|T Lymphocyte Antigen Receptor delta Chain Gene Rearrangement|T Cell delta-Chain Gene Rearrangement|T Cell delta Chain Gene Rearrangement|T Lymphocyte delta-Chain Gene Rearrangement|T Lymphocyte delta Chain Gene Rearrangement|Gene Rearrangement, delta-Chain T Cell Antigen Receptor|Gene Rearrangement, delta Chain T Cell Antigen Receptor
 D016695	Glycosyltransferases	Glycoside Transferases|Transferases, Glycoside
 D016697	Herpes Zoster Oticus	Ramsay Hunt Auricular Syndrome|Neuralgia, Geniculate|Geniculate Neuralgia|Geniculate Neuralgias|Neuralgias, Geniculate|Ramsay Hunt Syndrome|Syndrome, Ramsay Hunt|Auricular Syndrome of Ramsay Hunt|Herpes Zoster Cephalicus|Herpetic Geniculate Ganglionitis|Ganglionitis, Herpetic Geniculate|Geniculate Ganglionitides, Herpetic|Geniculate Ganglionitis, Herpetic|Herpetic Geniculate Ganglionitides|Herpes Zoster Auricularis|Geniculate Herpes Zoster|Herpes Zoster, Geniculate
@@ -17238,7 +17656,7 @@ D016708	Synaptophysin	p38 Membrane Protein, Synaptic Vesicle
 D016709	Yin-Yang	Yin Yang
 D016710	Yin Deficiency	Yin Deficiencies|Yin Xu|Xu, Yin|Yin Hsu|Hsu, Yin|Yinxu|Deficiency, Yin
 D016711	Yang Deficiency	Yangxu|Yang Xu|Xu, Yang|Deficiency, Yang|Yang Hsu|Hsu, Yang
-D016712	Mupirocin	Pseudomonic Acid A|Pseudomonic Acid|Acid, Pseudomonic
+D016712	Mupirocin	Pseudomonic Acid A
 D016713	Ritanserin	6-(2-(4-(Bis(4-fluorophenyl)methylene)-1-piperidinyl)ethyl)-7-methyl-5H-thiazolo(3,2-a)pyrimidin-5-one
 D016715	Proteus Syndrome	Elephant Man Disease
 D016716	PC12 Cells	PC12 Cell|Pheochromocytoma Cell Line|Cell Line, Pheochromocytoma|Cell Lines, Pheochromocytoma|Pheochromocytoma Cell Lines
@@ -17255,7 +17673,7 @@ D016727	Orbital Pseudotumor	Orbital Pseudotumors|Pseudotumor, Orbital|Pseudotumo
 D016728	Self-Injurious Behavior	Behavior, Self-Injurious|Behaviors, Self-Injurious|Self Injurious Behavior|Self-Injurious Behaviors|Nonsuicidal Self Injury|Nonsuicidal Self Injuries|Self Injuries, Nonsuicidal|Self Injury, Nonsuicidal|Self-Injury|Self Injury|Self-Injuries|Non-Suicidal Self Injury|Non Suicidal Self Injury|Non-Suicidal Self Injuries|Self Injuries, Non-Suicidal|Self Injury, Non-Suicidal|Self-Destructive Behavior|Behavior, Self-Destructive|Behaviors, Self-Destructive|Self Destructive Behavior|Self-Destructive Behaviors|Deliberate Self-Harm|Deliberate Self Harm|Self-Harm, Deliberate
 D016729	Leuprolide	Leuprorelin
 D016730	Program Development	Development, Program
-D016731	Erythema Infectiosum	Fifth Disease
+D016731	Erythema Infectiosum	Fifth Disease|Parvovirus B19 Infection|Infection, Parvovirus B19|Parvovirus B19 Infections
 D016732	Parvovirus B19, Human	B19 virus|B19 viruses|Human Parvovirus B19
 D016733	Rubber Dams	Dam, Rubber|Dams, Rubber|Rubber Dam|Rubberdam|Rubberdams
 D016734	Dental Clasps	Clasps, Dental|Denture Clasps|Clasp, Denture|Clasps, Denture|Denture Clasp|Clasp, Dental|Dental Clasp
@@ -17285,7 +17703,7 @@ D016757	Death, Sudden, Cardiac	Sudden Cardiac Death|Cardiac Death, Sudden|Death,
 D016758	Genes, jun	jun Genes|jun Gene
 D016759	Oncogene Protein p65(gag-jun)	Oncogene Protein jun|Protein jun, Oncogene|jun, Oncogene Protein|jun Oncogene Protein|Oncogene Protein, jun|Protein, jun Oncogene|Oncogene Product v-jun|Oncogene Product v jun|Product v-jun, Oncogene|v-jun, Oncogene Product|v-jun Protein|Protein, v-jun|v jun Protein|Oncogene Protein v-jun|Oncogene Protein v jun|Protein v-jun, Oncogene|v-jun, Oncogene Protein|p65 gag-jun|gag-jun, p65|p65 gag jun|p65(gag-jun)|Fusion Proteins, gag-jun|Fusion Proteins, gag jun|Proteins, gag-jun Fusion|gag-jun Fusion Proteins
 D016760	Proto-Oncogene Proteins c-fos	Proto Oncogene Proteins c fos|fos Proto-Oncogene Proteins|fos Proto Oncogene Proteins|Proto-Oncogene Proteins fos|Proto Oncogene Proteins fos|p55(c-fos)|Proto-Oncogene Products c-fos|Proto Oncogene Products c fos|c-fos Proteins|c fos Proteins|p55 c-fos|p55 c fos
-D016761	Oncogene Proteins v-fos	Oncogene Proteins v fos|fos Oncogene Proteins|v-fos Proteins|v fos Proteins|Oncogene Proteins fos|Oncogene Products v-fos|Oncogene Products v fos
+D016761	Oncogene Proteins v-fos	Oncogene Proteins v fos|v-fos Proteins|v fos Proteins|Oncogene Products v-fos|Oncogene Products v fos|Oncogene Proteins fos|fos Oncogene Proteins
 D016762	Genes, fos	fos Genes|fos Gene
 D016764	Cell Polarity	Cell Polarities|Polarities, Cell|Polarity, Cell
 D016765	Coronavirus, Feline	Coronaviruses, Feline|Feline Coronavirus|Feline Coronaviruses|FECV|Feline Enteric Coronavirus|Coronavirus, Feline Enteric|Coronaviruses, Feline Enteric|Enteric Coronavirus, Feline|Enteric Coronaviruses, Feline|Feline Enteric Coronaviruses
@@ -17336,7 +17754,7 @@ D016817	Apansporoblastina	Apansporoblastinas
 D016818	Nosema	Nosemas
 D016819	Encephalitozoon	Encephalitozoons
 D016822	Euglenida	Euglenidas|Euglenids|Euglenid|Euglenophyta|Euglenophytas
-D016823	Volvocida	Chlamydomonadales
+D016823	Volvocida	Volvocidas
 D016824	Antigens, Human Platelet	Platelet Alloantigens|Alloantigens, Platelet|Platelet-Specific Antigens|Platelet Specific Antigens|Human Platelet Antigens|Platelet Antigens, Human|Antigens, Platelet-Specific|Antigens, Platelet Specific
 D016825	Chlamydomonas reinhardtii	Chlamydomonas reinhardtius|reinhardtii, Chlamydomonas|Chlamydomonas reinhardii|Chlamydomonas reinhardius|reinhardius, Chlamydomonas
 D016827	CD8 Antigens	T8 Antigens, T-Cell|Antigens, T-Cell T8|T-Cell T8 Antigens|T8 Antigens, T Cell|Leu-2 Antigens|Antigens, Leu-2|Leu 2 Antigens|CD8 Antigen|Antigen, CD8|Antigens, CD8
@@ -17406,7 +17824,7 @@ D016894	Endarterectomy, Carotid	Carotid Endarterectomy|Carotid Endarterectomies|
 D016895	Culture Media, Serum-Free	Culture Media, Serum Free|Media, Serum-Free Culture|Serum-Free Culture Media|Serum-Free Media|Media, Serum-Free|Serum Free Media|Protein-Free Media|Media, Protein-Free|Protein Free Media
 D016896	Treatment Outcome	Outcome, Treatment
 D016897	Respiratory Burst	Burst, Respiratory|Bursts, Respiratory|Respiratory Bursts|Oxidative Burst|Burst, Oxidative|Bursts, Oxidative|Oxidative Bursts
-D016898	Interferon-alpha	Interferon alpha|alpha-Interferon|alpha Interferon|Interferon, Lymphoblastoid|Lymphoblastoid Interferon|Interferon, Lymphoblast|Lymphoblast Interferon|Interferon Alfa|Interferon, alpha|Interferon, Leukocyte|Leukocyte Interferon
+D016898	Interferon-alpha	Interferon alpha|alpha-Interferon|Interferon, Lymphoblastoid|Lymphoblastoid Interferon|Interferon, Lymphoblast|Lymphoblast Interferon|Interferon Alfa|Interferon, alpha|alpha Interferon|Interferon, Leukocyte|Leukocyte Interferon
 D016899	Interferon-beta	Interferon beta|Interferon, Fibroblast|Fibroblast Interferon|Interferon, beta|beta Interferon|beta-Interferon
 D016900	Neurofilament Proteins	Proteins, Neurofilament
 D016901	Intergenerational Relations	Relations, Intergenerational|Intergenerational Relation|Relation, Intergenerational
@@ -17417,7 +17835,7 @@ D016906	Interleukin-9	Interleukin 9|T-Cell Growth Factor P40|T Cell Growth Facto
 D016907	Adverse Drug Reaction Reporting Systems	Drug Reaction Reporting Systems, Adverse
 D016908	Gram-Positive Bacterial Infections	Gram Positive Bacterial Infections|Infections, Gram-Positive Bacterial|Bacterial Infection, Gram-Positive|Gram-Positive Bacterial Infection|Infection, Gram-Positive Bacterial|Infections, Gram Positive Bacterial|Bacterial Infections, Gram-Positive|Bacterial Infections, Gram Positive
 D016909	Tibial Arteries	Arteries, Tibial|Artery, Tibial|Tibial Artery
-D016910	Orthodontic Brackets	Bracket, Orthodontic|Brackets, Orthodontic|Orthodontic Bracket|Dental Braces|Brace, Dental|Braces, Dental|Dental Brace|Orthodontic Braces|Brace, Orthodontic|Braces, Orthodontic|Orthodontic Brace
+D016910	Orthodontic Brackets	Bracket, Orthodontic|Brackets, Orthodontic|Orthodontic Bracket|Orthodontic Braces|Brace, Orthodontic|Braces, Orthodontic|Orthodontic Brace|Dental Braces|Brace, Dental|Braces, Dental|Dental Brace
 D016911	Koro	
 D016912	Levonorgestrel	l-Norgestrel|l Norgestrel|D-Norgestrel|D Norgestrel
 D016913	Blood Component Transfusion	Blood Component Transfusions|Component Transfusion, Blood|Component Transfusions, Blood|Transfusion, Blood Component|Transfusions, Blood Component
@@ -17425,7 +17843,7 @@ D016914	Ribonuclease H	RNase H|Endoribonuclease H|RNAase H
 D016915	AIDS Vaccines	
 D016916	Joint Deformities, Acquired	Acquired Joint Deformities|Acquired Joint Deformity|Deformities, Acquired Joint|Deformity, Acquired Joint|Joint Deformity, Acquired
 D016917	Angiomatosis, Bacillary	Angiomatoses, Bacillary|Bacillary Angiomatoses|Angiomatosis, Epithelioid|Angiomatoses, Epithelioid|Epithelioid Angiomatoses|Epithelioid Angiomatosis|Bacillary Angiomatosis|Angiomatosis, Bacillary Epithelioid|Angiomatoses, Bacillary Epithelioid|Bacillary Epithelioid Angiomatoses|Bacillary Epithelioid Angiomatosis|Epithelioid Angiomatoses, Bacillary|Epithelioid Angiomatosis, Bacillary
-D016918	Arthritis, Reactive	Arthritides, Reactive|Reactive Arthritides|Reactive Arthritis|Post-Infectious Arthritis|Post Infectious Arthritis|Postinfectious Arthritis|Arthritis, Post-Infectious|Arthritides, Post-Infectious|Arthritis, Post Infectious|Post-Infectious Arthritides|Arthritis, Postinfectious|Arthritides, Postinfectious|Postinfectious Arthritides
+D016918	Arthritis, Reactive	Arthritides, Reactive|Reactive Arthritides|Arthritis, Postinfectious|Arthritides, Postinfectious|Postinfectious Arthritides|Reactive Arthritis|Arthritis, Post-Infectious|Arthritides, Post-Infectious|Arthritis, Post Infectious|Post-Infectious Arthritides|Post-Infectious Arthritis|Post Infectious Arthritis|Postinfectious Arthritis
 D016919	Meningitis, Cryptococcal	Cryptococcal Meningitides|Meningitides, Cryptococcal|Cryptococcal Meningitis
 D016920	Meningitis, Bacterial	Meningitides, Bacterial|Bacterial Meningitides|Bacterial Meningitis
 D016921	Meningitis, Fungal	Fungal Meningitides|Meningitides, Fungal|Fungal Meningitis
@@ -17462,7 +17880,7 @@ D016956	Burkholderia cepacia	Pseudomonas cepacia
 D016957	Burkholderia pseudomallei	Pseudomonas pseudomallei
 D016958	Pseudomonas putida	
 D016959	Xanthomonas campestris	
-D016960	Agrobacterium tumefaciens	Rhizobium radiobacter|Agrobacterium radiobacter
+D016960	Agrobacterium tumefaciens	Agrobacterium radiobacter|Rhizobium radiobacter
 D016961	Rhizobium leguminosarum	
 D016962	Sinorhizobium meliloti	Rhizobium meliloti
 D016963	Thermus thermophilus	
@@ -17725,9 +18143,9 @@ D017262	Siderophores	Siderochromes
 D017263	Technetium Tc 99m Mertiatide	99mTc-Mercaptoacetyltriglycine|99mTc Mercaptoacetyltriglycine|Technetium 99m Mercaptoacetylglycyl-glycyl-glycine|99m Mercaptoacetylglycyl-glycyl-glycine, Technetium|Mercaptoacetylglycyl-glycyl-glycine, Technetium 99m|Technetium 99m Mercaptoacetylglycyl glycyl glycine|Technetium-99m-Mercaptoacetyltriglycine|Technetium 99m Mercaptoacetyltriglycine|Tc 99m Mertiatide|99m Mertiatide, Tc|Mertiatide, Tc 99m|Technetium-99m-MAG3|Technetium 99m MAG3|99mTc-MAG3|99mTc MAG3|Technetium-99m-Mercaptoacetylglycylglycylglycine|Technetium 99m Mercaptoacetylglycylglycylglycine
 D017265	Procaterol	(R*,S*)-(+-)-8-Hydroxy-5-(1-hydroxy-2-((1-methylethyl)amino)butyl)-2(1H)-quinolinone
 D017266	Dental Prosthesis	Prosthesis, Dental|Dental Prostheses|Prostheses, Dental
-D017267	Dental Prosthesis Design	Design, Dental Prosthesis|Prosthesis Design, Dental|Prosthesis Designs, Dental|Dental Prosthesis Designs|Designs, Dental Prosthesis
+D017267	Dental Prosthesis Design	Prosthesis Designs, Dental|Designs, Dental Prosthesis|Prosthesis Design, Dental|Dental Prosthesis Designs|Design, Dental Prosthesis
 D017268	Dental Prosthesis Retention	Prosthesis Retention, Dental|Retention, Dental Prosthesis
-D017269	Dental Prosthesis Repair	Prosthesis Repair, Dental|Repair, Dental Prosthesis|Repairs, Dental Prosthesis|Dental Prosthesis Repairs|Prosthesis Repairs, Dental
+D017269	Dental Prosthesis Repair	Repairs, Dental Prosthesis|Prosthesis Repairs, Dental|Repair, Dental Prosthesis|Dental Prosthesis Repairs|Prosthesis Repair, Dental
 D017270	Lipoprotein(a)	Lipoprotein Lp(a)|Lipoprotein (a)|Lipoprotein a
 D017271	Craniomandibular Disorders	Craniomandibular Disorder|Disorder, Craniomandibular|Disorders, Craniomandibular|Craniomandibular Diseases|Craniomandibular Disease|Disease, Craniomandibular|Diseases, Craniomandibular
 D017272	Celiprolol	N'-(3-Acetyl-4-(3-((1,1-dimethylethyl)amino)-2-hydroxypropoxy)phenyl)-N,N-diethylurea
@@ -17761,19 +18179,19 @@ D017304	Annexin A5	Annexin V|Placental Anticoagulant Protein I|Endonexin II|Lipo
 D017305	Annexin A1	Calpactin II|Renocortin|Lipocortin 1|Lipocortin I|Annexin I|Chromobindin 9
 D017306	Annexin A2	Annexin II, P36|P36 Annexin II|Lipocortin II|Annexin II|Capactin I Heavy Chain
 D017307	Xamoterol	
-D017308	Etodolac	Etodolic Acid|Acid, Etodolic
+D017308	Etodolac	Etodolic Acid
 D017310	Annexin A7	Synexin|Annexin VII
 D017311	Amlodipine	
 D017312	Toremifene	
 D017313	Fenretinide	N-(4-Hydroxyphenyl)-trans-Retinamide|Fenretinimide|N-(4-Hydroxyphenyl)retinamide|4-HPR|4-Hydroxyphenylretinamide|4 Hydroxyphenylretinamide
 D017314	Annexin A4	Placental Anticoagulant Protein II|Lipocortin IV|Annexin IV|Calelectrin 32-kDa|32-kDa, Calelectrin|Calelectrin 32 kDa
-D017315	Cilazapril	Cilazapril Monohydrate|Monohydrate, Cilazapril|Cilazapril Hydrate|Hydrate, Cilazapril
+D017315	Cilazapril	
 D017316	Fadrozole	
 D017317	Annexin A6	Calcimedin 67-kDa|Calcimedin 67 kDa|Lipocortin VI|Calelectrin 67-kDa|Calelectrin 67 kDa|Calphobindin II|Annexin VI|Calcium and Phospholipid-Binding Protein p68|Calcium and Phospholipid Binding Protein p68
 D017318	Annexin A3	Placental Anticoagulant Protein III|Lipocortin III|Annexin III|Calcimedin 35 alpha
 D017319	Photosensitizing Agents	Agents, Photosensitizing|Photosensitizers
 D017320	HIV Protease Inhibitors	Inhibitors, HIV Protease|Protease Inhibitors, HIV
-D017321	Clinical Trials, Phase I as Topic	Clinical Trials, Phase I|Phase 1 Clinical Trials|Phase I Clinical Trials|Clinical Trials, Phase 1
+D017321	Clinical Trials, Phase I as Topic	Phase 1 Clinical Trials|Clinical Trials, Phase 1|Phase I Clinical Trials|Clinical Trials, Phase I
 D017322	Clinical Trials, Phase II as Topic	
 D017323	Dihematoporphyrin Ether	Ether, Dihematoporphyrin|Dihematoporphyrin Ester|Porfimer|DHP Ether
 D017324	Hematoporphyrin Derivative	Hematoporphyrin YHPD|YHPD, Hematoporphyrin|Hematoporphyrin D
@@ -18027,7 +18445,7 @@ D017615	Enteric Nervous System	Enteric Nervous Systems|Nervous System, Enteric|N
 D017616	Magnesium Compounds	Compounds, Magnesium
 D017619	Hemibody Irradiation	Irradiation, Half-Body|Irradiation, Half Body|Sequential Hemibody Irradiation|Hemibody Irradiation, Sequential|Hemibody Irradiations, Sequential|Irradiation, Sequential Hemibody|Irradiations, Sequential Hemibody|Sequential Hemibody Irradiations|Hemi-Body Irradiation|Hemi Body Irradiation|Hemi-Body Irradiations|Irradiation, Hemi-Body|Irradiations, Hemi-Body|Irradiation, Hemibody|Hemibody Irradiations|Irradiations, Hemibody|Half-Body Irradiation|Half Body Irradiation|Half-Body Irradiations|Irradiations, Half-Body|Systemic Hemibody Irradiation|Hemibody Irradiation, Systemic|Hemibody Irradiations, Systemic|Irradiation, Systemic Hemibody|Irradiations, Systemic Hemibody|Systemic Hemibody Irradiations
 D017622	Periodontal Attachment Loss	Attachment Loss, Periodontal|Loss, Periodontal Attachment
-D017624	WAGR Syndrome	Syndrome, WAGR|WAGR Syndromes|Contiguous Gene Syndrome, WAGR|WAGR Complex|Complex, WAGR|WAGR Complices|WAGR Contiguous Gene Syndrome|Wilms Tumor-Aniridia-Genital Anomalies-Retardation Syndrome|Wilms Tumor, Aniridia, Genitourinary Anomalies, Mental Retardation Syndrome|Wilms Tumor-Aniridia-Genitourinary Anomalies-MR Syndrome|Wilms Tumor-Aniridia-Gonadoblastoma-Mental Retardation Syndrome|11p Partial Monosomy Syndrome|Chromosome 11p13 Deletion Syndrome|Wilms Tumor, Aniridia, Genitourinary Anomalies, And Mental Retardation Syndrome
+D017624	WAGR Syndrome	Syndrome, WAGR|WAGR Syndromes|Wilms Tumor-Aniridia-Genitourinary Anomalies-MR Syndrome|WAGR Complex|Complex, WAGR|WAGR Complices|WAGR Contiguous Gene Syndrome|Wilms Tumor-Aniridia-Genital Anomalies-Retardation Syndrome|Wilms Tumor-Aniridia-Gonadoblastoma-Mental Retardation Syndrome|Wilms Tumor, Aniridia, Genitourinary Anomalies, And Mental Retardation Syndrome|Chromosome 11p13 Deletion Syndrome|11p Partial Monosomy Syndrome|Contiguous Gene Syndrome, WAGR|Wilms Tumor, Aniridia, Genitourinary Anomalies, Mental Retardation Syndrome
 D017626	Cochlear Nucleus	Cochlear Nuclei|Nuclei, Cochlear|Nucleus, Cochlear
 D017628	Microglia	
 D017629	Gap Junctions	Gap Junction|Junction, Gap|Junctions, Gap
@@ -18054,7 +18472,7 @@ D017667	Adipocytes	Adipocyte|Lipocytes|Lipocyte|Fat Cells|Cell, Fat|Cells, Fat|F
 D017668	Age of Onset	Onset Age|Age-at-Onset|Age at Onset
 D017669	Mercury Compounds	Compounds, Mercury
 D017670	Sodium Compounds	Compounds, Sodium
-D017671	Platinum Compounds	Compounds, Platinum|Platinum Compounds, Inorganic|Compounds, Inorganic Platinum|Inorganic Platinum Compounds
+D017671	Platinum Compounds	Compounds, Platinum|Plantinum-Containing Compounds|Compounds, Plantinum-Containing|Plantinum Containing Compounds|Platinum Compounds, Inorganic|Compounds, Inorganic Platinum|Inorganic Platinum Compounds
 D017672	Nitrogen Compounds	Compounds, Nitrogen
 D017673	Sodium Chloride, Dietary	Table Salt|Salt, Table|Dietary Sodium Chloride|Chloride, Dietary Sodium
 D017674	Hypophosphatemia	Hypophosphatemias
@@ -18069,7 +18487,7 @@ D017682	Myocardial Stunning	Stunning, Myocardial
 D017683	Oncorhynchus	
 D017684	Oncorhynchus kisutch	Salmon, Coho|Coho Salmon|Salmon, Silver|Silver Salmon
 D017685	Oncorhynchus keta	Salmon, Chum|Chum Salmon|Salmon, Dog|Dog Salmon
-D017686	Oncorhynchus mykiss	Salmo gairdneri|Trout, Rainbow|Rainbow Trout
+D017686	Oncorhynchus mykiss	Trout, Rainbow|Rainbow Trout|Salmo gairdneri
 D017687	Radon Daughters	Daughters, Radon|Radon Daughter Nuclides|Daughter Nuclides, Radon|Radon Progeny|Radon Decay Products|Decay Products, Radon
 D017688	Cholera Morbus	Cholera, Summer|Choleras, Summer|Summer Cholera|Summer Choleras
 D017689	Polydactyly	Polydactylies|Polydactylia|Polydactylias|Polydactylism|Polydactylisms|Hyperdactyly|Hyperdactylies
@@ -18104,7 +18522,7 @@ D017723	Drug Utilization Review	Evaluation, Drug Utilization|Drug-Use Review|Dru
 D017725	Ventricular Pressure	Pressure, Ventricular|Pressures, Ventricular|Ventricular Pressures|Intraventricular Pressure|Intraventricular Pressures|Pressure, Intraventricular|Pressures, Intraventricular
 D017726	Cytomegalovirus Retinitis	Cytomegaloviral Retinitis|Retinitis, Cytomegaloviral|Retinitis, Cytomegalovirus
 D017727	Chicken anemia virus	Chicken anemia viruses|Chicken Anemia Agent|Chicken Anemia Agents|Chicken Infectious Anemia Virus|Infectious Anemia Virus, Chicken
-D017728	Lymphoma, Large-Cell, Anaplastic	CD30-Positive Anaplastic Large-Cell Lymphoma|CD30 Positive Anaplastic Large Cell Lymphoma|Ki-1 Lymphoma|Ki 1 Lymphoma|Ki-1 Lymphomas|Lymphoma, Ki-1|Lymphomas, Ki-1|Systemic Anaplastic Large-Cell Lymphoma|Systemic Anaplastic Large Cell Lymphoma|Anaplastic Large-Cell Lymphoma|Anaplastic Large Cell Lymphoma|Anaplastic Large-Cell Lymphomas|Large-Cell Lymphoma, Anaplastic|Large-Cell Lymphomas, Anaplastic|Lymphoma, Anaplastic Large-Cell|Lymphomas, Anaplastic Large-Cell|CD30+ Anaplastic Large-Cell Lymphoma|CD30+ Anaplastic Large Cell Lymphoma|Lymphoma, Large-Cell, Ki-1
+D017728	Lymphoma, Large-Cell, Anaplastic	CD30-Positive Anaplastic Large-Cell Lymphoma|CD30 Positive Anaplastic Large Cell Lymphoma|Systemic Anaplastic Large-Cell Lymphoma|Systemic Anaplastic Large Cell Lymphoma|Lymphoma, Large-Cell, Ki-1|Anaplastic Large-Cell Lymphoma|Anaplastic Large Cell Lymphoma|Anaplastic Large-Cell Lymphomas|Large-Cell Lymphoma, Anaplastic|Large-Cell Lymphomas, Anaplastic|Lymphoma, Anaplastic Large-Cell|Lymphomas, Anaplastic Large-Cell|CD30+ Anaplastic Large-Cell Lymphoma|CD30+ Anaplastic Large Cell Lymphoma|Ki-1 Lymphoma|Ki 1 Lymphoma|Ki-1 Lymphomas|Lymphoma, Ki-1|Lymphomas, Ki-1
 D017729	Presynaptic Terminals	Presynaptic Terminal|Terminal, Presynaptic|Terminals, Presynaptic|Synaptic Terminals|Synaptic Terminal|Terminal, Synaptic|Terminals, Synaptic|Synaptic Boutons|Bouton, Synaptic|Boutons, Synaptic|Synaptic Bouton|Axon Terminals|Axon Terminal|Terminal, Axon|Terminals, Axon|Nerve Endings, Presynaptic|Ending, Presynaptic Nerve|Endings, Presynaptic Nerve|Nerve Ending, Presynaptic|Presynaptic Nerve Ending|Presynaptic Nerve Endings
 D017730	Ki-1 Antigen	Antigen, Ki-1|Ki 1 Antigen|CD30 Antigens|Antigens, CD30|Ber-H2 Antigen|Antigen, Ber-H2|Ber H2 Antigen|TNFRSF8 Receptor|Receptor, TNFRSF8|Antigens, Ki-1|Antigens, Ki 1|Ki-1 Antigens|Ki 1 Antigens|Tumor Necrosis Factor Receptor Superfamily, Member 8|CD30 Antigen|Antigen, CD30|Ber-H2 Antigens|Antigens, Ber-H2|Ber H2 Antigens
 D017731	Lymphomatoid Papulosis	Lymphomatoid Papuloses|Papuloses, Lymphomatoid|Papulosis, Lymphomatoid
@@ -18125,7 +18543,7 @@ D017746	Joint Capsule	Capsule, Joint|Capsules, Joint|Joint Capsules|Capsula Arti
 D017747	Seafood	Seafoods|Sea-Food|Sea Food|Sea-Foods
 D017748	Time Management	Management, Time|Managements, Time|Time Managements
 D017749	Total Quality Management	Management, Total Quality|Continuous Quality Management|Management, Continuous Quality
-D017750	Animal Technicians	Animal Technician|Technician, Animal|Technicians, Animal|Animal Care Technicians|Animal Care Technician|Care Technician, Animal|Care Technicians, Animal|Technician, Animal Care|Technicians, Animal Care|Technicians, Veterinary|Technician, Veterinary|Veterinary Technician|Veterinary Technicians|Veterinary Nurses|Veterinary Assistants|Nurses, Veterinary|Nurse, Veterinary|Veterinary Nurse|Animal Care Assistants|Animal Care Assistant|Assistant, Animal Care|Assistants, Animal Care|Care Assistant, Animal|Care Assistants, Animal|Assistants, Veterinary|Assistant, Veterinary|Veterinary Assistant
+D017750	Animal Technicians	Animal Technician|Technician, Animal|Technicians, Animal|Veterinary Assistants|Animal Care Assistants|Animal Care Assistant|Assistant, Animal Care|Assistants, Animal Care|Care Assistant, Animal|Care Assistants, Animal|Veterinary Nurses|Technicians, Veterinary|Technician, Veterinary|Veterinary Technician|Veterinary Technicians|Nurses, Veterinary|Nurse, Veterinary|Veterinary Nurse|Assistants, Veterinary|Assistant, Veterinary|Veterinary Assistant|Animal Care Technicians|Animal Care Technician|Care Technician, Animal|Care Technicians, Animal|Technician, Animal Care|Technicians, Animal Care
 D017751	Safety Management	Management, Safety
 D017752	Greenhouse Effect	Effect, Greenhouse
 D017753	Ecosystem	Ecosystems|Systems, Ecological|Ecological System|Ecological Systems|System, Ecological|Ecologic System|System, Ecologic|Systems, Ecologic|Ecologic Systems
@@ -18294,7 +18712,7 @@ D017957	Hepatitis A Virus, Human	Human hepatitis A virus
 D017958	Lentiviruses, Primate	Lentivirus, Primate|Primate Lentivirus|Primate Lentiviruses|Primate Immunodeficiency Viruses|Immunodeficiency Virus, Primate|Primate Immunodeficiency Virus|Virus, Primate Immunodeficiency|Viruses, Primate Immunodeficiency|Immunodeficiency Viruses, Primate
 D017960	Lentiviruses, Bovine	Bovine Lentiviruses|Bovine Lentivirus|Lentivirus, Bovine
 D017961	Lentiviruses, Equine	Equine Lentiviruses|Equine Lentivirus|Lentivirus, Equine
-D017962	alpha-Linolenic Acid	alpha Linolenic Acid|Linolenic Acid
+D017962	alpha-Linolenic Acid	alpha Linolenic Acid
 D017963	Azithromycin	Azythromycin
 D017964	Itraconazole	
 D017965	gamma-Linolenic Acid	Acid, gamma-Linolenic|gamma Linolenic Acid|Gamolenic Acid|Acid, Gamolenic
@@ -18341,7 +18759,7 @@ D018010	Receptors, Invertebrate Peptide	Receptors, Invertebrate Peptides|Inverte
 D018011	Chalcogens	Group 16 Elements|Elements, Group 16
 D018013	Receptors, Neuropeptide	Receptors, Neuropeptides|Neuropeptides Receptors|Neuropeptide Receptors|Neuropeptide Receptor|Receptor, Neuropeptide
 D018014	Gene Transfer Techniques	Technique, Gene Transfer|Techniques, Gene Transfer|Transfer Technique, Gene|Transfer Techniques, Gene|Transgenesis|Gene Transfer Technique
-D018015	Receptors, Calcitonin Gene-Related Peptide	Receptors, Calcitonin Gene Related Peptide|Calcitonin Gene-Related Peptide Receptors|Calcitonin Gene Related Peptide Receptors|Receptors, CGRP|CGRP Receptor|CGRP Receptors|Calcitonin-Gene Related Peptide Receptor|Calcitonin Gene Related Peptide Receptor
+D018015	Receptors, Calcitonin Gene-Related Peptide	Receptors, Calcitonin Gene Related Peptide|Receptors, CGRP|CGRP Receptor|CGRP Receptors|Calcitonin-Gene Related Peptide Receptor|Calcitonin Gene Related Peptide Receptor|Calcitonin Gene-Related Peptide Receptors|Calcitonin Gene Related Peptide Receptors
 D018016	Receptors, Parathyroid Hormone	Parathyroid Hormone Receptors
 D018017	Receptors, Pituitary Hormone-Regulating Hormone	Receptors, Pituitary Hormone Regulating Hormone|Pituitary Hormone-Regulating Hormone Receptors|Pituitary Hormone Regulating Hormone Receptors
 D018018	Arterivirus	Arteriviruses
@@ -18354,7 +18772,7 @@ D018025	Receptors, Thyrotropin-Releasing Hormone	Receptors, Thyrotropin Releasin
 D018026	Receptors, Pancreatic Hormone	Pancreatic Hormone Receptors|Hormone Receptors, Pancreatic|Pancreatic Hormone Receptor|Hormone Receptor, Pancreatic|Receptor, Pancreatic Hormone|Receptors, Pancreatic Hormones|Hormones Receptors, Pancreatic|Pancreatic Hormones Receptors
 D018027	Receptors, Glucagon	Glucagon Receptor|Receptor, Glucagon|Glucagon Receptors
 D018028	Receptors, Neurotensin	Neurotensin Receptor|Receptor, Neurotensin|Neurotensin Receptors
-D018029	Rho(D) Immune Globulin	Rho(D) Immune Human Globulin|Immune Globulin, Rh|Anti-D-Immunoglobulin|Anti D Immunoglobulin|Rh Immune Globulin|Globulin, Rh Immune
+D018029	Rho(D) Immune Globulin	Rho(D) Immune Human Globulin|Anti-D-Immunoglobulin|Anti D Immunoglobulin
 D018030	Silver Compounds	Compounds, Silver
 D018031	Connexin 43	Connexin43|Cx43
 D018033	Antibodies, Bispecific	Bispecific Antibodies|Bifunctional Antibodies|Antibodies, Bifunctional
@@ -18391,7 +18809,7 @@ D018068	Encephalitis Virus, Murray Valley	Murray Valley encephalitis virus
 D018069	Hair Cells, Vestibular	Hair Cell, Vestibular|Vestibular Hair Cell|Vestibular Hair Cells
 D018070	Biological Specimen Banks	Specimen Banks, Biological|Bank, Biological Substance|Banks, Biological Substance|Biological Specimen Bank|Substance Bank, Biological|Substance Banks, Biological|Biological Substance Banks|Bank, Biological Specimen|Banks, Biological Specimen|Specimen Bank, Biological|Biological Substance Bank
 D018071	Polydnaviridae	
-D018072	Hair Cells, Auditory, Outer	Cochlear Outer Hair Cells|Cochlear Outer Hair Cell|Outer Auditory Hair Cells|Auditory Hair Cells, Outer|Hair Cell, Auditory, Outer|Hair Cells, Auditory, Outer Inner|Outer Auditory Hair Cell|Outer Hair Cells|Hair Cells, Outer|Auditory Hair Cell, Outer
+D018072	Hair Cells, Auditory, Outer	Cochlear Outer Hair Cell|Hair Cells, Auditory, Outer Inner|Cochlear Outer Hair Cells|Outer Auditory Hair Cell|Auditory Hair Cells, Outer|Hair Cell, Auditory, Outer|Auditory Hair Cell, Outer|Outer Hair Cells|Hair Cells, Outer|Outer Auditory Hair Cells
 D018073	Haemophilus Vaccines	Vaccines, Haemophilus|Hemophilus Vaccines|Vaccines, Hemophilus|Haemophilus influenzae Vaccines|Vaccines, Haemophilus influenzae|Haemophilus Vaccine|Vaccine, Haemophilus
 D018074	Vaccines, Conjugate	Conjugate Vaccines
 D018075	RNA, Complementary	cRNA|Complementary RNA
@@ -18517,7 +18935,7 @@ D018204	Neoplasms, Connective and Soft Tissue	Connective and Soft Tissue Neoplas
 D018205	Neoplasms, Adipose Tissue	Adipose Tissue Neoplasms|Adipose Tissue Neoplasm|Neoplasm, Adipose Tissue
 D018206	Angiolipoma	Angiolipomas
 D018207	Angiomyolipoma	Angiomyolipomas
-D018208	Liposarcoma, Myxoid	Liposarcomas, Myxoid|Myxoid Liposarcomas|Myxoid Liposarcoma
+D018208	Liposarcoma, Myxoid	Liposarcomas, Myxoid|Myxoid Liposarcomas|Myxoid Liposarcoma|Round Cell Liposarcoma|Liposarcoma, Round Cell|Round Cell Liposarcomas
 D018209	Myelolipoma	Myelolipomas
 D018210	Chondromatosis	Chondromatoses
 D018211	Chondrosarcoma, Mesenchymal	Chondrosarcomas, Mesenchymal|Mesenchymal Chondrosarcoma|Mesenchymal Chondrosarcomas
@@ -18529,14 +18947,14 @@ D018216	Osteochondromatosis	Osteochondromatoses
 D018217	Osteosarcoma, Juxtacortical	Juxtacortical Osteosarcoma|Juxtacortical Osteosarcomas|Osteosarcomas, Juxtacortical
 D018218	Neoplasms, Fibrous Tissue	Fibrous Tissue Neoplasms|Fibrous Tissue Neoplasm|Neoplasm, Fibrous Tissue
 D018219	Histiocytoma, Benign Fibrous	Benign Fibrous Histiocytomas|Fibrous Histiocytoma, Benign|Fibrous Histiocytomas, Benign|Histiocytomas, Benign Fibrous|Benign Fibrous Histiocytoma|Histiocytoma, Fibrous|Fibrous Histiocytoma|Fibrous Histiocytomas|Histiocytomas, Fibrous
-D018220	Fibroma, Desmoplastic	Desmoplastic Fibroma|Desmoplastic Fibromas|Fibromas, Desmoplastic
+D018220	Fibroma, Desmoplastic	Desmoplastic Fibroma|Desmoplastic Fibromas|Desmoplastic Fibroblastoma|Desmoplastic Fibroblastomas|Fibroblastoma, Desmoplastic|Collagenous Fibroma|Collagenous Fibromas|Fibroma, Collagenous
 D018221	Fibromatosis, Abdominal	Abdominal Fibromatoses|Abdominal Fibromatosis|Fibromatoses, Abdominal
 D018222	Fibromatosis, Aggressive	Aggressive Fibromatoses|Aggressive Fibromatosis|Fibromatoses, Aggressive|Desmoid|Desmoids
 D018223	Dermatofibrosarcoma	Dermatofibrosarcomas|Darier-Hoffmann Tumor|Darier Hoffmann Tumor|Tumor, Darier-Hoffmann|Dermatofibrosarcoma Protuberan|Dermatofibrosarcoma Protuberans|Protuberan, Dermatofibrosarcoma|Protuberans, Dermatofibrosarcoma|Darier-Ferrand Tumor|Darier Ferrand Tumor|Tumor, Darier-Ferrand
 D018224	Myofibromatosis	Myofibromatoses
 D018225	Neoplasms, Fibroepithelial	Fibroepithelial Neoplasms|Fibroepithelial Neoplasm|Neoplasm, Fibroepithelial
 D018226	Fibroadenoma	Fibroadenomas
-D018227	Sarcoma, Clear Cell	Clear Cell Sarcoma|Clear Cell Sarcomas|Sarcomas, Clear Cell|Melanoma, Malignant, of Soft Parts
+D018227	Sarcoma, Clear Cell	Clear Cell Sarcoma|Clear Cell Sarcomas|Sarcomas, Clear Cell|Melanoma, Malignant, of Soft Parts|Clear Cell Sarcoma of Soft Tissue|Malignant Melanoma of Soft Parts|Melanoma of Soft Parts
 D018228	Sarcoma, Small Cell	Cell Sarcoma, Small|Cell Sarcomas, Small|Sarcomas, Small Cell|Small Cell Sarcoma|Small Cell Sarcomas
 D018229	Angiomyoma	Angiomyomas|Leiomyoma, Vascular|Leiomyomas, Vascular|Vascular Leiomyoma|Vascular Leiomyomas|Angioleiomyoma|Angioleiomyomas
 D018230	Leiomyoma, Epithelioid	Epithelioid Leiomyoma|Epithelioid Leiomyomas|Leiomyomas, Epithelioid|Leiomyoblastoma|Leiomyoblastomas
@@ -18553,7 +18971,7 @@ D018240	Endodermal Sinus Tumor	Endodermal Sinus Tumors|Tumor, Endodermal Sinus|T
 D018241	Neuroectodermal Tumors, Primitive, Peripheral	Peripheral Primitive Neuroectodermal Tumors|(pPNET) Peripheral Primitive Neuroectodermal Tumors|Neuroepithelioma, Peripheral|Neuroepitheliomas, Peripheral|Peripheral Neuroepithelioma|Peripheral Neuroepitheliomas|Neuroectodermal Neoplasm, Peripheral Primitive|Neuroectodermal Tumor, Peripheral Primitive|Peripheral Primitive Neuroectodermal Neoplasm|Primitive Neuroectodermal Tumor, Extracranial|Neuroectodermal Tumor, Peripheral|Neuroectodermal Tumors, Peripheral|Peripheral Neuroectodermal Tumor|Peripheral Neuroectodermal Tumors|Tumor, Peripheral Neuroectodermal|Tumors, Peripheral Neuroectodermal|Extracranial Primitive Neuroectodermal Tumor
 D018242	Neuroectodermal Tumors, Primitive	Neuroectodermal Tumor, Primitive|Primitive Neuroectodermal Tumor|Primitive Neuroectodermal Tumors|Tumor, Primitive Neuroectodermal|Tumors, Primitive Neuroectodermal|Primitive Neuroepithelial Neoplasms|Neuroepithelial Tumors, Primitive|Neuroepithelial Tumor, Primitive|Primitive Neuroepithelial Tumor|Primitive Neuroepithelial Tumors|Tumor, Primitive Neuroepithelial|Tumors, Primitive Neuroepithelial|PNET|PNETs|Neoplasms, Primitive Neuroepithelial|Neoplasm, Primitive Neuroepithelial|Neuroepithelial Neoplasm, Primitive|Primitive Neuroepithelial Neoplasm|Neuroepithelial Neoplasms, Primitive
 D018243	Teratocarcinoma	Teratocarcinomas
-D018244	Chromosomes, Artificial, Yeast	Chromosomes, Yeast Artificial|YACs (Chromosomes)|YAC (Chromosome)|Yeast Artificial Chromosomes|Artificial Chromosomes, Yeast|Artificial Chromosome, Yeast|Chromosome, Yeast Artificial|Yeast Artificial Chromosome
+D018244	Chromosomes, Artificial, Yeast	YACs (Chromosomes)|Artificial Chromosomes, Yeast|Artificial Chromosome, Yeast|Chromosome, Yeast Artificial|Yeast Artificial Chromosome|YAC (Chromosome)|Yeast Artificial Chromosomes|Chromosomes, Yeast Artificial
 D018245	Trophoblastic Tumor, Placental Site	Trophoblastic Tumor, Placental|Placental Trophoblastic Tumor|Placental Trophoblastic Tumors|Trophoblastic Tumors, Placental|Tumor, Placental Trophoblastic|Tumors, Placental Trophoblastic|Placental-Site Trophoblastic Tumor|Placental Site Trophoblastic Tumor|Placental-Site Trophoblastic Tumors|Trophoblastic Tumor, Placental-Site|Trophoblastic Tumors, Placental-Site|Tumor, Placental-Site Trophoblastic|Tumors, Placental-Site Trophoblastic
 D018246	Adrenocortical Adenoma	Adenomas, Adrenocortical|Adrenocortical Adenomas|Adenoma, Adrenocortical|Adenoma, Adrenal Cortical|Adenomas, Adrenal Cortical|Adrenal Cortical Adenoma|Adrenal Cortical Adenomas
 D018247	Helicobacter heilmannii	Gastrospirillum hominis
@@ -18712,13 +19130,13 @@ D018431	Newspaper Article
 D018432	Drug Resistance, Multiple	Multiple Drug Resistance|Resistance, Multiple Drug|Multidrug Resistance|Multi-Drug Resistance
 D018433	Twin Studies as Topic	
 D018434	Sickness Impact Profile	Impact Profile, Sickness|Impact Profiles, Sickness|Profile, Sickness Impact|Profiles, Sickness Impact|Sickness Impact Profiles
-D018435	ATP Binding Cassette Transporter, Sub-Family B	ATP Binding Cassette Transporter, Sub Family B|Multidrug Resistance Proteins|ATP-Binding Cassette, Sub-Family B Proteins|ATP Binding Cassette, Sub Family B Proteins|P-Glycoproteins|P Glycoproteins
+D018435	ATP Binding Cassette Transporter, Subfamily B	ATP-Binding Cassette, Sub-Family B Proteins|ATP Binding Cassette, Sub Family B Proteins|Multidrug Resistance Proteins|ATP Binding Cassette Transporter, Sub-Family B|ATP Binding Cassette Transporter, Sub Family B|P-Glycoproteins|P Glycoproteins
 D018436	Ancient Lands	
 D018437	Brown-Sequard Syndrome	Brown Sequard Syndrome|Syndrome, Brown-Sequard|Brown-Sequard's Disease|Brown Sequard's Disease|Brown-Sequards Disease|Brown-Sequard's Syndrome|Brown Sequard's Syndrome|Brown-Sequards Syndrome|Syndrome, Brown-Sequard's|Hemiparaplegic Syndrome|Hemiparaplegic Syndromes|Syndrome, Hemiparaplegic|Syndromes, Hemiparaplegic|Hemispinal Cord Syndrome|Hemispinal Cord Syndromes|Syndrome, Hemispinal Cord|Syndromes, Hemispinal Cord|Hemicord Syndrome|Hemicord Syndromes|Syndrome, Hemicord|Syndromes, Hemicord|Brown-Sequard Disease|Brown Sequard Disease
 D018438	Blue Toe Syndrome	Syndrome, Blue Toe
 D018440	beta-Lactam Resistance	beta Lactam Resistance|beta-Lactamase Resistant|Resistant, beta-Lactamase|beta Lactamase Resistant|beta-Lactam Resistant|beta Lactam Resistant|beta-Lactamase Resistance|Resistance, beta-Lactamase|beta Lactamase Resistance
 D018441	Biofilms	Biofilm
-D018442	Lymphoma, B-Cell, Marginal Zone	MALT Lymphoma|Lymphoma, MALT|Lymphomas, MALT|MALT Lymphomas|Lymphoma of Mucosa-Associated Lymphoid Tissue|Lymphoma of Mucosa Associated Lymphoid Tissue|Mucosa-Associated Lymphoid Tissue Lymphoma|Mucosa Associated Lymphoid Tissue Lymphoma|Lymphoma, Mucosa-Associated Lymphoid Tissue|Lymphoma, Mucosa Associated Lymphoid Tissue|Marginal Zone B-Cell Lymphoma|Marginal Zone B Cell Lymphoma
+D018442	Lymphoma, B-Cell, Marginal Zone	Lymphoma of Mucosa-Associated Lymphoid Tissue|Lymphoma of Mucosa Associated Lymphoid Tissue|Marginal Zone B-Cell Lymphoma|Marginal Zone B Cell Lymphoma|Mucosa-Associated Lymphoid Tissue Lymphoma|Mucosa Associated Lymphoid Tissue Lymphoma|Lymphoma, Mucosa-Associated Lymphoid Tissue|Lymphoma, Mucosa Associated Lymphoid Tissue|MALT Lymphoma|Lymphoma, MALT|Lymphomas, MALT|MALT Lymphomas
 D018445	Infectious Disease Transmission, Vertical	Pathogen Transmission, Vertical|Transmission, Vertical Pathogen|Vertical Pathogen Transmission|Vertical Transmission of Infectious Disease|Vertical Infection Transmission|Vertical Infectious Disease Transmission|Infection Transmission, Vertical|Transmission, Vertical Infection
 D018447	Medical Futility	Futility, Medical
 D018448	Models, Immunological	Immunologic Model|Immunologic Models|Models, Immunologic|Model, Immunologic|Immunological Models|Immunological Model|Model, Immunological
@@ -18833,7 +19251,7 @@ D018567	Breast Neoplasms, Male	Breast Neoplasm, Male|Male Breast Neoplasm|Neopla
 D018568	Crown-Rump Length	Crown Rump Length|Crown-Rump Lengths|Length, Crown-Rump|Lengths, Crown-Rump
 D018570	Risk Assessment	Assessments, Risk|Risk Assessments|Health Risk Assessment|Assessment, Health Risk|Assessments, Health Risk|Health Risk Assessments|Risk Assessment, Health|Risk Assessments, Health|Assessment, Risk
 D018571	Sentinel Surveillance	Surveillance, Sentinel|Syndromic Surveillance|Surveillance, Syndromic|Biosurveillance Systems|Biosurveillance System
-D018572	Disease-Free Survival	Disease Free Survival|Event-Free Survival|Event Free Survival|Event-Free Survivals|Survival, Event-Free|Survivals, Event-Free|Survival, Disease-Free|Disease-Free Survivals|Survival, Disease Free|Survivals, Disease-Free
+D018572	Disease-Free Survival	Disease Free Survival|Survival, Disease-Free|Survival, Disease Free
 D018574	Home Care Agencies	Agencies, Home Care|Agency, Home Care|Care Agencies, Home|Care Agency, Home|Home Care Agency
 D018575	Home Care Services, Hospital-Based	Cares, Hospital-Based Home|Cares, Hospital Based Home|Home Care, Hospital-Based|Home Care, Hospital Based|Home Cares, Hospital-Based|Home Cares, Hospital Based|Hospital Home Care Services|Hospital-Based Home Care|Hospital Based Home Care|Home Care Services, Hospital Based|Hospital-Based Home Care Services|Hospital Based Home Care Services|Care, Hospital-Based Home|Care, Hospital Based Home|Hospital-Based Home Cares|Hospital Based Home Cares
 D018576	Home Health Aides	Aide, Home Health|Aides, Home Health|Health Aide, Home|Health Aides, Home|Home Health Aide|Homemaker-Home Health Aides|Aide, Homemaker-Home Health|Aides, Homemaker-Home Health|Health Aide, Homemaker-Home|Health Aides, Homemaker-Home|Homemaker Home Health Aides|Homemaker-Home Health Aide|Home Care Aides|Aide, Home Care|Aides, Home Care|Care Aide, Home|Care Aides, Home|Home Care Aide
@@ -18911,7 +19329,7 @@ D018660	Blood Pressure Monitoring, Ambulatory	Ambulatory Blood Pressure Monitori
 D018661	Mycoplasma penetrans	
 D018662	Fundoplication	Nissen Operation|Operation, Nissen
 D018663	Adrenergic Agents	Agents, Adrenergic|Adrenergics|Adrenergic Drugs|Drugs, Adrenergic
-D018664	Interleukin-12	Natural Killer Cell Stimulatory Factor|IL-12|Cytotoxic Lymphocyte Maturation Factor|IL 12|Edodekin Alfa|IL-12 p70|Interleukin-12 p70|Interleukin 12 p70|p70, Interleukin-12|Interleukin 12|IL12
+D018664	Interleukin-12	IL 12|IL12|Interleukin 12|IL-12
 D018666	Ureteroscopy	Ureteroscopies
 D018667	Tilt-Table Test	Test, Tilt-Table|Tilt Table Test
 D018668	Muntjacs	Muntjac|Muntjaks|Muntjak|Muntiacus
@@ -18938,12 +19356,12 @@ D018690	Excitatory Amino Acid Agonists	Amino Acid Agonist, Excitatory|Amino Acid
 D018691	Excitatory Amino Acid Antagonists	Antagonists, Excitatory Amino Acid|Amino Acids, Excitatory, Antagonists|Glutamate Receptor Antagonists|Antagonists, Glutamate Receptor|Receptor Antagonists, Glutamate|EAA Antagonists|Antagonists, EAA|Glutamate Antagonists|Antagonists, Glutamate|Amino Acid Antagonists, Excitatory
 D018692	Antimanic Agents	Agents, Antimanic|Antimanic Drugs|Drugs, Antimanic|Antimanics
 D018696	Neuroprotective Agents	Agents, Neuroprotective|Neuroprotectants|Neuroprotective Drugs|Drugs, Neuroprotective
-D018697	Nootropic Agents	Agents, Nootropic|Nootropics|Cognitive Enhancers|Enhancers, Cognitive|Nootropic Drugs|Drugs, Nootropic
+D018697	Nootropic Agents	Agents, Nootropic|Nootropic Drugs|Drugs, Nootropic|Procognitive Agents|Agents, Procognitive|Nootropics|Anti-Dementia Agents|Agents, Anti-Dementia|Anti Dementia Agents|Antidementia Agents|Agents, Antidementia|Cognitive Enhancers|Enhancers, Cognitive
 D018698	Glutamic Acid	L-Glutamic Acid|L Glutamic Acid
 D018699	Coated Vesicles	Coated Vesicle|Vesicle, Coated|Vesicles, Coated
 D018700	Pleurodesis	
 D018701	Mononegavirales Infections	Infections, Mononegavirales|Infection, Mononegavirales|Mononegavirales Infection
-D018702	Filoviridae Infections	Infections, Filoviridae|Filoviridae Infection|Infection, Filoviridae
+D018702	Filoviridae Infections	Filoviridae Infection|Infection, Filoviridae|Filovirus Infections|Filovirus Infection|Infection, Filovirus|Infections, Filoviridae
 D018703	Founder Effect	Effect, Founder|Effects, Founder|Founder Effects
 D018704	Orthodontic Retainers	Retainers, Orthodontic|Orthodontic Retainer|Retainer, Orthodontic
 D018707	Volcanic Eruptions	Volcanic Eruption|Eruption, Volcanic|Eruptions, Volcanic
@@ -18957,7 +19375,7 @@ D018715	Microscopy, Video	Videomicrography|Videomicrographies|Videomicroscopy|Vi
 D018716	Molecular Mimicry	Mimicries, Molecular|Molecular Mimicries|Mimicry, Molecular
 D018717	Purple Membrane	Membrane, Purple|Membranes, Purple|Purple Membranes
 D018718	Home Infusion Therapy	Infusion Therapy, Home|Infusion Therapies, Home|Therapies, Home Infusion|Therapy, Home Infusion|Home Infusion Therapies
-D018719	Receptor, ErbB-2	ErbB-2 Receptor|Antigens, CD340|CD340 Antigens|Proto-Oncogene Proteins c-erbB-2|Proto Oncogene Proteins c erbB 2|p185(c-neu)|c-erbB-2 Protein|c erbB 2 Protein|erbB-2 Proto-Oncogene Protein|Proto-Oncogene Protein, erbB-2|erbB 2 Proto Oncogene Protein|erbB-2 Receptor Protein-Tyrosine Kinase|erbB 2 Receptor Protein Tyrosine Kinase|neu Proto-Oncogene Protein|Proto-Oncogene Protein, neu|neu Proto Oncogene Protein|HER-2 Proto-Oncogene Protein|HER 2 Proto Oncogene Protein|Proto-Oncogene Protein, HER-2|Proto-Oncogene Protein HER-2|Proto Oncogene Protein HER 2|Receptors, erbB-2|erbB-2 Receptors|Neu Receptor|Receptor, Neu|Metastatic Lymph Node Gene 19 Protein|Proto-oncogene Protein Neu|Neu, Proto-oncogene Protein|Proto-oncogene c-ErbB-2|c-ErbB-2, Proto-oncogene|Tyrosine Kinase-type Cell Surface Receptor HER2|Tyrosine Kinase type Cell Surface Receptor HER2|p185erbB2 Protein|CD340 Antigen|Oncogene Protein HER-2|Oncogene Protein HER 2|Proto-Oncogene Protein p185(neu)
+D018719	Receptor, ErbB-2	ErbB-2 Receptor|Antigens, CD340|CD340 Antigens|Proto-Oncogene Protein p185(neu)|Proto-Oncogene Proteins c-erbB-2|Proto Oncogene Proteins c erbB 2|p185(c-neu)|c-erbB-2 Protein|c erbB 2 Protein|erbB-2 Proto-Oncogene Protein|Proto-Oncogene Protein, erbB-2|erbB 2 Proto Oncogene Protein|erbB-2 Receptor Protein-Tyrosine Kinase|erbB 2 Receptor Protein Tyrosine Kinase|neu Proto-Oncogene Protein|Proto-Oncogene Protein, neu|neu Proto Oncogene Protein|HER-2 Proto-Oncogene Protein|HER 2 Proto Oncogene Protein|Proto-Oncogene Protein, HER-2|Proto-Oncogene Protein HER-2|Proto Oncogene Protein HER 2|Receptors, erbB-2|erbB-2 Receptors|Neu Receptor|Receptor, Neu|Metastatic Lymph Node Gene 19 Protein|Proto-oncogene Protein Neu|Neu, Proto-oncogene Protein|Proto-oncogene c-ErbB-2|c-ErbB-2, Proto-oncogene|Tyrosine Kinase-type Cell Surface Receptor HER2|Tyrosine Kinase type Cell Surface Receptor HER2|p185erbB2 Protein|CD340 Antigen|Erb-b2 Receptor Tyrosine Kinases|Erb b2 Receptor Tyrosine Kinases|Oncogene Protein HER-2|Oncogene Protein HER 2
 D018720	Prevotella	
 D018721	Muscarinic Agonists	Agonists, Muscarinic|Muscarinic Agonist|Agonist, Muscarinic|Cholinergic Muscarinic Agonists|Agonists, Cholinergic Muscarinic|Muscarinic Agonists, Cholinergic|Cholinergic Agonist, Muscarinic|Agonist, Muscarinic Cholinergic|Muscarinic Cholinergic Agonist|Cholinergic Agonists, Muscarinic|Agonists, Muscarinic Cholinergic|Muscarinic Cholinergic Agonists
 D018722	Nicotinic Agonists	Agonists, Nicotinic|Cholinergic Agonists, Nicotinic|Agonists, Nicotinic Cholinergic|Nicotinic Cholinergic Agonists|Nicotinic Agonist|Agonist, Nicotinic|Cholinergic Agonist, Nicotinic|Agonist, Nicotinic Cholinergic|Nicotinic Cholinergic Agonist
@@ -18966,7 +19384,7 @@ D018724	Spinacia oleracea
 D018725	Tar-Water	Tar Water
 D018726	Anti-Dyskinesia Agents	Agents, Anti-Dyskinesia|Anti Dyskinesia Agents|Movement Disorder Agents|Agents, Movement Disorder|Disorder Agents, Movement
 D018727	Muscarinic Antagonists	Antagonists, Muscarinic|Antimuscarinics|Antimuscarinic Agents|Agents, Antimuscarinic|Cholinergic Muscarinic Antagonists|Antagonists, Cholinergic Muscarinic|Muscarinic Antagonists, Cholinergic
-D018728	Entorhinal Cortex	Cortex, Entorhinal|Secondary Olfactory Cortex|Cortex, Secondary Olfactory|Cortices, Secondary Olfactory|Olfactory Cortex, Secondary|Olfactory Cortices, Secondary|Secondary Olfactory Cortices|Entorhinal Cortices|Cortices, Entorhinal|Area Entorhinalis|Area Entorhinali|Entorhinali, Area|Entorhinalis, Area|Entorhinal Area|Area, Entorhinal|Areas, Entorhinal|Entorhinal Areas
+D018728	Entorhinal Cortex	Cortex, Entorhinal|Entorhinal Cortices|Cortices, Entorhinal|Area Entorhinalis|Area Entorhinali|Entorhinali, Area|Entorhinalis, Area|Secondary Olfactory Cortex|Cortex, Secondary Olfactory|Cortices, Secondary Olfactory|Olfactory Cortex, Secondary|Olfactory Cortices, Secondary|Secondary Olfactory Cortices|Entorhinal Area|Area, Entorhinal|Areas, Entorhinal|Entorhinal Areas
 D018729	Fontan Procedure	Procedure, Fontan|Stage 3 Norwood Procedure|Norwood Procedure, Stage 3|Norwood Procedure, Stage III|Fontan Operation|Operation, Fontan|Stage III Norwood Procedure
 D018730	Infant Behavior	Behavior, Infant
 D018732	Forensic Anthropology	Anthropology, Forensic
@@ -19000,7 +19418,7 @@ D018765	Dopamine Uptake Inhibitors	Reuptake Inhibitors, Dopamine|Inhibitors, Dop
 D018771	Arthralgia	Arthralgias|Joint Pain|Joint Pains|Pain, Joint|Pains, Joint
 D018772	Dental Marginal Adaptation	Adaptation, Dental Marginal|Adaptations, Dental Marginal|Dental Marginal Adaptations|Marginal Adaptations, Dental|Marginal Adaptation, Dental|Adaptation, Marginal, Dental
 D018773	Genes, erbB-1	Genes, erbB1|Gene, erbB1|erbB1 Gene|erbB1 Genes|erbB-1 Genes|erbB 1 Genes|erbB-1 Gene
-D018774	Oncogene Proteins v-erbA	Oncogene Proteins v erbA|v-erbA Proteins|v erbA Proteins|erbA Oncogene Proteins|Oncogene Products v-erbA|Oncogene Products v erbA
+D018774	Oncogene Proteins v-erbA	Oncogene Proteins v erbA|Oncogene Products v-erbA|Oncogene Products v erbA|v-erbA Proteins|v erbA Proteins|erbA Oncogene Proteins
 D018775	Bone Demineralization Technique	Bone Demineralization Techniques|Demineralization Technique, Bone|Demineralization Techniques, Bone|Technique, Bone Demineralization|Techniques, Bone Demineralization|Bone Demineralization Technic|Bone Demineralization Technics|Demineralization Technic, Bone|Demineralization Technics, Bone|Technic, Bone Demineralization|Technics, Bone Demineralization
 D018776	Genes, erbA	erbA Gene|erbA Genes
 D018777	Multiple Chemical Sensitivity	Multiple Chemical Sensitivities|Multiple Chemical Sensitivity Syndrome|Sensitivities, Multiple Chemical|Idiopathic Environmental Intolerance|Environmental Intolerance, Idiopathic|Environmental Intolerances, Idiopathic|Intolerance, Idiopathic Environmental|Intolerances, Idiopathic Environmental|Chemical Sensitivities, Multiple|Chemical Sensitivity, Multiple|Idiopathic Environmental Intolerances|Sensitivity, Multiple Chemical
@@ -19072,7 +19490,7 @@ D018857	Food Packaging	Packaging, Food
 D018858	Germinal Center	Center, Germinal|Centers, Germinal|Germinal Centers
 D018859	Hair Follicle	Follicle, Hair|Follicles, Hair|Hair Follicles
 D018860	Sneddon Syndrome	Syndrome, Sneddon|Sneddon-Champion Syndrome|Sneddon Champion Syndrome|Syndrome, Sneddon-Champion|Livedo Reticularis And Cerebrovascular Accidents|Livedo Reticularis, Systemic Involvement
-D018862	Merkel Cells	Cells, Merkel|Merkel's Receptor|Merkels Receptor|Receptor, Merkel's|Receptors, Merkel's|Merkel's Receptors|Receptors, Merkels|Receptor, Merkel|Merkel Receptor|Merkel Receptors|Receptors, Merkel
+D018862	Merkel Cells	Cells, Merkel|Merkel Receptors|Receptors, Merkel|Merkel's Receptor|Merkels Receptor|Receptor, Merkel's|Receptor, Merkel|Merkel Receptor|Receptors, Merkel's|Merkel's Receptors|Receptors, Merkels
 D018864	Cultural Diversity	Cultural Diversities|Diversities, Cultural|Diversity, Cultural|Multiculturalism|Multiculturalisms
 D018865	Dental Research	Research, Dental
 D018868	Insurance, Disability	Disability Insurance
@@ -19096,7 +19514,7 @@ D018887	Landau-Kleffner Syndrome	Landau Kleffner Syndrome|Syndrome, Landau-Kleff
 D018888	Aphasia, Primary Progressive	Aphasias, Primary Progressive|Primary Progressive Aphasia|Primary Progressive Aphasias|Progressive Aphasia, Primary|Progressive Aphasias, Primary|Mesulam's Syndrome|Syndrome, Mesulam's|Mesulam Syndrome|Syndrome, Mesulam
 D018889	Ilizarov Technique	Technique, Ilizarov|Ilizarov Method|Method, Ilizarov|Ilizarov Technic|Technic, Ilizarov
 D018890	Chemoprevention	Chemoprophylaxis
-D018891	Dentate Gyrus	Gyrus, Dentate|Gyrus Dentatus|Fascia Dentata|Dentata, Fascia|Area Dentata|Area Dentatas|Dentata, Area|Dentatas, Area|Dentate Fascia|Fascia, Dentate
+D018891	Dentate Gyrus	Gyrus, Dentate|Area Dentata|Area Dentatas|Dentata, Area|Dentatas, Area|Fascia Dentata|Dentata, Fascia|Dentate Fascia|Fascia, Dentate|Gyrus Dentatus
 D018892	Proton-Motive Force	Proton Motive Force|Proton-Motive Forces
 D018893	Bronchoalveolar Lavage	Bronchoalveolar Lavages|Lavage, Bronchoalveolar|Lavages, Bronchoalveolar|Lung Lavage|Lavage, Lung|Lavages, Lung|Lung Lavages|Lavage, Bronchopulmonary|Bronchioalveolar Lavage|Bronchioalveolar Lavages|Lavage, Bronchioalveolar|Lavages, Bronchioalveolar|Bronchopulmonary Lavage|Bronchopulmonary Lavages|Lavages, Bronchopulmonary
 D018894	Reverse Transcriptase Inhibitors	Inhibitors, Reverse Transcriptase
@@ -19176,7 +19594,7 @@ D018976	Insulin-Like Growth Factor Binding Protein 6	Insulin Like Growth Factor 
 D018977	Micronutrients	Micronutrient
 D018978	Molting	Moltings|Moulting|Moultings|Ecdysis|Ecdyses
 D018979	Myositis, Inclusion Body	Inclusion Body Myositides|Myositides, Inclusion Body|Inclusion Body Myositis
-D018980	Williams Syndrome	Syndrome, Williams|Contiguous Gene Syndrome, Williams|Supravalvar Aortic Stenosis Syndrome|Williams-Beuren Syndrome|Syndrome, Williams-Beuren|Williams Beuren Syndrome|Beuren Syndrome|Syndrome, Beuren|Hypercalcemia-Supravalvar Aortic Stenosis|Aortic Stenoses, Hypercalcemia-Supravalvar|Aortic Stenosis, Hypercalcemia-Supravalvar|Hypercalcemia Supravalvar Aortic Stenosis|Hypercalcemia-Supravalvar Aortic Stenoses|Stenoses, Hypercalcemia-Supravalvar Aortic|Stenosis, Hypercalcemia-Supravalvar Aortic|Chromosome 7q11.23 Deletion Syndrome|Williams Contiguous Gene Syndrome
+D018980	Williams Syndrome	Syndrome, Williams|Williams Contiguous Gene Syndrome|Supravalvar Aortic Stenosis Syndrome|Chromosome 7q11.23 Deletion Syndrome|Beuren Syndrome|Syndrome, Beuren|Hypercalcemia-Supravalvar Aortic Stenosis|Aortic Stenoses, Hypercalcemia-Supravalvar|Aortic Stenosis, Hypercalcemia-Supravalvar|Hypercalcemia Supravalvar Aortic Stenosis|Hypercalcemia-Supravalvar Aortic Stenoses|Stenoses, Hypercalcemia-Supravalvar Aortic|Stenosis, Hypercalcemia-Supravalvar Aortic|Contiguous Gene Syndrome, Williams|Williams-Beuren Syndrome|Syndrome, Williams-Beuren|Williams Beuren Syndrome
 D018981	Congenital Disorders of Glycosylation	Glycoprotein Syndrome, Carbohydrate-Deficient|Carbohydrate-Deficient Glycoprotein Syndrome|Carbohydrate Deficient Glycoprotein Syndrome|Carbohydrate-Deficient Glycoprotein Syndromes|Syndrome, Carbohydrate-Deficient Glycoprotein|Syndromes, Carbohydrate-Deficient Glycoprotein
 D018983	DNA Footprinting	DNA Footprintings|Footprinting, DNA|Footprintings, DNA
 D018984	Epitopes, T-Lymphocyte	Epitopes, T Lymphocyte|T-Cell Epitopes|Epitopes, T-Cell|T Cell Epitopes|T-Lymphocyte Epitopes|T Lymphocyte Epitopes|T-Cell Epitope|Epitope, T-Cell|T Cell Epitope|T-Lymphocyte Epitope|Epitope, T-Lymphocyte|T Lymphocyte Epitope
@@ -19208,7 +19626,7 @@ D019011	Antigens, CD7	CD7 Antigens|CD7 Antigen|Antigen, CD7
 D019012	Integrin beta1	CD29 Antigen|Antigen, CD29|CD29 Antigens|beta1 Integrin|Integrin, beta1|4B4 Antigen|Antigen, 4B4|CDw29 Antigen|Antigen, CDw29|Antigens, CD29
 D019013	CD40 Antigens	TNFRSF5 Receptor|Receptor, TNFRSF5|CDw40 Antigen|Antigen, CDw40|Tumor Necrosis Factor Receptor Superfamily, Member 5|CD40 Antigen|Antigen, CD40|Antigens, CD40
 D019014	fas Receptor	Receptor, fas|fas Antigen|fas Antigens|APO-1 Antigen|APO 1 Antigen|CD95 Antigen|TNFRSF6 Receptor|Receptor, TNFRSF6|Antigens, CD95|Receptors, fas|fas Receptors|Tumor Necrosis Factor Receptor Superfamily, Member 6|Fas Cell Surface Death Receptor|CD95 Antigens
-D019015	Geologic Sediments	Geologic Sediment|Sediments, Geologic|Sediment, Geologic
+D019015	Geologic Sediments	Geologic Sediment|Sediment, Geologic|Sediments, Geologic
 D019016	Mineral Fibers	Fibers, Mineral|Mineral Fiber|Fiber, Mineral
 D019017	Eritrea	
 D019018	Imagery (Psychotherapy)	Imageries (Psychotherapy)|Imagery|Guided Imagery|Imagery, Guided
@@ -19241,7 +19659,7 @@ D019049	Developed Countries	Countries, Developed|Country, Developed|Developed Co
 D019050	Acupressure	
 D019051	Rhizotomy	Rhizotomies
 D019052	Depression, Postpartum	Postnatal Depression|Depression, Postnatal|Post-Partum Depression|Depression, Post-Partum|Post Partum Depression|Postpartum Depression|Post-Natal Depression|Depression, Post-Natal|Post Natal Depression
-D019053	HIV Enteropathy	Enteropathies, HIV|HIV Enteropathies|Idiopathic AIDS Enteropathy|AIDS Enteropathies, Idiopathic|AIDS Enteropathy, Idiopathic|Enteropathies, Idiopathic AIDS|Enteropathy, Idiopathic AIDS|Idiopathic AIDS Enteropathies|Enteropathy, HIV-Associated|Enteropathies, HIV-Associated|Enteropathy, HIV Associated|HIV-Associated Enteropathies|AIDS-Associated Enteropathy|AIDS Associated Enteropathy|AIDS-Associated Enteropathies|Enteropathies, AIDS-Associated|Enteropathy, AIDS-Associated|Enteropathy, AIDS Associated|Enteropathy, HIV|HIV-Associated Enteropathy|HIV Associated Enteropathy|AIDS Enteropathy|AIDS Enteropathies|Enteropathies, AIDS|Enteropathy, AIDS
+D019053	HIV Enteropathy	Enteropathies, HIV|HIV Enteropathies|AIDS-Associated Enteropathy|AIDS Associated Enteropathy|AIDS-Associated Enteropathies|Enteropathies, AIDS-Associated|AIDS Enteropathy|AIDS Enteropathies|Enteropathies, AIDS|Enteropathy, AIDS|Idiopathic AIDS Enteropathy|AIDS Enteropathies, Idiopathic|AIDS Enteropathy, Idiopathic|Enteropathies, Idiopathic AIDS|Enteropathy, Idiopathic AIDS|Idiopathic AIDS Enteropathies|HIV-Associated Enteropathy|HIV Associated Enteropathy|Enteropathy, HIV|Enteropathy, AIDS-Associated|Enteropathy, AIDS Associated|Enteropathy, HIV-Associated|Enteropathies, HIV-Associated|Enteropathy, HIV Associated|HIV-Associated Enteropathies
 D019054	Evoked Potentials, Motor	Evoked Potential, Motor|Motor Evoked Potential|Potential, Motor Evoked|Potentials, Motor Evoked|Motor Evoked Potentials
 D019055	No-Observed-Adverse-Effect Level	Level, No-Observed-Adverse-Effect|Levels, No-Observed-Adverse-Effect|No Observed Adverse Effect Level|No-Observed-Adverse-Effect Levels|NOAEL
 D019056	Receptors, Polymeric Immunoglobulin	Polymeric Immunoglobulin Receptors|Immunoglobulin Receptors, Polymeric|Receptor, Polyimmunoglobulin|Receptor, Polymeric Ig|Poly-Ig Receptor|Poly Ig Receptor|Receptor, Poly-Ig|Polyimmunoglobulin Receptor|Polymeric Immunoglobulin Receptor|Immunoglobulin Receptor, Polymeric|Receptor, Polymeric Immunoglobulin|Polymeric Ig Receptor|Ig Receptor, Polymeric
@@ -19410,7 +19828,7 @@ D019258	Saquinavir	Saquinivir
 D019259	Lamivudine	3TC|2',3'-Dideoxy-3'-thiacytidine|2',3' Dideoxy 3' thiacytidine
 D019260	Expressed Emotion	Emotion, Expressed|Emotions, Expressed|Expressed Emotions
 D019261	Epithalamus	
-D019262	Habenula	Habenulas|Habenula Complex|Complex, Habenula|Complices, Habenula|Habenula Complices|Nucleus Habenularis|Habenulari, Nucleus|Habenularis, Nucleus|Nucleus Habenulari
+D019262	Habenula	Habenulas|Nucleus Habenularis|Habenulari, Nucleus|Habenularis, Nucleus|Nucleus Habenulari|Habenula Complex|Complex, Habenula|Complices, Habenula|Habenula Complices
 D019263	Dysthymic Disorder	Disorder, Dysthymic|Dysthymic Disorders
 D019264	Adoptive Transfer	Adoptive Transfers
 D019265	Spectroscopy, Near-Infrared	Near-Infrared Spectroscopies|Near-Infrared Spectroscopy|Spectroscopies, Near-Infrared|Spectroscopy, Near Infrared|NIR Spectroscopy|NIR Spectroscopies|Spectroscopies, NIR|Spectroscopy, NIR|Spectrometry, Near-Infrared|Near-Infrared Spectrometries|Near-Infrared Spectrometry|Spectrometries, Near-Infrared|Spectrometry, Near Infrared
@@ -19421,7 +19839,7 @@ D019269	Phosphatidylinositol 4,5-Diphosphate	4,5-Diphosphate, Phosphatidylinosit
 D019270	Fructosamine	D-Isoglucosamine|D Isoglucosamine
 D019271	Hypoxanthine	
 D019272	Leukocyte Elastase	Elastase, Leukocyte|Polymorphonuclear Leukocyte Elastase|Elastase, Polymorphonuclear Leukocyte|Leukocyte Elastase, Polymorphonuclear|Neutrophil Elastase|Elastase, Neutrophil|PMN Elastase|Elastase, PMN|Granulocyte Elastase|Elastase, Granulocyte|Lysosomal Elastase|Elastase, Lysosomal
-D019274	Botulinum Toxins, Type A	Botulinum Neurotoxin A|Neurotoxin A, Botulinum|Clostridium botulinum A Toxin|Clostridium Botulinum Toxin Type A|Botulinum A Toxin|Toxin, Botulinum A|Botulinum Toxin Type A
+D019274	Botulinum Toxins, Type A	Clostridium Botulinum Toxin Type A|Botulinum Toxin Type A|Clostridium botulinum A Toxin|Botulinum Neurotoxin A|Neurotoxin A, Botulinum|Botulinum A Toxin|Toxin, Botulinum A
 D019275	Radiopharmaceuticals	
 D019276	Glycocalyx	Glycocalix|Cell Coat|Cell Coats|Coat, Cell|Coats, Cell
 D019277	Entropy	Entropies
@@ -19483,11 +19901,11 @@ D019338	Polypharmacy	Polymedication
 D019339	Port-Wine Stain	Port Wine Stain|Port-Wine Stains|Stain, Port-Wine|Stains, Port-Wine|Nevus Flammeus
 D019340	Osteotomy, Le Fort	Le Fort Osteotomy|Osteotomy, LeFort|LeFort Osteotomy
 D019341	Aromatherapy	Aromatherapies|Aroma Therapy|Aroma Therapies|Therapies, Aroma|Therapy, Aroma
-D019342	Acetic Acid	Acid, Acetic|Glacial Acetic Acid|Acetic Acid, Glacial|Acid, Glacial Acetic|Acetic Acid Glacial|Acid Glacial, Acetic|Glacial, Acetic Acid
-D019343	Citric Acid	Citric Acid Monohydrate|Acid Monohydrate, Citric|Monohydrate, Citric Acid
+D019342	Acetic Acid	Glacial Acetic Acid|Acetic Acid, Glacial|Acetic Acid Glacial|Glacial, Acetic Acid
+D019343	Citric Acid	
 D019344	Lactic Acid	2-Hydroxypropanoic Acid|2 Hydroxypropanoic Acid|2-Hydroxypropionic Acid|2 Hydroxypropionic Acid
-D019345	Zinc Acetate	Acetate, Zinc|Zinc Acetate Dihydrate|Acetate Dihydrate, Zinc|Dihydrate, Zinc Acetate
-D019346	Sodium Acetate	Acetate, Sodium|Sodium Acetate Trihydrate|Acetate Trihydrate, Sodium|Trihydrate, Sodium Acetate
+D019345	Zinc Acetate	
+D019346	Sodium Acetate	
 D019347	Potassium Acetate	Acetate, Potassium
 D019348	Empiricism	
 D019349	Roseolovirus Infections	Infections, Roseolovirus|Infection, Roseolovirus|Roseolovirus Infection
@@ -19517,7 +19935,7 @@ D019379	Teriparatide	hPTH (1-34)|Human Parathyroid Hormone (1-34)
 D019380	Anti-HIV Agents	Agents, Anti-HIV|Anti HIV Agents|Anti-AIDS Agents|Agents, Anti-AIDS|Anti AIDS Agents|Anti-HIV Drugs|Anti HIV Drugs|Drugs, Anti-HIV|AIDS Drugs|Drugs, AIDS|Anti-AIDS Drugs|Anti AIDS Drugs|Drugs, Anti-AIDS
 D019382	Human Growth Hormone	Growth Hormone, Human|hGH (Human Growth Hormone)|Somatropin (Human)|Somatotropin (Human)|Somatropin
 D019384	Nucleic Acid Synthesis Inhibitors	Inhibitors, Nucleic Acid Synthesis
-D019386	Alendronate	Aminohydroxybutane Bisphosphonate|Bisphosphonate, Aminohydroxybutane|4-Amino-1-Hydroxybutylidene 1,1-Biphosphonate|4 Amino 1 Hydroxybutylidene 1,1 Biphosphonate
+D019386	Alendronate	4-Amino-1-Hydroxybutylidene 1,1-Biphosphonate|Aminohydroxybutane Bisphosphonate
 D019388	Cytochrome P-450 CYP1A2	CYP1A2, Cytochrome P-450|Cytochrome P 450 CYP1A2|Cytochrome P-450d|Cytochrome P 450d|Phenacetin O-Dealkylase|O-Dealkylase, Phenacetin|Phenacetin O Dealkylase|Caffeine Demethylase|Demethylase, Caffeine|Cytochrome P-450 LM4|Cytochrome P 450 LM4|P-450 LM4, Cytochrome|Cytochrome P450 1A2|CYP1A2|CYP 1A2|Cytochrome P-450 LM(4)
 D019389	Cytochrome P-450 CYP2D6	CYP2D6, Cytochrome P-450|Cytochrome P 450 CYP2D6|P-450 CYP2D6, Cytochrome|Sparteine Monooxygenase|Monooxygenase, Sparteine|Cytochrome P450 2D6|P450 2D6, Cytochrome|Debrisoquine 4-Monooxygenase|4-Monooxygenase, Debrisoquine|Debrisoquine 4 Monooxygenase|Imipramine 2-Hydroxylase|2-Hydroxylase, Imipramine|Imipramine 2 Hydroxylase|CYP2D6|CYP 2D6|Debrisoquine 4-Hydroxylase|4-Hydroxylase, Debrisoquine|Debrisoquine 4 Hydroxylase|Debrisoquine Hydroxylase|Hydroxylase, Debrisoquine
 D019390	Arrestins	
@@ -19540,7 +19958,7 @@ D019413	Qi	Vital Energy (Philosophy)|Energies, Vital (Philosophy)|Energy, Vital 
 D019414	Chlorobi	Bacteria, Green Sulfur|Green Sulfur Bacteria
 D019415	Torque	Torques
 D019416	Head Movements	Head Movement|Movement, Head|Movements, Head
-D019417	Hindlimb Suspension	Suspension, Hindlimb|Hindlimb Unloading|Unloading, Hindlimb|Unloadings, Hindlimb|Hindlimb Elevation|Elevation, Hindlimb|Hindlimb Immobilization|Immobilization, Hindlimb
+D019417	Hindlimb Suspension	Suspension, Hindlimb|Hindlimb Elevation|Elevation, Hindlimb|Hindlimb Unloading|Unloading, Hindlimb|Unloadings, Hindlimb|Hindlimb Immobilization|Immobilization, Hindlimb
 D019418	Evolution, Chemical	Chemical Evolution|Chemical Evolutions|Evolutions, Chemical
 D019419	Evolution, Planetary	Planetary Evolution
 D019422	Dietary Sucrose	Table Sugar|Sugars, Table|Table Sugars|Sucrose, Dietary|Dietary Sucroses|Sucroses, Dietary
@@ -19591,64 +20009,64 @@ D019468	Disease Management	Disease Managements|Management, Disease|Managements, 
 D019469	Indinavir	
 D019470	Biolistics	Biolistic|Gene-Gun Technique|Gene Gun Technique|Gene-Gun Techniques
 D019471	Elementary Particle Interactions	Particle Interactions, Elementary|Elementary Particle Interaction|Interaction, Elementary Particle|Interactions, Elementary Particle|Particle Interaction, Elementary
-D019472	Universal Coverage	Coverage, Universal
+D019472	Universal Health Insurance	Health Insurance, Universal|Insurance, Universal Health|Universal Coverage|Coverage, Universal
 D019473	Transcription Factors, TFII	TFII Transcription Factors
 D019474	Transcription Factors, TFIII	TFIII Transcription Factors|Factors, TFIII Transcription
 D019475	Camphor 5-Monooxygenase	Camphor 5 Monooxygenase|Cytochrome P-450-cam|Cytochrome P 450 cam|CYP101|Cytochrome P450(cam)|P450cam|Cytochrome P-450 101|Cytochrome P 450 101|Camphor-5-Monooxygenase|Cytochrome P-450(cam)
 D019476	Insect Proteins	Proteins, Insect
-D019477	Portraits	
-D019478	Academic Dissertations	
-D019479	Account Books	
-D019480	Advertisements	
-D019482	Almanacs	
+D019477	Portrait	Portraits
+D019478	Academic Dissertation	Academic Dissertations
+D019479	Account Book	Account Books
+D019480	Advertisement	Advertisements
+D019482	Almanac	Almanacs
 D019483	Disintegrins	
-D019484	Addresses	
+D019484	Address	Addresses
 D019485	Bone Morphogenetic Proteins	Morphogenetic Proteins, Bone|Bone Morphogenetic Protein|Morphogenetic Protein, Bone
 D019486	Animation	
-D019487	Annual Reports	
-D019488	Architectural Drawings	
+D019487	Annual Report	Annual Reports
+D019488	Architectural Drawing	Architectural Drawings
 D019489	Book Illustrations	
-D019490	Broadsides	Broadside
+D019490	Broadside	Broadsides
 D019491	Bookplates	Book Plates
-D019492	Caricatures	
-D019493	Cartoons	
-D019494	Catalogs	
+D019492	Caricature	Caricatures
+D019493	Cartoon	Cartoons
+D019494	Catalog	Catalogs
 D019496	Cancer Vaccines	Vaccines, Tumor|Vaccines, Neoplasm|Tumor Vaccines|Vaccines, Cancer|Neoplasm Vaccines
-D019497	Diaries	
+D019497	Diary	Diaries
 D019499	Documentaries and Factual Films	
-D019500	Encyclopedias	
+D019500	Encyclopedia	Encyclopedias
 D019502	Ephemera	
-D019504	Eulogies	
-D019505	Funeral Sermons	
-D019508	Guidebooks	
-D019509	Herbals	
+D019504	Eulogy	Eulogies
+D019505	Funeral Sermon	Funeral Sermons
+D019508	Guidebook	Guidebooks
+D019509	Herbal	Herbals
 D019512	Pancreatitis, Alcoholic	Alcoholic Pancreatitis
 D019513	Feminism	
 D019514	Instructional Films and Videos	
 D019516	Orthodontic Space Closure	Space Closure, Orthodontic|Closure, Orthodontic Space|Closures, Orthodontic Space|Orthodontic Space Closures|Space Closures, Orthodontic
 D019517	Unedited Footage	
 D019518	Postprandial Period	Period, Postprandial|Periods, Postprandial|Postprandial Periods|Postcibal Period|Period, Postcibal|Periods, Postcibal|Postcibal Periods
-D019519	Posters	
+D019519	Poster	Posters
 D019520	Living Donors	Donors, Living|Donor, Living|Living Donor
 D019521	Body Patterning	Patterning, Body|Body Pattern Specification|Pattern Specification, Body|Specification, Body Pattern|Body Pattern Formation|Pattern Formation, Body
 D019522	Vaginal Discharge	Discharge, Vaginal|Discharges, Vaginal|Vaginal Discharges
-D019523	Sermons	
-D019525	Price Lists	
-D019527	Prospectuses	
-D019528	Lecture Notes	
+D019523	Sermon	Sermons
+D019525	Price List	Price Lists
+D019527	Prospectuses	Prospectuse
+D019528	Lecture Note	Lecture Notes
 D019529	Sexuality	
-D019531	Lectures	
-D019532	Maps	
+D019531	Lecture	Lectures
+D019532	Maps	Map
 D019533	Streptococcus oralis	
 D019534	Shoulder Impingement Syndrome	Shoulder Impingement Syndromes|Rotator Cuff Impingement Syndrome|Rotator Cuff Impingement|Impingement, Rotator Cuff|Impingements, Rotator Cuff|Rotator Cuff Impingements
 D019535	Mycoplasma hominis	
 D019538	Health Care Surveys	Care Survey, Health|Care Surveys, Health|Health Care Survey|Survey, Health Care|Surveys, Health Care|Healthcare Surveys|Healthcare Survey|Survey, Healthcare|Surveys, Healthcare
-D019539	Pharmacopoeias	
+D019539	Pharmacopoeia	Pharmacopoeias
 D019540	Area Under Curve	Area Under Curves|Curve, Area Under|Curves, Area Under|Under Curve, Area|Under Curves, Area|AUC
-D019542	Programs	
+D019542	Programs	Program
 D019544	Equipment Failure Analysis	Analysis, Equipment Failure|Analyses, Equipment Failure|Equipment Failure Analyses|Failure Analyses, Equipment|Failure Analysis, Equipment
 D019545	Intuition	
-D019546	Couples Therapy	Couples Therapies|Therapies, Couples|Therapy, Couples|Couple Therapy|Couple Therapies|Therapies, Couple|Therapy, Couple
+D019546	Couples Therapy	Couples Therapies|Therapy, Couples|Couple Therapy|Therapies, Couple|Therapy, Couple
 D019547	Neck Pain	Neck Pains|Pain, Neck|Pains, Neck|Neck Ache|Ache, Neck|Aches, Neck|Neck Aches|Cervicalgia|Cervicalgias|Cervicodynia|Cervicodynias|Neckache|Neckaches|Cervical Pain|Cervical Pains|Pain, Cervical|Pains, Cervical
 D019548	Crime Victims	Crime Victim|Victim, Crime|Victims, Crime
 D019550	Environmental Medicine	Medicine, Environmental
@@ -19679,10 +20097,10 @@ D019575	Blindness, Cortical	Cortical Blindness
 D019576	Porpoises	Porpoise|Phocoenidae
 D019577	Mole Rats	Mole Rat|Rat, Mole|Rats, Mole|Molerats|Molerat|Mole-Rats|Mole-Rat
 D019578	Multiple System Atrophy	Atrophy, Multiple System|Multiple System Atrophies|Multisystem Atrophy|Atrophies, Multisystem|Atrophy, Multisystem|Multisystem Atrophies|Multisystemic Atrophy|Atrophies, Multisystemic|Atrophy, Multisystemic|Multisystemic Atrophies|Multiple System Atrophy Syndrome
-D019579	Neocortex	Neocortices|Isocortex|Isocortices|Neopallium|Neopalliums|Substantia Corticalis|Corticali, Substantia|Corticalis, Substantia|Substantia Corticali|Cerebral Neocortex|Cerebral Neocortices|Neocortex, Cerebral|Neocortices, Cerebral|Neopallial Cortex|Cortex, Neopallial|Cortices, Neopallial|Neopallial Cortices
-D019580	Perforant Pathway	Pathway, Perforant|Pathways, Perforant|Perforant Pathways|Perforant Path|Path, Perforant|Paths, Perforant|Perforant Paths|Perforating Fasciculus|Fasciculus, Perforating
+D019579	Neocortex	Neocortices|Substantia Corticalis|Corticali, Substantia|Corticalis, Substantia|Substantia Corticali|Cerebral Neocortex|Cerebral Neocortices|Neocortex, Cerebral|Neocortices, Cerebral|Neopallial Cortex|Cortex, Neopallial|Cortices, Neopallial|Neopallial Cortices|Neopallium|Neopalliums|Isocortex|Isocortices
+D019580	Perforant Pathway	Pathway, Perforant|Pathways, Perforant|Perforant Pathways|Perforating Fasciculus|Fasciculus, Perforating|Perforant Path|Path, Perforant|Paths, Perforant|Perforant Paths
 D019581	Neuropil	Neuropils|Neuropile|Neuropiles
-D019583	Dose Fractionation	Dose Fractionations|Fractionation, Dose|Fractionations, Dose|Radiotherapy Dose Fractionation|Dose Fractionation, Radiotherapy|Dose Fractionations, Radiotherapy|Fractionation, Radiotherapy Dose|Fractionations, Radiotherapy Dose|Radiotherapy Dose Fractionations
+D019583	Dose Fractionation, Radiation	Fractionation, Radiation Dose|Dose Fractionation, Radiotherapy|Dose Fractionations, Radiotherapy|Fractionation, Radiotherapy Dose|Fractionations, Radiotherapy Dose|Radiotherapy Dose Fractionations|Radiotherapy Dose Fractionation|Radiation Dose Fractionation
 D019584	Hot Flashes	Flashes, Hot
 D019585	Intracranial Hypotension	Hypotension, Intracranial
 D019586	Intracranial Hypertension	Hypertension, Intracranial|Intracranial Pressure Increase|Pressure Increase, Intracranial|ICP (Intracranial Pressure) Elevation|ICP (Intracranial Pressure) Increase|Elevated ICP (Intracranial Pressure)|ICP, Elevated (Intracranial Pressure)|Elevated Intracranial Pressure|Intracranial Pressure, Elevated|Pressure, Elevated Intracranial
@@ -19746,7 +20164,7 @@ D019656	Loss of Heterozygosity	Heterozygosity Loss|Allelic Loss|Allelic Losses|H
 D019657	Solanaceae	
 D019658	Linaceae	
 D019659	Asteraceae	Compositae
-D019660	Malvaceae	Mallow Family|Families, Mallow|Family, Mallow|Mallow Families
+D019660	Malvaceae	Sterculiaceae|Mallow Family|Mallow Families
 D019661	Apiaceae	Umbelliferae
 D019662	Cucurbitaceae	
 D019663	Chenopodiaceae	
@@ -19811,7 +20229,7 @@ D019731	Carbon-Nitrogen Ligases	Carbon Nitrogen Ligases|Ligases, Carbon-Nitrogen
 D019732	Amide Synthases	Synthases, Amide|Acid-Ammonia Ligases|Acid Ammonia Ligases|Ligases, Acid-Ammonia|Acid-Amide Ligases|Acid Amide Ligases|Ligases, Acid-Amide
 D019733	Carbon-Nitrogen Ligases with Glutamine as Amide-N-Donor	Carbon Nitrogen Ligases with Glutamine as Amide N Donor
 D019735	Carbon-Carbon Ligases	Carbon Carbon Ligases|Ligases, Carbon-Carbon
-D019736	Prostheses and Implants	Implants and Prostheses
+D019736	Prostheses and Implants	Implants and Prostheses|Prosthetic Implants|Implant, Prosthetic|Implants, Prosthetic|Prosthetic Implant
 D019737	Transplants	Transplant|Grafts|Graft
 D019738	Surgically-Created Structures	Surgically Created Structures|Surgically-Created Structure|Surgically Created Structure|Structure, Surgically-Created|Structure, Surgically Created|Structures, Surgically-Created|Structures, Surgically Created
 D019739	Skeletal Muscle Ventricle	Muscle Ventricle, Skeletal|Muscle Ventricles, Skeletal|Skeletal Muscle Ventricles|Ventricle, Skeletal Muscle|Ventricles, Skeletal Muscle
@@ -19898,7 +20316,7 @@ D019844	Antibodies, Archaeal	Archaeal Antibodies
 D019845	Antigens, Archaeal	Archaeal Antigens
 D019846	Miller Fisher Syndrome	Syndrome, Miller Fisher|Guillain Barre Syndrome, Miller Fisher Variant|Ophthalmoplegia, Ataxia and Areflexia Syndrome|Miller Fisher Variant of Guillain Barre Syndrome|Miller-Fisher Syndrome|Syndrome, Miller-Fisher|Fisher Syndrome|Syndrome, Fisher|Guillain-Barre Syndrome, Miller Fisher Variant
 D019847	Chromosomes, Archaeal	Archaeal Chromosome|Archaeal Chromosomes|Chromosome, Archaeal
-D019848	Gene Expression Regulation, Archaeal	Regulation of Gene Expression, Archaeal|Regulation, Gene Expression, Archaeal|Archaeal Gene Expression Regulation
+D019848	Gene Expression Regulation, Archaeal	Archaeal Gene Expression Regulation|Regulation of Gene Expression, Archaeal|Regulation, Gene Expression, Archaeal
 D019849	Sex Determination Processes	Determination Processes, Sex|Processes, Sex Determination|Sex Determination Process|Determination Process, Sex|Process, Sex Determination|Sex Determination Genetics|Genetics, Sex Determination|Sex Determination Genetic Processes
 D019850	Heptanol	1-Heptanol|1 Heptanol|Alcohol, Heptyl|Heptyl Alcohol|n-Heptanol|n Heptanol
 D019851	Thrombophilia	Thrombophilias|Hypercoagulability|Hypercoagulabilities
@@ -19916,7 +20334,7 @@ D019863	Gastrin-Secreting Cells	Cell, Gastrin-Secreting|Cells, Gastrin-Secreting
 D019864	Somatostatin-Secreting Cells	Somatostatin Secreting Cells|Somatostatin-Secreting Cell|delta Cells|delta Cell|D Cells|D Cell|Somatostatin Cells|Somatostatin Cell
 D019867	Anti-Glomerular Basement Membrane Disease	Anti Glomerular Basement Membrane Disease|Anti-GBM Disease|Anti GBM Disease|Lung Purpura with Nephritis|Goodpasture's Syndrome|Goodpastures Syndrome|Syndrome, Goodpasture's|Goodpasture Syndrome|Syndrome, Goodpasture
 D019868	Kanamycin Kinase	Kinase, Kanamycin|Aminocyclitol Phosphotransferase|Phosphotransferase, Aminocyclitol|Neomycin Phosphotransferase|Phosphotransferase, Neomycin|Aminoglycoside Phosphotransferase|Phosphotransferase, Aminoglycoside|Kanamycin-Neomycin Phosphate Transferase|Kanamycin Neomycin Phosphate Transferase|Phosphate Transferase, Kanamycin-Neomycin|Transferase, Kanamycin-Neomycin Phosphate|Amikacin 3'-Phosphotransferase|3'-Phosphotransferase, Amikacin|Amikacin 3' Phosphotransferase|Aminoglycoside 3'-Phosphotransferase Type VIII|Aminoglycoside 3' Phosphotransferase Type VIII
-D019869	Phosphatidylinositol 3-Kinases	Phosphatidylinositol 3 Kinases|Phosphoinositide 3-Hydroxykinase|PI 3-Kinase|PtdIns 3-Kinases|3-Kinases, PtdIns|PtdIns 3 Kinases|PI-3K|PI3 Kinases|Kinases, PI3|PI3-Kinase|PtdIns 3-Kinase|Phosphatidylinositol-3-OH Kinase|PI-3 Kinase
+D019869	Phosphatidylinositol 3-Kinases	Phosphatidylinositol 3 Kinases|Phosphoinositide 3-Hydroxykinase|3-Hydroxykinase, Phosphoinositide|Phosphoinositide 3 Hydroxykinase|PI 3-Kinase|PI 3 Kinase|PI-3 Kinase|Kinase, PI-3|Phosphoinositide 3 Kinases|Kinases, Phosphoinositide 3|PI3 Kinases|Kinases, PI3|PI3-Kinase|PI3 Kinase|PtdIns 3-Kinase|PtdIns 3 Kinase|PtdIns 3-Kinases|PtdIns 3 Kinases|Phosphatidylinositol-3-OH Kinase|Kinase, Phosphatidylinositol-3-OH|Phosphatidylinositol 3 OH Kinase|PI-3K
 D019870	1-Phosphatidylinositol 4-Kinase	1 Phosphatidylinositol 4 Kinase|Phosphoinositide Kinase|Kinase, Phosphoinositide|Phosphatidylinositiol Kinase|Kinase, Phosphatidylinositiol|Phosphatidylinositol 4-Kinase|Phosphatidylinositol 4 Kinase|PI 4-Kinase|PI 4 Kinase|Phosphatidylinositol Kinase Type II|PtdIns 4-Kinase|PtdIns 4 Kinase
 D019871	Dyskeratosis Congenita	
 D019872	Chief Cells, Gastric	Chief Cell, Gastric|Gastric Chief Cell|Gastric Zymogenic Cells|Cell, Gastric Zymogenic|Cells, Gastric Zymogenic|Gastric Zymogenic Cell|Zymogenic Cell, Gastric|Zymogenic Cells, Gastric|Gastric Chief Cells
@@ -20009,7 +20427,7 @@ D019970	Cocaine-Related Disorders	Cocaine Related Disorders|Cocaine-Related Diso
 D019973	Alcohol-Related Disorders	Alcohol Related Disorders|Alcohol-Related Disorder|Disorder, Alcohol-Related|Disorders, Alcohol-Related
 D019974	Pan paniscus	Bonobo|Bonobos|Chimpanzee, Pygmy|Chimpanzees, Pygmy|Pygmy Chimpanzees|Pygmy Chimpanzee
 D019976	Cloning, Organism	Clonings, Organism|Organism Cloning|Organism Clonings
-D019980	Amoxicillin-Potassium Clavulanate Combination	Amoxicillin Potassium Clavulanate Combination|Co-amoxiclav|Co amoxiclav|Coamoxiclav|Clavulanate Potentiated Amoxycillin|Amoxycillin, Clavulanate Potentiated|Potentiated Amoxycillin, Clavulanate|Amoxicillin-Clavulanic Acid|Amoxicillin Clavulanic Acid|Potassium Clavulanate-Amoxicillin Combination|Clavulanate-Amoxicillin Combination, Potassium|Combination, Potassium Clavulanate-Amoxicillin|Potassium Clavulanate Amoxicillin Combination|Amoxycillin-Clavulanic Acid|Amoxycillin Clavulanic Acid|Amox-clav|Amox clav|Amoxi-Clavulanate|Amoxi Clavulanate
+D019980	Amoxicillin-Potassium Clavulanate Combination	Amoxicillin Potassium Clavulanate Combination|Co-amoxiclav|Co amoxiclav|Coamoxiclav|Amoxicillin-Clavulanic Acid|Amoxicillin Clavulanic Acid|Amoxi-Clavulanate|Amoxi Clavulanate|Potassium Clavulanate-Amoxicillin Combination|Potassium Clavulanate Amoxicillin Combination|Amoxycillin-Clavulanic Acid|Amoxycillin Clavulanic Acid|Amox-clav|Amox clav|Clavulanate Potentiated Amoxycillin|Amoxycillin, Clavulanate Potentiated
 D019981	Health Care Sector	Health Care Sectors|Sector, Health Care|Sectors, Health Care|Healthcare Sector|Healthcare Sectors|Sector, Healthcare|Sectors, Healthcare
 D019982	Organizational Case Studies	Case Studies, Organizational|Studies, Organizational Case
 D019983	Guideline Adherence	Adherence, Guideline
@@ -20081,7 +20499,7 @@ D020075	Phanerochaete	Phanerochaetes
 D020076	Pleurotus	
 D020077	Endogenous Retroviruses	ERVs|Retroviruses, Endogenous|Endogenous Retrovirus|Retrovirus, Endogenous
 D020078	Neurogenic Inflammation	Inflammation, Neurogenic|Inflammations, Neurogenic|Neurogenic Inflammations
-D020079	Terminal Repeat Sequences	Repeat Sequence, Terminal|Repeat Sequences, Terminal|Sequence, Terminal Repeat|Sequences, Terminal Repeat|Terminal Repeat Sequence|Flanking Repeat Sequences|Flanking Repeat Sequence|Repeat Sequence, Flanking|Repeat Sequences, Flanking|Sequence, Flanking Repeat|Sequences, Flanking Repeat|Terminal Repeat|Repeat, Terminal|Repeats, Terminal|Terminal Repeats
+D020079	Terminal Repeat Sequences	Repeat Sequence, Terminal|Repeat Sequences, Terminal|Sequence, Terminal Repeat|Sequences, Terminal Repeat|Terminal Repeat Sequence|Terminal Repeat|Repeat, Terminal|Repeats, Terminal|Terminal Repeats|Flanking Repeat Sequences|Flanking Repeat Sequence|Repeat Sequence, Flanking|Repeat Sequences, Flanking|Sequence, Flanking Repeat|Sequences, Flanking Repeat
 D020080	Tandem Repeat Sequences	Repeat Sequence, Tandem|Repeat Sequences, Tandem|Sequence, Tandem Repeat|Sequences, Tandem Repeat|Tandem Repeat Sequence|Tandem Repeat|Repeat, Tandem|Repeats, Tandem|Tandem Repeats
 D020081	Phyllachorales	Phyllachorale
 D020082	Magnaporthe	Magnaporthes
@@ -20164,7 +20582,7 @@ D020163	Ornithine Carbamoyltransferase Deficiency Disease	Ornithine Carbamoyltra
 D020164	Chemical Actions and Uses	
 D020165	Carbamoyl-Phosphate Synthase I Deficiency Disease	Carbamyl-Phosphate Synthetase I Deficiency Disease|Carbamyl Phosphate Synthetase I Deficiency Disease|Carbamoyl Phosphate Synthase (Ammonia) Deficiency Disease|Carbamoyl-Phosphate Synthetase I Deficiency Disease|Carbamoyl Phosphate Synthetase I Deficiency Disease|Carbamoyl-Phosphate Synthase I Deficiency Disease (Ornithine Carbamoyl Phosphate Deficiency)|Carbamyl Phosphate Synthetase Deficiency Disease|Carbamoyl-Phosphate Synthase 1 Deficiency Disease (Ornithine Carbamoyl Phosphate Deficiency)|Carbamoyl Phosphate Synthase 1 Deficiency Disease (Ornithine Carbamoyl Phosphate Deficiency)|Carbamoylphosphate Synthetase 1 Deficiency Disease -|Carbamoylphosphate Synthetase 1 Deficiency Disease|Carbamyl-Phosphate Synthetase 1 Deficiency Disease|Carbamyl Phosphate Synthetase 1 Deficiency Disease|Carbamoyl-Phosphate Synthase 1 Deficiency Disease|Carbamoyl Phosphate Synthase 1 Deficiency Disease|Carbamoylphosphate Synthetase I Deficiency Disease
 D020167	Hyperlysinemias	Hyperlysinemia|L-Lysine:NAD-Oxido-Reductase Deficiency|Deficiencies, L-Lysine:NAD-Oxido-Reductase|Deficiency, L-Lysine:NAD-Oxido-Reductase|L Lysine:NAD Oxido Reductase Deficiency|L-Lysine:NAD-Oxido-Reductase Deficiencies|Lysine:Alpha-Ketoglutarate Reductase Deficiency|Deficiencies, Lysine:Alpha-Ketoglutarate Reductase|Deficiency, Lysine:Alpha-Ketoglutarate Reductase|Lysine:Alpha Ketoglutarate Reductase Deficiency|Lysine:Alpha-Ketoglutarate Reductase Deficiencies|Reductase Deficiencies, Lysine:Alpha-Ketoglutarate|Reductase Deficiency, Lysine:Alpha-Ketoglutarate|Familial Hyperlysinemia|Hyperlysinemia, Familial|Familial Hyperlysinemias|Hyperlysinemias, Familial
-D020168	ATP-Binding Cassette, Sub-Family B, Member 1	CD243 Antigen|Antigen, CD243|P-Glycoprotein|P Glycoprotein|PGY-1 Protein|PGY 1 Protein|Multidrug Resistance Protein 1|ABCB1 Protein|MDR1 Protein
+D020168	ATP Binding Cassette Transporter, Subfamily B, Member 1	CD243 Antigen|Antigen, CD243|ATP Binding Cassette Transporter, Sub-Family B, Member 1|PGY-1 Protein|PGY 1 Protein|MDR1 Protein|Multidrug Resistance Protein 1|ATP-Binding Cassette, Sub-Family B, Member 1|ABCB1 Protein|P-Glycoprotein|P Glycoprotein
 D020169	Caspases	
 D020170	Caspase 1	Interleukin-1beta Converting Enzyme|Converting Enzyme, Interleukin-1beta|Interleukin 1beta Converting Enzyme|ICE Protease|IL1BC Enzyme|IL-1 beta Convertase|Convertase, IL-1 beta|IL 1 beta Convertase|beta Convertase, IL-1|CASP1 Caspase|Caspase, CASP1|Interleukin-1 Converting Enzyme|Converting Enzyme, Interleukin-1|Interleukin 1 Converting Enzyme|IL-1 beta-Converting Enzyme|IL 1 beta Converting Enzyme|beta-Converting Enzyme, IL-1
 D020171	Botrytis	Botryti
@@ -20182,7 +20600,7 @@ D020186	Sleep Bruxism	Bruxism, Sleep|Bruxisms, Sleep|Sleep Bruxisms|Nocturnal Te
 D020187	REM Sleep Behavior Disorder	Behavior Disorder, REM|Behavior Disorders, REM|REM Behavior Disorders|REM Behavior Disorder|Behavior Disorder, Rapid Eye Movement Sleep|Rapid Eye Movement Sleep Behavior Disorder
 D020188	Sleep Paralysis	Paralysis, Sleep
 D020189	Nocturnal Myoclonus Syndrome	Myoclonus Syndrome, Nocturnal|Nocturnal Myoclonus Syndromes|Syndrome, Nocturnal Myoclonus|Periodic Leg Movements, Excessive, Sleep-Related|Sleep Myoclonus Syndrome|Myoclonus Syndrome, Sleep|Myoclonus Syndromes, Sleep|Sleep Myoclonus Syndromes|Syndrome, Sleep Myoclonus|Syndromes, Sleep Myoclonus|Periodic Movement Disorder, Sleep|Sleep Disorder, Periodic Movements|Sleep-Related Periodic Leg Movements, Excessive|Sleep Related Periodic Leg Movements, Excessive|Excessive Periodic Sleep-Related Leg Movements|Excessive Periodic Sleep Related Leg Movements|Periodic Limb Movement Disorder
-D020190	Myoclonic Epilepsy, Juvenile	Epilepsies, Juvenile Myoclonic|Epilepsy, Juvenile Myoclonic|Juvenile Myoclonic Epilepsies|Myoclonic Epilepsies, Juvenile|Impulsive Petit Mal, Janz|Janz Syndrome|Juvenile Myoclonic Epilepsy|Impulsive Petit Mal Epilepsy|Janz Impulsive Petit Mal|Janz Juvenile Myoclonic Epilepsy|Juvenile Myoclonic Epilepsy of Janz|JME (Juvenile Myoclonic Epilepsy)|JMEs (Juvenile Myoclonic Epilepsy)|Myoclonic Epilepsy, Adolescent|Adolescent Myoclonic Epilepsies|Epilepsies, Adolescent Myoclonic|Epilepsy, Adolescent Myoclonic|Myoclonic Epilepsies, Adolescent|Petit Mal, Impulsive, Janz|Myoclonic Epilepsy, Juvenile, 1|Petit Mal, Impulsive|Petit Mals, Impulsive|Epilepsy, Myoclonic Juvenile|Epilepsies, Myoclonic Juvenile|Juvenile Epilepsies, Myoclonic|Juvenile Epilepsy, Myoclonic|Myoclonic Juvenile Epilepsies|Myoclonic Juvenile Epilepsy|Adolescent Myoclonic Epilepsy|Panayiotopoulos Syndrome|Panayiotopoulos Syndromes|Epilepsy, Myoclonic, Juvenile
+D020190	Myoclonic Epilepsy, Juvenile	Epilepsy, Juvenile Myoclonic|Epilepsy, Myoclonic Juvenile|Juvenile Epilepsy, Myoclonic|Myoclonic Juvenile Epilepsy|JME (Juvenile Myoclonic Epilepsy)|JMEs (Juvenile Myoclonic Epilepsy)|Epilepsy, Myoclonic, Juvenile|Juvenile Myoclonic Epilepsy
 D020191	Myoclonic Epilepsies, Progressive	Epilepsies, Progressive Myoclonic|Epilepsy, Progressive Myoclonic|Progressive Myoclonic Epilepsies|Progressive Myoclonic Epilepsy|Myoclonic Epilepsy, Progressive|Progressive Myoclonus Epilepsies|Epilepsies, Progressive Myoclonus|Epilepsy, Progressive Myoclonus|Myoclonus Epilepsies, Progressive|Progressive Myoclonus Epilepsy
 D020192	Lafora Disease	Progressive Myoclonic Epilepsy, Lafora Type|Lafora Body Disease|Lafora Progressive Myoclonic Epilepsy|Lafora Type Progressive Myoclonic Epilepsy|Epilepsy, Progressive Myoclonic 2A|Lafora Body Disorder|Myoclonic Epilepsy of Lafora|Lafora Myoclonic Epilepsy|Epilepsy Progressive Myoclonic 2|Lafora Progressive Myoclonus Epilepsy|Progressive Myoclonic Epilepsy Type 2|Progressive Myoclonus Epilepsy, Lafora Type|Epilepsy, Progressive Myoclonic, Lafora|Progressive Myoclonic Epilepsy, Lafora
 D020194	Unverricht-Lundborg Syndrome	Syndrome, Unverricht-Lundborg|Unverricht Lundborg Syndrome|Baltic Myoclonus|Myoclonus, Baltic|Mediterranean Myoclonic Epilepsy|Epilepsy, Mediterranean Myoclonic|Myoclonic Epilepsy, Mediterranean|Baltic Myoclonus Epilepsy|Baltic Myoclonus Epilepsies|Epilepsies, Baltic Myoclonus|Epilepsy, Baltic Myoclonus|Myoclonus Epilepsies, Baltic|Myoclonus Epilepsy, Baltic|Unverricht Disease|Disease, Unverricht|Diseases, Unverricht|Unverricht Diseases|Myoclonus Progressive Epilepsy of Unverricht and Lundborg|Progressive Myoclonus Epilepsy 1|Epilepsy, Progressive Myoclonus 1|Myoclonic Epilepsy of Unverricht and Lundborg|Progressive Myoclonus Epilepsybaltic Myoclonic Epilepsy|Epilepsy, Progressive Myoclonic 1|Epilepsy, Progressive Myoclonic 1a|Baltic Myoclonic Epilepsy|Baltic Myoclonic Epilepsies|Epilepsies, Baltic Myoclonic|Epilepsy, Baltic Myoclonic|Myoclonic Epilepsies, Baltic|Myoclonic Epilepsy, Baltic|Unverricht-Lundborg Disease|Disease, Unverricht-Lundborg|Diseases, Unverricht-Lundborg|Unverricht Lundborg Disease|Unverricht-Lundborg Diseases|Lundborg-Unverricht Syndrome|Lundborg Unverricht Syndrome|Syndrome, Lundborg-Unverricht|Epilepsy, Progressive Myoclonic Type 1
@@ -20210,9 +20628,9 @@ D020216	Carotid-Cavernous Sinus Fistula	Carotid Cavernous Sinus Fistula|Carotid-
 D020217	Vertebral Artery Dissection	Artery Dissection, Vertebral|Artery Dissections, Vertebral|Dissection, Vertebral Artery|Dissections, Vertebral Artery|Vertebral Artery Dissections|Dissecting Vertebral Artery Aneurysm
 D020218	Response Elements	Element, Response|Elements, Response|Response Element
 D020219	Chondrogenesis	
-D020220	Facial Nerve Injuries	Facial Nerve Injury|Injuries, Facial Nerve|Nerve Injuries, Facial|Facial Nerve Trauma|Facial Nerve Traumas|Nerve Trauma, Facial|Nerve Traumas, Facial|Trauma, Facial Nerve|Traumas, Facial Nerve|Facial Neuropathy, Traumatic|Facial Neuropathies, Traumatic|Neuropathies, Traumatic Facial|Neuropathy, Traumatic Facial|Traumatic Facial Neuropathies|Traumatic Facial Neuropathy|Seventh Cranial Nerve Injuries|Injuries, Seventh Cranial Nerve|Injury, Facial Nerve|Nerve Injury, Facial|Cranial Nerve VII Injuries|Injuries, Cranial Nerve VII
-D020221	Optic Nerve Injuries	Injuries, Optic Nerve|Injury, Optic Nerve|Nerve Injuries, Optic|Nerve Injury, Optic|Optic Nerve Injury|Optic Nerve Trauma|Nerve Trauma, Optic|Nerve Traumas, Optic|Optic Nerve Traumas|Trauma, Optic Nerve|Traumas, Optic Nerve|Trauma, Second Cranial Nerve|Second Cranial Nerve Injuries|Second Cranial Nerve Trauma|Cranial Nerve II Injuries|Optic Neuropathy, Traumatic|Neuropathies, Traumatic Optic|Neuropathy, Traumatic Optic|Optic Neuropathies, Traumatic|Traumatic Optic Neuropathies|Traumatic Optic Neuropathy
-D020222	Abducens Nerve Injury	Abducens Nerve Injuries|Injuries, Abducens Nerve|Injury, Abducens Nerve|Nerve Injuries, Abducens|Nerve Injury, Abducens|Abducens Neuropathy, Traumatic|Abducens Neuropathies, Traumatic|Traumatic Abducens Neuropathies|Traumatic Abducens Neuropathy|Cranial Nerve VI Injury|Injury, Cranial Nerve VI|Sixth Cranial Nerve Injuries|Sixth Cranial Nerve Injury|Sixth-Nerve Palsy, Traumatic|Sixth Nerve Palsy, Traumatic|Sixth-Nerve Palsies, Traumatic|Traumatic Sixth-Nerve Palsies|Sixth-Nerve Trauma|Sixth Nerve Trauma|Sixth-Nerve Traumas|Trauma, Sixth-Nerve|Traumas, Sixth-Nerve|Traumatic Sixth-Nerve Palsy|Traumatic Sixth Nerve Palsy|Abducens Nerve Trauma|Abducens Nerve Traumas|Nerve Trauma, Abducens|Nerve Traumas, Abducens|Trauma, Abducens Nerve|Traumas, Abducens Nerve|Injury, Sixth Cranial Nerve
+D020220	Facial Nerve Injuries	Facial Nerve Injury|Injuries, Facial Nerve|Nerve Injuries, Facial|Facial Neuropathy, Traumatic|Facial Neuropathies, Traumatic|Neuropathies, Traumatic Facial|Neuropathy, Traumatic Facial|Traumatic Facial Neuropathies|Traumatic Facial Neuropathy|Cranial Nerve VII Injuries|Seventh Cranial Nerve Injuries|Injuries, Seventh Cranial Nerve|Injury, Facial Nerve|Nerve Injury, Facial|Facial Nerve Trauma|Facial Nerve Traumas|Nerve Trauma, Facial|Nerve Traumas, Facial|Trauma, Facial Nerve|Traumas, Facial Nerve|Injuries, Cranial Nerve VII
+D020221	Optic Nerve Injuries	Injuries, Optic Nerve|Injury, Optic Nerve|Nerve Injuries, Optic|Nerve Injury, Optic|Optic Nerve Injury|Optic Neuropathy, Traumatic|Neuropathies, Traumatic Optic|Neuropathy, Traumatic Optic|Optic Neuropathies, Traumatic|Traumatic Optic Neuropathies|Traumatic Optic Neuropathy|Trauma, Second Cranial Nerve|Cranial Nerve II Injuries|Second Cranial Nerve Injuries|Optic Nerve Trauma|Nerve Trauma, Optic|Nerve Traumas, Optic|Optic Nerve Traumas|Trauma, Optic Nerve|Traumas, Optic Nerve|Second Cranial Nerve Trauma
+D020222	Abducens Nerve Injury	Abducens Nerve Injuries|Injuries, Abducens Nerve|Injury, Abducens Nerve|Nerve Injuries, Abducens|Nerve Injury, Abducens|Sixth-Nerve Palsy, Traumatic|Sixth Nerve Palsy, Traumatic|Sixth-Nerve Palsies, Traumatic|Traumatic Sixth-Nerve Palsies|Abducens Nerve Trauma|Abducens Nerve Traumas|Nerve Trauma, Abducens|Nerve Traumas, Abducens|Trauma, Abducens Nerve|Traumas, Abducens Nerve|Cranial Nerve VI Injury|Sixth Cranial Nerve Injuries|Sixth-Nerve Trauma|Sixth Nerve Trauma|Sixth-Nerve Traumas|Trauma, Sixth-Nerve|Traumas, Sixth-Nerve|Sixth Cranial Nerve Injury|Injury, Cranial Nerve VI|Injury, Sixth Cranial Nerve|Abducens Neuropathy, Traumatic|Abducens Neuropathies, Traumatic|Traumatic Abducens Neuropathies|Traumatic Abducens Neuropathy|Traumatic Sixth-Nerve Palsy|Traumatic Sixth Nerve Palsy
 D020223	Chromosome Painting	Chromosome Paintings|Painting, Chromosome|Paintings, Chromosome
 D020224	Expressed Sequence Tags	Expressed Sequence Tag|Sequence Tag, Expressed|Sequence Tags, Expressed|Tag, Expressed Sequence|Tags, Expressed Sequence|ESTs
 D020225	Sagittal Sinus Thrombosis	Sagittal Sinus Thromboses|Sinus Thromboses, Sagittal|Sinus Thrombosis, Sagittal|Thromboses, Sagittal Sinus|Thrombosis, Sagittal Sinus
@@ -20259,11 +20677,11 @@ D020270	Alcohol Withdrawal Seizures	Alcohol Withdrawal Seizure|Seizure, Alcohol 
 D020271	Heredodegenerative Disorders, Nervous System	Degenerative Hereditary Diseases, Nervous System|Degenerative Hereditary Disorders, Nervous System|Hereditary Diseases, Neurodegenerative|Disease, Neurodegenerative Hereditary|Diseases, Neurodegenerative Hereditary|Hereditary Disease, Neurodegenerative|Neurodegenerative Hereditary Disease|Neurodegenerative Hereditary Diseases|Neurodegenerative Diseases, Hereditary|Disease, Hereditary Neurodegenerative|Diseases, Hereditary Neurodegenerative|Hereditary Neurodegenerative Disease|Neurodegenerative Disease, Hereditary|Hereditary-Degenerative Disorders, Nervous System|Hereditary Degenerative Disorders, Nervous System|Nervous System Degenerative Hereditary Diseases|Nervous System Diseases, Degenerative, Hereditary|Nervous System Hereditary Degenerative Diseases|Degenerative Disease, Nervous System, Hereditary|Hereditary Neurodegenerative Diseases
 D020273	Orbital Implants	Implant, Orbital|Implants, Orbital|Orbital Implant
 D020274	Autoimmune Diseases of the Nervous System	Autoimmune Diseases, Neurologic|Autoimmune Disease, Neurologic|Disease, Neurologic Autoimmune|Diseases, Neurologic Autoimmune|Neurologic Autoimmune Disease|Neurologic Autoimmune Diseases|Autoimmune Disorders, Nervous System|Autoimmune Nervous System Diseases|Nervous System Autoimmune Diseases|Autoimmune Diseases, Nervous System|Autoimmune Disorders of the Nervous System
-D020275	Guillain-Barre Syndrome	Guillain Barre Syndrome|Syndrome, Guillain-Barre|Acute Inflammatory Polyneuropathy|Acute Inflammatory Polyneuropathies|Inflammatory Polyneuropathies, Acute|Inflammatory Polyneuropathy, Acute|Polyneuropathies, Acute Inflammatory|Guillain-Barre Syndrome, Familial|Guillain-Barré Syndrome|Guillaine-Barre Syndrome|Guillaine Barre Syndrome|Syndrome, Guillaine-Barre|Inflammatory Demyelinating Polyradiculoneuropathy, Acute|Inflammatory Polyneuropathy Acute|Acute, Inflammatory Polyneuropathy|Inflammatory Polyneuropathy Acutes|Polyneuropathy Acute, Inflammatory|Landry-Guillain-Barre Syndrome|Landry Guillain Barre Syndrome|Syndrome, Landry-Guillain-Barre|Polyneuropathy, Acute Inflammatory|Polyneuropathy, Inflammatory Demyelinating, Acute|Polyradiculoneuropathy, Acute Inflammatory|Polyradiculoneuropathy, Acute Inflammatory Demyelinating|Acute Autoimmune Neuropathy|Acute Autoimmune Neuropathies|Autoimmune Neuropathies, Acute|Autoimmune Neuropathy, Acute|Neuropathies, Acute Autoimmune|Neuropathy, Acute Autoimmune|Acute Infectious Polyneuritis|Acute Inflammatory Demyelinating Polyneuropathy|Acute Inflammatory Demyelinating Polyradiculoneuropathy|Acute Inflammatory Polyradiculoneuropathy|Acute Inflammatory Polyradiculoneuropathies|Inflammatory Polyradiculoneuropathies, Acute|Polyradiculoneuropathies, Acute Inflammatory|Demyelinating Polyradiculoneuropathy, Acute Inflammatory
+D020275	Guillain-Barre Syndrome	Guillain Barre Syndrome|Syndrome, Guillain-Barre|Guillain-Barré Syndrome|Guillain Barré Syndrome|Guillain-Barré Syndromes|Syndrome, Guillain-Barré|Syndromes, Guillain-Barré|Acute Infectious Polyneuritis|Infectious Polyneuritis, Acute|Polyneuritis, Acute Infectious|Guillaine-Barre Syndrome|Guillaine Barre Syndrome|Syndrome, Guillaine-Barre|Acute Autoimmune Neuropathy|Acute Autoimmune Neuropathies|Autoimmune Neuropathies, Acute|Autoimmune Neuropathy, Acute|Neuropathies, Acute Autoimmune|Neuropathy, Acute Autoimmune|Landry-Guillain-Barre Syndrome|Landry Guillain Barre Syndrome|Syndrome, Landry-Guillain-Barre
 D020276	HIV Long-Term Survivors	HIV Long Term Survivors|Long-Term Survivors, HIV|HIV Long-Term Survivor|Long Term Survivors, HIV|Long-Term Survivor, HIV|Survivor, HIV Long-Term|Survivors, HIV Long-Term|HIV-1 Long-Term Survivors|HIV 1 Long Term Survivors|HIV-1 Long-Term Survivor|Long-Term Survivor, HIV-1|Long-Term Survivors, HIV-1|Survivor, HIV-1 Long-Term|Survivors, HIV-1 Long-Term
 D020277	Polyradiculoneuropathy, Chronic Inflammatory Demyelinating	CIDP|Polyneuropathy, Inflammatory Demyelinating, Chronic|Inflammatory Polyradiculopathy, Chronic|Chronic Inflammatory Polyradiculopathies|Chronic Inflammatory Polyradiculopathy|Inflammatory Polyradiculopathies, Chronic|Polyradiculopathies, Chronic Inflammatory|Polyradiculopathy, Chronic Inflammatory|Polyradiculoneuropathy, Chronic Inflammatory|Chronic Inflammatory Polyradiculoneuropathy|Chronic Inflammatory Polyradiculoneuropathies|Polyradiculoneuropathies, Chronic Inflammatory|Chronic Inflammatory Demyelinating Polyradiculoneuropathy
 D020278	Demyelinating Autoimmune Diseases, CNS	Demyelinating Autoimmune Disorders, CNS|Demyelinating Disease, Autoimmune, CNS|CNS Demyelinating Autoimmune Diseases|Autoimmune Demyelinating Diseases, CNS|Autoimmune Demyelinating Disorders, CNS|CNS Autoimmune Demyelinating Disorders|Demyelinating Autoimmune Diseases, Central Nervous System|Autoimmune Demyelinating Diseases, Central Nervous System
-D020279	Hereditary Central Nervous System Demyelinating Diseases	Central Nervous System Demyelinating Hereditary Diseases|Hereditary Demyelinating Diseases, Central Nervous System|Demyelinating Central Nervous System Diseases, Hereditary|Demyelinating Diseases, Central Nervous System, Hereditary|Central Nervous System Demyelinating Diseases, Hereditary|Central Nervous System Hereditary Demyelinating Diseases
+D020279	Hereditary Central Nervous System Demyelinating Diseases	Demyelinating Central Nervous System Diseases, Hereditary|Hereditary Demyelinating Diseases, Central Nervous System|Central Nervous System Demyelinating Hereditary Diseases|Central Nervous System Hereditary Demyelinating Diseases|Central Nervous System Demyelinating Diseases, Hereditary|Demyelinating Diseases, Central Nervous System, Hereditary
 D020280	Sertraline	
 D020283	Photoreceptors, Microbial	Microbial Photoreceptors|Photoreceptor, Microbial|Microbial Photoreceptor
 D020285	Cryoelectron Microscopy	Cryoelectron Microscopies|Microscopies, Cryoelectron|Microscopy, Cryoelectron|Electron Cryomicroscopy|Cryomicroscopies, Electron|Cryomicroscopy, Electron|Electron Cryomicroscopies|Cryo-electron Microscopy|Cryo electron Microscopy|Cryo-electron Microscopies|Microscopies, Cryo-electron|Microscopy, Cryo-electron
@@ -20347,11 +20765,11 @@ D020382	Interleukin-18	Interleukin 18|IFN-gamma-Inducing Factor|IL-18|Interferon
 D020383	Neutral Glycosphingolipids	Glycosphingolipids, Neutral
 D020384	Acidic Glycosphingolipids	Glycosphingolipids, Acidic
 D020385	Myokymia	Myokymias|Kymatism|Kymatisms|Morvan's Chorea|Chorea, Morvan's|Choreas, Morvan's|Morvan's Choreas|Morvans Chorea|Morvan's Fibrillary Chorea|Chorea, Morvan's Fibrillary|Fibrillary Chorea, Morvan's|Morvan Fibrillary Chorea|Morvans Fibrillary Chorea|Fibrillary Chorea|Chorea, Fibrillary|Choreas, Fibrillary|Fibrillary Choreas|Morvan Chorea|Chorea, Morvan|Choreas, Morvan|Morvan Choreas
-D020386	Isaacs Syndrome	Gamstorp-Wohlfart Syndrome|Gamstorp Wohlfart Syndrome|Gamstorp-Wohlfart Syndromes|Syndromes, Gamstorp-Wohlfart|Isaacs' Syndrome|Isaac Syndrome|Isaacs-Mertens Syndrome|Isaacs Mertens Syndrome|Syndromes, Isaacs-Mertens|Myokymia, Myotonia, Muscle Wasting, And Hyperhidrosis|Neuromyotonia|Pseudomyotonia|Pseudomyotonia Syndrome of Isaacs|Isaacs Pseudomyotonia Syndrome|Quantal Squander|Syndrome of Continuous Muscle Activity|Continuous Muscle Activity Syndrome|Myokymia, Continuous|Continuous Myokymia|Continuous Myokymias|Myokymias, Continuous
+D020386	Isaacs Syndrome	Gamstorp-Wohlfart Syndrome|Gamstorp Wohlfart Syndrome|Isaacs' Syndrome|Isaac Syndrome|Myokymia, Myotonia, Muscle Wasting, And Hyperhidrosis|Myokymia, Continuous|Continuous Myokymia|Continuous Myokymias|Myokymias, Continuous|Pseudomyotonia Syndrome of Isaacs|Isaacs Pseudomyotonia Syndrome|Quantal Squander|Syndrome of Continuous Muscle Activity|Continuous Muscle Activity Syndrome|Isaacs-Mertens Syndrome|Isaacs Mertens Syndrome
 D020387	Food Chain	Chain, Food|Chains, Food|Food Chains
 D020388	Muscular Dystrophy, Duchenne	Cardiomyopathy, Dilated, X-Linked|Childhood Muscular Dystrophy, Pseudohypertrophic|Childhood Pseudohypertrophic Muscular Dystrophy|Duchenne Muscular Dystrophy|Duchenne-Type Progressive Muscular Dystrophy|Duchenne Type Progressive Muscular Dystrophy|Muscular Dystrophy, Childhood, Pseudohypertrophic|Muscular Dystrophy, Duchenne Type|Muscular Dystrophy, Pseudohypertrophic|Pseudohypertrophic Muscular Dystrophy|Muscular Dystrophy, Pseudohypertrophic Progressive, Duchenne Type|Muscular Dystrophy, Pseudohypertrophic, Childhood|Progressive Muscular Dystrophy, Duchenne Type|Pseudohypertrophic Childhood Muscular Dystrophy|Pseudohypertrophic Muscular Dystrophy, Childhood|Cardiomyopathy, Dilated, 3B
 D020389	Muscular Dystrophy, Emery-Dreifuss	Muscular Dystrophy, Emery Dreifuss|Emery-Dreifuss Syndrome|Emery Dreifuss Syndrome|Muscular Dystrophy, Emery-Dreifuss Type|Emery-Dreifuss Muscular Dystrophy|Emery Dreifuss Muscular Dystrophy|Emery-Dreifuss Type Muscular Dystrophy
-D020390	Tooth Socket	Socket, Tooth|Sockets, Tooth|Tooth Sockets|Alveolus Dentalis|Alveolus Dentali|Dentali, Alveolus|Dentalis, Alveolus|Dental Alveolus|Alveolus, Dental
+D020390	Tooth Socket	Socket, Tooth|Sockets, Tooth|Tooth Sockets|Dental Alveolus|Alveolus, Dental|Alveolus Dentalis|Alveolus Dentali|Dentali, Alveolus|Dentalis, Alveolus
 D020391	Muscular Dystrophy, Facioscapulohumeral	Dystrophies, Facioscapulohumeral Muscular|Dystrophy, Facioscapulohumeral Muscular|Facioscapulohumeral Muscular Dystrophies|Muscular Dystrophies, Facioscapulohumeral|Facioscapulohumeral Atrophy|Atrophies, Facioscapulohumeral|Atrophy, Facioscapulohumeral|Facioscapulohumeral Atrophies|Facioscapulohumeral Muscular Dystrophy|Facioscapulohumeral Type Progressive Muscular Dystrophy|FSH Muscular Dystrophy|Landouzy-Dejerine Dystrophy|Dystrophies, Landouzy-Dejerine|Dystrophy, Landouzy-Dejerine|Landouzy Dejerine Dystrophy|Landouzy-Dejerine Dystrophies|Muscular Dystrophy, Landouzy Dejerine|Progressive Muscular Dystrophy, Facioscapulohumeral Type|Facio-Scapulo-Humeral Dystrophy|Facioscapuloperoneal Muscular Dystrophy
 D020392	Entopeduncular Nucleus	Nucleus, Entopeduncular|Endopeduncular Nucleus|Nucleus, Endopeduncular|Nucleus Endopeduncularis|Endopeduncularis, Nucleus|Nucleus Entopeduncularis|Entopeduncularis, Nucleus
 D020393	Manipulation, Spinal	Spinal Manipulation
@@ -20362,7 +20780,7 @@ D020398	Medicare Part C	Part C, Medicare|Medicare+Choice Program (US)|Medicare+C
 D020399	Practice Management	Management, Practice|Managements, Practice|Practice Managements
 D020400	Provider-Sponsored Organizations	Organization, Provider-Sponsored|Organizations, Provider-Sponsored|Provider Sponsored Organizations|Provider-Sponsored Organization
 D020401	Primed In Situ Labeling	PRINS|In Situ Labeling, Primed|Direct In Situ Copy PCR|DISC-PCR
-D020402	Medical Savings Accounts	Accounts, Medical Savings|Account, Medical Savings|Medical Savings Account|Savings Account, Medical|Savings Accounts, Medical
+D020402	Medical Savings Accounts	Savings Accounts, Medical|Health Savings Accounts|Health Savings Account|Accounts, Medical Savings|Medical Savings Account
 D020403	Patient Freedom of Choice Laws	Selective Provider Restrictions|Provider Restriction, Selective|Provider Restrictions, Selective|Restriction, Selective Provider|Restrictions, Selective Provider|Selective Provider Restriction|Choice of Health Care Provider Laws|Choice of Healthcare Provider Laws|AWS-FOC Laws
 D020404	Glycerophospholipids	Phosphoglycerides
 D020405	Dermis	Corium
@@ -20372,7 +20790,7 @@ D020408	Health Insurance Portability and Accountability Act	PL 104-191|PL104-191
 D020409	Molecular Motor Proteins	Motor Proteins, Molecular|Proteins, Molecular Motor
 D020410	Activated-Leukocyte Cell Adhesion Molecule	Activated Leukocyte Cell Adhesion Molecule|CD166 Antigens|CD6 Ligand|Antigens, CD166|KG-CAM|ALCAM
 D020411	Oligonucleotide Array Sequence Analysis	Sequence Analysis, Oligonucleotide Array|Oligodeoxyribonucleotide Array Sequence Analysis
-D020412	Multifactorial Inheritance	Inheritance, Multifactorial|Inheritances, Multifactorial|Multifactorial Inheritances
+D020412	Multifactorial Inheritance	Inheritance, Multifactorial|Complex Inheritance|Inheritance, Complex|Oligogenic Inheritance|Inheritance, Oligogenic|Multigenic Inheritance|Inheritance, Multigenic|Polygenic Inheritance|Inheritance, Polygenic
 D020413	3' Untranslated Regions	3'UTR|3'UTRs|3' Untranslated Region|Region, 3' Untranslated|Regions, 3' Untranslated|Untranslated Region, 3'|Untranslated Regions, 3'|3' UTR|3' UTRs|UTR, 3'|UTRs, 3'
 D020414	Risk Sharing, Financial	Financial Risk Sharing|Financial Risk Sharings|Risk Sharings, Financial|Sharing, Financial Risk|Sharings, Financial Risk
 D020415	Personnel Downsizing	Downsizing, Personnel|Staff Downsizing|Downsizing, Staff
@@ -20383,18 +20801,18 @@ D020419	Photoreceptor Cells, Vertebrate	Cell, Vertebrate Photoreceptor|Cells, Ve
 D020420	Cyst Fluid	Cyst Fluids|Fluid, Cyst|Fluids, Cyst
 D020421	Vagus Nerve Diseases	Vagus Nerve Disease|Vagus Neuropathy|Neuropathies, Vagus|Neuropathy, Vagus|Vagus Neuropathies|Tenth Cranial Nerve Diseases|Vagus Nerve Disorders|Vagus Nerve Disorder|Cranial Nerve X Diseases|Pneumogastric Nerve Disorders|Disorder, Pneumogastric Nerve|Disorders, Pneumogastric Nerve|Pneumogastric Nerve Disorder
 D020422	Mononeuropathies	Mononeuropathy
-D020423	Median Neuropathy	Median Neuropathies|Neuropathies, Median|Neuropathy, Median|Median Nerve Diseases|Median Nerve Disease|Nerve Disease, Median|Nerve Diseases, Median
+D020423	Median Neuropathy	Median Neuropathies|Median Nerve Neuropathy|Median Nerve Neuropathies|Nerve Neuropathy, Median|Neuropathy, Median Nerve|Neuropathy, Median|Median Nerve Diseases|Median Nerve Disease|Nerve Disease, Median|Median Mononeuropathy|Median Mononeuropathies|Mononeuropathy, Median
 D020424	Ulnar Neuropathies	Neuropathies, Ulnar|Neuropathy, Ulnar|Ulnar Neuropathy|Ulnar Nerve Diseases|Nerve Disease, Ulnar|Nerve Diseases, Ulnar|Ulnar Nerve Disease
-D020425	Radial Neuropathy	Neuropathies, Radial|Neuropathy, Radial|Radial Neuropathies|Radial Nerve Diseases|Nerve Disease, Radial|Nerve Diseases, Radial|Radial Nerve Disease
+D020425	Radial Neuropathy	Neuropathy, Radial|Radial Neuropathies|Radial Nerve Diseases|Radial Nerve Disease|Radial Nerve Compression|Compression, Radial Nerve|Nerve Compression, Radial|Radial Nerve Compressions|Radial Mononeuropathy|Mononeuropathy, Radial|Radial Mononeuropathies|Supinator Syndrome|Supinator Syndromes|Syndrome, Supinator
 D020426	Sciatic Neuropathy	Neuropathies, Sciatic|Neuropathy, Sciatic|Sciatic Neuropathies|Sciatic Nerve Diseases|Nerve Disease, Sciatic|Nerve Diseases, Sciatic|Sciatic Nerve Disease
-D020427	Peroneal Neuropathies	Neuropathies, Peroneal|Neuropathy, Peroneal|Peroneal Neuropathy|Peroneal Nerve Diseases|Nerve Disease, Peroneal|Nerve Diseases, Peroneal|Peroneal Nerve Disease|Fibular Nerve Diseases|Fibular Nerve Disease|Nerve Disease, Fibular|Nerve Diseases, Fibular
-D020428	Femoral Neuropathy	Femoral Neuropathies|Neuropathies, Femoral|Neuropathy, Femoral|Mononeuropathy, Femoral|Femoral Mononeuropathy|Femoral Mononeuropathies|Mononeuropathies, Femoral|Femoral Nerve Diseases|Femoral Nerve Disease|Nerve Disease, Femoral|Nerve Diseases, Femoral
+D020427	Peroneal Neuropathies	Neuropathy, Peroneal|Peroneal Neuropathy|Peroneal Mononeuropathies|Mononeuropathy, Peroneal|Peroneal Mononeuropathy|Fibular Nerve Diseases|Fibular Nerve Disease|Nerve Disease, Fibular|Peroneal Nerve Diseases|Peroneal Nerve Disease
+D020428	Femoral Neuropathy	Femoral Neuropathies|Neuropathy, Femoral|Mononeuropathy, Femoral|Femoral Mononeuropathy|Femoral Mononeuropathies|Femoral Nerve Diseases|Femoral Nerve Disease|Nerve Disease, Femoral|Nerve Diseases, Femoral
 D020429	Tibial Neuropathy	Neuropathies, Tibial|Neuropathy, Tibial|Tibial Neuropathies|Medial Popliteal Neuropathy|Medial Popliteal Neuropathies|Neuropathies, Medial Popliteal|Neuropathy, Medial Popliteal|Popliteal Neuropathies, Medial|Popliteal Neuropathy, Medial|Posterior Tibial Neuropathy|Neuropathies, Posterior Tibial|Neuropathy, Posterior Tibial|Posterior Tibial Neuropathies|Tibial Neuropathies, Posterior|Tibial Neuropathy, Posterior|Tibial Nerve Diseases|Nerve Disease, Tibial|Nerve Diseases, Tibial|Tibial Nerve Disease|Internal Popliteal Neuropathy|Internal Popliteal Neuropathies|Neuropathies, Internal Popliteal|Neuropathy, Internal Popliteal|Popliteal Neuropathies, Internal|Popliteal Neuropathy, Internal|Posterior Tibial Nerve Diseases
 D020430	Cubital Tunnel Syndrome	Cubital Tunnel Syndromes|Syndrome, Cubital Tunnel|Syndromes, Cubital Tunnel|Tunnel Syndrome, Cubital|Tunnel Syndromes, Cubital|Ulnar Nerve Entrapment, Elbow|Ulnar Nerve Compression, Cubital Tunnel
 D020431	Olfactory Nerve Diseases	Olfactory Nerve Disease|Cranial Nerve I Disorders|First Cranial Nerve Diseases|Cranial Nerve I Diseases
 D020432	Trochlear Nerve Diseases	Trochlear Nerve Disease|Trochlear Neuropathy|Neuropathies, Trochlear|Neuropathy, Trochlear|Trochlear Neuropathies|Trochlear Nerve Disorders|Trochlear Nerve Disorder|Cranial Nerve IV Diseases|Fourth Cranial Nerve Diseases
 D020433	Trigeminal Nerve Diseases	Trigeminal Nerve Disease|Trigeminal Neuropathy|Neuropathies, Trigeminal|Neuropathy, Trigeminal|Trigeminal Neuropathies|Trigeminal Nerve Disorders|Trigeminal Nerve Disorder|Cranial Nerve V Diseases|Fifth Cranial Nerve Diseases
-D020434	Abducens Nerve Diseases	Abducens Nerve Disease|Lateral Rectus Palsy|Lateral Rectus Palsies|Palsies, Lateral Rectus|Palsy, Lateral Rectus|Sixth Cranial Nerve Disorders|Abducens Nerve Palsy|Abducens Nerve Palsies|Palsies, Abducens Nerve|Palsy, Abducens Nerve|Cranial Nerve VI Palsy|Sixth Cranial Nerve Palsy|Sixth Nerve Palsy|Palsies, Sixth Nerve|Palsy, Sixth Nerve|Sixth Nerve Palsies|VIth Cranial Nerve Diseases|VI Nerve Palsy|Nerve Palsies, VI|Nerve Palsy, VI|Palsies, VI Nerve|Palsy, VI Nerve|6th Nerve Palsy|6th Nerve Palsies|Nerve Palsies, 6th|Nerve Palsy, 6th|Palsies, 6th Nerve|Palsy, 6th Nerve|Cranial Nerve VI Diseases|Sixth Cranial Nerve Diseases
+D020434	Abducens Nerve Diseases	Abducens Nerve Disease|VIth Cranial Nerve Diseases|Sixth Cranial Nerve Diseases|Cranial Nerve VI Diseases|Sixth Cranial Nerve Disorders
 D020435	Glossopharyngeal Nerve Diseases	Glossopharyngeal Nerve Disease|Cranial Nerve IX Disorders|Ninth Cranial Nerve Diseases|Cranial Nerve IX Diseases
 D020436	Accessory Nerve Diseases	Accessory Nerve Disease|Spinal Accessory Nerve Diseases|Cranial Nerve XI Diseases|Eleventh Cranial Nerve Disease|Cranial Nerve Eleven Diseases|Cranial Nerve Eleven Disorders
 D020437	Hypoglossal Nerve Diseases	Hypoglossal Nerve Disease|Twelfth Cranial Nerve Disorder|Twelfth Cranial Nerve Diseases|Cranial Nerve XII Diseases|Cranial Nerve XII Disorders
@@ -20424,42 +20842,42 @@ D020461	Madurella
 D020462	Gliocladium	Gliocladiums
 D020463	Abbreviations	
 D020465	Anecdotes	
-D020466	Atlases	
+D020466	Atlas	Atlases
 D020467	Biobibliography	
-D020468	Charts	
+D020468	Chart	Charts
 D020469	Chronology	
-D020470	Collected Works	
-D020471	Collections	
-D020472	Drawings	
-D020474	Essays	
-D020475	Examination Questions	
-D020476	Exhibitions	
-D020478	Forms	
-D020479	Handbooks	
-D020480	Humor	
-D020481	Indexes	
+D020470	Collected Work	Collected Works
+D020471	Collection	
+D020472	Drawing	Drawings
+D020474	Essays	Essay
+D020475	Examination Question	Examination Questions
+D020476	Exhibition	Exhibitions
+D020478	Form	Forms
+D020479	Handbook	Handbooks
+D020480	Wit and Humor	
+D020481	Index	Indexes
 D020482	Juvenile Literature	
-D020484	Laboratory Manuals	
+D020484	Laboratory Manual	Laboratory Manuals
 D020485	Legislation	
-D020486	Manuscripts	
-D020488	Nurses' Instruction	
-D020489	Outlines	
-D020490	Patents	
-D020492	Periodicals	
+D020486	Manuscript	Manuscripts
+D020488	Nurses Instruction	Nurses' Instruction
+D020489	Outline	Outlines
+D020490	Patent	Patents
+D020492	Periodical	Periodicals
 D020493	Autobiography	Autobiographies
-D020494	Phrases	
-D020495	Pictorial Works	
-D020496	Popular Works	
+D020494	Phrase	Phrases
+D020495	Pictorial Work	Pictorial Works
+D020496	Popular Work	Popular Works
 D020497	Problems and Exercises	
 D020498	Programmed Instruction	
 D020500	Statistics	
-D020501	Tables	
+D020501	Table	Tables
 D020502	Terminology	
 D020503	Union Lists	
 D020504	Abstracts	
 D020505	Collected Correspondence	
 D020506	Untranslated Regions	Region, Untranslated|Regions, Untranslated|Untranslated Region|UTRs
-D020507	Resource Guides	
+D020507	Resource Guide	Resource Guides
 D020508	Fungi, Unclassified	Fungus, Unclassified|Unclassified Fungi|Unclassified Fungus|Fungi, incertae sedis|Fungus, incertae sedis|incertae sedis Fungi|incertae sedis Fungus|sedis Fungi, incertae|sedis Fungus, incertae
 D020511	Neuromuscular Junction Diseases	Neuromuscular Junction Disease|Neuromuscular Transmission Disorders|Neuromuscular Transmission Disorder|Neuromuscular Junction Disorders|Neuromuscular Junction Disorder
 D020512	Myopathy, Central Core	Central Core Myopathies|Myopathies, Central Core|Shy-Magee Syndrome|Shy Magee Syndrome|Syndrome, Shy-Magee|Central Core Myopathy|Central Core Disease|Central Core Diseases|Central Core Disease of Muscle
@@ -20480,10 +20898,10 @@ D020527	Microscopy, Scanning Probe	Scanning Probe Microscopy
 D020528	Multiple Sclerosis, Chronic Progressive	Chronic Progressive Multiple Sclerosis
 D020529	Multiple Sclerosis, Relapsing-Remitting	Multiple Sclerosis, Relapsing Remitting|Remitting-Relapsing Multiple Sclerosis|Multiple Sclerosis, Remitting-Relapsing|Remitting Relapsing Multiple Sclerosis|Relapsing-Remitting Multiple Sclerosis|Relapsing Remitting Multiple Sclerosis
 D020530	Subthalamus	
-D020531	Subthalamic Nucleus	Nucleus, Subthalamic|Nucleus of Luys|Luys Nucleus|Nucleus Subthalamicus|Subthalamicus, Nucleus|Subthalamic Nucleus of Luys|Luys Subthalamic Nucleus|Body of Luys|Luys Body|Corpus Luysi|Luysi, Corpus
+D020531	Subthalamic Nucleus	Nucleus, Subthalamic|Subthalamic Nucleus of Luys|Luys Subthalamic Nucleus|Body of Luys|Luys Body|Nucleus Subthalamicus|Subthalamicus, Nucleus|Corpus Luysi|Luysi, Corpus|Nucleus of Luys|Luys Nucleus
 D020532	Basal Nucleus of Meynert	Meynert Basal Nucleus|Nucleus Basalis of Meynert
 D020533	Angiogenesis Inhibitors	Neovascularization Inhibitors|Angiogenic Antagonists|Angiogenic Inhibitors|Angiostatic Agents|Agents, Angiostatic|Antagonists, Angiogenic|Anti-Angiogenetic Agents|Agents, Anti-Angiogenetic|Anti Angiogenetic Agents|Anti-Angiogenic Drugs|Anti Angiogenic Drugs|Drugs, Anti-Angiogenic|Antiangiogenic Agents|Agents, Antiangiogenic|Inhibitors, Angiogenesis|Inhibitors, Angiogenetic|Inhibitors, Angiogenic|Inhibitors, Neovascularization|Angiogenetic Antagonists|Antagonists, Angiogenetic|Angiogenetic Inhibitors
-D020534	Parahippocampal Gyrus	Gyrus, Parahippocampal|Parahippocampal Gyri|Gyri, Parahippocampal|Hippocampal Gyri|Gyri, Hippocampal|Gyrus, Hippocampal|Hippocampal Gyrus|Gyrus Hippocampi|Gyrus Hippocampus|Gyrus Parahippocampalis|Parahippocampalis, Gyrus
+D020534	Parahippocampal Gyrus	Gyrus, Parahippocampal|Hippocampal Gyri|Gyri, Hippocampal|Gyrus, Hippocampal|Hippocampal Gyrus|Parahippocampal Gyri|Gyri, Parahippocampal|Gyrus Hippocampi|Gyrus Hippocampus|Gyrus Parahippocampalis|Parahippocampalis, Gyrus
 D020535	Video-Assisted Surgery	Surgeries, Video-Assisted|Video Assisted Surgery|Video-Assisted Surgeries|Surgery, Video-Assisted|Surgery, Video Assisted
 D020536	Enzyme Activators	Activators, Enzyme|Activators of Enzymes|Enzymes Activators
 D020537	RNA, Small Nucleolar	Small Nucleolar RNA|snoRNA
@@ -20582,15 +21000,15 @@ D020639	Lawsonia Bacteria
 D020640	Arcobacter	
 D020641	Polymorphism, Single Nucleotide	Nucleotide Polymorphism, Single|Nucleotide Polymorphisms, Single|Polymorphisms, Single Nucleotide|Single Nucleotide Polymorphisms|SNPs|Single Nucleotide Polymorphism
 D020642	Acatalasia	Takahara Disease|Disease, Takahara|Takahara's Disease|Disease, Takahara's|Takaharas Disease|Acatalasemia
-D020643	Anterior Thalamic Nuclei	Nuclei, Anterior Thalamic|Thalamic Nuclei, Anterior|Anterior Thalamus|Thalamus, Anterior|Anterior Thalamic Nucleus|Anterior Nuclear Group|Anterior Nucleus of Thalamus|Thalamus Anterior Nucleus
-D020644	Midline Thalamic Nuclei	Midline Thalamic Nucleus|Nuclei, Midline Thalamic|Nucleus, Midline Thalamic|Thalamic Nuclei, Midline|Thalamic Nucleus, Midline|Midline Nuclei of Thalamus|Thalamus Midline Nuclei|Thalamus Midline Nucleus|Periventricular Nuclei of Thalamus|Thalamus Periventricular Nuclei|Midline Nuclear Group|Nuclear Group, Midline
-D020645	Mediodorsal Thalamic Nucleus	Nucleus, Mediodorsal Thalamic|Thalamic Nucleus, Mediodorsal|Dorsomedial Nucleus|Nucleus, Dorsomedial|Dorsomedial Thalamic Nucleus|Nucleus, Dorsomedial Thalamic|Thalamic Nucleus, Dorsomedial|Medial Dorsal Nucleus|Nucleus, Medial Dorsal|Nucleus Medialis Dorsalis|Dorsali, Nucleus Medialis|Dorsalis, Nucleus Medialis|Medialis Dorsali, Nucleus|Medialis Dorsalis, Nucleus|Nucleus Medialis Dorsali|Medial Thalamic Nucleus|Nucleus, Medial Thalamic|Thalamic Nucleus, Medial|Medial Thalamic Nuclei|Nuclei, Medial Thalamic|Thalamic Nuclei, Medial|Medial Dorsal Thalamic Nucleus|Nucleus Dorsomedialis Thalami|Dorsomedialis Thalami, Nucleus|Dorsomedialis Thalamus, Nucleus|Nucleus Dorsomedialis Thalamus|Thalami, Nucleus Dorsomedialis|Thalamus, Nucleus Dorsomedialis|Dorsal Medial Nucleus|Nucleus, Dorsal Medial|Mediodorsal Nucleus|Nucleus, Mediodorsal
+D020643	Anterior Thalamic Nuclei	Nuclei, Anterior Thalamic|Thalamic Nuclei, Anterior|Anterior Thalamic Nucleus|Anterior Nucleus of Thalamus|Thalamus Anterior Nucleus|Anterior Nuclear Group|Anterior Thalamus|Thalamus, Anterior
+D020644	Midline Thalamic Nuclei	Midline Thalamic Nucleus|Nuclei, Midline Thalamic|Nucleus, Midline Thalamic|Thalamic Nuclei, Midline|Thalamic Nucleus, Midline|Periventricular Nuclei of Thalamus|Thalamus Periventricular Nuclei|Midline Nuclei of Thalamus|Thalamus Midline Nuclei|Thalamus Midline Nucleus|Midline Nuclear Group|Nuclear Group, Midline
+D020645	Mediodorsal Thalamic Nucleus	Nucleus, Mediodorsal Thalamic|Thalamic Nucleus, Mediodorsal|Dorsomedial Thalamic Nucleus|Nucleus, Dorsomedial Thalamic|Thalamic Nucleus, Dorsomedial|Medial Dorsal Nucleus|Nucleus, Medial Dorsal|Dorsomedial Nucleus|Nucleus, Dorsomedial|Nucleus Medialis Dorsalis|Dorsali, Nucleus Medialis|Dorsalis, Nucleus Medialis|Medialis Dorsali, Nucleus|Medialis Dorsalis, Nucleus|Nucleus Medialis Dorsali|Medial Thalamic Nucleus|Nucleus, Medial Thalamic|Thalamic Nucleus, Medial|Medial Thalamic Nuclei|Nuclei, Medial Thalamic|Thalamic Nuclei, Medial|Medial Dorsal Thalamic Nucleus|Nucleus Dorsomedialis Thalami|Dorsomedialis Thalami, Nucleus|Dorsomedialis Thalamus, Nucleus|Nucleus Dorsomedialis Thalamus|Thalami, Nucleus Dorsomedialis|Thalamus, Nucleus Dorsomedialis|Dorsal Medial Nucleus|Nucleus, Dorsal Medial|Mediodorsal Nucleus|Nucleus, Mediodorsal
 D020646	Intralaminar Thalamic Nuclei	Nuclei, Intralaminar Thalamic|Nucleus, Intralaminar Thalamic|Thalamic Nuclei, Intralaminar|Thalamic Nucleus, Intralaminar|Interlaminar Nuclei of Thalamus|Thalamus Interlaminar Nuclei|Intralaminar Nuclear Group|Nuclear Group, Intralaminar
 D020647	Lateral Thalamic Nuclei	Nuclei, Lateral Thalamic|Nucleus, Lateral Thalamic|Thalamic Nuclei, Lateral|Lateral Nucleus Of Thalamus|Lateral Nuclear Group|Nuclear Group, Lateral
 D020648	Peptide Elongation Factor 1	Elongation Factor 1|EF-1H|EF 1H|EF 1|EF-1
 D020649	Pulvinar	Pulvinars|Pulvinar Thalamus|Pulvinar Thalami|Thalami, Pulvinar|Thalamus, Pulvinar|Nucleus Pulvinaris|Nucleus Pulvinari|Pulvinari, Nucleus|Pulvinaris, Nucleus|Pulvinar Nucleus|Nucleus, Pulvinar
 D020650	Combinatorial Chemistry Techniques	Techniques, Combinatorial Chemistry|Chemistry Technique, Combinatorial|Combinatorial Chemistry Technique|Technics, Combinatorial Chemistry|Chemistry Technic, Combinatorial|Chemistry Technics, Combinatorial|Combinatorial Chemistry Technic|Combinatorial Chemistry Technics|Technic, Combinatorial Chemistry|Chemistry Techniques, Combinatorial|Technique, Combinatorial Chemistry
-D020651	Ventral Thalamic Nuclei	Nuclei, Ventral Thalamic|Nucleus, Ventral Thalamic|Thalamic Nuclei, Ventral|Thalamic Nucleus, Ventral|Ventral Thalamic Nucleus|Ventral Nuclear Mass|Mass, Ventral Nuclear|Masses, Ventral Nuclear|Nuclear Mass, Ventral|Nuclear Masses, Ventral|Ventral Nuclear Masses|Ventral Nuclei of Thalamus|Ventral Nuclear Group|Group, Ventral Nuclear|Nuclear Group, Ventral|Ventral Nuclear Groups
+D020651	Ventral Thalamic Nuclei	Nuclei, Ventral Thalamic|Nucleus, Ventral Thalamic|Thalamic Nuclei, Ventral|Thalamic Nucleus, Ventral|Ventral Thalamic Nucleus|Ventral Nuclei of Thalamus|Ventral Nuclear Mass|Mass, Ventral Nuclear|Masses, Ventral Nuclear|Nuclear Mass, Ventral|Nuclear Masses, Ventral|Ventral Nuclear Masses|Ventral Nuclear Group|Group, Ventral Nuclear|Nuclear Group, Ventral|Ventral Nuclear Groups
 D020652	Peptide Elongation Factor 2	NSP 100|Elongation Factor 2|Cytoplasmic Elongation Factor 2|EF-2|EF 2|NSP100
 D020653	Peptide Elongation Factor G	fusA Protein|Elongation Factor G|EF-G|EF G|fusA Gene Product
 D020656	Posterior Thalamic Nuclei	Nuclei, Posterior Thalamic|Posterior Thalamic Nucleus|Thalamic Nuclei, Posterior|Thalamic Nucleus, Posterior|Posterior Thalamic Nuclear Group|Posterior Nuclear Complex|Complices, Posterior Nuclear|Nuclear Complex, Posterior|Nuclear Complices, Posterior|Posterior Nuclear Complices
@@ -20613,7 +21031,7 @@ D020678	Microscopic Angioscopy	Angioscopies, Microscopic|Angioscopy, Microscopic
 D020679	Arthroscopes	Arthroscope
 D020680	Bronchoscopes	Bronchoscope
 D020681	Colposcopes	Colposcope
-D020682	Cefixime	Cefixime Trihydrate|Trihydrate, Cefixime
+D020682	Cefixime	
 D020683	Culdoscopes	Culdoscope
 D020684	Cystoscopes	Cystoscope
 D020685	Colonoscopes	Colonoscope
@@ -20684,7 +21102,7 @@ D020760	Spinal Cord Ischemia	Cord Ischemia, Spinal|Cord Ischemias, Spinal|Ischem
 D020761	rab1 GTP-Binding Proteins	GTP-Binding Proteins, rab1|rab1 GTP Binding Proteins
 D020762	Infarction, Posterior Cerebral Artery	Stroke, Posterior Cerebral Artery|Posterior Cerebral Artery Stroke|PCA Infarction|Infarction, PCA|Posterior Cerebral Artery Infarction
 D020763	Pathological Conditions, Anatomical	Anatomical Pathological Condition|Anatomical Pathological Conditions|Condition, Anatomical Pathological|Conditions, Anatomical Pathological|Pathological Condition, Anatomical
-D020764	cdc42 GTP-Binding Protein	GTP-Binding Protein, cdc42|cdc42 GTP Binding Protein|p21 cdc42|cdc42, p21|cdc42 Protein|G25K Protein
+D020764	cdc42 GTP-Binding Protein	GTP-Binding Protein, cdc42|cdc42 GTP Binding Protein|Cell Division Cycle 42 Protein|p21 cdc42|cdc42, p21|G25K Protein|cdc42 Protein|G25K GTP-Binding Protein|G25K GTP Binding Protein|GTP-Binding Protein, G25K|Cell Division Control Protein 42 Homolog
 D020765	Intracranial Arterial Diseases	Arterial Disease, Intracranial|Intracranial Arterial Disease|Intracranial Arterial Disorders|Arterial Disorder, Intracranial|Arterial Disorders, Intracranial|Intracranial Arterial Disorder|Arterial Diseases, Intracranial
 D020766	Intracranial Embolism	Embolism, Intracranial
 D020767	Intracranial Thrombosis	Intracranial Thromboses|Thromboses, Intracranial|Thrombus, Intracranial|Intracranial Thrombus|Thrombosis, Intracranial
@@ -20791,7 +21209,7 @@ D020884	Colpotomy	Colpotomies|Vaginotomy|Vaginotomies
 D020885	Ribonucleoprotein, U7 Small Nuclear	U7 Small Nuclear Ribonucleoproteins|U7 snRNP|snRNP, U7|Small Nuclear Ribonucleoproteins, U7
 D020886	Somatosensory Disorders	Somatosensory Disorder|Somatic Sensation Disorders|Sensation Disorder, Somatic|Sensation Disorders, Somatic|Somatic Sensation Disorder
 D020887	Selenious Acid	Acid, Selenious|Selenous Acid|Acid, Selenous
-D020888	Vigabatrin	gamma-Vinyl-GABA|gamma Vinyl GABA|gamma-Vinyl-gamma-Aminobutyric Acid|Acid, gamma-Vinyl-gamma-Aminobutyric|gamma Vinyl gamma Aminobutyric Acid
+D020888	Vigabatrin	gamma-Vinyl-gamma-Aminobutyric Acid|gamma Vinyl gamma Aminobutyric Acid|gamma-Vinyl-GABA|gamma Vinyl GABA
 D020889	Rolipram	
 D020890	Neuregulin-1	Neuregulin 1|NRG1 Protein|NDF Protein
 D020891	Raclopride	
@@ -20810,7 +21228,7 @@ D020907	Calcium Channels, Q-Type	Calcium Channels, Q Type|Q-Type Voltage-Depende
 D020908	Calcium Channels, R-Type	Calcium Channels, R Type|R-Type VDCC|R Type VDCC|VDCC, R-Type|R-Type Voltage-Dependent Calcium Channels|R Type Voltage Dependent Calcium Channels|R-Type Calcium Channels|R Type Calcium Channels|R-Type Calcium Channel|Calcium Channel, R-Type|Channel, R-Type Calcium|R Type Calcium Channel
 D020909	Acarbose	
 D020910	Ketorolac	
-D020911	Ketorolac Tromethamine	Tromethamine, Ketorolac
+D020911	Ketorolac Tromethamine	
 D020912	Moclobemide	Moclobamide
 D020913	Perindopril	Pirindopril
 D020914	Myopathies, Structural, Congenital	Structural Myopathies, Congenital|Myotubular Myopathy|Non-Progressive Myopathies, Congenital|Non Progressive Myopathies, Congenital|Myopathy, Myotubular|Myopathies, Myotubular|Myotubular Myopathies|Congenital Structural Myopathies|Congenital Structural Myopathy|Myopathies, Congenital Structural|Myopathy, Congenital Structural|Structural Myopathy, Congenital|Congenital Non-Progressive Myopathies|Congenital Non Progressive Myopathies|Congenital Non-Progressive Myopathy|Myopathies, Congenital Non-Progressive|Myopathy, Congenital Non-Progressive|Non-Progressive Myopathy, Congenital
@@ -20918,7 +21336,7 @@ D021862	Enterocytozoon	Enterocytozoons
 D021863	Vittaforma	Vittaformas
 D021864	Pleistophora	Pleistophoras
 D021865	Isosporiasis	Isosporiases|Isospora Infection|Infection, Isospora|Isospora Infections
-D021866	Cyclosporiasis	Cyclosporiases|Cyclospora Infection|Cyclospora Infections|Infection, Cyclospora|Infections, Cyclospora
+D021866	Cyclosporiasis	Cyclosporiases
 D021881	DNA, Catalytic	Deoxyribozymes|DNAzymes|Catalytic DNA|Deoxyribozyme|DNAzyme
 D021901	DNA, Intergenic	DNAs, Intergenic|Intergenic DNAs|Intergenic DNA
 D021902	Enterobacter aerogenes	Klebsiella mobilus|Aerobacter aerogenes|Klebsiella aerogenes
@@ -20991,7 +21409,7 @@ D022561	Advanced Cardiac Life Support	Cardiac Life Support, Advanced|Life Suppor
 D022562	Salmonella Vaccines	Vaccines, Salmonella|Salmonellosis Vaccines|Vaccines, Salmonellosis
 D022581	Vaccines, Marker	Marker Vaccines
 D022603	Shiga Toxins	Toxins, Shiga|Vero Cell Cytotoxin|Cytotoxin, Vero Cell|Vero Cell Cytotoxins|Cell Cytotoxins, Vero|Cytotoxins, Vero Cell|Verotoxins|Vero Cytoxins|Cytoxins, Vero|Vero Toxin|Toxin, Vero|Vero Toxins|Toxins, Vero|Verotoxin|Shiga-Like Toxins|Shiga Like Toxins|Toxins, Shiga-Like|Vero Cytotoxin|Cytotoxin, Vero
-D022621	Shiga Toxin	Toxin, Shiga|Stx Protein, Shigella dysenteria|Stx Protein|Shigella Cytotoxin|Cytotoxin, Shigella|Shigella Toxin|Toxin, Shigella
+D022621	Shiga Toxin	Toxin, Shiga|Shigella Toxin|Toxin, Shigella|Stx Protein, Shigella dysenteria|Stx Protein|Shigella Cytotoxin|Cytotoxin, Shigella
 D022622	Shiga Toxin 1	Shiga-Like Toxin I|Shiga Like Toxin I|SLT-I|SLT I|VT1 Cytotoxin|Stx1 Protein|Protein, Stx1|Verocytotoxin 1|Verotoxin I|Vero Cytotoxin VT1|SLTI
 D022641	Shiga Toxin 2	Shiga Toxin 2, Escherichia coli|Shiga-Like Toxin II|VT2 Cytotoxin|Cytotoxin, VT2|SLTII|Stx2 protein|Vero Cytotoxin VT2|Verotoxin 2|Shiga Like Toxin II|SLT-II|SLT II
 D022642	Vaccines, Contraceptive	Vaccines, Antifertility|Antifertility Vaccines|Contraceptive Vaccines
@@ -21011,11 +21429,11 @@ D022801	Complementarity Determining Regions	Region, Complementarity Determining|
 D022821	RNA Splice Sites	
 D022861	Hermanski-Pudlak Syndrome	Hermanski Pudlak Syndrome|Hermansky-Pudlak Syndrome|Hermansky Pudlak Syndrome
 D022882	Trihalomethanes	Trihalomethane
-D022902	Unpublished Works	
-D022903	Government Publications	
-D022921	Book Reviews	
-D022922	Fictional Works	
-D022923	Textbooks	
+D022902	Unpublished Work	Unpublished Works
+D022903	Government Document	Government Publications
+D022921	Book Review	Book Reviews
+D022922	Fictional Work	Fictional Works
+D022923	Textbook	Textbooks
 D022981	Allelic Imbalance	Allelic Imbalances|Imbalance, Allelic|Imbalances, Allelic
 D023001	Transplantation Tolerance	Tolerance, Transplantation
 D023041	Xenograft Model Antitumor Assays	Tumor Xenograft Assay|Xenograft Antitumor Assays|Antitumor Assay, Xenograft|Antitumor Assays, Xenograft|Assay, Xenograft Antitumor|Assays, Xenograft Antitumor|Xenograft Antitumor Assay|Antitumor Assays, Xenograft Model
@@ -21150,7 +21568,7 @@ D024581	Glyceraldehyde-3-Phosphate Dehydrogenase (Phosphorylating)	Glyceraldehyd
 D024601	Glyceraldehyde 3-Phosphate Dehydrogenase (NADP+)	GAPD(NADP+)|Glyceraldehyde 3-Phosphate Dehydrogenase, NADP|Glyceraldehyde 3-Phosphate-Dehydrogenase, NADP-Dependent|NADP-Dependent Glyceraldehyde 3-Phosphate-Dehydrogenase
 D024602	Glyceraldehyde-3-Phosphate Dehydrogenase (NADP+)(Phosphorylating)	Glyceraldehyde-3-Phosphate Dehydrogenase, NADP-Dependent, Phosphorylating|Glyceraldehyde-3-Phosphate Dehydrogenase, NADP, Phosphorylating|GAPD(NADP+)(Phosphorylating)
 D024642	Potassium Channels, Voltage-Gated	Potassium Channels, Voltage Gated|Kv Potassium Channels|Potassium Channels, Kv|Potassium Channel, Voltage-Gated|Potassium Channel, Voltage Gated|Voltage-Gated Potassium Channel|Voltage Gated Potassium Channel|Voltage-Gated Potassium Channels|Voltage Gated Potassium Channels|Voltage-Gated K+ Channels|K+ Channels, Voltage-Gated|Voltage Gated K+ Channels
-D024661	Potassium Channels, Inwardly Rectifying	Inward Rectifier K+ Channel|Inward Rectifier Potassium Channel|Inwardly Rectifying Potassium Channel|Inward Rectifier Potassium Channels|Inward Rectifier K+ Channels|K+ Channels, Inwardly Rectifying|Potassium Channel, Inwardly Rectifying|IRK1 Channel|Channel, IRK1|Inwardly Rectifying Postassium Channels
+D024661	Potassium Channels, Inwardly Rectifying	K+ Channels, Inwardly Rectifying|Inwardly Rectifying Potassium Channels|Inwardly Rectifying Potassium Channel|Inward Rectifier Potassium Channel|Inward Rectifier Potassium Channels|Potassium Channel, Inwardly Rectifying|Inward Rectifier K+ Channels|Inward Rectifier K+ Channel
 D024681	Potassium Channels, Calcium-Activated	Potassium Channels, Calcium Activated|Calcium-Activated Potassium Channels|Calcium Activated Potassium Channels|K+ Channels, Ca2+-Activated|K+ Channels, Ca2+ Activated|Potassium Channels, Calcium-Dependent|Potassium Channels, Calcium Dependent|Potassium Channel, Calcium-Activated|Potassium Channel, Calcium Activated|Calcium-Activated Potassium Channel|Calcium Activated Potassium Channel|Calcium-Dependent Potassium Channels|Calcium Dependent Potassium Channels|Channels, Calcium-Dependent Potassium|K+ Channels, Calcium-Activated|Calcium-Activated K+ Channels|K+ Channels, Calcium Activated|Ca2+-Activated K+ Channels|Ca2+ Activated K+ Channels
 D024682	BRCA2 Protein	FANCD1 Protein|Fanconi Anemia Complementation Group D1 Protein|Fanconi Anemia Group D1 Protein|BRCA2 Gene Product|Breast Cancer 2 Gene Product|Fanconi Anemia Group D1 Complementing Protein|Breast Cancer 2 Protein
 D024683	Potassium Channels, Tandem Pore Domain	Potassium Channels, Leak|Leak Potassium Channels|Potassium Channels, Baseline|Baseline Potassium Channels|K+ Channels, Tandem Pore Domain|Potassium Channel, Baseline|Baseline Potassium Channel|Potassium Channel, Tandem Pore Domain|Tandem Pore Domain Potassium Channel|Potassium Channel, Leak|Leak Potassium Channel|Potassium Channel, Background|Background Potassium Channel|Potassium Channels, Background|Background Potassium Channels|Tandem Pore Domain Potassium Channels
@@ -21167,7 +21585,7 @@ D024761	AT-Hook Motifs	AT Hook Motifs|AT-Hook Motif|Motif, AT-Hook|Motifs, AT-Ho
 D024763	Leeching	Leech Therapy
 D024764	Hirudin Therapy	
 D024801	Tauopathies	Tauopathy
-D024802	Nurse's Role	Nurse Role|Nurse's Roles|Role, Nurse's|Roles, Nurse's|Nurses' Role|Nurses' Roles|Role, Nurses'|Roles, Nurses'
+D024802	Nurse's Role	Nurse's Roles|Role, Nurse's|Roles, Nurse's|Nurses Role|Nurses Roles|Role, Nurses|Roles, Nurses|Nurse's Scope of Practice|Nurse Scope, Practice|Nurses Scope, Practice|Practice Nurse's Scope|Practice Nurse's Scopes|Nurses' Role|Nurse Role|Nurses' Roles|Role, Nurses'|Roles, Nurses'
 D024803	Biomedical Enhancement	Biomedical Enhancements|Enhancements, Biomedical|Enhancement, Biomedical
 D024821	Metabolic Syndrome	Metabolic Syndromes|Syndrome, Metabolic|Syndromes, Metabolic|Metabolic Syndrome X|Insulin Resistance Syndrome X|Syndrome X, Metabolic|Syndrome X, Insulin Resistance|Metabolic X Syndrome|Syndrome, Metabolic X|X Syndrome, Metabolic|Dysmetabolic Syndrome X|Syndrome X, Dysmetabolic|Reaven Syndrome X|Syndrome X, Reaven|Metabolic Cardiovascular Syndrome|Cardiovascular Syndrome, Metabolic|Cardiovascular Syndromes, Metabolic|Syndrome, Metabolic Cardiovascular
 D024841	Fluoroquinolones	
@@ -21285,7 +21703,7 @@ D026281	DEFICIENS Protein	DEFA Protein
 D026301	Manipulation, Osteopathic	Osteopathic Manipulative Treatment|Osteopathic Manipulative Treatments|Treatment, Osteopathic Manipulative|Treatments, Osteopathic Manipulative|Osteopathic Manipulation
 D026302	Tai Ji	Tai-ji|Tai Chi|Chi, Tai|Tai Ji Quan|Ji Quan, Tai|Quan, Tai Ji|Taiji|Taijiquan|T'ai Chi|Tai Chi Chuan
 D026321	Piperaceae	
-D026323	Myristica fragrans	Myristica fragran|fragran, Myristica
+D026323	Myristica	
 D026324	Myristicaceae	
 D026341	Minichromosome Maintenance 1 Protein	Transcription Factor MCM1|MCM1Transcription Factor
 D026342	AGAMOUS Protein, Arabidopsis	Arabidopsis AGAMOUS Protein|AGAMOUS 1 Protein
@@ -21367,7 +21785,7 @@ D027342	Excitatory Amino Acid Transporter 2	EAAT2 Neurotransmitter Transporter|N
 D027343	Rhizome	Rhizomes
 D027361	Organic Anion Transporters	Anion Transporters, Organic|Transporters, Organic Anion|Membrane Transport Proteins, Organic Anion
 D027362	Organic Anion Transport Protein 1	Renal PAN transporter|PAN transporter, Renal|p-Aminohippurate Transporter|Transporter, p-Aminohippurate|p Aminohippurate Transporter|PAH Transporter|Solute Carrier Family 22 (Organic Anion Transporter), Member 6|OAT1 Protein|SLC22A6 Transporter|Transporter, SLC22A6
-D027381	Solute Carrier Organic Anion Transporter Family Member 1b1	Liver-Specific Organic Anion Transporter, LST-1|Liver Specific Organic Anion Transporter, LST 1|Solute Carrier Family-21(Organic Anion Transporter), Member 6 Protein|LST-1 Transport Protein|LST 1 Transport Protein|Transport Protein, LST-1|Organic Anion Transport Polypeptide C|Oatp-C Transport Protein|Oatp C Transport Protein|Transport Protein, Oatp-C|SLCO1B1 Protein|SLC21A6 Transporter|Transporter, SLC21A6
+D027381	Liver-Specific Organic Anion Transporter 1	Liver Specific Organic Anion Transporter 1|SLC21A6 Transporter|Transporter, SLC21A6|LST-1 Transport Protein|LST 1 Transport Protein|Transport Protein, LST-1|Oatp-C Transport Protein|Oatp C Transport Protein|Transport Protein, Oatp-C|Solute Carrier Family-21(Organic Anion Transporter), Member 6 Protein|Liver-Specific Organic Anion Transporter, LST-1|Liver Specific Organic Anion Transporter, LST 1|Organic Anion Transport Polypeptide C
 D027382	Polyomaviridae	
 D027383	Papillomaviridae	
 D027384	Oncogene Proteins v-raf	Oncogene Proteins v raf|Proteins v-raf, Oncogene|v-raf, Oncogene Proteins|v-raf Kinases|Kinases, v-raf|v raf Kinases
@@ -21375,7 +21793,7 @@ D027421	Persea	Perseas
 D027422	Umbellularia	Umbellularias
 D027423	Cinnamomum camphora	Cinnamomum camphoras|camphoras, Cinnamomum|Camphor Tree|Camphor Trees|Tree, Camphor|Trees, Camphor|Camphor Laurel|Camphor Laurels|Laurel, Camphor|Laurels, Camphor
 D027424	Cinnamomum	Cinnamomums
-D027425	Multidrug Resistance-Associated Proteins	Multidrug Resistance Associated Proteins|Multispecific Organic Anion Transporter|Multispecific Organic Anion Transport Proteins|ATP-Binding Cassette, Sub-Family C Proteins|ATP Binding Cassette, Sub Family C Proteins|MOAT Protein|Multidrug Resistance-Associated Protein|Multidrug Resistance Associated Protein|Resistance-Associated Protein, Multidrug
+D027425	Multidrug Resistance-Associated Proteins	Multidrug Resistance Associated Proteins|Multispecific Organic Anion Transport Proteins|Multidrug Resistance-Associated Protein|Multidrug Resistance Associated Protein|Resistance-Associated Protein, Multidrug|ATP-Binding Cassette, Sub-Family C Proteins|ATP Binding Cassette, Sub Family C Proteins|MOAT Protein|Multispecific Organic Anion Transporter
 D027441	Sassafras	
 D027442	Laurus	
 D027443	Lindera	Linderas
@@ -21443,7 +21861,7 @@ D027861	Prunus
 D027882	Agave	Agaves
 D027883	Astragalus Plant	Astragalus Plants|Plant, Astragalus|Plants, Astragalus
 D027884	Astragalus gummifer	Astragalus gummifers|gummifers, Astragalus
-D027885	Astragalus membranaceus	
+D027885	Astragalus propinquus	
 D027901	Acanthaceae	
 D027902	Justicia	Adhatoda
 D027922	Caprifoliaceae	
@@ -21524,7 +21942,6 @@ D028521	Musa	Musas|Banana Plant|Banana Plants|Plant, Banana|Plants, Banana
 D028522	Musaceae	
 D028523	Elettaria	Elettarias
 D028524	Anethum graveolens	Dill Plant|Dill Plants|Plant, Dill|Plants, Dill|Dill|Dills
-D028525	Apium graveolens	
 D028526	Coriandrum	Coriandrums
 D028527	Cuminum	Cuminums
 D028528	Petroselinum	Petroselinums
@@ -21624,7 +22041,7 @@ D029502	Anemia, Hypoplastic, Congenital	Hypoplastic Anemia, Congenital|Congenita
 D029503	Anemia, Diamond-Blackfan	Anemia, Diamond Blackfan|Anemia, Diamond-Blackfan Type|Anemia, Diamond Blackfan Type|Diamond-Blackfan Type Anemia|Blackfan-Diamond Syndrome|Blackfan Diamond Syndrome|Diamond-Blackfan Anemia|Diamond Blackfan Anemia|Erythrogenesis Imperfecta|Erythrogenesis Imperfectas|Imperfecta, Erythrogenesis|Imperfectas, Erythrogenesis|Red Cell Aplasia, Pure, Hereditary|Blackfan Diamond Anemia|Anemia, Blackfan Diamond|Diamond Anemia, Blackfan|Blackfan-Diamond Disease|Blackfan Diamond Disease|Disease, Blackfan-Diamond|Chronic Congenital Agenerative Anemia|Congenital Erythroid Hypoplastic Anemia|Congenital Hypoplastic Anemia of Blackfan and Diamond|Congenital Pure Red Cell Anemia|Congenital Pure Red Cell Aplasia|Hypoplastic Congenital Anemia|Anemia, Hypoplastic Congenital|Anemias, Hypoplastic Congenital|Congenital Anemia, Hypoplastic|Congenital Anemias, Hypoplastic|Hypoplastic Congenital Anemias|Inherited Erythroblastopenia|Erythroblastopenia, Inherited|Erythroblastopenias, Inherited|Inherited Erythroblastopenias|Pure Hereditary Red Cell Aplasia|Anemia, Congenital Hypoplastic, Of Blackfan And Diamond
 D029521	Influenzavirus A	
 D029522	Hydrophyllaceae	
-D029523	Illicium	Illiciums
+D029523	Illicium	
 D029524	Influenzavirus B	
 D029525	Juglandaceae	
 D029541	Loganiaceae	
@@ -21644,7 +22061,6 @@ D029587	Moringa	Moringas
 D029588	Moringa oleifera	Moringa oleiferas|oleifera, Moringa|Drumsticktree|Drumsticktrees
 D029589	Seminal Plasma Proteins	
 D029590	Myricaceae	
-D029591	Myrsinaceae	
 D029592	Oleaceae	
 D029593	Jervell-Lange Nielsen Syndrome	Jervell Lange Nielsen Syndrome|Syndrome, Jervell-Lange Nielsen|Cardioauditory Syndrome of Jervell and Lange-Nielsen|Cardioauditory Syndrome of Jervell and Lange Nielsen|Surdo-Cardiac Syndrome|Surdo Cardiac Syndrome|Surdo-Cardiac Syndromes|Syndrome, Surdo-Cardiac|Jervell and Lange-Nielsen Syndrome|Jervell and Lange Nielsen Syndrome|Jervell And Lange-Nielsen Syndrome 1|Prolonged QT Interval in EKG and Sudden Death|Cardio-Auditory-Syncope Syndrome|Deafness, Congenital, and Functional Heart Disease
 D029594	Onagraceae	
@@ -21662,20 +22078,18 @@ D029607	Seminal Vesicle Secretory Proteins	Seminal Vesicle Proteins|Proteins, Se
 D029608	Polygalaceae	
 D029621	Polypodiaceae	
 D029622	Portulacaceae	
-D029623	Primulaceae	
+D029623	Primulaceae	Myrsinaceae
 D029624	Ferns	Fern
 D029625	Pteridaceae	
 D029626	Ranunculaceae	
 D029627	Crassulaceae	
 D029628	Hydrangeaceae	
-D029629	Salicaceae	
 D029630	Santalaceae	
 D029631	Sapindaceae	
 D029632	Sapotaceae	
 D029633	Schisandraceae	
 D029641	Simaroubaceae	
 D029642	Smilacaceae	
-D029643	Sterculiaceae	
 D029644	Styracaceae	
 D029645	Thymelaeaceae	
 D029646	Tiliaceae	
@@ -21852,7 +22266,7 @@ D030281	Simian T-lymphotropic virus 2	Simian T lymphotropic virus 2|STLV-2
 D030282	Primate T-lymphotropic virus 3	Primate T lymphotropic virus 3|PLTV-3
 D030283	Epsilonretrovirus	Epsilonretroviruses
 D030301	Activin Receptors, Type II	Activin Receptors Type II|Activin Receptor Like Kinases, Type II
-D030321	Denys-Drash Syndrome	Denys Drash Syndrome|Syndrome, Denys-Drash|Nephropathy, Wilms Tumor, and Genital Anomalies|Wilms Tumor and Pseudohermaphroditism|Drash Syndrome|Syndrome, Drash|Pseudohermaphroditism, Nephron Disorder and Wilms' Tumor
+D030321	Denys-Drash Syndrome	Denys Drash Syndrome|Syndrome, Denys-Drash|Pseudohermaphroditism, Nephron Disorder and Wilms' Tumor|Nephropathy, Wilms Tumor, and Genital Anomalies|Drash Syndrome|Syndrome, Drash|Wilms Tumor and Pseudohermaphroditism
 D030341	Nidovirales Infections	
 D030342	Genetic Diseases, Inborn	Disease, Inborn Genetic|Diseases, Inborn Genetic|Genetic Disease, Inborn|Inborn Genetic Disease|Inborn Genetic Diseases
 D030361	Papillomavirus Infections	Papillomavirus Infection|HPV Infection|HPV Infections|Human Papillomavirus Infection|Human Papillomavirus Infections|Papillomavirus Infection, Human|Papillomavirus Infections, Human
@@ -21874,7 +22288,7 @@ D030702	Nymphaeaceae	Water Lily Family|Family, Water Lily|Lily Family, Water|Wat
 D030721	Nymphaea	Water Lily|Lily, Water|Waterlily
 D030741	Carbonic Anhydrase IV	Carbonic Anhydrase 4|Anhydrase 4, Carbonic|Carbonic Anhydrase Isozyme IV
 D030762	Estrous Cycle	Cycle, Estrous|Cycles, Estrous|Estrous Cycles
-D030781	Organisms, Genetically Modified	GMO Organisms|Genetically Engineered Organisms|Genetically Modified Organisms
+D030781	Organisms, Genetically Modified	Modified Organism, Genetically|Genetically Modified Organism|Genetically Engineered Organisms|Organisms, Genetically Engineered|Genetically Modified Organisms|GMO Organisms|GMO Organism|Organism, Genetically Modified
 D030801	Animals, Genetically Modified	Animal, Genetically Modified|Genetically Modified Animal|Modified Animal, Genetically|Modified Animals, Genetically|GMO Animals|Animal, GMO|Animals, GMO|GMO Animal|Genetically Engineered Animals|Animal, Genetically Engineered|Animals, Genetically Engineered|Engineered Animal, Genetically|Engineered Animals, Genetically|Genetically Engineered Animal|Genetically Modified Animals
 D030821	Plants, Genetically Modified	Genetically Modified Plant|Modified Plant, Genetically|Modified Plants, Genetically|Plant, Genetically Modified|GMO Plants|GMO Plant|Plant, GMO|Plants, GMO|Genetically Engineered Plants|Engineered Plant, Genetically|Engineered Plants, Genetically|Genetically Engineered Plant|Plant, Genetically Engineered|Plants, Genetically Engineered|Genetically Modified Plants
 D030841	Food, Genetically Modified	Foods, Genetically Modified|Genetically Modified Foods|GMO Food|Food, GMO|Foods, GMO|GMO Foods|Genetically Modified Food
@@ -22037,7 +22451,7 @@ D031304	Tephrosia	Tephrosias
 D031305	Tetrapleura	Tetrapleuras
 D031306	Vicia	Vicias|Vetch|Vetchs
 D031307	Vicia faba	Vicia fabas|fabas, Vicia|Fava Bean|Bean, Fava|Beans, Fava|Fava Beans|Bean, Faba|Beans, Faba|Faba Beans|Faba Bean|Horsebean|Horsebeans|Bean, Horse|Beans, Horse|Horse Bean|Horse Beans
-D031308	Flacourtiaceae	
+D031308	Salicaceae	Flacourtiaceae
 D031309	Ryania	Ryanias
 D031310	Fumariaceae	
 D031311	Corydalis	Corydali|Fumewort|Fumeworts
@@ -22189,7 +22603,7 @@ D031672	Orobanche	Orobanches|Broomrape|Broomrapes|Broom Rape|Broom Rapes|Rape, B
 D031673	Pandanaceae	
 D031674	Argemone	Argemones
 D031675	Eschscholzia	Eschscholzias
-D031681	Sanguinaria	Sanguinarias
+D031681	Sanguinaria	
 D031683	Passifloraceae	
 D031684	Harpagophytum	Harpagophytums
 D031685	Sesamum	Sesamums
@@ -22240,7 +22654,7 @@ D031843	Adonis	Adoni|Oxeye Daisy|Daisy, Oxeye|Daisies, Oxeye|Oxeye Daisies
 D031844	Nigella	Nigellas
 D031845	Hajdu-Cheney Syndrome	Hajdu Cheney Syndrome|Cheney Syndrome|Acroosteolysis with Osteoporosis and Changes in Skull and Mandible|Arthrodentoosteodysplasia|Arthrodentoosteodysplasias|Osteolysis, Multicentric|Multicentric Osteolyses|Multicentric Osteolysis|Osteolyses, Multicentric
 D031861	Nigella damascena	Nigella damascenas|damascena, Nigella|Fennel, Wild|Fennels, Wild|Wild Fennel|Wild Fennels
-D031881	Nigella sativa	Nigella sativas|sativa, Nigella|Black Cumin|Black Cumins|Cumins, Black|Cumin, Black|Kalonji|Kalonjus
+D031881	Nigella sativa	Nigella sativas|sativa, Nigella|Cumin, Black|Kalonji|Kalonjus|Black Cumin|Black Cumins|Cumins, Black
 D031882	Delphinium	Delphiniums|Larkspur|Larkspurs
 D031883	Anemone	Anemones
 D031884	Aquilegia	Aquilegias|Columbine|Columbines
@@ -22254,13 +22668,13 @@ D031945	Coreopsis	Coreopses|Dahlia, Sea|Dahlias, Sea|Sea Dahlia|Sea Dahlias|Tick
 D031946	Pulsatilla	Pulsatillas|Pasqueflower|Pasqueflowers
 D031947	Ranunculus	
 D031948	Semiaquilegia	Semiaquilegias|Tian kui|Tian kuus|kuus, Tian
-D031949	Thalictrum	Thalictrums|Rue, Meadow|Meadow Rue|Meadow Rues|Rues, Meadow
+D031949	Thalictrum	Thalictrums|Meadow Rue|Meadow Rues|Rues, Meadow|Rue, Meadow
 D031950	Xanthorhiza	Xanthorhizas|Yellowroot|Yellowroots
 D031951	Resedaceae	
 D031952	Ceanothus	
 D031953	Colubrina	Colubrinas
 D031954	Choriocarcinoma, Non-gestational	Choriocarcinoma, Non gestational|Choriocarcinomas, Non-gestational|Non-gestational Choriocarcinomas|Non-gestational Choriocarcinoma|Non gestational Choriocarcinoma
-D031955	Frangula	Frangulas
+D031955	Rhamnus	Rhamnus purshiana|Rhamnus purshianas|purshiana, Rhamnus|Rhamnus frangula|Frangula|Frangulas
 D031956	Karwinskia	Karwinskias|Coyotillo|Coyotillos
 D031957	Ziziphus	Zizyphus
 D031961	Connaraceae	
@@ -22407,7 +22821,7 @@ D032447	Wisteria	Wisterias|Wistaria|Wistarias
 D032448	Myoblasts, Skeletal	Myoblast, Skeletal|Skeletal Myoblast|Skeletal Myoblasts
 D032449	Canavalia	Canavalias
 D032461	Chromosomes, Plant	Chromosome, Plant|Plant Chromosome|Plant Chromosomes
-D032462	Cycadopsida	Gymnosperms|Gymnosperm
+D032462	Cycadopsida	Cycadophyta|Cycadophytas|Gymnosperms|Gymnosperm
 D032481	Zamiaceae	
 D032482	Coniferophyta	Coniferophytas|Conifers|Conifer
 D032483	Cephalotaxus	
@@ -22641,7 +23055,7 @@ D034882	Lamins
 D034901	Alismataceae	
 D034902	Alisma	Alismas
 D034903	Sagittaria	Sagittarias|Arrowhead|Arrowheads
-D034904	Lamin Type A	Lamin A|Type A Lamins|Lamins, Type A|Lamin A-C|Lamin A C
+D034904	Lamin Type A	Type A Lamins|Lamins, Type A
 D034921	Lamin Type B	Lamin B|Type B Lamins|Lamins, Type B
 D034941	Upper Extremity	Extremities, Upper|Upper Extremities|Membrum superius|Upper Limb|Limb, Upper|Limbs, Upper|Upper Limbs|Extremity, Upper
 D034961	Antigens, Nuclear	Nuclear Antigens
@@ -22656,7 +23070,7 @@ D035082	Federal Government	Government, Federal|National Government
 D035141	Voluntary Programs	Program, Voluntary|Programs, Voluntary|Voluntary Program
 D035161	Bombacaceae	
 D035162	Adansonia	Adansonias|Baobab|Baobabs
-D035163	Bombax	Bombaxs
+D035163	Bombax	
 D035164	Ceiba	Ceibas
 D035165	Transcription Factors, General	General Transcription Factors
 D035181	TATA-Box Binding Protein	TATA Box Binding Protein|Transcription Factor TBP|TATA-Box-Binding Protein|RNA Polymerase II TATA-Binding Protein|RNA Polymerase II TATA Binding Protein|TATA-Binding Protein|TATA Binding Protein
@@ -22877,10 +23291,10 @@ D037701	Pulmonary Surfactant-Associated Protein B	Pulmonary Surfactant Associate
 D037721	Pulmonary Surfactant-Associated Protein C	Pulmonary Surfactant Associated Protein C|Surfactant Polypeptide SP-C|SP-C, Surfactant Polypeptide|Surfactant Polypeptide SP C|SP-C protein|SP C protein|Pulmonary Surfactant Protein C|Pulmonary Surfactant-Associated Protein SP-C|Pulmonary Surfactant Associated Protein SP C
 D037741	Fullerenes	Fullerene|Buckyballs|Buckyball|Buckminsterfullerenes|Buckminsterfullerene
 D037742	Nanotubes, Carbon	Carbon Nanotube|Nanotube, Carbon|Carbon Nanotubes|Buckytubes|Buckytube
-D037761	Sirtuins	Sir2-like Proteins|Sir2 like Proteins|Silent Mating Type Information Regulator 2-like Proteins|Silent Mating Type Information Regulator 2 like Proteins
+D037761	Sirtuins	Silent Mating Type Information Regulator 2-like Proteins|Silent Mating Type Information Regulator 2 like Proteins|Sir2-like Proteins|Sir2 like Proteins|SIRTs
 D037801	Hammer Toe Syndrome	Hammertoe Syndrome
 D037821	Casearia	Casearias
-D037841	Pregnant Women	Women, Pregnant|Pregnant Woman|Woman, Pregnant
+D037841	Pregnant Women	Pregnant Woman|Woman, Pregnant|Women, Pregnant
 D037881	Aborted Fetus	Aborted Embryo|Aborted Embryos|Embryo, Aborted|Embryos, Aborted|Fetus, Aborted|Aborted Fetuses|Fetuses, Aborted
 D037901	Euthanasia, Animal	Mercy Killing, Animal|Animal Mercy Killing|Animal Euthanasia
 D037921	Gift Giving	Giftgiving
@@ -22945,7 +23359,7 @@ D038781	Otoscopy
 D038801	International Classification of Diseases	International Statistical Classification of Diseases and Related Health Problems
 D038821	Mycorrhizae	Mycorrhiza|Mycorrhizas
 D038861	Medicine, Tibetan Traditional	Tibetan Traditional Medicine|Tibetan Medicine, Traditional|Medicine, Traditional Tibetan|Traditional Tibetan Medicine|Tibetan Medicine|Medicine, Tibetan|Traditional Medicine, Tibetan
-D038901	Mental Retardation, X-Linked	Mental Retardation, X Linked|Retardation, X-Linked Mental|X-Linked Mental Retardations|X-Linked Mental Retardation Disorders|X Linked Mental Retardation Disorders|X-Linked Mental Retardation Syndromes|X Linked Mental Retardation Syndromes|X-Linked Mental Retardation|X Linked Mental Retardation
+D038901	Mental Retardation, X-Linked	Mental Retardation, X Linked|Retardation, X-Linked Mental|X-Linked Mental Retardations|X-Linked Mental Retardation Syndromes|X Linked Mental Retardation Syndromes|X-Linked Mental Retardation Disorders|X Linked Mental Retardation Disorders|X-Linked Mental Retardation|X Linked Mental Retardation
 D038921	Coffin-Lowry Syndrome	Coffin Lowry Syndrome|Syndrome, Coffin-Lowry|Coffin Syndrome|Syndrome, Coffin|Mental Retardation with Osteocartilaginous Abnormalities
 D038941	Polypyrimidine Tract-Binding Protein	Polypyrimidine Tract Binding Protein|Tract-Binding Protein, Polypyrimidine|p57 Cytoplasmic RNA-Binding Protein|p57 Cytoplasmic RNA Binding Protein|PTB Splicing Factor|Splicing Factor, PTB|pPTB|PTB Protein
 D038961	O-Acetyl-ADP-Ribose	O Acetyl ADP Ribose|O-Acetyl-Adenosine-Diphosphate-Ribose|O Acetyl Adenosine Diphosphate Ribose|Adenosine-Diphosphate-Ribose, O-Acetyl-|Adenosine Diphosphate Ribose, O Acetyl|O-Acetyl- Adenosine-Diphosphate-Ribose|AADPR
@@ -23011,7 +23425,7 @@ D039662	Prokaryotic Initiation Factors	Initiation Factors, Prokaryotic|Peptide I
 D039663	Integrin beta4	beta4, Integrin|beta4 Integrin|Integrin, beta4|CD104 Antigens|Antigens, CD104|CD104 Antigen|Antigen, CD104|Integrin beta(4)
 D039665	Prokaryotic Initiation Factor-3	Initiation Factor-3, Prokaryotic|Prokaryotic Initiation Factor 3|Peptide Initiation Factor 3|Translation Initiation Factor 3|Prokaryotic Peptide Initiation Factor-3|Prokaryotic Peptide Initiation Factor 3|TIF IF3|Initiation Factor IF-3|IF-3, Initiation Factor|Initiation Factor IF 3|Peptide Initiation Factor IF-3|Peptide Initiation Factor IF 3
 D039681	Pyranocoumarins	
-D039682	HIV-Associated Lipodystrophy Syndrome	HIV Associated Lipodystrophy Syndrome|Lipodystrophy Syndrome, HIV-Associated|HIV Lipodystrophy Syndrome|HIV-Associated Lipodystrophy|HIV Associated Lipodystrophy|Lipodystrophy, HIV-Associated|Lipodystrophy Syndrome, HIV
+D039682	HIV-Associated Lipodystrophy Syndrome	HIV Associated Lipodystrophy Syndrome|Lipodystrophy Syndrome, HIV-Associated|HIV Lipodystrophy Syndrome|Lipodystrophy Syndrome, HIV|HIV-Associated Lipodystrophy|HIV Associated Lipodystrophy|Lipodystrophy, HIV-Associated
 D039702	Current Procedural Terminology	
 D039703	Logical Observation Identifiers Names and Codes	LOINC
 D039721	Diagnostic and Statistical Manual of Mental Disorders	
@@ -23097,7 +23511,7 @@ D041021	Brucella suis	Brucella melitensis biovar suis
 D041022	Candida tropicalis	Candida tropicali|tropicalis, Candida
 D041041	Citrobacter koseri	Citrobacter diversus
 D041061	Ehrlichia canis	
-D041081	Anaplasma phagocytophilum	HGE Agent|Cytoecetes phagocytophila|Ehrlichia equi|Ehrlichia phagocytophila
+D041081	Anaplasma phagocytophilum	HGE Agent|Ehrlichia phagocytophila|Ehrlichia equi|Cytoecetes phagocytophila
 D041101	Neorickettsia sennetsu	Ehrlichia sennetsu
 D041102	Neorickettsia	
 D041103	Neorickettsia risticii	Ehrlichia risticii
@@ -23146,7 +23560,7 @@ D041641	Musculoskeletal Development	Development, Musculoskeletal|Musculoskeletal
 D041681	NIH 3T3 Cells	3T3 Cell, NIH|Cell, NIH 3T3|Cells, NIH 3T3|NIH 3T3 Cell|NIH-3T3 Cells|Cell, NIH-3T3|Cells, NIH-3T3|NIH-3T3 Cell|3T3 Cells, NIH
 D041701	Swiss 3T3 Cells	3T3 Cells, Swiss|Cells, Swiss 3T3|3T3-Swiss Albino|3T3 Swiss Albino
 D041702	BALB 3T3 Cells	3T3 Cell, BALB|BALB 3T3 Cell|Cell, BALB 3T3|Cells, BALB 3T3|BALB-3T3 Cells|BALB-3T3 Cell|Cell, BALB-3T3|Cells, BALB-3T3|BALB-c 3T3 Cells|3T3 Cell, BALB-c|3T3 Cells, BALB-c|BALB c 3T3 Cells|BALB-c 3T3 Cell|Cell, BALB-c 3T3|Cells, BALB-c 3T3|3T3 Cells, BALB
-D041721	3T3-L1 Cells	3T3 L1 Cells|3T3-L1 Cell|Cell, 3T3-L1|Cells, 3T3-L1
+D041721	3T3-L1 Cells	3T3 L1 Cells|3T3-L1 Cell|Cell, 3T3-L1|Cells, 3T3-L1|3T3-L1
 D041722	Genes, Transgenic, Suicide	Transgenic Suicide Genes|Transduced Suicide Genes|Suicide Transgenes|Suicide Transgene|Transgene, Suicide|Transgenes, Suicide|Suicide Genes, Transgenic|Gene, Transgenic Suicide|Genes, Transgenic Suicide|Suicide Gene, Transgenic|Transgenic Suicide Gene|Suicide Genes, Transduced|Gene, Transduced Suicide|Genes, Transduced Suicide|Suicide Gene, Transduced|Transduced Suicide Gene
 D041741	Lower Gastrointestinal Tract	Gastrointestinal Tract, Lower|Lower GI Tract
 D041742	Upper Gastrointestinal Tract	Gastrointestinal Tract, Upper|Upper GI Tract|GI Tract, Upper
@@ -23450,7 +23864,7 @@ D044142	Pasteurella pneumotropica
 D044147	Piscirickettsiaceae	
 D044148	Lymphatic Abnormalities	Abnormalities, Lymphatic|Abnormality, Lymphatic|Lymphatic Abnormality
 D044149	Vibrio alginolyticus	
-D044162	Parathyroid Hormone-Related Protein	Hormone-Related Protein, Parathyroid|Parathyroid Hormone Related Protein|Parathyroid Hormone-Like Protein|Parathyroid Hormone Like Protein|Parathyroid Hormone-Related Peptide|Parathyroid Hormone Related Peptide|PTHrP|Tumor Hypercalcemic Factor|Hypercalcemic Factor, Tumor|Hypercalcemic Hormone of Malignancy|PTH Like Tumor Factor|PTH-Like Protein|PTH Like Protein|Parathyroid Hormone Like Tumor Factor|PTH-Related Peptide|PTH Related Peptide
+D044162	Parathyroid Hormone-Related Protein	Hormone-Related Protein, Parathyroid|Parathyroid Hormone Related Protein|Hypercalcemic Hormone of Malignancy|PTH Like Tumor Factor|PTH-Like Protein|PTH Like Protein|PTH-Related Peptide|PTH Related Peptide|Parathyroid Hormone Like Tumor Factor|Parathyroid Hormone-Like Protein|Parathyroid Hormone Like Protein|Parathyroid Hormone-Related Peptide|Parathyroid Hormone Related Peptide|Tumor Hypercalcemic Factor|Hypercalcemic Factor, Tumor|PTHrP
 D044163	Vibrio cholerae non-O1	
 D044164	Vibrio mimicus	
 D044165	Aliivibrio salmonicida	Vibrio salmonicida
@@ -23471,7 +23885,7 @@ D044223	Pseudomonas stutzeri
 D044224	Pseudomonas syringae	
 D044225	Piscirickettsiaceae Infections	Piscirickettsiaceae Infection|Piscirickettsiosis|Piscirickettsioses
 D044242	Trans Fatty Acids	Acids, Trans Fatty|Fatty Acids, Trans|Trans-Fatty Acids|Acids, Trans-Fatty
-D044243	Linoleic Acids, Conjugated	Acids, Conjugated Linoleic|Conjugated Linoleic Acids
+D044243	Linoleic Acids, Conjugated	Acids, Conjugated Linoleic|Conjugated Linoleic Acids|Conjugated Linoleic Acid (CLA)
 D044244	Receptors, Thromboxane A2, Prostaglandin H2	Thromboxane A2, Prostaglandin H2 Receptors|TXA2-PGH2 Receptors|TXA2 PGH2 Receptors|Receptors, TXA2-PGH2|Receptors, TXA2 PGH2
 D044262	Prostaglandin H2	PGH2|PGH(2)
 D044263	Receptors, Serotonin, 5-HT1	5-HT1 Receptors|5 HT1 Receptors|Receptors, 5-HT1|Serotonin 5-HT1 Receptors|5-HT1 Receptors, Serotonin|Receptors, Serotonin 5-HT1|Serotonin 5 HT1 Receptors|Serotonin 5-HT1 Receptor|5-HT1 Receptor, Serotonin|Receptor, Serotonin 5-HT1|Serotonin 5 HT1 Receptor|Serotonin Receptors, 5-HT1|5-HT1 Serotonin Receptors|Receptors, 5-HT1 Serotonin|Serotonin Receptors, 5 HT1|5-HT1 Receptor|5 HT1 Receptor|Receptor, 5-HT1|Serotonin, 5-HT1 Receptors|5-HT1 Receptors Serotonin|Receptors Serotonin, 5-HT1|Serotonin, 5 HT1 Receptors
@@ -23567,7 +23981,7 @@ D044783	F-Box Proteins	F Box Proteins|F-Box Domain Protein|Domain Protein, F-Box
 D044784	Chara	Charas
 D044785	Cryptophyta	Cryptophytas|Cryptomonads|Cryptomonad
 D044786	S-Phase Kinase-Associated Proteins	Kinase-Associated Proteins, S-Phase|Proteins, S-Phase Kinase-Associated|S Phase Kinase Associated Proteins|Skp Domain Protein|S-Phase Kinase Associated Protein|S Phase Kinase Associated Protein|Skp Domain Proteins
-D044802	Euglena longa	Euglena longas|longa, Euglena|Astasia longa|Astasia longas|longas, Astasia
+D044802	Euglena longa	
 D044822	Biodiversity	Biological Diversity|Diversity, Biological
 D044842	Cullin Proteins	Cullin Domain Proteins|Cullins|Cullin Domain Protein|Cullin Protein
 D044843	SKP Cullin F-Box Protein Ligases	SKP Cullin F Box Protein Ligases|SCF Ubiquitin Ligase|Ligase, SCF Ubiquitin|Ubiquitin Ligase, SCF
@@ -23581,7 +23995,7 @@ D044885	Campylobacter upsaliensis
 D044902	beta-Mannosidase	beta Mannosidase|beta-Mannanase|beta Mannanase|manA protein (beta-Mannosidase)|beta-D-Mannosidase|beta D Mannosidase
 D044903	Congenital Hyperinsulinism	Congenital Hyperinsulinisms|Hyperinsulinisms, Congenital|Hyperinsulinemia Hypoglycemia of Infancy|Infancy Hyperinsulinemia Hypoglycemias|Hyperinsulinemic Hypoglycemia, Persistent|Hyperinsulinemic Hypoglycemias, Persistent|Hypoglycemia, Persistent Hyperinsulinemic|Hypoglycemias, Persistent Hyperinsulinemic|Persistent Hyperinsulinemic Hypoglycemias|Hyperinsulinism, Congenital|Hyperinsulinism, Familial|Familial Hyperinsulinisms|Hyperinsulinisms, Familial|PHHI Hypoglycemia|Hypoglycemia, PHHI|Hypoglycemias, PHHI|PHHI Hypoglycemias|Hypoglycemia, Hyperinsulinemic, of Infancy|Infancy Hyperinsulinemia Hypoglycemia|Neonatal Hyperinsulinism|Persistent Hyperinsulinemia Hypoglycemia of Infancy|Persistent Hyperinsulinemic Hypoglycemia|Familial Hyperinsulinism|Hyperinsulinism, Neonatal|Hyperinsulinisms, Neonatal|Neonatal Hyperinsulinisms
 D044904	Mannosidase Deficiency Diseases	Deficiency Disease, Mannosidase|Deficiency Diseases, Mannosidase|Diseases, Mannosidase Deficiency|Mannosidase Deficiency Disease|Mannosidase Deficiency Syndromes|Deficiency Syndrome, Mannosidase|Deficiency Syndromes, Mannosidase|Mannosidase Deficiency Syndrome|Mannosidosis|Mannosidoses
-D044905	beta-Mannosidosis	beta Mannosidosis|beta-Mannosidoses|Mannosidosis, beta A, Lysosomal|Lysosomal beta A Mannosidosis|Lysosomal beta-Mannosidase Deficiency|Lysosomal beta Mannosidase Deficiency|Lysosomal beta-Mannosidase Deficiencies|beta-Mannosidase Deficiency|beta Mannosidase Deficiency|beta-Mannosidase Deficiencies
+D044905	beta-Mannosidosis	beta Mannosidosis|beta-Mannosidoses|Lysosomal beta A Mannosidosis|beta-Mannosidase Deficiency|beta Mannosidase Deficiency|beta-Mannosidase Deficiencies|Lysosomal beta-Mannosidase Deficiency|Lysosomal beta Mannosidase Deficiency|Lysosomal beta-Mannosidase Deficiencies|Mannosidosis, beta A, Lysosomal
 D044922	Helicobacter felis	
 D044923	Helicobacter hepaticus	
 D044925	Oxidoreductases Acting on CH-CH Group Donors	Oxidoreductases Acting on CH CH Group Donors
@@ -23729,7 +24143,7 @@ D045725	Tetrapyrroles
 D045726	Metalloproteases	Metalloproteinases|Metallopeptidases
 D045727	Metalloexopeptidases	Metalloexoproteinase|Metalloexoproteinases|Metalloexopeptidase
 D045728	Corrinoids	
-D045729	Pneumonia of Swine, Mycoplasmal	Enzootic Pneumonia of Swine|Swine Enzootic Pneumonia|Pneumonia of Swine, Enzootic|Mycoplasma Pneumonia of Swine|Swine Mycoplasma Pneumonia|Mycoplasmal Pneumonia of Swine|Swine Mycoplasmal Pneumonia|Enzootic Pneumonia of Pigs|Mycoplasma Pneumonia of Pigs
+D045729	Pneumonia of Swine, Mycoplasmal	Mycoplasma Pneumonia of Swine|Swine Mycoplasma Pneumonia|Mycoplasma Pneumonia of Pigs|Pneumonia of Swine, Enzootic|Enzootic Pneumonia of Pigs|Mycoplasmal Pneumonia of Swine|Swine Mycoplasmal Pneumonia|Enzootic Pneumonia of Swine|Swine Enzootic Pneumonia
 D045730	Soy Foods	Food, Soy|Foods, Soy|Soy Food
 D045743	Scleroderma, Diffuse	Scleroderma, Progressive|Progressive Scleroderma|Diffuse Cutaneous Systemic Sclerosis|Sudden Onset Scleroderma|Scleroderma, Sudden Onset|Sclerodermas, Sudden Onset|Sudden Onset Sclerodermas|Diffuse Systemic Sclerosis|Diffuse Systemic Scleroses|Scleroses, Diffuse Systemic|Sclerosis, Diffuse Systemic|Systemic Scleroses, Diffuse|Systemic Sclerosis, Diffuse|Diffuse Scleroderma|Sclerosis, Progressive Systemic|Progressive Systemic Sclerosis|Systemic Sclerosis, Progressive
 D045744	Cell Line, Tumor	Cell Lines, Tumor|Line, Tumor Cell|Lines, Tumor Cell|Tumor Cell Lines|Tumor Cell Line
@@ -23914,7 +24328,7 @@ D046937	Nostoc
 D046938	Plectonema	
 D046939	Synechocystis	
 D046940	Synechococcus	
-D046948	Secologanin Tryptamine Alkaloids	Alkaloids, Secologanin Tryptamine|Tryptamine Alkaloids, Secologanin|Terpenoid Indole Alkaloids|Alkaloids, Terpenoid Indole|Indole Alkaloids, Terpenoid|Monoterpenoid Indole Alkaloids|Alkaloids, Monoterpenoid Indole|Indole Alkaloids, Monoterpenoid|Secologanin Indole Alkaloids|Alkaloids, Secologanin Indole|Indole Alkaloids, Secologanin
+D046948	Secologanin Tryptamine Alkaloids	Alkaloids, Secologanin Tryptamine|Tryptamine Alkaloids, Secologanin|Monoterpenoid Indole Alkaloids|Alkaloids, Monoterpenoid Indole|Indole Alkaloids, Monoterpenoid|Terpenoid Indole Alkaloids|Alkaloids, Terpenoid Indole|Indole Alkaloids, Terpenoid|Strictosidine Derivatives|Derivatives, Strictosidine|Secologanin Indole Alkaloids|Alkaloids, Secologanin Indole|Indole Alkaloids, Secologanin
 D046949	Thermotoga neapolitana	
 D046950	Thermoanaerobacterium	
 D046968	Thermoanaerobacter	
@@ -24076,7 +24490,7 @@ D048068	PPAR-beta	PPAR beta|PPARbeta
 D048069	Tumor Necrosis Factors	Necrosis Factors, Tumor|TNF Receptor Ligands|Receptor Ligands, TNF
 D048070	Fetal Nutrition Disorders	Fetal Nutrition Disorder|Nutrition Disorder, Fetal|Nutrition Disorders, Fetal
 D048088	Informatics	
-D048089	Pneumonia of Calves, Enzootic	Enzootic Pneumonia of Calves|Enzootic Calf Pneumonia|Calf Pneumonia, Enzootic|Enzootic Calf Pneumonias|Pneumonia, Enzootic Calf|Pneumonias, Enzootic Calf
+D048089	Pneumonia of Calves, Enzootic	Enzootic Calf Pneumonia|Calf Pneumonia, Enzootic|Enzootic Calf Pneumonias|Pneumonia, Enzootic Calf|Pneumonias, Enzootic Calf|Enzootic Pneumonia of Calves
 D048090	Bovine Respiratory Disease Complex	
 D048091	Guided Tissue Regeneration	Tissue Regeneration, Guided|Regeneration, Guided Tissue
 D048108	Nursing Informatics	Informatics, Nursing
@@ -24319,7 +24733,7 @@ D049935	Hernandiaceae
 D049936	Anthocerotophyta	Anthocerotophytas|Hornworts|Hornwort
 D049950	Hyperparathyroidism, Primary	Hyperparathyroidisms, Primary|Primary Hyperparathyroidisms|Primary Hyperparathyroidism
 D049951	X Chromosome Inactivation	Chromosome Inactivation, X|Inactivation, X Chromosome|Lyonization|X-Inactivation|X Inactivation|Inactivation, X|X Inactivations
-D049970	Graves Ophthalmopathy	Ophthalmopathy, Graves|Ophthalmopathies, Thyroid-Associated|Ophthalmopathies, Thyroid Associated|Thyroid-Associated Ophthalmopathies|Thyroid Associated Ophthalmopathies|Thyroid-Associated Ophthalmopathy|Thyroid Associated Ophthalmopathy|Dysthyroid Ophthalmopathy|Dysthyroid Ophthalmopathies|Ophthalmopathies, Dysthyroid|Ophthalmopathy, Dysthyroid|Ophthalmopathy, Thyroid-Associated|Ophthalmopathy, Thyroid Associated
+D049970	Graves Ophthalmopathy	Ophthalmopathy, Graves|Ophthalmopathies, Thyroid-Associated|Ophthalmopathies, Thyroid Associated|Thyroid-Associated Ophthalmopathies|Thyroid Associated Ophthalmopathies|Dysthyroid Ophthalmopathy|Dysthyroid Ophthalmopathies|Ophthalmopathies, Dysthyroid|Ophthalmopathy, Dysthyroid|Thyroid-Associated Ophthalmopathy|Thyroid Associated Ophthalmopathy|Graves Orbitopathy|Graves Orbitopathies|Orbitopathies, Graves|Orbitopathy, Graves|Ophthalmopathy, Thyroid-Associated|Ophthalmopathy, Thyroid Associated
 D049971	Thiazides	
 D049990	Membrane Transport Modulators	Modulators, Membrane Transport|Transport Modulators, Membrane|Membrane Transport Protein Modulators
 D049992	Sodium Chloride Symporters	Chloride Symporters, Sodium|Symporters, Sodium Chloride|Sodium-Chloride Transporter|Sodium Chloride Transporter|Transporter, Sodium-Chloride|Sodium-Chloride Cotransporter|Cotransporter, Sodium-Chloride|Sodium Chloride Cotransporter|Na-Cl-Symporters|Na Cl Symporters|Sodium Chloride Cotransporters|Chloride Cotransporters, Sodium|Cotransporters, Sodium Chloride
@@ -24332,7 +24746,7 @@ D050032	Postpartum Thyroiditis	Postpartum Thyroiditides|Thyroiditides, Postpartu
 D050033	Thyroid Dysgenesis	Dysgenesis, Thyroid
 D050034	Antidiuretic Agents	Agents, Antidiuretic|Anti-Diuretic Agents|Agents, Anti-Diuretic|Anti Diuretic Agents
 D050035	Sexual Infantilism	Infantilism, Sexual
-D050050	Protein Carbonylation	Carbonylations, Protein|Protein Carbonylations|Carbonylated Protein Formation|Formation, Carbonylated Protein|Protein Formation, Carbonylated|Protein Carbonyl Formation|Carbonyl Formation, Protein|Formation, Protein Carbonyl|Carbonylation, Protein
+D050050	Protein Carbonylation	Carbonylations, Protein|Protein Carbonylations|Carbonylated Protein Formation|Protein Carbonyl Formation|Carbonyl Formation, Protein|Carbonylation, Protein
 D050051	Transient Receptor Potential Channels	TRP Membrane Proteins|Membrane Proteins, TRP|Proteins, TRP Membrane|TRP Cation Channels|Cation Channels, TRP|Channels, TRP Cation|Transient Receptor Potential Cation Channels
 D050052	TRPC Cation Channels	Cation Channels, TRPC|Channels, TRPC Cation|Transient Receptor Potential Channels, Type C|Transient Receptor Potential Cation Channel Subfamily C
 D050053	TRPM Cation Channels	Cation Channels, TRPM|Channels, TRPM Cation|Transient Receptor Potential Channels, Type M
@@ -24377,7 +24791,7 @@ D050262	Loma	Lomas
 D050263	Thelohania	Thelohanias
 D050276	Hand Bones	Bones, Hand|Bones of Hands|Hands Bones|Bones of Hand
 D050277	Toe Phalanges	Phalanges, Toe|Phalanges of Toes|Toe Bones|Bones, Toe|Bones of Toes|Toes Bones
-D050278	Finger Phalanges	Phalanges, Finger|Bones of Fingers|Fingers Bones|Finger Bones|Bones, Finger|Phalanges of Fingers
+D050278	Finger Phalanges	Phalanges, Finger|Phalanges of Fingers|Bones of Fingers|Fingers Bones|Finger Bones|Bones, Finger
 D050279	Metacarpal Bones	Bones, Metacarpal|Metacarpals
 D050280	Arm Bones	Arm Bone|Bone, Arm|Bones, Arm|Bones of Arm
 D050281	Bones of Lower Extremity	Extremity Bones, Lower|Lower Extremity Bones
@@ -24398,8 +24812,8 @@ D050380	Monckeberg Medial Calcific Sclerosis	Monckeberg's Medial Calcific Sclero
 D050396	TRPP Cation Channels	Cation Channels, TRPP|Channels, TRPP Cation|Polycystins
 D050397	Radiotherapy, Intensity-Modulated	Intensity-Modulated Radiotherapies|Intensity-Modulated Radiotherapy|Radiotherapies, Intensity-Modulated|Radiotherapy, Intensity Modulated
 D050398	Adamantinoma	Adamantinomas
-D050416	Glucagon-Secreting Cells	Cell, Glucagon-Secreting|Cells, Glucagon-Secreting|Glucagon Secreting Cells|Glucagon-Secreting Cell|Pancreatic A Cells|Pancreatic A Cell|alpha Cells, Pancreatic|Pancreatic alpha Cell|alpha Cell, Pancreatic|Pancreatic alpha Cells
-D050417	Insulin-Secreting Cells	Cell, Insulin-Secreting|Cells, Insulin-Secreting|Insulin Secreting Cells|Insulin-Secreting Cell|beta Cells, Pancreatic|Pancreatic beta Cell|beta Cell, Pancreatic|Pancreatic B Cells|B Cell, Pancreatic|B Cells, Pancreatic|Pancreatic B Cell|Pancreatic beta Cells
+D050416	Glucagon-Secreting Cells	Cell, Glucagon-Secreting|Cells, Glucagon-Secreting|Glucagon Secreting Cells|Glucagon-Secreting Cell|alpha Cells, Pancreatic|Pancreatic alpha Cell|alpha Cell, Pancreatic|Pancreatic alpha Cells|Pancreatic A Cells|Pancreatic A Cell
+D050417	Insulin-Secreting Cells	Cell, Insulin-Secreting|Cells, Insulin-Secreting|Insulin Secreting Cells|Insulin-Secreting Cell|Pancreatic B Cells|B Cell, Pancreatic|B Cells, Pancreatic|Pancreatic B Cell|Pancreatic beta Cells|beta Cells, Pancreatic|Pancreatic beta Cell|beta Cell, Pancreatic
 D050418	Pancreatic Polypeptide-Secreting Cells	Cell, Pancreatic Polypeptide-Secreting|Cells, Pancreatic Polypeptide-Secreting|Pancreatic Polypeptide Secreting Cells|Pancreatic Polypeptide-Secreting Cell|PP Cells, Pancreatic|PP Cell, Pancreatic|Pancreatic PP Cell|Pancreatic PP Cells|Pancreatic Polypeptide Cells|Pancreatic Polypeptide Cell
 D050436	Regulatory Elements, Transcriptional	Elements, Transcriptional Regulatory|Transcriptional Regulatory Elements|Transcriptional Regulatory Element|Element, Transcriptional Regulatory|Regulatory Element, Transcriptional
 D050437	Genes, Developmental	Developmental Genes|Developmental Gene|Gene, Developmental
@@ -24537,7 +24951,7 @@ D050706	Stenella
 D050716	Complement C4b-Binding Protein	C4b-Binding Protein, Complement|Complement C4b Binding Protein|Protein, Complement C4b-Binding|C4b-C3b Inactivator Cofactor|C4b C3b Inactivator Cofactor|Cofactor, C4b-C3b Inactivator|C4bC3bINA-Cofactor|C4bC3bINA Cofactor|Complement C3b-C4b Inactivator Cofactor|Complement C3b C4b Inactivator Cofactor|Complement Component 4b-Binding Protein|Complement Component 4b Binding Protein|C4b-Binding Protein|C4b Binding Protein|Protein, C4b-Binding|Complement 4b Binding Protein
 D050717	Retinoblastoma-Like Protein p130	p130, Retinoblastoma-Like Protein|Retinoblastoma Like Protein p130|Retinoblastoma-Like Protein 2|Retinoblastoma Like Protein 2|RBL2 Protein
 D050718	Complement C1 Inhibitor Protein	Serpin Family G Member 1|C1 Esterase Inhibitor|Esterase Inhibitor, C1|C1-Inhibitor Protein|C1 Inhibitor Protein|Serpin G1|G1, Serpin|Plasma Protease C1 Inhibitor|Complement C1-Inhibitor Protein|SERPING1|C1-INH Protein|C1 INH Protein
-D050719	Crk-Associated Substrate Protein	Crk Associated Substrate Protein|Substrate Protein, Crk-Associated|p130 Cas Protein|Cas Protein, p130|BCAR1 Protein|p130 Crk-Associated Substrate|Crk-Associated Substrate, p130|Substrate, p130 Crk-Associated|p130 Crk Associated Substrate|p130Cas Protein|Breast Cancer Anti-Estrogen Resistance 1 Protein|Breast Cancer Anti Estrogen Resistance 1 Protein|Crk-Associated Substrate|Crk Associated Substrate|CKRAS Protein
+D050719	Crk-Associated Substrate Protein	Crk Associated Substrate Protein|BCAR1 p130Cas Protein|Protein, BCAR1 p130Cas|p130Cas Protein, BCAR1|Crk-Associated Substrate|Crk Associated Substrate|p130 Crk-Associated Substrate|p130 Crk Associated Substrate|BCAR1 Protein|p130Cas Protein|Breast Cancer Anti-Estrogen Resistance 1 Protein|Breast Cancer Anti Estrogen Resistance 1 Protein|CRKAS Protein|Protein, CRKAS|p130 Cas Protein
 D050720	Retinoblastoma-Like Protein p107	p107, Retinoblastoma-Like Protein|Retinoblastoma-Like Protein 1|Retinoblastoma Like Protein 1|RBL1 Protein|Retinoblastoma Like Protein p107|p107 Tumor Suppressor Protein
 D050721	Proto-Oncogene Proteins c-cbl	Proto Oncogene Proteins c cbl|c-cbl, Proto-Oncogene Proteins|RING Finger Protein 55|c-cbl Protein|cbl Proto-Oncogene Protein|Proto-Oncogene Protein, cbl|cbl Proto Oncogene Protein|CBL E3 Ubiquitin Protein Ligase|c-cbl Proto-Oncogene Protein|Proto-Oncogene Protein, c-cbl|c cbl Proto Oncogene Protein|RNF55 Protein|Proto-Oncogene Protein c-cbl|Proto Oncogene Protein c cbl|c-cbl, Proto-Oncogene Protein
 D050722	Oncogene Protein v-cbl	Oncogene Protein v cbl|v-cbl, Oncogene Protein|v-cbl Protein|Oncogene Protein cbl|cbl, Oncogene Protein|v-cbl Oncogene Protein|Oncogene Protein, v-cbl|v cbl Oncogene Protein|Casitas B-Lineage Lymphoma Protein|Casitas B Lineage Lymphoma Protein|cbl Oncogene Protein|Oncogene Protein, cbl
@@ -24795,7 +25209,7 @@ D051217	Toll-Like Receptor 9	Toll Like Receptor 9|TLR9 Receptor|Receptor, TLR9|T
 D051218	Lymphocyte Antigen 96	LY96 Protein|MD-2 Protein
 D051219	Pituitary Adenylate Cyclase-Activating Polypeptide	PACAP|Pituitary Adenylate Cyclase Activating Polypeptide
 D051220	Pisiform Bone	Bone, Pisiform|Bones, Pisiform|Pisiform Bones|Os Pisiforme
-D051221	Triquetrum Bone	Bone, Triquetrum|Bones, Triquetrum|Triquetrum Bones|Triquetral Bone|Bone, Triquetral|Bones, Triquetral|Triquetral Bones|Os Triquetrum
+D051221	Triquetrum Bone	Bone, Triquetrum|Bones, Triquetrum|Triquetrum Bones|Os Triquetrum|Triquetral Bone|Bone, Triquetral|Bones, Triquetral|Triquetral Bones
 D051222	Trapezium Bone	Bone, Trapezium|Bones, Trapezium|Trapezium Bones|Os Trapezium
 D051223	Trapezoid Bone	Bone, Trapezoid|Bones, Trapezoid|Trapezoid Bones|Os Trapezoideum
 D051224	Capitate Bone	Bone, Capitate|Bones, Capitate|Capitate Bones|Os Capitatum
@@ -25141,7 +25555,7 @@ D052116	Sialomucins	Sialomucin
 D052117	Benzodioxoles	1,3-Dioxindans|1,3 Dioxindans|Methylenedioxybenzenes|1,3-Dioxaindans|1,3 Dioxaindans
 D052118	Lysosomal-Associated Membrane Protein 1	Lysosomal Associated Membrane Protein 1|LAMP1 Protein|CD107a Antigens|LAMPA Protein|Antigens, CD107a|CD107a Antigen|LGP120 Protein
 D052119	Lysosomal-Associated Membrane Protein 2	Lysosomal Associated Membrane Protein 2|LAMP2 Protein|Antigens, CD107b|LGP-B Protein|LGP B Protein|CD107b Antigens|CD107b Antigen|LGP110 Protein
-D052120	Glycogen Storage Disease Type IIb	Danon Disease|Glycogen Storage Cardiomyopathy|Cardiomyopathies, Glycogen Storage|Cardiomyopathy, Glycogen Storage|Glycogen Storage Cardiomyopathies|Glycogen Storage Disease IIb|Glycogen Storage Disease Limited to the Heart|Lysosomal Glycogen Storage Disease with Normal Acid Maltase|Lysosomal Glycogen Storage Disease without Acid Maltase Deficiency|Pseudoglycogenosis 2|Pseudoglycogenosis 2s|Pseudoglycogenosis II|Pseudoglycogenosis IIs|Vacuolar Cardiomyopathy and Myopathy, X-linked|Vacuolar Cardiomyopathy and Myopathy, X linked|X-Linked Vacuolar Cardiomyopathy and Myopathy|X Linked Vacuolar Cardiomyopathy and Myopathy|Antopol Disease|Disease, Antopol|Glycogen Storage Disease Type 2B
+D052120	Glycogen Storage Disease Type IIb	Vacuolar Cardiomyopathy and Myopathy, X-linked|Vacuolar Cardiomyopathy and Myopathy, X linked|Glycogen Storage Disease IIb|X-Linked Vacuolar Cardiomyopathy and Myopathy|X Linked Vacuolar Cardiomyopathy and Myopathy|Pseudoglycogenosis 2|Pseudoglycogenosis 2s|Pseudoglycogenosis II|Pseudoglycogenosis IIs|Glycogen Storage Disease Type 2B|Antopol Disease|Disease, Antopol|Lysosomal Glycogen Storage Disease with Normal Acid Maltase|Glycogen Storage Disease Limited to the Heart|Lysosomal Glycogen Storage Disease without Acid Maltase Deficiency|Danon Disease|Glycogen Storage Cardiomyopathy|Cardiomyopathies, Glycogen Storage|Cardiomyopathy, Glycogen Storage|Glycogen Storage Cardiomyopathies
 D052138	Genes, Neoplasm	Gene, Neoplasm|Neoplasm Gene|Neoplasm Genes
 D052139	Intracellular Calcium-Sensing Proteins	Intracellular Calcium Sensing Proteins|Calcium-Sensing Proteins, Intracellular|Calcium Sensing Proteins, Intracellular
 D052140	Human papillomavirus 11	HPV-11|HPV 11|Human papillomavirus type 11
@@ -25168,7 +25582,7 @@ D052200	Lactobacillus reuteri
 D052201	Lactobacillus rhamnosus	
 D052202	Hydrocolpos	
 D052203	Ferrosoferric Oxide	Oxide, Ferrosoferric|Ferriferrous Oxide|Oxide, Ferriferrous
-D052216	Glucagon-Like Peptide 1	Glucagon Like Peptide 1|Glucagon-Like Peptide-1|GLP-1|GLP 1
+D052216	Glucagon-Like Peptide 1	Glucagon Like Peptide 1|GLP-1|GLP 1|Glucagon-Like Peptide-1
 D052217	Fanconi Anemia Complementation Group A Protein	Fanconi Anemia Group A Complementing Protein|Fanconi Anemia Group A Protein|FANCA Protein
 D052218	Fanconi Anemia Complementation Group C Protein	Fanconi Anemia Group C Complementing Protein|Fanconi Anemia Group C Protein|FANCC Protein
 D052219	Fanconi Anemia Complementation Group F Protein	Fanconi Anemia Group F Protein|FANCF Protein|Fanconi Anemia Group F Complementing Protein
@@ -25209,7 +25623,7 @@ D052516	Sulfatidosis	Sulfatidoses
 D052517	Multiple Sulfatase Deficiency Disease	Multiple Sulfatase Deficiency|Multiple Sulfatase Deficiencies|Multiple Sulphatase Deficiency Disease|Mucosulfatidosis
 D052536	Niemann-Pick Disease, Type A	Niemann Pick Disease, Type A|Classical Niemann-Pick Disease|Classical Niemann Pick Disease|Niemann-Pick Disease, Classical|Niemann-Pick Disease, Acute Neuronopathic Form|Niemann Pick Disease, Acute Neuronopathic Form|Niemann-Pick Disease, Acute Neurovisceral Form|Niemann Pick Disease, Acute Neurovisceral Form|Niemann-Pick Disease, Neuronopathic Type|Niemann Pick Disease, Neuronopathic Type|Sphingomyelinase Deficiency Disease|Sphingomyelinase Deficiency Diseases|Sphingomyelin Cholesterol Lipidosis|Cholesterol Lipidoses, Sphingomyelin|Cholesterol Lipidosis, Sphingomyelin|Lipidoses, Sphingomyelin Cholesterol|Lipidosis, Sphingomyelin Cholesterol|Sphingomyelin Cholesterol Lipidoses|Type A Niemann-Pick Disease|Type A Niemann Pick Disease|Niemann-Pick's Disease Type A|Niemann Pick's Disease Type A|Sphingomyelin Lipidosis|Lipidoses, Sphingomyelin|Lipidosis, Sphingomyelin|Sphingomyelin Lipidoses|Sphingomyelinase Deficiency|Deficiencies, Sphingomyelinase|Deficiency, Sphingomyelinase|Sphingomyelinase Deficiencies|Neuronal Cholesterol Lipidosis|Cholesterol Lipidoses, Neuronal|Cholesterol Lipidosis, Neuronal|Lipidoses, Neuronal Cholesterol|Lipidosis, Neuronal Cholesterol|Neuronal Cholesterol Lipidoses|Ophthalmoplegia, Supraoptic Vertical|Ophthalmoplegias, Supraoptic Vertical|Supraoptic Vertical Ophthalmoplegia|Supraoptic Vertical Ophthalmoplegias|Vertical Ophthalmoplegia, Supraoptic|Vertical Ophthalmoplegias, Supraoptic
 D052537	Niemann-Pick Disease, Type B	Niemann Pick Disease, Type B|Niemann-Pick Disease, Visceral|Niemann Pick Disease, Visceral|Type B Niemann-Pick Disease|Type B Niemann Pick Disease|Niemann-Pick Disease, Non-Neuronopathic Type|Niemann Pick Disease, Non Neuronopathic Type|Niemann-Pick's Disease Type B|Niemann Pick's Disease Type B
-D052556	Niemann-Pick Disease, Type C	Niemann Pick Disease, Type C|Niemann-Pick's Disease Type C|Niemann Pick's Disease Type C|Niemann-Pick Disease without Sphingomyelinase Deficiency|Niemann Pick Disease without Sphingomyelinase Deficiency|Niemann-Pick Disease, Chronic Neuronopathic Form|Niemann Pick Disease, Chronic Neuronopathic Form|Neurovisceral Storage Disease with Vertical Supranuclear Ophthalmoplegia|Niemann-Pick Disease with Cholesterol Esterification Block|Niemann Pick Disease with Cholesterol Esterification Block
+D052556	Niemann-Pick Disease, Type C	Niemann Pick Disease, Type C|Niemann-Pick Disease, Chronic Neuronopathic Form|Niemann Pick Disease, Chronic Neuronopathic Form|Niemann-Pick Disease with Cholesterol Esterification Block|Niemann Pick Disease with Cholesterol Esterification Block|Niemann-Pick Disease without Sphingomyelinase Deficiency|Niemann Pick Disease without Sphingomyelinase Deficiency|Niemann-Pick's Disease Type C|Niemann Pick's Disease Type C|Neurovisceral Storage Disease with Vertical Supranuclear Ophthalmoplegia
 D052557	Clostridium septicum	
 D052576	Menstrual Hygiene Products	Hygiene Product, Menstrual|Hygiene Products, Menstrual|Menstrual Hygiene Product|Menstrual Products|Menstrual Product
 D052577	Infant, Extremely Low Birth Weight	Extremely Low Birth Weight Infant
@@ -25277,7 +25691,7 @@ D052859	Houttuynia
 D052878	Urolithiasis	Urinary Lithiasis|Lithiasis, Urinary
 D052879	Subacute Combined Degeneration	Neuropathy, Subacute Combined Degeneration|Subacute Combined Neuropathy Degeneration
 D052880	Pyomyositis	
-D052898	Optical Tweezers	Optical Tweezer|Tweezer, Optical|Tweezers, Optical|Optical Trapping|Trapping, Optical|Laser Tweezers|Laser Tweezer|Tweezer, Laser|Tweezers, Laser|Optical Trap|Optical Traps|Trap, Optical|Traps, Optical
+D052898	Optical Tweezers	Optical Tweezer|Tweezer, Optical|Tweezers, Optical|Optical Trap|Optical Traps|Trap, Optical|Traps, Optical|Optical Trapping|Trapping, Optical|Laser Tweezers|Laser Tweezer|Tweezer, Laser|Tweezers, Laser
 D052899	Pore Forming Cytotoxic Proteins	
 D052918	Environmental Restoration and Remediation	
 D052919	Refsum Disease, Infantile	Disease, Infantile Refsum|Infantile Phytanic Acid Storage Disease|Refsum's Disease, Infantile|Refsums Disease, Infantile|Infantile Refsum's Disease|Disease, Infantile Refsum's|Infantile Refsums Disease|Refsum Disease, Infantile Form|Infantile Form of Phytanic Acid Storage Disease|Infantile Refsum Disease
@@ -25304,7 +25718,7 @@ D053060	West Nile Virus Vaccines
 D053061	Herpes Zoster Vaccine	Vaccine, Herpes Zoster|Zoster Vaccine|Vaccine, Zoster|Shingles Vaccine|Vaccine, Shingles
 D053078	Membrane Potential, Mitochondrial	Membrane Potentials, Mitochondrial|Mitochondrial Membrane Potentials|Potential, Mitochondrial Membrane|Potentials, Mitochondrial Membrane|Mitochondrial Membrane Potential
 D053079	Trager duck spleen necrosis virus	Spleen Necrosis Virus|Necrosis Virus, Spleen|Necrosis Viruses, Spleen|Spleen Necrosis Viruses|Virus, Spleen Necrosis|Viruses, Spleen Necrosis
-D053098	Familial Hypophosphatemic Rickets	Hypophosphatemic Rickets, Familial|Rickets, Familial Hypophosphatemic|Hypocalcemic Vitamin D-Resistant Rickets|Hypocalcemic Vitamin D Resistant Rickets|Rickets, Hereditary Vitamin D-Resistant|Rickets, Hereditary Vitamin D Resistant|Vitamin D-Resistant Rickets With End-Organ Unresponsiveness To 1,25-Dihydroxycholecalciferol|Vitamin D Resistant Rickets With End Organ Unresponsiveness To 1,25 Dihydroxycholecalciferol|Vitamin D Resistant Rickets|Vitamin D-Resistant Rickets, Hereditary|Vitamin D Resistant Rickets, Hereditary|Hereditary Vitamin D-Resistant Rickets|Hereditary Vitamin D Resistant Rickets|Hereditary Hypophosphatemic Rickets|Hypophosphatemic Rickets, Hereditary|Rickets, Hereditary Hypophosphatemic|Generalized Resistance To 1,25-Dihydroxyvitamin D|Generalized Resistance To 1,25 Dihydroxyvitamin D
+D053098	Familial Hypophosphatemic Rickets	Hypophosphatemic Rickets, Familial|Rickets, Familial Hypophosphatemic|Hypocalcemic Vitamin D-Resistant Rickets|Hypocalcemic Vitamin D Resistant Rickets|Hereditary Hypophosphatemic Rickets|Hypophosphatemic Rickets, Hereditary|Rickets, Hereditary Hypophosphatemic|Vitamin D-Resistant Rickets With End-Organ Unresponsiveness To 1,25-Dihydroxycholecalciferol|Vitamin D Resistant Rickets With End Organ Unresponsiveness To 1,25 Dihydroxycholecalciferol|Vitamin D-Resistant Rickets, Hereditary|Vitamin D Resistant Rickets, Hereditary|Hereditary Vitamin D-Resistant Rickets|Hereditary Vitamin D Resistant Rickets|Generalized Resistance To 1,25-Dihydroxyvitamin D|Generalized Resistance To 1,25 Dihydroxyvitamin D|Rickets, Hereditary Vitamin D-Resistant|Rickets, Hereditary Vitamin D Resistant
 D053099	Azotemia	
 D053118	Influenza A Virus, H1N1 Subtype	H1N1 Virus|H1N1 Viruses|Virus, H1N1|Viruses, H1N1
 D053119	Benzophenanthridines	
@@ -25346,7 +25760,7 @@ D053206	Nocturnal Enuresis	Enuresis, Nocturnal|Nighttime Urinary Incontinence|In
 D053207	Diurnal Enuresis	Enuresis, Diurnal|Daytime Wetting|Wetting, Daytime|Daytime Urinary Incontinence|Incontinence, Daytime Urinary|Urinary Incontinence, Daytime
 D053208	Kaplan-Meier Estimate	Estimate, Kaplan-Meier|Kaplan-Meier Test|Kaplan Meier Test|Test, Kaplan-Meier|Product-Limit Method|Method, Product-Limit|Methods, Product-Limit|Product Limit Method|Product-Limit Methods|Kaplan-Meier Analysis|Analysis, Kaplan-Meier|Kaplan Meier Analysis
 D053209	Herbicide Resistance	Resistance, Herbicide
-D053210	Pharmaceutical Preparations, Dental	Dental Pharmaceutical Preparations|Preparations, Dental Pharmaceutical|Dental Drugs|Drugs, Dental
+D053210	Pharmaceutical Preparations, Dental	Dental Pharmaceutical Preparations|Preparations, Dental Pharmaceutical|Drugs, Dental|Dental Drugs|Pharmaceuticals, Dental|Dental Pharmaceuticals
 D053218	Receptors, Death Domain	Death Receptors|Death Domain Receptors|Receptors, Death Domain Family|Receptors, DR Family|DR Family Receptors
 D053219	Receptors, Tumor Necrosis Factor, Member 25	Death Receptor 3|Lymphocyte Associated Receptor of Death Protein|Tumor Necrosis Factor Receptor Superfamily, Member 25|DR3 Receptor|Receptor, DR3|TRAMP Receptor|Receptor, TRAMP|Apo-3 Receptor|Apo 3 Receptor|Receptor, Apo-3|WSL-1 Protein|WSL 1 Protein|TNFRSF25 Receptor|Receptor, TNFRSF25
 D053220	Receptors, TNF-Related Apoptosis-Inducing Ligand	Receptors, TNF Related Apoptosis Inducing Ligand|Tumor Necrosis Factor Receptor Superfamily, Member 10|TRAIL Receptors|Receptors, TRAIL|Receptors, Tumor Necrosis Factor, Member 10|TNF-Related Apoptosis-Inducing Ligand Receptors|TNF Related Apoptosis Inducing Ligand Receptors
@@ -25366,12 +25780,12 @@ D053263	Gene Regulatory Networks	Gene Regulatory Network|Network, Gene Regulator
 D053264	B-Cell Activating Factor	Activating Factor, B-Cell|B-Lymphocyte Activating Factor|Activating Factor, B-Lymphocyte|B Lymphocyte Activating Factor|THANK Protein|BAFF Ligand|BLyS Protein|B Cell Activating Factor|B Lymphocyte Stimulator|CD257 Antigen|Antigen, CD257|Antigens, CD257|TNF and APOL-Related Leukocyte Expressed Ligand 1|TNF and APOL Related Leukocyte Expressed Ligand 1|TNF Superfamily, Member 13b|Tumor Necrosis Factor Ligand Superfamily Member 13b|CD257 Antigens|TNFSF13B Protein|TALL-1 Protein|TALL 1 Protein
 D053265	B-Cell Activation Factor Receptor	B Cell Activation Factor Receptor|Receptor, B Cell-Activating Factor|Receptor, B Cell Activating Factor|Tumor Necrosis Factor Receptor Superfamily, Member 13C|CD268 Antigens|CD268 Antigen|Antigen, CD268|Antigens, CD268|BR3 B-Cell Activation Factor Receptor|BR3 B Cell Activation Factor Receptor|B Cell-Activating Factor Receptor|B Cell Activating Factor Receptor|BAFF Receptor|Receptor, BAFF
 D053278	OX40 Ligand	CD134L Protein|Tumor Necrosis Factor Ligand Superfamily Member 4|OX40L Protein|TNF Superfamily, Member 4|Tumor Necrosis Factor (Ligand) Superfamily, Member 4|CD134 Ligand|gp34 Tumor Necrosis Factor
-D053279	Polyacetylenes	Polyynes|Polyacetylene
+D053279	Polyynes	
 D053280	Diynes	
 D053281	Enediynes	Enediyne Group
 D053282	CD27 Ligand	Ligand, CD27|Antigens, CD70|CD70 Antigens|Tumor Necrosis Factor Ligand Superfamily Member 7|CD27L Protein|CD70 Antigen|Antigen, CD70|TNF Superfamily, Member 7
 D053283	Apolipoprotein B-48	Apolipoprotein B 48|Apo B-48|Apo B 48|ApoB-48|ApoB 48|ApoB48|Apolipoprotein B48|Apoprotein B-48|Apoprotein B 48|Chylomicron Apo B|Chylomicron Apolipoprotein B|Apo B, Chylomicron|Apolipoprotein B, Chylomicron
-D053284	Polyunsaturated Alkamides	Alkamides, Polyunsaturated|Alkylamides, Polyunsaturated|Polyunsaturated Alkylamides
+D053284	Polyunsaturated Alkamides	Alkamides, Polyunsaturated|Polyunsaturated Alkylamides|Alkylamides, Polyunsaturated
 D053285	CD30 Ligand	CD153 Antigens|Tumor Necrosis Factor Ligand Superfamily Member 8|TNF Superfamily, Member 8|CD153 Antigen|Antigen, CD153|Antigens, CD153
 D053298	Chylomicron Remnants	Remnants, Chylomicron|Chylomicron Remnant|Remnant, Chylomicron
 D053299	Apolipoprotein B-100	Apolipoprotein B 100|ApoB-100|ApoB 100|Apo B-100|Apo B 100|Apo-B-100
@@ -25498,7 +25912,7 @@ D053544	Marinomonas
 D053545	Spirulina	
 D053546	Keratoderma, Palmoplantar, Epidermolytic	EPPK (Epidermolytic Palmoplantar Keratoderma)|EPPKs (Epidermolytic Palmoplantar Keratoderma)|Hyperkeratosis, Localized Epidermolytic|Epidermolytic Hyperkeratoses, Localized|Epidermolytic Hyperkeratosis, Localized|Hyperkeratoses, Localized Epidermolytic|Localized Epidermolytic Hyperkeratoses|Localized Epidermolytic Hyperkeratosis|Palmoplantar Keratoderma, Epidermolytic|Keratoderma, Epidermolytic Palmoplantar|Epidermolytic Palmoplantar Keratoderma|Epidermolytic Palmoplantar Keratodermas|Keratodermas, Epidermolytic Palmoplantar|Palmoplantar Keratodermas, Epidermolytic|Unna-Thost Disease, Epidermolytic|Epidermolytic Unna-Thost Disease|Unna Thost Disease, Epidermolytic|Thost-Unna Disease, Epidermolytic|Epidermolytic Thost-Unna Disease|Thost Unna Disease, Epidermolytic
 D053547	Keratin-14	Keratin 14|Cytokeratin 14|Cytokeratin-14
-D053549	Pachyonychia Congenita	Congenita, Pachyonychia|Pachyonychia Congenita Syndrome|Congenita Syndrome, Pachyonychia|Congenita Syndromes, Pachyonychia|Pachyonychia Congenita Syndromes|Syndrome, Pachyonychia Congenita|Syndromes, Pachyonychia Congenita|Congenital Pachyonychia|Congenital Pachyonychias|Pachyonychia, Congenital|Pachyonychias, Congenital
+D053549	Pachyonychia Congenita	Pachyonychia Congenita Syndrome|Congenital Pachyonychia|Pachyonychia, Congenital
 D053550	Keratin-10	Keratin 10
 D053551	Keratin-12	Keratin 12|Cytokeratin-12|Cytokeratin 12
 D053552	Keratin-7	Keratin CK7|Keratin 7|Cytokeratin 7|Cytokeratin-7
@@ -25712,7 +26126,7 @@ D054041	Weapons	Weapon
 D054042	Bombs	Bomb
 D054043	Nuclear Weapons	Nuclear Weapon|Weapon, Nuclear|Weapons, Nuclear
 D054044	Weapons of Mass Destruction	Mass Destruction Weapon|Mass Destruction Weapons|Weapon of Mass Destruction
-D054045	Biological Warfare Agents	Agent, Biological Warfare|Agents, Biological Warfare|Biological Warfare Agent|Warfare Agent, Biological|Warfare Agents, Biological|Biological Select Agents|Agent, Biological Select|Agents, Biological Select|Biological Select Agent|Select Agent, Biological|Select Agents, Biological|Biowarfare Agents|Agent, Biowarfare|Agents, Biowarfare|Biowarfare Agent|Bioterrorism Agents|Agent, Bioterrorism|Agents, Bioterrorism|Bioterrorism Agent
+D054045	Biological Warfare Agents	Agent, Biological Warfare|Agents, Biological Warfare|Biological Warfare Agent|Warfare Agent, Biological|Warfare Agents, Biological|Bioterrorism Agents|Agent, Bioterrorism|Agents, Bioterrorism|Bioterrorism Agent|Biological Select Agents|Agent, Biological Select|Agents, Biological Select|Biological Select Agent|Select Agent, Biological|Select Agents, Biological|Biowarfare Agents|Agent, Biowarfare|Agents, Biowarfare|Biowarfare Agent
 D054046	Plant Stomata	Plant Stomatas|Stomatas, Plant|Stomata, Plant
 D054047	Surgical Stomas	Stoma, Surgical|Surgical Stoma|Stomata, Surgical|Surgical Stomata|Stomas, Surgical
 D054048	Peritoneal Stomata	Diaphragmatic Stomata|Diaphragmatic Stomatas|Stomata, Diaphragmatic|Stomatas, Diaphragmatic|Stomata, Peritoneal|Lymphatic Stomata|Stomata, Lymphatic|Peritoneal Stomas|Peritoneal Stoma|Stoma, Peritoneal|Stomas, Peritoneal|Diaphragmatic Stomas|Diaphragmatic Stoma|Stoma, Diaphragmatic|Stomas, Diaphragmatic|Lymphatic Stomas|Lymphatic Stoma|Stoma, Lymphatic|Stomas, Lymphatic
@@ -25722,7 +26136,7 @@ D054060	Pulmonary Infarction	Infarctions, Pulmonary|Pulmonary Infarctions|Infarc
 D054061	Ischemic Contracture	Contracture, Ischemic|Contractures, Ischemic|Ischemic Contractures|Volkmann Contracture|Volkmann's Ischemic Contracture|Contracture, Volkmann's Ischemic|Ischemic Contracture, Volkmann's|Volkmann Ischemic Contracture|Volkmanns Ischemic Contracture|Contracture, Volkmann|Contractures, Volkmann|Volkmann Contractures
 D054062	Deaf-Blind Disorders	Deaf Blind Disorders|Deaf-Blind Disorder|Disorder, Deaf-Blind|Disorders, Deaf-Blind|Blindness-Deafness|Blindness Deafness|Vision and Hearing Loss|Deafness-Blindness|Deafness Blindness|Hearing and Vision Loss|Blind-Deaf Disorders|Blind Deaf Disorders|Blind-Deaf Disorder|Disorder, Blind-Deaf|Disorders, Blind-Deaf|Deaf-Blindness Disorders|Deaf Blindness Disorders|Deaf-Blindness Disorder|Disorder, Deaf-Blindness|Disorders, Deaf-Blindness
 D054063	Superior Sagittal Sinus	Sagittal Sinus, Superior|Sinus, Superior Sagittal|Superior Longitudinal Sinus|Longitudinal Sinus, Superior|Sinus, Superior Longitudinal|Sinus Sagittalis Superior
-D054064	Transverse Sinuses	Sinuses, Transverse|Transverse Sinuse|Lateral Sinuses|Lateral Sinuse|Sinuses, Lateral|Sinus Transversus|Transversus, Sinus|Lateral Sinus|Sinus, Lateral
+D054064	Transverse Sinuses	Sinuses, Transverse|Transverse Sinuse|Lateral Sinuses|Lateral Sinuse|Sinuses, Lateral|Lateral Sinus|Sinus, Lateral|Sinus Transversus|Transversus, Sinus
 D054066	Leukemia, Large Granular Lymphocytic	Aggressive NK Cell Leukemia|Leukemia, Lymphocytic, Large Granular|Large Granular Lymphocyte Leukemia|LGL Leukemia|LGL Leukemias|Leukemias, LGL|Lymphoproliferative Disease of Large Granular Lymphocytes|Leukemia, LGL|Aggressive Natural Killer Cell Leukemia|Lymphoproliferative Disease of Granular Lymphocytes
 D054067	Dihydropyrimidine Dehydrogenase Deficiency	Deficiencies, Dihydropyrimidine Dehydrogenase|Deficiency, Dihydropyrimidine Dehydrogenase|Dehydrogenase Deficiencies, Dihydropyrimidine|Dehydrogenase Deficiency, Dihydropyrimidine|Dihydropyrimidine Dehydrogenase Deficiencies|Pyrimidinemia, Familial|Thymine-Uraciluria, Hereditary|Hereditary Thymine-Uracilurias|Thymine Uraciluria, Hereditary|Thymine-Uracilurias, Hereditary|Hereditary Thymine-Uraciluria|Hereditary Thymine Uraciluria|DPD Deficiency|DPD Deficiencies|Deficiencies, DPD|Deficiency, DPD|Familial Pyrimidinemia|Familial Pyrimidinemias|Pyrimidinemias, Familial|Familial Pyrimidemia|Familial Pyrimidemias|Pyrimidemia, Familial|Pyrimidemias, Familial
 D054068	Livedo Reticularis	
@@ -25780,7 +26194,7 @@ D054300	Oscillatoria
 D054301	gag Gene Products, Human Immunodeficiency Virus	gag Proteins, Human Immunodeficiency Virus|gag Gene Products, HIV
 D054302	pol Gene Products, Human Immunodeficiency Virus	pol Proteins, Human Immunodeficiency Virus|pol Gene Products, HIV
 D054303	HIV Reverse Transcriptase	Transcriptase, HIV Reverse|Reverse Transcriptase, Human Immunodeficiency Virus|Reverse Transcriptase, HIV
-D054304	Anti-Mullerian Hormone	Anti Mullerian Hormone|Antimullerian Hormone|Mullerian Inhibiting Hormone|Mullerian Inhibiting Substance|Mullerian-Inhibitory Substance|Mullerian Inhibitory Substance|Mullerian-Inhibiting Factor|Mullerian Inhibiting Factor|Mullerian-Inhibiting Hormone|Anti-Mullerian Factor|Anti Mullerian Factor|Mullerian Regression Factor
+D054304	Anti-Mullerian Hormone	Anti Mullerian Hormone|Mullerian-Inhibiting Factor|Mullerian Inhibiting Factor|Anti-Mullerian Factor|Anti Mullerian Factor|Mullerian-Inhibitory Substance|Mullerian Inhibitory Substance|Mullerian Inhibiting Hormone|Mullerian Inhibiting Substance|Mullerian Regression Factor|Mullerian-Inhibiting Hormone|Anti-Muellerian Hormone|Anti Muellerian Hormone|Hormone, Anti-Muellerian|Antimullerian Hormone
 D054306	Dideoxynucleotides	
 D054307	Enterotoxigenic Escherichia coli	Escherichia coli, Enterotoxigenic|E coli, Enterotoxigenic|ETEC|Enterotoxigenic E. coli
 D054308	Enteropathogenic Escherichia coli	E coli, Enteropathogenic|Escherichia coli, Enteropathogenic|EPEC|Enteropathogenic E. coli
@@ -25887,7 +26301,7 @@ D054442	Cell Migration Assays, Macrophage	Macrophage Migration Test|Macrophage M
 D054443	Cell Migration Assays	Assay, Cell Migration|Assays, Cell Migration|Cell Migration Assay|Migration Assay, Cell|Migration Assays, Cell
 D054444	Immunoglobulin Light Chains, Surrogate	Surrogate L Chain Protein|Surrogate Light Chains|Light Chains, Surrogate|Pseudo Immunoglobulin Light Chain|psiL Chain, Immunoglobulin|Immunoglobulin psiL Chain|Surrogate Light Chain|Light Chain, Surrogate|Surrogate Immunoglobulin Light Chains
 D054445	Facial Transplantation	Facial Transplantations|Transplantation, Facial|Transplantations, Facial|Face Transplantation|Face Transplantations|Transplantation, Face|Transplantations, Face|Facial Transplant|Facial Transplants|Transplant, Facial|Transplants, Facial|Face Transplant|Face Transplants|Transplant, Face|Transplants, Face
-D054446	Lymphoma, Primary Cutaneous Anaplastic Large Cell	Primary Cutaneous Anaplastic Large Cell Lymphoma|Primary Cutaneous CD30-positive Large T-Cell Lymphoma|Primary Cutaneous CD30 positive Large T Cell Lymphoma
+D054446	Lymphoma, Primary Cutaneous Anaplastic Large Cell	Primary Cutaneous CD30-positive Large T-Cell Lymphoma|Primary Cutaneous CD30 positive Large T Cell Lymphoma|Primary Cutaneous Anaplastic Large Cell Lymphoma
 D054447	Receptors, CCR10	CCR10 Receptor|Receptor, CCR10|CCR10 Receptors|CC Chemokine Receptor 10|G-Protein Coupled Receptor 2|G Protein Coupled Receptor 2
 D054448	Precursor Cells, B-Lymphoid	B-Lymphoid Precursor Cell|Cell, B-Lymphoid Precursor|Cells, B-Lymphoid Precursor|Precursor Cell, B-Lymphoid|Precursor Cells, B Lymphoid|Immature B-Lymphocytes|B-Lymphocyte, Immature|B-Lymphocytes, Immature|Immature B Lymphocytes|Immature B-Lymphocyte|Transitional B-Cells|B-Cell, Transitional|B-Cells, Transitional|Transitional B Cells|Transitional B-Cell|B-Lymphoid Precursor Cells|B Lymphoid Precursor Cells|Transitional B-Lymphocytes|B-Lymphocyte, Transitional|B-Lymphocytes, Transitional|Transitional B Lymphocytes|Transitional B-Lymphocyte|Immature B-Cells|B-Cell, Immature|B-Cells, Immature|Immature B Cells|Immature B-Cell
 D054457	Tissue Scaffolds	Scaffold, Tissue|Scaffolds, Tissue|Tissue Scaffold|Tissue Scaffolding|Scaffolding, Tissue|Scaffoldings, Tissue|Tissue Scaffoldings
@@ -26125,7 +26539,7 @@ D054853	Malignant Atrophic Papulosis	Atrophic Papuloses, Malignant|Atrophic Papu
 D054854	Vertebroplasty	
 D054855	Drug-Eluting Stents	Drug Eluting Stents|Drug-Eluting Stent|Stent, Drug-Eluting|Stents, Drug-Eluting|Stents, Drug Eluting
 D054856	G-Quadruplexes	G Quadruplexes|Guanine-Quadruplexes|Guanine Quadruplexes
-D054868	Jacobsen Distal 11q Deletion Syndrome	11q Deletion Disorder|Deletion Disorder, 11q|Disorder, 11q Deletion|11q Deletion Syndrome|11q- Deletion Syndrome|Paris-Trousseau Syndrome|Paris Trousseau Syndrome|Syndrome, Paris-Trousseau|Chromosome 11q Deletion Syndrome|Partial 11q Monosomy Syndrome|11q Terminal Deletion Disorder|Jacobsen Syndrome|Syndrome, Jacobsen
+D054868	Jacobsen Distal 11q Deletion Syndrome	11q Deletion Disorder|Deletion Disorder, 11q|11q- Deletion Syndrome|11q- Deletion Syndromes|Deletion Syndrome, 11q-|Jacobsen Syndrome|Chromosome 11q Deletion Syndrome|Partial 11q Monosomy Syndrome|11q Terminal Deletion Disorder|11q Deletion Syndrome
 D054869	Clinical Audit	Audit, Clinical|Audits, Clinical|Clinical Audits
 D054872	Fatty Acid Synthesis Inhibitors	
 D054873	Dipeptidyl-Peptidase IV Inhibitors	Dipeptidyl Peptidase IV Inhibitors|Inhibitors, Dipeptidyl-Peptidase IV|Gliptins|Dipeptidyl-Peptidase 4 Inhibitors|Dipeptidyl Peptidase 4 Inhibitors
@@ -26135,7 +26549,7 @@ D054876	Prenylation
 D054877	Wolf-Hirschhorn Syndrome	Syndrome, Wolf-Hirschhorn|Wolf Hirschhorn Syndrome|Wolf Syndrome|Syndrome, Wolf|Wolf-Hirchhorn Syndrome|Syndrome, Wolf-Hirchhorn|Wolf Hirchhorn Syndrome|Partial Monosomy 4p|4p- Syndrome|Chromosome 4p Deletion Syndrome|Chromosome 4p Monosomy|Del(4p) Syndrome|Chromosome 4p Syndrome|4p Syndrome, Chromosome|4p Syndromes, Chromosome|Chromosome 4p Syndromes|Syndrome, Chromosome 4p|Syndromes, Chromosome 4p|4p Deletion Syndrome
 D054878	Lipoylation	
 D054879	Halogenation	
-D054880	Aspartylglucosaminuria	Aspartylglucosaminurias|AGA Deficiency|AGA Deficiencies|Deficiencies, AGA|Deficiency, AGA|Aspartylglucosamidase Deficiency|Aspartylglucosamidase Deficiencies|Deficiencies, Aspartylglucosamidase|Deficiency, Aspartylglucosamidase|Aspartylglycosaminuria|Aspartylglycosaminurias|Glycoasparaginase|Glycoasparaginases
+D054880	Aspartylglucosaminuria	Aspartylglucosaminurias|Glycoasparaginase Deficiency|Deficiencies, Glycoasparaginase|Deficiency, Glycoasparaginase|Glycoasparaginase Deficiencies|AGA Deficiency|AGA Deficiencies|Deficiencies, AGA|Deficiency, AGA|Aspartylglycosaminuria|Aspartylglycosaminurias|Aspartylglucosamidase Deficiency|Aspartylglucosamidase Deficiencies|Deficiencies, Aspartylglucosamidase|Deficiency, Aspartylglucosamidase
 D054881	Sex Determination by Skeleton	
 D054882	Antley-Bixler Syndrome Phenotype	Antley Bixler Syndrome Phenotype|Phenotype, Antley-Bixler Syndrome|Syndrome Phenotype, Antley-Bixler
 D054883	Oxylipins	
@@ -26183,7 +26597,7 @@ D055034	Osteochondrosis	Osteochondroses
 D055035	Spinal Osteochondrosis	Osteochondroses, Spinal|Osteochondrosis, Spinal|Spinal Osteochondroses|Osteochondrosis of Spine|Spine Osteochondroses|Spine Osteochondrosis
 D055036	Campomelic Dysplasia	Campomelic Dysplasias|Dysplasia, Campomelic|Dysplasias, Campomelic|Campomelic Syndrome|Campomelic Syndromes|Syndrome, Campomelic|Syndromes, Campomelic|Campomelic Dwarfism|Campomelic Dwarfisms|Dwarfism, Campomelic|Dwarfisms, Campomelic|Cmpd1 Sra1|Cmpd1 Sra1s|Sra1, Cmpd1|Sra1s, Cmpd1|Camptomelic Dysplasia|Camptomelic Dysplasias|Dysplasia, Camptomelic|Dysplasias, Camptomelic
 D055048	Integrative Medicine	Medicine, Integrative
-D055049	Salt-Tolerance	Salt Tolerance|Saline-Tolerance|Saline Tolerance
+D055049	Salt Tolerance	Salt Tolerances|Tolerance, Salt|Saline-Tolerance|Saline Tolerance|Salinity Tolerance|Salinity Tolerances|Tolerance, Salinity|Salt-Tolerance
 D055050	Diet, Gluten-Free	Diet, Gluten Free|Gluten-Free Diet|Diets, Gluten-Free|Gluten Free Diet|Gluten-Free Diets
 D055051	Salt-Tolerant Plants	Plant, Salt-Tolerant|Salt Tolerant Plants|Salt-Tolerant Plant|Saline-Resistant Plants|Plant, Saline-Resistant|Plants, Saline-Resistant|Saline Resistant Plants|Saline-Resistant Plant|Salt-Resistant Plants|Plant, Salt-Resistant|Plants, Salt-Resistant|Salt Resistant Plants|Salt-Resistant Plant|Saline-Tolerant Plants|Plant, Saline-Tolerant|Plants, Saline-Tolerant|Saline Tolerant Plants|Saline-Tolerant Plant|Plants, Salt-Tolerant|Plants, Salt Tolerant
 D055052	Athletic Tape	Tape, Athletic|Orthotic Tape|Tape, Orthotic
@@ -26208,7 +26622,7 @@ D055101	Semen Analysis	Semen Analyses|Semen Quality Analysis|Analyses, Semen Qua
 D055103	Hypodermoclysis	Subcutaneous Hydration|Hydration, Subcutaneous|Subcutaneous Fluid Administration|Administration, Subcutaneous Fluid|Fluid Administration, Subcutaneous
 D055104	Infusions, Subcutaneous	Infusion, Subcutaneous|Subcutaneous Infusion|Subcutaneous Infusions
 D055105	Waist Circumference	Circumference, Waist|Circumferences, Waist|Waist Circumferences
-D055106	Genome-Wide Association Study	Association Studies, Genome-Wide|Association Study, Genome-Wide|Genome-Wide Association Studies|Studies, Genome-Wide Association|Study, Genome-Wide Association|Genome Wide Association Scan|Genome Wide Association Studies|GWA Study|GWA Studies|Studies, GWA|Study, GWA|Whole Genome Association Analysis|Whole Genome Association Study|Genome Wide Association Analysis|Genome Wide Association Study
+D055106	Genome-Wide Association Study	Association Studies, Genome-Wide|Association Study, Genome-Wide|Genome-Wide Association Studies|Studies, Genome-Wide Association|Study, Genome-Wide Association|Whole Genome Association Analysis|Genome Wide Association Study|GWA Study|GWA Studies|Studies, GWA|Study, GWA|Genome Wide Association Scan|Genome Wide Association Studies|Genome Wide Association Analysis|Whole Genome Association Study
 D055107	Suntan	
 D055108	Sunbathing	
 D055109	Ankle Brachial Index	Ankle Brachial Indices|Brachial Index, Ankle|Brachial Indices, Ankle|Index, Ankle Brachial|Indices, Ankle Brachial|Ankle-Brachial Index|Ankle-Brachial Indices|Index, Ankle-Brachial|Indices, Ankle-Brachial
@@ -26217,8 +26631,8 @@ D055111	Failed Back Surgery Syndrome
 D055112	Pyometra	Pyometras
 D055113	Chronic Periodontitis	Chronic Periodontitides|Periodontitides, Chronic|Periodontitis, Chronic|Adult Periodontitis|Adult Periodontitides|Periodontitides, Adult|Periodontitis, Adult
 D055114	X-Ray Microtomography	Microtomography, X-Ray|X Ray Microtomography|MicroCT|MicroCTs|X-Ray Micro-CAT Scans|Micro-CAT Scan, X-Ray|Micro-CAT Scans, X-Ray|Scan, X-Ray Micro-CAT|Scans, X-Ray Micro-CAT|X Ray Micro CAT Scans|X-Ray Micro-CAT Scan|X-Ray Micro-Computed Tomography|Micro-Computed Tomography, X-Ray|Tomography, X-Ray Micro-Computed|X Ray Micro Computed Tomography|Xray MicroCT|MicroCT, Xray|MicroCTs, Xray|Xray MicroCTs|X-Ray Micro-CT Scans|Micro-CT Scan, X-Ray|Micro-CT Scans, X-Ray|Scan, X-Ray Micro-CT|Scans, X-Ray Micro-CT|X Ray Micro CT Scans|X-Ray Micro-CT Scan|X-Ray Microcomputed Tomography|Microcomputed Tomography, X-Ray|Tomography, X-Ray Microcomputed|X Ray Microcomputed Tomography|X-ray MicroCT|MicroCT, X-ray|MicroCTs, X-ray|X ray MicroCT|X-ray MicroCTs|Xray Micro-CT|Micro-CT, Xray|Micro-CTs, Xray|Xray Micro CT|Xray Micro-CTs|Microcomputed Tomography|Tomography, Microcomputed|X-Ray Micro-CT|Micro-CT, X-Ray|Micro-CTs, X-Ray|X Ray Micro CT|X-Ray Micro-CTs
-D055115	Light-Curing of Dental Adhesives	Dental Adhesives Light-Curing|Light Curing of Dental Adhesives|Light-Curing of Dental Resins|Dental Resins Light-Curings|Light Curing of Dental Resins|Dental Bonding, Light-Cured|Dental Bonding, Light Cured|Dental Bondings, Light-Cured|Light-Cured Dental Bonding|Light-Cured Dental Bondings|Light-Curing of Dental Cements|Dental Cements Light-Curing|Light Curing of Dental Cements
-D055116	Self-Curing of Dental Resins	Self Curing of Dental Resins|Dental Bonding, Chemically-Cured|Chemically-Cured Dental Bonding|Dental Bonding, Chemically Cured|Dental Bonding, Self-Cured|Dental Bonding, Self Cured|Self-Cured Dental Bonding|Chemical-Curing of Dental Adhesives|Chemical Curing of Dental Adhesives
+D055115	Light-Curing of Dental Adhesives	Dental Adhesives Light-Curing|Light Curing of Dental Adhesives|Dental Bonding, Light-Cured|Dental Bonding, Light Cured|Dental Bondings, Light-Cured|Light-Cured Dental Bonding|Light-Cured Dental Bondings|Light-Curing of Dental Cements|Dental Cements Light-Curing|Light Curing of Dental Cements|Light-Curing of Dental Resins|Dental Resins Light-Curings|Light Curing of Dental Resins
+D055116	Self-Curing of Dental Resins	Self Curing of Dental Resins|Chemical-Curing of Dental Adhesives|Chemical Curing of Dental Adhesives|Dental Bonding, Chemically-Cured|Chemically-Cured Dental Bonding|Dental Bonding, Chemically Cured|Dental Bonding, Self-Cured|Dental Bonding, Self Cured|Self-Cured Dental Bonding
 D055117	Curing Lights, Dental	Curing Light, Dental|Dental Curing Light|Light, Dental Curing|Lights, Dental Curing|Dental Curing Lights
 D055118	Medication Adherence	Adherence, Medication
 D055119	Elastic Modulus	Modulus, Elastic|Young's Modulus|Modulus, Young's|Youngs Modulus|Modulus of Elasticity|Elasticity Modulus|Young Modulus|Modulus, Young
@@ -26304,7 +26718,7 @@ D055356	Endometrial Ablation Techniques	Ablation Technique, Endometrial|Ablation
 D055357	Uterine Artery Embolization	Artery Embolization, Uterine|Artery Embolizations, Uterine|Embolization, Uterine Artery|Embolizations, Uterine Artery|Uterine Artery Embolizations
 D055358	Cone Opsins	Opsins, Cone|Cone Opsin|Opsin, Cone
 D055359	Antistatic Agents	Agents, Antistatic|Anti-Static Agents|Agents, Anti-Static|Anti Static Agents
-D055360	Osteopathic Physicians	Physician, Osteopathic|Physicians, Osteopathic|Osteopath|Osteopaths|Doctor of Osteopathy|Osteopathy Doctor|Osteopathy Doctors|Osteopathic Physician
+D055360	Osteopathic Physicians	Physician, Osteopathic|Physicians, Osteopathic|Osteopaths|Osteopathic Physician|Doctor of Osteopathy|Osteopathy Doctor|Osteopathy Doctors|Osteopath
 D055361	Multilevel Analysis	Analyses, Multilevel|Analysis, Multilevel|Multilevel Analyses
 D055362	Agrocybe	Agrocybes
 D055363	Cortinarius	
@@ -26387,7 +26801,7 @@ D055519	Photoreceptors, Plant	Plant Photoreceptors
 D055531	Gemini of Coiled Bodies	Coiled Bodies Gemini|GEMS Cell Nucleus Structures
 D055532	SMN Complex Proteins	Gemin Proteins|Survival of Motor Neuron Complex Proteins|Gem-Associated Proteins|Gem Associated Proteins
 D055533	Survival of Motor Neuron 1 Protein	SMN Protein (Spinal Muscular Atrophy)|Survival of Motor Neuron 1, Telomeric Protein|Survival Motor Neuron Protein 1
-D055534	Bulbo-Spinal Atrophy, X-Linked	Atrophies, X-Linked Bulbo-Spinal|Atrophy, X-Linked Bulbo-Spinal|Bulbo Spinal Atrophy, X Linked|Bulbo-Spinal Atrophies, X-Linked|X-Linked Bulbo-Spinal Atrophies|Kennedy Disease|Disease, Kennedy|Kennedy Spinal and Bulbar Muscular Atrophy|Kennedy Syndrome|Syndrome, Kennedy|X-Linked Bulbo-Spinal Atrophy|X Linked Bulbo Spinal Atrophy|X-linked Bulbospinal Muscular Atrophy|X linked Bulbospinal Muscular Atrophy|Kennedy's Disease|Disease, Kennedy's|Kennedys Disease|X-Linked Spinal and Bulbar Muscular Atrophy|X Linked Spinal and Bulbar Muscular Atrophy|Bulbospinal Muscular Atrophy, X-linked|Bulbospinal Muscular Atrophy, X linked|Spinal And Bulbar Muscular Atrophy, X-Linked 1|Spinal And Bulbar Muscular Atrophy, X Linked 1
+D055534	Bulbo-Spinal Atrophy, X-Linked	Bulbo Spinal Atrophy, X Linked|Bulbospinal Muscular Atrophy, X-linked|Bulbospinal Muscular Atrophy, X linked|Kennedy Spinal and Bulbar Muscular Atrophy|Spinal and Bulbar Muscular Atrophy|X-linked Bulbospinal Muscular Atrophy|X linked Bulbospinal Muscular Atrophy|Kennedy's Disease|Spinobulbar Muscular Atrophy|Spinal And Bulbar Muscular Atrophy, X-Linked 1|Spinal And Bulbar Muscular Atrophy, X Linked 1|Kennedy Syndrome|X-Linked Bulbo-Spinal Atrophy|Atrophies, X-Linked Bulbo-Spinal|Atrophy, X-Linked Bulbo-Spinal|Bulbo-Spinal Atrophies, X-Linked|X Linked Bulbo Spinal Atrophy|X-Linked Bulbo-Spinal Atrophies|Atrophy, Muscular, Spinobulbar|Muscular Atrophy, Spinobulbar|Atrophy, Spinobulbar Muscular|Spinobulbar Muscular Atrophies|Kennedy Disease|X-Linked Spinal and Bulbar Muscular Atrophy|X Linked Spinal and Bulbar Muscular Atrophy
 D055535	Morgellons Disease	Disease, Morgellons|Morgellons|Morgellon|Morgellons Syndrome|Syndrome, Morgellons|Morgellon's
 D055536	Vagus Nerve Stimulation	Nerve Stimulation, Vagus|Nerve Stimulations, Vagus|Stimulation, Vagus Nerve|Stimulations, Vagus Nerve|Vagus Nerve Stimulations|Vagal Nerve Stimulation|Nerve Stimulation, Vagal|Nerve Stimulations, Vagal|Stimulation, Vagal Nerve|Stimulations, Vagal Nerve|Vagal Nerve Stimulations
 D055537	Light Signal Transduction	Transduction, Light Signal|Signal Transduction, Light|Phototransduction
@@ -26530,9 +26944,9 @@ D055818	Public-Private Sector Partnerships	Partnership, Public-Private Sector|Pa
 D055819	Hospitals, Isolation	Hospital, Isolation|Isolation Hospital|Isolation Hospitals
 D055820	New Orleans	
 D055821	Poetry	
-D055823	Cookbooks	Cookbook|Recipe Books
-D055824	Formularies	
-D055825	National Institute of Neurological Disorders and Stroke (U.S.)	National Institute of Neurological Disorders and Stroke|NINDS
+D055823	Cookbook	Recipe Books|Cookbooks
+D055824	Formulary	Formularies
+D055825	National Institute of Neurological Disorders and Stroke (U.S.)	NINDS|National Institute of Neurological Disorders and Stroke
 D055826	Afghan Campaign 2001-	Afghan War, 2001-|2001- Afghan War|2001- Afghan Wars|Afghan War, 2001|Afghan Wars, 2001-|War, 2001- Afghan|Wars, 2001- Afghan|Operation Enduring Freedom|Operation Enduring Freedoms
 D055827	Integumentary System Physiological Phenomena	Integumentary System Physiology|Physiology, Integumentary System|Integumentary System Physiological Phenomenon Concepts|Integumentary System Physiological Phenomenon
 D055847	Lynch Syndrome II	Lynch cancer family syndrome 2|Lynch Cancer Family Syndrome II|Colon Cancer, Familial Nonpolyposis, Type 2|Colorectal Cancer, Hereditary Nonpolyposis, Type 2
@@ -26542,9 +26956,9 @@ D055865	Sleep Phase Chronotherapy	Chronotherapies, Sleep Phase|Chronotherapy, Sl
 D055866	Earthquakes	Earthquake
 D055867	Cyclonic Storms	Cyclonic Storm|Storm, Cyclonic|Storms, Cyclonic|Cyclone|Cyclones
 D055868	Floods	
-D055869	Tornadoes	Tornadoe|Tornado
+D055869	Tornadoes	Tornado|Tornados
 D055870	Drug Chronotherapy	Chronotherapies, Drug|Chronotherapy, Drug|Drug Chronotherapies
-D055871	Tidal Waves	Tidal Wave|Wave, Tidal|Waves, Tidal|Ocean Tides|Ocean Tide|Tide, Ocean|Tides, Ocean|Tidalwaves|Tidalwave|Earth Tides|Earth Tide|Tide, Earth|Tides, Earth
+D055871	Tidal Waves	Tidal Wave|Wave, Tidal|Waves, Tidal|Ocean Tides|Tides, Ocean|Tidalwaves|Tidalwave|Earth Tides|Tides, Earth
 D055872	Surge Capacity	Capacities, Surge|Capacity, Surge|Surge Capacities
 D055873	Extreme Cold	Cold, Extreme
 D055874	Extreme Heat	Extreme Heats|Heat, Extreme|Heats, Extreme
@@ -26623,13 +27037,13 @@ D056246	Chemistry, Analytic	Analytic Chemistry
 D056264	Sin3 Histone Deacetylase and Corepressor Complex	SIN-3 Histone Deacetylase Complex|SIN 3 Histone Deacetylase Complex|SIN3 Complex|SIN3 Histone Deacetylase Complex|Sin3 Corepressor Complex|Corepressor Complex, Sin3|Sin3-Histone Deacetylase (HDAC) Corepressor Complex
 D056265	Microbial Interactions	Interaction, Microbial|Interactions, Microbial|Microbial Interaction
 D056266	Erythrokeratodermia Variabilis	Mendes De Costa Syndrome|Erythrokeratodermia Figurata, Congenital Familial, in Plaques|Erythro et Keratodermia Variabilis|Erythrokeratodermia, Progressive Symmetric|Progressive Symmetric Erythrokeratodermia|Erythrokeratodermia Variabilis with Erythema Gyratum Repens|Erythrokeratodermia Figurata Variabilis
-D056267	Pagetoid Reticulosis	Pagetoid Reticuloses|Reticuloses, Pagetoid|Reticulosis, Pagetoid|Woringer Kolopp Disease|Disease, Woringer Kolopp|Kolopp Disease, Woringer|Woringer-Kolopp Disease|Disease, Woringer-Kolopp
+D056267	Pagetoid Reticulosis	Pagetoid Reticuloses|Reticuloses, Pagetoid|Reticulosis, Pagetoid|Woringer-Kolopp Disease|Disease, Woringer-Kolopp|Woringer Kolopp Disease|Disease, Woringer Kolopp|Kolopp Disease, Woringer
 D056284	Histone Deacetylase 1	Deacetylase 1, Histone|HDAC1 Histone Deacetylase|Deacetylase, HDAC1 Histone|Histone Deacetylase, HDAC1|RPD3L1 Histone Deacetylase|Deacetylase, RPD3L1 Histone|Histone Deacetylase, RPD3L1
 D056285	Cryptococcus gattii	Cryptococcus gattius|gattius, Cryptococcus|Cryptococcus neoformans var. gattii
 D056286	Retinoblastoma Binding Proteins	RBBP Proteins|Retinoblastoma Protein Binding Proteins
 D056304	Genu Valgum	Genu Valgums|Knock Knee|Knees, Knock|Knock Knees|Genu Valga|Genu Valgas|Valga, Genu|Valgas, Genu
 D056305	Genu Varum	Bow Leg|Bow Legs|Leg, Bow|Legs, Bow|Genu Varus
-D056324	Diffusion Tensor Imaging	Imaging, Diffusion Tensor
+D056324	Diffusion Tensor Imaging	Imaging, Diffusion Tensor|Diffusion Tensor Magnetic Resonance Imaging|Diffusion Tensor MRI|Diffusion Tensor MRIs|MRI, Diffusion Tensor|DTI MRI
 D056325	Neuronal Tract-Tracers	Neuronal Tract Tracers|Tract-Tracers, Neuronal|Neuroanatomical Tract-Tracing Markers|Markers, Neuroanatomical Tract-Tracing|Neuroanatomical Tract Tracing Markers|Tract-Tracing Markers, Neuroanatomical
 D056344	Executive Function	Executive Functions|Function, Executive|Functions, Executive|Executive Control|Executive Controls
 D056345	Theory of Mind	Mentalizing|Mentalizings
@@ -26673,15 +27087,15 @@ D056511	Metallochaperones	Metallochaperone
 D056524	Retinoblastoma-Binding Protein 7	Retinoblastoma Binding Protein 7|RbAp46 Protein|RBBP7 Protein|Retinoblastoma-Associated Protein 46|Retinoblastoma Associated Protein 46
 D056545	Group III Histone Deacetylases	NAD-Dependent Histone Deacetylases|Deacetylases, NAD-Dependent Histone|Histone Deacetylases, NAD-Dependent|NAD Dependent Histone Deacetylases|Sir2-like Deacetylases|Deacetylases, Sir2-like|Sir2 like Deacetylases
 D056546	Lactobacillales	Lactic Acid Bacteria
-D056547	CA1 Region, Hippocampal	Hippocampal CA1 Region|Region, Hippocampal CA1|Cornu Ammonis 1 Area|Hippocampus CA1 Field|CA1 Field, Hippocampus|Field, Hippocampus CA1|Regio Superior of Hippocampus|Hippocampus Regio Superior|CA1 Field of Hippocampus|Hippocampal Sector CA1|CA1, Hippocampal Sector|Sector CA1, Hippocampal
-D056564	Sirtuin 1	Silent Mating Type Information Regulation 2 Homolog 1
-D056565	Sirtuin 2	Silent Mating Type Information Regulation 2 Homolog 2
-D056566	Sirtuin 3	Silent Mating Type Information Regulation 2 Homolog 3
+D056547	CA1 Region, Hippocampal	Hippocampal CA1 Region|Region, Hippocampal CA1|Regio Superior of Hippocampus|Hippocampus Regio Superior|CA1 Field of Hippocampus|Hippocampus CA1 Field|CA1 Field, Hippocampus|Field, Hippocampus CA1|Cornu Ammonis 1 Area|Hippocampal Sector CA1|CA1, Hippocampal Sector|Sector CA1, Hippocampal
+D056564	Sirtuin 1	Sirt1|Silent Mating Type Information Regulation 2 Homolog 1
+D056565	Sirtuin 2	Silent Mating Type Information Regulation 2 Homolog 2|Sirt2
+D056566	Sirtuin 3	Silent Mating Type Information Regulation 2 Homolog 3|Sirt3
 D056567	Aerococcaceae	
 D056568	Carnobacteriaceae	
 D056569	Enterococcaceae	
 D056570	Aerococcus	
-D056571	Postcards	
+D056571	Postcard	Postcards
 D056572	Histone Deacetylase Inhibitors	Deacetylase Inhibitors, Histone|Inhibitors, Histone Deacetylase|Histone Deacetylase Inhibitor|Deacetylase Inhibitor, Histone|Inhibitor, Histone Deacetylase|HDAC Inhibitors|Inhibitors, HDAC
 D056573	Carnobacterium	
 D056584	Leuconostocaceae	
@@ -26701,9 +27115,9 @@ D056647	Systemic Vasculitis	Systemic Vasculitides|Vasculitides, Systemic|Vasculi
 D056648	Anti-Neutrophil Cytoplasmic Antibody-Associated Vasculitis	Anti Neutrophil Cytoplasmic Antibody Associated Vasculitis|ANCA-Associated Vasculitis|ANCA Associated Vasculitis|Vasculitis, ANCA-Associated|Pauci-Immune Vasculitis|Pauci Immune Vasculitis|Pauci-Immune Vasculitides|Vasculitides, Pauci-Immune|Vasculitis, Pauci-Immune|ANCA-Associated Vasculitides|ANCA Associated Vasculitides|ANCA-Associated Vasculitide|Vasculitide, ANCA-Associated|Vasculitides, ANCA-Associated
 D056649	Cathepsin G	
 D056650	Vulvodynia	Vulvodynias
-D056651	CA2 Region, Hippocampal	Hippocampal CA2 Region|Region, Hippocampal CA2|Cornu Ammonis 2 Area|Hippocampus CA2 Field|CA2 Field, Hippocampus|Field, Hippocampus CA2|CA2 Field of Hippocampus|Hippocampal Sector CA2|Sector CA2, Hippocampal
+D056651	CA2 Region, Hippocampal	Hippocampal CA2 Region|Region, Hippocampal CA2|Hippocampus CA2 Field|CA2 Field, Hippocampus|Field, Hippocampus CA2|Hippocampal Sector CA2|Sector CA2, Hippocampal|CA2 Field of Hippocampus|Cornu Ammonis 2 Area
 D056653	Rheumatoid Vasculitis	Rheumatoid Vasculitides|Vasculitides, Rheumatoid|Vasculitis, Rheumatoid
-D056654	CA3 Region, Hippocampal	Hippocampal CA3 Region|Hippocampal CA3 Regions|Region, Hippocampal CA3|Regio Inferior of Hippocampus|Hippocampal Sector CA3|CA3, Hippocampal Sector|Sector CA3, Hippocampal|Hippocampus CA3 Field|CA3 Field, Hippocampus|Field, Hippocampus CA3|CA3 Field of Hippocampus|Cornu Ammonis 3 Area
+D056654	CA3 Region, Hippocampal	Hippocampal CA3 Region|Hippocampal CA3 Regions|Region, Hippocampal CA3|Regio Inferior of Hippocampus|Cornu Ammonis 3 Area|Hippocampus CA3 Field|CA3 Field, Hippocampus|Field, Hippocampus CA3|CA3 Field of Hippocampus|Hippocampal Sector CA3|CA3, Hippocampal Sector|Sector CA3, Hippocampal
 D056655	Cathepsin H	
 D056656	Lab-On-A-Chip Devices	Device, Lab-On-A-Chip|Devices, Lab-On-A-Chip|Lab On A Chip Devices|Lab-On-A-Chip Device
 D056657	Cathepsin K	
@@ -26720,7 +27134,7 @@ D056669	Galactogogues	Galactagogues
 D056684	Yellow Nail Syndrome	Nail Syndrome, Yellow|Nail Syndromes, Yellow|Syndrome, Yellow Nail|Syndromes, Yellow Nail|Yellow Nail Syndromes|Lymphedema And Yellow Nails
 D056685	Costello Syndrome	Syndrome, Costello|Faciocutaneoskeletal Syndrome|Faciocutaneoskeletal Syndromes|Syndrome, Faciocutaneoskeletal|Syndromes, Faciocutaneoskeletal|FCS Syndrome|FCS Syndromes|Syndrome, FCS|Syndromes, FCS
 D056686	Mimiviridae	
-D056687	Off-Label Use	Off Label Use|Off-Label Uses|Use, Off-Label|Uses, Off-Label|Off-Label Prescribing|Off Label Prescribing|Off-Label Prescribings|Prescribing, Off-Label|Prescribings, Off-Label|Unlabeled Indication|Indication, Unlabeled|Indications, Unlabeled|Unlabeled Indications
+D056687	Off-Label Use	Off Label Use|Off-Label Uses|Off-Label Prescribing|Off Label Prescribing|Off-Label Prescribings|Prescribing, Off-Label|Unlabeled Indication|Indication, Unlabeled|Unlabeled Indications
 D056689	Uropathogenic Escherichia coli	Uropathogenic E. coli
 D056690	Prolactin-Releasing Hormone	Prolactin Releasing Hormone|Prolactin-Releasing Peptide|Prolactin Releasing Peptide
 D056692	Prebiotics	Prebiotic
@@ -26769,7 +27183,7 @@ D056805	Consciousness Monitors	Consciousness Monitor|Monitor, Consciousness|Moni
 D056806	Urea Cycle Disorders, Inborn	Urea Cycle Disorders|Disorder, Urea Cycle|Disorders, Urea Cycle|Urea Cycle Disorder|Inborn Urea Cycle Disorder
 D056807	Argininosuccinic Aciduria	Aciduria, Argininosuccinic|Acidurias, Argininosuccinic|Argininosuccinic Acidurias|Argininosuccinase Deficiency|Argininosuccinate Acidemia|Acidemia, Argininosuccinate|Acidemias, Argininosuccinate|Argininosuccinate Acidemias|Argininosuccinate Lyase Deficiency|Argininosuccinate Lyase Deficiencies|Deficiencies, Argininosuccinate Lyase|Deficiency, Argininosuccinate Lyase|Argininosuccinic Acid Lyase Deficiency|Argininosuccinicaciduria|Argininosuccinicacidurias|ASA Deficiency|ASA Deficiencies|Deficiencies, ASA|Deficiency, ASA|ASL Deficiency|ASL Deficiencies|Deficiencies, ASL|Deficiency, ASL|Inborn Error of Urea Synthesis, Arginino Succinic Type|Urea Cycle Disorder, Arginino Succinase Type|Argininosuccinic Acidemia|Argininosuccinyl-Coa Lyase Deficiency|Arginosuccinase Deficiency|Asauria|Arginino Succinase Deficiency|Arginino Succinase Deficiencies|Deficiencies, Arginino Succinase|Deficiency, Arginino Succinase
 D056808	Biostatistics	Biological Statistics|Biological Statistic|Statistic, Biological|Statistics, Biological
-D056809	Alveolar Epithelial Cells	Alveolar Epithelial Cell|Cell, Alveolar Epithelial|Cells, Alveolar Epithelial|Epithelial Cell, Alveolar|Epithelial Cells, Alveolar|Pneumocyte|Alveolar Cells|Alveolar Cell|Cell, Alveolar|Cells, Alveolar|Pneumocytes
+D056809	Alveolar Epithelial Cells	Alveolar Epithelial Cell|Cell, Alveolar Epithelial|Cells, Alveolar Epithelial|Epithelial Cell, Alveolar|Epithelial Cells, Alveolar|Pneumocytes|Pneumocyte|Alveolar Cells|Alveolar Cell|Cell, Alveolar|Cells, Alveolar
 D056810	Acaricides	Miticide|Mite Control Agent|Agent, Mite Control|Control Agent, Mite
 D056811	Unfolded Protein Response	Protein Response, Unfolded|Protein Responses, Unfolded|Response, Unfolded Protein|Responses, Unfolded Protein|Unfolded Protein Responses
 D056824	Upper Extremity Deep Vein Thrombosis	
@@ -26825,7 +27239,7 @@ D056925	Circadian Rhythm Signaling Peptides and Proteins	Circadian Clock Protein
 D056926	CLOCK Proteins	Circadian Locomotor Output Cycles Kaput Proteins|CLOCK Protein
 D056928	X-Ray Absorption Spectroscopy	Absorption Spectroscopy, X-Ray|Spectroscopy, X-Ray Absorption|X Ray Absorption Spectroscopy
 D056929	Liddle Syndrome	Syndrome, Liddle|Pseudoaldosteronism
-D056930	ARNTL Transcription Factors	Transcription Factors, ARNTL|Brain and Muscle ARNT-like Proteins|Brain and Muscle ARNT like Proteins|Aryl Hydrocarbon Receptor Nuclear Translocator-like Transcription Factors|Aryl Hydrocarbon Receptor Nuclear Translocator like Transcription Factors
+D056930	ARNTL Transcription Factors	Transcription Factors, ARNTL|Aryl Hydrocarbon Receptor Nuclear Translocator-like Transcription Factors|Aryl Hydrocarbon Receptor Nuclear Translocator like Transcription Factors|Brain and Muscle ARNT-like Proteins|Brain and Muscle ARNT like Proteins
 D056931	Cryptochromes	Cryptochrome|Cryptochrome Proteins
 D056945	Hep G2 Cells	Cell, Hep G2|Cells, Hep G2|Hep G2 Cell|HepG2 Cells|Cell, HepG2|Cells, HepG2|HepG2 Cell|Hep G2 Cell Line|Hepatoblastoma G2 Cell Line|Cell Line, Hep G2|Cell Line, Hepatoblastoma G2
 D056947	Enzyme Replacement Therapy	Enzyme Replacement Therapies|Replacement Therapies, Enzyme|Replacement Therapy, Enzyme|Therapies, Enzyme Replacement|Therapy, Enzyme Replacement
@@ -26834,7 +27248,7 @@ D056949	Phototropins	Phototropin
 D056950	Period Circadian Proteins	Circadian Clock Protein Period|Period Proteins
 D056951	Photoelectron Spectroscopy	Spectroscopy, Photoelectron|Photoelectron Emission Spectroscopy|Emission Spectroscopies, Photoelectron|Emission Spectroscopy, Photoelectron|Spectroscopy, Photoelectron Emission|Photoemission Spectroscopy|Spectroscopy, Photoemission
 D056952	Hypermastigia	Hypermastigotes|Hypermastigote
-D056953	Nuclear Receptor Subfamily 1, Group D, Member 1	Rev-erb-alpha Nuclear Receptors|Nuclear Receptors, Rev-erb-alpha|Rev erb alpha Nuclear Receptors|V-erbA-Related Protein EAR-1|V erbA Related Protein EAR 1|Nuclear Receptor NR1D1|NR1D1, Nuclear Receptor|Receptor NR1D1, Nuclear
+D056953	Nuclear Receptor Subfamily 1, Group D, Member 1	V-erbA-Related Protein EAR-1|V erbA Related Protein EAR 1|Nuclear Receptor NR1D1|NR1D1, Nuclear Receptor|Receptor NR1D1, Nuclear|Rev-erb-alpha Nuclear Receptors|Nuclear Receptors, Rev-erb-alpha|Rev erb alpha Nuclear Receptors
 D056965	Injections, Intraocular	Injection, Intraocular|Intraocular Injection|Intraocular Injections|Injections, Intra-Ocular|Injection, Intra-Ocular|Injections, Intra Ocular|Intra-Ocular Injection|Intra-Ocular Injections
 D056966	Excitation Contraction Coupling	Contraction Coupling, Excitation|Contraction Couplings, Excitation|Coupling, Excitation Contraction|Couplings, Excitation Contraction|Excitation Contraction Couplings
 D056968	Lac Repressors	Repressors, Lac|LacI Proteins|Proteins, LacI|Lac Repressor|Repressor, Lac
@@ -26885,8 +27299,8 @@ D057090	Eccrine Porocarcinoma	Eccrine Porocarcinomas|Porocarcinoma, Eccrine|Poro
 D057091	Poroma	Poromas|Poromatosis|Poromatoses
 D057092	Geographic Atrophy	Atrophies, Geographic|Atrophy, Geographic|Geographic Atrophies|Dry Macular Degeneration|Degeneration, Dry Macular|Degenerations, Dry Macular|Dry Macular Degenerations|Macular Degeneration, Dry|Macular Degenerations, Dry
 D057093	Orphan Nuclear Receptors	Nuclear Receptors, Orphan|Receptors, Orphan Nuclear
-D057094	Nuclear Receptor Subfamily 1, Group F, Member 1	Retinoid-Related Orphan Receptor-alpha|Retinoid Related Orphan Receptor alpha|RAR-Related Orphan Receptor A|RAR Related Orphan Receptor A|Nuclear Receptor NR1F1|NR1F1, Nuclear Receptor|Receptor NR1F1, Nuclear|Nuclear Receptor ROR-alpha|Nuclear Receptor ROR alpha
-D057095	Nuclear Receptor Subfamily 1, Group F, Member 2	Nuclear Receptor NR1F2|Receptor NR1F2, Nuclear|RAR-related Orphan Receptor-B|Orphan Receptor-B, RAR-related|Retinoid-related Orphan Receptor-beta|Orphan Receptor-beta, Retinoid-related|Retinoid related Orphan Receptor beta|Nuclear Receptor RZR-beta|Nuclear Receptor RZR beta|Receptor RZR-beta, Nuclear|RAR-related Orphan Receptor B|RAR related Orphan Receptor B
+D057094	Nuclear Receptor Subfamily 1, Group F, Member 1	Nuclear Receptor NR1F1|NR1F1, Nuclear Receptor|Receptor NR1F1, Nuclear|Retinoid-Related Orphan Receptor-alpha|Retinoid Related Orphan Receptor alpha|Nuclear Receptor ROR-alpha|Nuclear Receptor ROR alpha|RAR-Related Orphan Receptor A|RAR Related Orphan Receptor A
+D057095	Nuclear Receptor Subfamily 1, Group F, Member 2	RAR-related Orphan Receptor B|RAR related Orphan Receptor B|Nuclear Receptor NR1F2|Receptor NR1F2, Nuclear|Nuclear Receptor RZR-beta|Nuclear Receptor RZR beta|Receptor RZR-beta, Nuclear|RAR-related Orphan Receptor-B|Orphan Receptor-B, RAR-related|Retinoid-related Orphan Receptor-beta|Orphan Receptor-beta, Retinoid-related|Retinoid related Orphan Receptor beta
 D057096	Shellfish Poisoning	Poisoning, Shellfish|Poisonings, Shellfish|Shellfish Poisonings
 D057097	Harmful Algal Bloom	Algal Bloom, Harmful|Algal Blooms, Harmful|Bloom, Harmful Algal|Blooms, Harmful Algal|Harmful Algal Blooms
 D057105	Nuclear Receptor Subfamily 4, Group A, Member 1	Nerve Growth Factor-inducible B Protein|Nerve Growth Factor inducible B Protein|Orphan Nuclear Receptor HMR|Orphan Nuclear Receptor NGFI-B|Orphan Nuclear Receptor NGFI B|Orphan Nuclear Receptor NR4A1|Nuclear Receptor NR4A1|TR3 Orphan Nuclear Receptor|Nur77 Orphan Nuclear Receptor|NGFI-B Orphan Nuclear Receptor|NGFI B Orphan Nuclear Receptor|Early Response Protein NAK1|Orphan Nuclear Receptor TR3
@@ -26937,7 +27351,7 @@ D057180	Frontotemporal Dementia	Dementias, Frontotemporal|Frontotemporal Dementi
 D057181	Pleasure	
 D057182	Mendelian Randomization Analysis	Analysis, Mendelian Randomization
 D057184	Practice Patterns, Nurses'	Nurses' Practice Patterns|Nurse's Practice Patterns|Nurse Practice Patterns|Nurse's Practice Pattern|Practice Pattern, Nurse's|Practice Patterns, Nurse's
-D057185	Sedentary Lifestyle	Lifestyle, Sedentary|Lifestyles, Sedentary|Sedentary Lifestyles
+D057185	Sedentary Behavior	Behavior, Sedentary|Sedentary Behaviors|Sedentary Lifestyle|Lifestyle, Sedentary
 D057186	Comparative Effectiveness Research	Effectiveness Research, Comparative|Research, Comparative Effectiveness
 D057187	Independent Living	Living, Independent
 D057188	Workflow	Workflows|Work Flow|Work Flows
@@ -26945,7 +27359,7 @@ D057189	Checklist	Checklists
 D057190	Stroop Test	Stroop Task
 D057191	Capacity Building	Building, Capacity
 D057192	Tsunamis	Tsunami
-D057193	Medical Tourism	Tourism, Medical
+D057193	Medical Tourism	Tourism, Medical|Health Tourism|Tourism, Health|Surgical Tourism|Tourism, Surgical
 D057194	Intention to Treat Analysis	
 D057205	Automation, Laboratory	Laboratory Automation
 D057207	Child Restraint Systems	Child Restraint System|Restraint System, Child|Restraint Systems, Child|System, Child Restraint|Systems, Child Restraint
@@ -27149,7 +27563,7 @@ D058106	Wound Closure Techniques	Closure Technique, Wound|Closure Techniques, Wo
 D058107	Abdominal Wound Closure Techniques	Abdominal Wound Closure|Abdominal Wound Closures|Closure, Abdominal Wound|Closures, Abdominal Wound|Wound Closure, Abdominal|Wound Closures, Abdominal|Abdominal Closure Techniques|Abdominal Closure Technique|Closure Technique, Abdominal|Closure Techniques, Abdominal|Technique, Abdominal Closure|Techniques, Abdominal Closure
 D058108	Glaucophyta	Glaucocystophyceae|Glaucophyceae
 D058109	Airway Management	Management, Airway|Airway Control|Control, Airway
-D058110	Counterfeit Drugs	Drugs, Counterfeit|Counterfeit Medicines|Medicines, Counterfeit|Fake Drugs|Drugs, Fake
+D058110	Counterfeit Drugs	Drugs, Counterfeit|Counterfeit Medicines|Medicines, Counterfeit
 D058112	Septins	
 D058113	Cerumenolytic Agents	Agents, Cerumenolytic|Cerumenolytic|Wax Solvent|Solvent, Wax|Cerumen Remover|Remover, Cerumen
 D058114	Desmidiales	Desmids|Desmid
@@ -27253,7 +27667,7 @@ D058457	Trichiasis	Trichiases
 D058458	Nitrogen Cycle	Cycle, Nitrogen|Cycles, Nitrogen|Nitrogen Cycles
 D058465	Nitrification	Nitrifications
 D058466	Cysteine Loop Ligand-Gated Ion Channel Receptors	Cysteine Loop Ligand Gated Ion Channel Receptors|Cys-Loop Receptor Superfamily|Cys Loop Receptor Superfamily|Receptor Superfamily, Cys-Loop|Superfamily, Cys-Loop Receptor|Cys-Loop Receptors|Cys Loop Receptors|Receptors, Cys-Loop
-D058467	Tardigrada	Tartigrades|Tartigrade|Water Bears|Bear, Water|Bears, Water|Water Bear
+D058467	Tardigrada	Water Bears|Water Bear|Tartigrades|Tartigrade
 D058468	Receptors, Ionotropic Glutamate	Glutamate Receptors, Ionotropic|Ionotropic Glutamate Receptors
 D058469	Receptors, Purinergic P2X	P2X Receptors, Purinergic|Purinergic P2X Receptors|P2X Purinoceptors|Purinoceptors, P2X|P2X Purinoceptor|Purinoceptor, P2X
 D058470	Receptors, Purinergic P2Y	P2Y Receptors, Purinergic|Purinergic P2Y Receptors|P2Y Purinoceptors|Purinoceptors, P2Y|P2Y Purinoceptor|Purinoceptor, P2Y
@@ -27269,7 +27683,7 @@ D058486	Receptors, Purinergic P2X7	P2X7 Receptors, Purinergic|Purinergic P2X7 Re
 D058487	Cercaria	
 D058488	Metacercariae	
 D058489	46, XX Disorders of Sex Development	46,XX Disorders of Sex Development|46,XX DSD|46, XX DSD
-D058490	46, XY Disorders of Sex Development	46,XY DSD|46,XY DSDs|DSD, 46,XY|DSDs, 46,XY|46,XY Disorders of Sex Development|46, XY DSD
+D058490	Disorder of Sex Development, 46,XY	46,XY Disorders of Sex Development|46,XY DSD|46,XY DSDs|DSD, 46,XY|DSDs, 46,XY|46, XY Disorders of Sex Development|46, XY DSD
 D058491	Bacterial Load	Bacterial Loads|Load, Bacterial|Loads, Bacterial
 D058492	Drug Repositioning	Repositioning, Drug|Drug Repurposing|Repurposing, Drug
 D058493	Sarcophagidae	Fleshfly|Fleshflies|Flesh Fly|Flesh Flies|Flies, Flesh|Fly, Flesh
@@ -27298,7 +27712,7 @@ D058535	Echogenic Bowel	Echogenic Bowels|Hyperechogenic Bowel|Hyperechogenic Bow
 D058536	Pyelectasis	Pyelectases|Prenatal Fetal Pyelectasis|Prenatal Fetal Pyelectases|Fetal Pyelectasis|Fetal Pyelectases|Pyelectases, Fetal|Pyelectasis, Fetal
 D058537	Electronic Supplementary Materials	Supplementary Information|Supporting Information|Supplementary Material|Electronic Supplementary Material
 D058538	Phosphatidylinositol-4-Phosphate 3-Kinase	Phosphatidylinositol 4 Phosphate 3 Kinase|1-Phosphatidylinositol-4-Phosphate 3-Kinase|1 Phosphatidylinositol 4 Phosphate 3 Kinase|3-Kinase, 1-Phosphatidylinositol-4-Phosphate
-D058539	Phosphatidylinositol 3-Kinase	Phosphatidylinositol 3 Kinase|1-Phosphatidylinositol 3-Kinase|1 Phosphatidylinositol 3 Kinase
+D058539	Phosphatidylinositol 3-Kinase	Phosphatidylinositol 3 Kinase|1-Phosphatidylinositol 3-Kinase|1 Phosphatidylinositol 3 Kinase|Phosphoinositide 3 Kinase|Kinase, Phosphoinositide 3
 D058540	Aicardi Syndrome	Syndrome, Aicardi|Corpus Callosum, Agenesis Of, With Chorioretinal Abnormality|Chorioretinal Anomalies with Acc|Agenesis of Corpus Callosum with Infantile Spasms and Ocular Abnormalities|Callosal Agenesis and Ocular Abnormalities|Aicardi's Syndrome|Syndrome, Aicardi's|Agenesis of Corpus Callosum with Chorioretinal Abnormality
 D058541	Class II Phosphatidylinositol 3-Kinases	Class II Phosphatidylinositol 3 Kinases|Phosphatidylinositol 3-Kinase, Class II|Phosphatidylinositol 3 Kinase, Class II
 D058542	Implantable Neurostimulators	Implantable Neurostimulator|Neurostimulator, Implantable|Neurostimulators, Implantable|Implanted Neurostimulators|Implanted Neurostimulator|Neurostimulator, Implanted|Neurostimulators, Implanted|Implanted Nerve Stimulation Electrodes
@@ -27311,7 +27725,7 @@ D058566	Sacroiliitis	Sacroiliitides
 D058567	Photoinitiators, Dental	Dental Photoinitiator|Dental Photoinitiators|Photoinitiator, Dental|Resin Photoinitiators, Dental|Dental Resin Photoinitiator|Dental Resin Photoinitiators|Photoinitiator, Dental Resin|Photoinitiators, Dental Resin|Resin Photoinitiator, Dental
 D058568	Necrolytic Migratory Erythema	Erythema, Necrolytic Migratory|Erythemas, Necrolytic Migratory|Migratory Erythema, Necrolytic|Migratory Erythemas, Necrolytic|Necrolytic Migratory Erythemas
 D058569	Elbow Prosthesis	Elbow Prostheses|Prostheses, Elbow|Prosthesis, Elbow
-D058570	TOR Serine-Threonine Kinases	Kinases, TOR Serine-Threonine|Serine-Threonine Kinases, TOR|TOR Serine Threonine Kinases|Target of Rapamycin Proteins|Rapamycin Proteins Target|mTOR Serine-Threonine Kinases|Kinases, mTOR Serine-Threonine|Serine-Threonine Kinases, mTOR|mTOR Serine Threonine Kinases|Mechanistic Target of Rapamycin Protein|FK506 Binding Protein 12-Rapamycin Associated Protein 1|FK506 Binding Protein 12 Rapamycin Associated Protein 1|TOR Kinases|FKBP12-Rapamycin Associated Protein|Associated Protein, FKBP12-Rapamycin|FKBP12 Rapamycin Associated Protein|Protein, FKBP12-Rapamycin Associated|FKBP12-Rapamycin Complex-Associated Protein|Complex-Associated Protein, FKBP12-Rapamycin|FKBP12 Rapamycin Complex Associated Protein|Protein, FKBP12-Rapamycin Complex-Associated|RAFT-1 Protein|Protein, RAFT-1|RAFT 1 Protein|Rapamycin Target Protein|Protein, Rapamycin Target|Target Protein, Rapamycin|mTOR Protein|Protein, mTOR
+D058570	TOR Serine-Threonine Kinases	Kinases, TOR Serine-Threonine|Serine-Threonine Kinases, TOR|TOR Serine Threonine Kinases|TOR Kinases|Target of Rapamycin Proteins|mTOR Serine-Threonine Kinases|Kinases, mTOR Serine-Threonine|Serine-Threonine Kinases, mTOR|mTOR Serine Threonine Kinases|Mechanistic Target of Rapamycin Protein|mTOR Protein|Protein, mTOR|FKBP12-Rapamycin Associated Protein|FKBP12 Rapamycin Associated Protein|FKBP12-Rapamycin Complex-Associated Protein|FKBP12 Rapamycin Complex Associated Protein|RAFT-1 Protein|Protein, RAFT-1|RAFT 1 Protein|Rapamycin Target Protein|Mammalian Target of Rapamycin|FK506 Binding Protein 12-Rapamycin Associated Protein 1|FK506 Binding Protein 12 Rapamycin Associated Protein 1
 D058571	Vacuolar Sorting Protein VPS15	Class III Phosphatidylinositol 3-Kinase, p150 Subunit|Class III Phosphatidylinositol 3 Kinase, p150 Subunit|Vps15 Protein Kinase|Protein Kinase, Vps15|Phosphoinositide-3-kinase, Regulatory Subunit 4|Phosphoinositide 3 kinase, Regulatory Subunit 4|Vacuolar Protein Sorting 15|VPS15 Protein|Class III Phosphatidylinositol 3-Kinase Regulatory Subunit|Class III Phosphatidylinositol 3 Kinase Regulatory Subunit|Phosphatidylinositol 3-Kinase, Regulatory Subunit, Polypeptide 4, p150
 D058572	Carbon Footprint	Carbon Footprints|Footprint, Carbon|Footprints, Carbon
 D058573	Performance-Enhancing Substances	Performance Enhancing Substances|Substances, Performance-Enhancing|Ergogenic Substances|Substances, Ergogenic
@@ -27348,7 +27762,7 @@ D058630	Spinal Cord Regeneration	Cord Regeneration, Spinal|Cord Regenerations, S
 D058631	Pycnodysostosis	Pycnodysostoses|Pyknodysostosis|Pyknodysostoses
 D058632	Neuroprostanes	
 D058633	Antipyretics	Antipyretic Agents|Agents, Antipyretic|Antifebrile Agents|Agents, Antifebrile
-D058634	Molecular Farming	Farming, Molecular
+D058634	Molecular Farming	Farming, Molecular|Pharming|Molecular Pharming|Pharming, Molecular
 D058635	Lipid-Linked Proteins	Lipid Linked Proteins|Lipid-Anchored Membrane Proteins|Lipid Anchored Membrane Proteins|Membrane Proteins, Lipid-Anchored|Proteins, Lipid-Anchored Membrane|Membrane Lipid-Linked Proteins|Lipid-Linked Proteins, Membrane|Membrane Lipid Linked Proteins|Proteins, Membrane Lipid-Linked|Lipid Anchored Proteins|Anchored Proteins, Lipid|Proteins, Lipid Anchored
 D058636	Surgical Drapes	Drape, Surgical|Drapes, Surgical|Surgical Drape
 D058637	Examination Tables	Examination Table|Table, Examination|Tables, Examination
@@ -27365,12 +27779,12 @@ D058647	Adrenergic alpha-2 Receptor Agonists	Adrenergic alpha 2 Receptor Agonist
 D058665	Adrenergic beta-1 Receptor Agonists	Adrenergic beta 1 Receptor Agonists|Adrenergic beta-1 Receptor Agonist|Adrenergic beta 1 Receptor Agonist|Adrenergic beta1-Agonists|Adrenergic beta1 Agonists|beta1-Agonists, Adrenergic|Adrenergic beta-1 Agonists|Adrenergic beta 1 Agonists|Agonists, Adrenergic beta-1|beta-1 Agonists, Adrenergic
 D058666	Adrenergic beta-2 Receptor Agonists	Adrenergic beta 2 Receptor Agonists|Adrenergic beta2-Agonists|Adrenergic beta2 Agonists|beta2-Agonists, Adrenergic|Adrenergic beta-2 Agonists|Adrenergic beta 2 Agonists|Agonists, Adrenergic beta-2|beta-2 Agonists, Adrenergic|Adrenergic beta-2 Receptor Agonist|Adrenergic beta 2 Receptor Agonist
 D058667	Adrenergic beta-3 Receptor Agonists	Adrenergic beta 3 Receptor Agonists|Adrenergic beta3-Agonists|Adrenergic beta3 Agonists|beta3-Agonists, Adrenergic|Adrenergic beta-3 Agonists|Adrenergic beta 3 Agonists|Agonists, Adrenergic beta-3|beta-3 Agonists, Adrenergic|Adrenergic beta-3 Receptor Agonist|Adrenergic beta 3 Receptor Agonist
-D058668	Adrenergic alpha-1 Receptor Antagonists	Adrenergic alpha 1 Receptor Antagonists|Adrenergic alpha1-Antagonists|Adrenergic alpha1 Antagonists|alpha1-Antagonists, Adrenergic|alpha-1 Adrenergic Blocking Agents|alpha 1 Adrenergic Blocking Agents|alpha1-Adrenoceptor Blocker|alpha1 Adrenoceptor Blocker|Adrenergic alpha-1 Antagonists|Adrenergic alpha 1 Antagonists|alpha-1 Antagonists, Adrenergic|Adrenergic alpha-1 Receptor Blockers|Adrenergic alpha 1 Receptor Blockers
-D058669	Adrenergic alpha-2 Receptor Antagonists	Adrenergic alpha 2 Receptor Antagonists|Adrenergic alpha-2 Receptor Blockers|Adrenergic alpha 2 Receptor Blockers|alpha-2 Adrenergic Blocking Agents|alpha 2 Adrenergic Blocking Agents|Adrenergic alpha-2 Antagonists|Adrenergic alpha 2 Antagonists|Antagonists, Adrenergic alpha-2|alpha-2 Antagonists, Adrenergic|Adrenergic alpha2-Antagonists|Adrenergic alpha2 Antagonists|alpha2-Antagonists, Adrenergic
+D058668	Adrenergic alpha-1 Receptor Antagonists	Adrenergic alpha 1 Receptor Antagonists|Adrenergic alpha-1 Antagonists|Adrenergic alpha 1 Antagonists|alpha-1 Antagonists, Adrenergic|Adrenergic alpha1-Antagonists|Adrenergic alpha1 Antagonists|alpha1-Antagonists, Adrenergic|alpha-1 Adrenergic Blocking Agents|alpha 1 Adrenergic Blocking Agents|alpha1-Adrenoceptor Blocker|alpha1 Adrenoceptor Blocker|alpha1-Adrenergic Antagonists|Antagonists, alpha1-Adrenergic|alpha1 Adrenergic Antagonists|Adrenergic alpha-1 Receptor Blockers|Adrenergic alpha 1 Receptor Blockers
+D058669	Adrenergic alpha-2 Receptor Antagonists	Adrenergic alpha 2 Receptor Antagonists|alpha-2 Adrenergic Blocking Agents|alpha 2 Adrenergic Blocking Agents|Adrenergic alpha-2 Receptor Blockers|Adrenergic alpha 2 Receptor Blockers|Adrenergic alpha2-Antagonists|Adrenergic alpha2 Antagonists|alpha2-Antagonists, Adrenergic|alpha2-Adrenergic Antagonists|Antagonists, alpha2-Adrenergic|alpha2 Adrenergic Antagonists|Adrenergic alpha-2 Antagonists|Adrenergic alpha 2 Antagonists|Antagonists, Adrenergic alpha-2|alpha-2 Antagonists, Adrenergic
 D058670	Tetrasomy	Tetrasomies
-D058671	Adrenergic beta-1 Receptor Antagonists	Adrenergic beta 1 Receptor Antagonists|Adrenergic beta1-Antagonists|Adrenergic beta1 Antagonists|beta1-Antagonists, Adrenergic|beta-1 Adrenergic Blocking Agents|beta 1 Adrenergic Blocking Agents|Adrenergic beta-1 Antagonists|Adrenergic beta 1 Antagonists|Antagonists, Adrenergic beta-1|beta-1 Antagonists, Adrenergic|Adrenergic beta-1 Receptor Blockers|Adrenergic beta 1 Receptor Blockers
-D058672	Adrenergic beta-2 Receptor Antagonists	Adrenergic beta 2 Receptor Antagonists|Adrenergic beta2-Antagonists|Adrenergic beta2 Antagonists|beta2-Antagonists, Adrenergic|beta-2 Adrenergic Blocking Agents|beta 2 Adrenergic Blocking Agents|Adrenergic beta-2 Antagonists|Adrenergic beta 2 Antagonists|Antagonists, Adrenergic beta-2|beta-2 Antagonists, Adrenergic|Adrenergic beta-2 Receptor Blockers|Adrenergic beta 2 Receptor Blockers
-D058673	Adrenergic beta-3 Receptor Antagonists	Adrenergic beta 3 Receptor Antagonists|beta-3 Adrenergic Blocking Agents|beta 3 Adrenergic Blocking Agents|Adrenergic beta-3 Antagonists|Adrenergic beta 3 Antagonists|Antagonists, Adrenergic beta-3|beta-3 Antagonists, Adrenergic|Adrenergic beta-3 Receptor Blockers|Adrenergic beta 3 Receptor Blockers
+D058671	Adrenergic beta-1 Receptor Antagonists	Adrenergic beta 1 Receptor Antagonists|Adrenergic beta1-Antagonists|Adrenergic beta1 Antagonists|beta1-Antagonists, Adrenergic|Adrenergic beta-1 Receptor Blockers|Adrenergic beta 1 Receptor Blockers|beta-1 Adrenergic Blocking Agents|beta 1 Adrenergic Blocking Agents|beta1-Adrenergic Antagonists|Antagonists, beta1-Adrenergic|beta1 Adrenergic Antagonists|Adrenergic beta-1 Antagonists|Adrenergic beta 1 Antagonists|Antagonists, Adrenergic beta-1|beta-1 Antagonists, Adrenergic
+D058672	Adrenergic beta-2 Receptor Antagonists	Adrenergic beta 2 Receptor Antagonists|Adrenergic beta2-Antagonists|Adrenergic beta2 Antagonists|beta2-Antagonists, Adrenergic|Adrenergic beta-2 Receptor Blockers|Adrenergic beta 2 Receptor Blockers|beta-2 Adrenergic Blocking Agents|beta 2 Adrenergic Blocking Agents|beta2-Adrenergic Antagonists|Antagonists, beta2-Adrenergic|beta2 Adrenergic Antagonists|Adrenergic beta-2 Antagonists|Adrenergic beta 2 Antagonists|Antagonists, Adrenergic beta-2|beta-2 Antagonists, Adrenergic
+D058673	Adrenergic beta-3 Receptor Antagonists	Adrenergic beta 3 Receptor Antagonists|beta-3 Adrenergic Blocking Agents|beta 3 Adrenergic Blocking Agents|Adrenergic beta-3 Receptor Blockers|Adrenergic beta 3 Receptor Blockers|beta3-Adrenergic Antagonists|Antagonists, beta3-Adrenergic|beta3 Adrenergic Antagonists|Adrenergic beta-3 Antagonists|Adrenergic beta 3 Antagonists|Antagonists, Adrenergic beta-3|beta-3 Antagonists, Adrenergic
 D058674	Chromosome Duplication	Chromosome Duplications|Duplications, Chromosome|Chromosomal Duplication|Chromosomal Duplications|Duplications, Chromosomal|Duplication, Chromosomal|Duplication, Chromosome
 D058675	Brevibacillus	
 D058676	Pasteuria	
@@ -27396,7 +27810,7 @@ D058738	Uterine Balloon Tamponade	Balloon Tamponade, Uterine|Balloon Tamponades,
 D058739	Aberrant Crypt Foci	Crypt Foci, Aberrant|Foci, Aberrant Crypt
 D058745	Iliotibial Band Syndrome	Syndrome, Iliotibial Band
 D058746	Gestational Sac	Gestational Sacs|Sac, Gestational|Sacs, Gestational|Gestation Sac|Gestation Sacs|Sac, Gestation|Sacs, Gestation
-D058747	CHARGE Syndrome	CHARGE Syndromes|Syndrome, CHARGE|CHARGE Association--Coloboma, Heart Anomaly, Choanal Atresia, Retardation, Genital and Ear Anomalies|CHARGE Association|Association, CHARGE|Associations, CHARGE|CHARGE Associations|Hall-Hittner Syndrome|Hall Hittner Syndrome|Syndrome, Hall-Hittner
+D058747	CHARGE Syndrome	CHARGE Syndromes|Syndrome, CHARGE|Hall-Hittner Syndrome|Hall Hittner Syndrome|Syndrome, Hall-Hittner|CHARGE Association--Coloboma, Heart Anomaly, Choanal Atresia, Retardation, Genital and Ear Anomalies|CHARGE Association|Association, CHARGE|Associations, CHARGE|CHARGE Associations
 D058748	Pain Perception	Pain Perceptions|Perception, Pain|Perceptions, Pain
 D058749	Military Facilities	Facilities, Military|Facility, Military|Military Facility
 D058750	Epithelial-Mesenchymal Transition	Epithelial Mesenchymal Transition|Epithelial-Mesenchymal Transitions|Transition, Epithelial-Mesenchymal|Transitions, Epithelial-Mesenchymal|Epithelial-Mesenchymal Transformation|Epithelial Mesenchymal Transformation|Epithelial-Mesenchymal Transformations|Transformation, Epithelial-Mesenchymal|Transformations, Epithelial-Mesenchymal
@@ -27428,7 +27842,7 @@ D058846	Antibodies, Monoclonal, Murine-Derived	Murine-Derived Monoclonal Antibod
 D058847	Inflammasomes	Pyroptosomes|Inflammasome|Pyroptosome
 D058848	Receptors, Purinergic P2X4	P2X4 Receptors, Purinergic|Purinergic P2X4 Receptors|Purinergic Receptor P2X, Ligand-Gated Ion Channel, 4|P2X4 Purinoceptor|Purinoceptor, P2X4|P2X4 Receptor|Receptor, P2X4
 D058849	Protein Refolding	Refolding, Protein
-D058850	Opiate Substitution Treatment	Opiate Substitution Treatments|Substitution Treatment, Opiate|Substitution Treatments, Opiate|Treatment, Opiate Substitution|Treatments, Opiate Substitution|Opioid Substitution Treatment|Opioid Substitution Treatments|Substitution Treatment, Opioid|Substitution Treatments, Opioid|Treatment, Opioid Substitution|Treatments, Opioid Substitution|Opioid Substitution Therapy|Opioid Substitution Therapies|Substitution Therapies, Opioid|Substitution Therapy, Opioid|Therapies, Opioid Substitution|Therapy, Opioid Substitution|Opiate Replacement Therapy|Opiate Replacement Therapies|Replacement Therapies, Opiate|Replacement Therapy, Opiate|Therapies, Opiate Replacement|Therapy, Opiate Replacement|Opioid Replacement Therapy|Opioid Replacement Therapies|Replacement Therapies, Opioid|Replacement Therapy, Opioid|Therapies, Opioid Replacement|Therapy, Opioid Replacement
+D058850	Opiate Substitution Treatment	Opiate Substitution Treatments|Substitution Treatment, Opiate|Opioid Substitution Treatment|Opioid Substitution Treatments|Substitution Treatment, Opioid|Opioid Substitution Therapy|Opioid Substitution Therapies|Substitution Therapy, Opioid|Therapy, Opioid Substitution|Opiate Replacement Therapy|Opiate Replacement Therapies|Replacement Therapy, Opiate|Opioid Replacement Therapy|Opioid Replacement Therapies|Replacement Therapy, Opioid
 D058851	GPI-Linked Proteins	GPI Linked Proteins|Proteins, GPI-Linked|GPI-Linked Membrane Proteins|GPI Linked Membrane Proteins|Membrane Proteins, GPI-Linked|Proteins, GPI-Linked Membrane|Glycosylphosphatidylinositol Linked Proteins|Linked Proteins, Glycosylphosphatidylinositol|Proteins, Glycosylphosphatidylinositol Linked
 D058865	Introduced Species	Species, Introduced
 D058866	Osteoporotic Fractures	Fracture, Osteoporotic|Fractures, Osteoporotic|Osteoporotic Fracture
@@ -27506,8 +27920,8 @@ D058985	Side-Population Cells	Cell, Side-Population|Cells, Side-Population|Side 
 D058986	Phosphodiesterase 5 Inhibitors	Inhibitors, Phosphodiesterase 5|Phosphodiesterase Type 5 Inhibitors|PDE-5 Inhibitors|Inhibitors, PDE-5|PDE 5 Inhibitors|PDE5 Inhibitors|Inhibitors, PDE5
 D058987	Phosphodiesterase 3 Inhibitors	Inhibitors, Phosphodiesterase 3|Phosphodiesterase Type 3 Inhibitors|PDE-3 Inhibitors|Inhibitors, PDE-3|PDE 3 Inhibitors|PDE3 Inhibitors|Inhibitors, PDE3
 D058988	Phosphodiesterase 4 Inhibitors	Inhibitors, Phosphodiesterase 4|PDE4 Inhibitors|Inhibitors, PDE4|Phosphodiesterase Type 4 Inhibitors|PDE-4 Inhibitors|Inhibitors, PDE-4|PDE 4 Inhibitors
-D058989	Vitrification	
-D058990	Molecular Targeted Therapy	Molecular Targeted Therapies|Targeted Therapies, Molecular|Targeted Therapy, Molecular|Therapies, Molecular Targeted|Therapy, Molecular Targeted|Targeted Molecular Therapy|Molecular Therapies, Targeted|Molecular Therapy, Targeted|Targeted Molecular Therapies|Therapies, Targeted Molecular|Therapy, Targeted Molecular
+D058989	Vitrification	Glass-Liquid Transition|Glass Liquid Transition|Transition, Glass-Liquid|Liquid-Glass Transition|Liquid Glass Transition|Transition, Liquid-Glass|Glass Transition|Transition, Glass
+D058990	Molecular Targeted Therapy	Molecular Targeted Therapies|Targeted Therapy, Molecular|Therapy, Molecular Targeted|Targeted Molecular Therapy|Molecular Therapy, Targeted|Targeted Molecular Therapies|Therapy, Targeted Molecular
 D058991	Patient Protection and Affordable Care Act	Health Care Reform Act|Obamacare|Public Law 111-148|Public Law 111 148|Affordable Care Act (ACA)|Acts, Affordable Care (ACA)|Care Act, Affordable (ACA)|Affordable Care Act|Act, Affordable Care|Acts, Affordable Care|Affordable Care Acts|Care Act, Affordable|Care Acts, Affordable|PL 111-148|111-148, PL|PL 111 148|PL111-148|PL111 148
 D058992	Social Participation	Participation, Social
 D058993	Oral Sprays	Sprays, Oral
@@ -27548,7 +27962,7 @@ D059032	Learning Curve	Curve, Learning|Learning Curves
 D059033	For-Profit Insurance Plans	For Profit Insurance Plans|For-Profit Insurance Plan|Insurance Plan, For-Profit|Insurance Plans, For-Profit|Plans, For-Profit Insurance
 D059034	Not-For-Profit Insurance Plans	Insurance Plan, Not-For-Profit|Insurance Plans, Not-For-Profit|Not For Profit Insurance Plans|Not-For-Profit Insurance Plan|Plan, Not-For-Profit Insurance|Plans, Not-For-Profit Insurance
 D059035	Perioperative Period	Period, Perioperative|Periods, Perioperative|Perioperative Periods
-D059036	Photographs	
+D059036	Photograph	Photographs
 D059037	Doulas	Doula
 D059038	Black Sea	
 D059039	Standard of Care	Care Standard|Care Standards|Standards of Care
@@ -27641,7 +28055,7 @@ D059425	Interferon-gamma Release Tests	Interferon gamma Release Tests|Interferon
 D059445	Anhedonia	Anhedonias
 D059446	Heterotaxy Syndrome	Heterotaxy Syndromes|Syndrome, Heterotaxy|Syndromes, Heterotaxy
 D059447	Cell Cycle Checkpoints	Cell Cycle Checkpoint|Checkpoint, Cell Cycle|Checkpoints, Cell Cycle
-D059451	Biosimilar Pharmaceuticals	Pharmaceuticals, Biosimilar
+D059451	Biosimilar Pharmaceuticals	Pharmaceuticals, Biosimilar|Follow-on Biologics|Biologics, Follow-on|Follow on Biologics|Subsequent Entry Biologics|Biologics, Subsequent Entry
 D059466	White Coat Hypertension	Hypertension, White Coat|Isolated Clinic Hypertension|Clinic Hypertension, Isolated|Hypertension, Isolated Clinic|White Coat Syndrome|Syndrome, White Coat
 D059467	Transcriptome	Transcriptomes
 D059468	Masked Hypertension	Hypertension, Masked|Hypertensions, Masked|Masked Hypertensions
@@ -27674,13 +28088,12 @@ D059611	Balamuthia mandrillaris
 D059625	Liquid-Liquid Extraction	Extraction, Liquid-Liquid|Extractions, Liquid-Liquid|Liquid Liquid Extraction|Liquid-Liquid Extractions|Liquid Phase Extraction|Extraction, Liquid Phase|Extractions, Liquid Phase|Liquid Phase Extractions|Phase Extraction, Liquid|Phase Extractions, Liquid
 D059627	Liquid Phase Microextraction	Liquid Phase Microextractions|Microextraction, Liquid Phase|Microextractions, Liquid Phase|Phase Microextraction, Liquid|Phase Microextractions, Liquid|Micro Liquid Phase Extraction|Micro Liquid-Liquid Extraction|Extraction, Micro Liquid-Liquid|Extractions, Micro Liquid-Liquid|Liquid-Liquid Extraction, Micro|Liquid-Liquid Extractions, Micro|Micro Liquid Liquid Extraction|Micro Liquid-Liquid Extractions|Liquid-Liquid Microextraction|Liquid Liquid Microextraction|Liquid-Liquid Microextractions|Microextraction, Liquid-Liquid|Microextractions, Liquid-Liquid
 D059629	Signal-To-Noise Ratio	Ratio, Signal-To-Noise|Ratios, Signal-To-Noise|Signal To Noise Ratio|Signal-To-Noise Ratios
-D059630	Mesenchymal Stromal Cells	Cell, Mesenchymal Stromal|Cells, Mesenchymal Stromal|Mesenchymal Stromal Cell|Stromal Cell, Mesenchymal|Stromal Cells, Mesenchymal
+D059630	Mesenchymal Stem Cells	Stem Cell, Mesenchymal|Stem Cells, Mesenchymal|Mesenchymal Stem Cell
 D059631	Wharton Jelly	Jelly, Wharton|Wharton's Jelly|Jelly, Wharton's|Whartons Jelly
 D059645	Mutation Rate	Mutation Rates|Rate, Mutation|Rates, Mutation|Mutation Frequency|Frequencies, Mutation|Frequency, Mutation|Mutation Frequencies
 D059646	Genome Size	Genome Sizes|Size, Genome|Sizes, Genome
 D059647	Gene-Environment Interaction	Gene Environment Interaction|Gene-Environment Interactions|Interaction, Gene-Environment|Interactions, Gene-Environment|Environment-Gene Interaction|Environment Gene Interaction|Environment-Gene Interactions|Interaction, Environment-Gene|Interactions, Environment-Gene
 D059648	Kisspeptins	Metastins
-D059665	Immunochromatography	
 D059666	Lysosomal-Associated Membrane Protein 3	Lysosomal Associated Membrane Protein 3|LAMP-3 Protein|LAMP 3 Protein|Antigens, CD208|DC-LAMP Protein|DC LAMP Protein|CD208 Antigens
 D059685	Herniorrhaphy	Herniorrhaphies|Hernia Repair|Hernia Repairs|Repair, Hernia|Repairs, Hernia|Hernioplasty|Hernioplasties
 D059705	Polar Bodies	Bodies, Polar|Body, Polar|Polar Body|Polar Cells|Cell, Polar|Cells, Polar|Polar Cell
@@ -27774,14 +28187,14 @@ D060169	Uroplakin Ib	Uroplakin 1b
 D060170	Uroplakin II	Uroplakin 2
 D060171	Uroplakin III	
 D060172	Morpholinos	Morpholino Oligonucleotides|Oligonucleotides, Morpholino|Phosphorodiamidate Morpholino Oligomers|Morpholino Oligomers, Phosphorodiamidate|Oligomers, Phosphorodiamidate Morpholino|PMO Oligomers|Oligomers, PMO|Morpholino Oligos|Oligos, Morpholino|MORF Oligomers|Oligomers, MORF
-D060185	Tetraspanin 24	Antigen CD151|CD151, Antigen|CD151 Antigen|Antigen, CD151|Antigens, CD151|CD151 Antigens
+D060185	Tetraspanin 24	Antigen CD151|CD151, Antigen|Antigens, CD151|CD151 Antigens|CD151 Antigen|Antigen, CD151
 D060186	Infusions, Spinal	Infusion, Spinal|Spinal Infusion|Spinal Infusions
 D060205	Therapeutic Occlusion	Occlusion, Therapeutic|Occlusions, Therapeutic|Therapeutic Occlusions
-D060225	Tetraspanin 28	TAPA-1 Antigen|Antigen, TAPA-1|TAPA 1 Antigen|CD81 Antigen|Antigen, CD81|Antigens, CD81|CD81 Antigens
+D060225	Tetraspanin 28	TAPA-1 Antigen|Antigen, TAPA-1|TAPA 1 Antigen|Antigens, CD81|CD81 Antigens|CD81 Antigen|Antigen, CD81
 D060226	Head Kidney	Head Kidneys|Kidney, Head|Kidneys, Head|Anterior Kidney|Anterior Kidneys|Kidney, Anterior|Kidneys, Anterior
 D060227	Imaginal Discs	Disc, Imaginal|Discs, Imaginal|Imaginal Disc|Imaginal Disks|Disk, Imaginal|Disks, Imaginal|Imaginal Disk
-D060245	Tetraspanin-29	Tetraspanin 29|Antigens, CD9|CD9 Antigens|27 kDa Diphtheria Toxin Receptor-Associated Protein|27 kDa Diphtheria Toxin Receptor Associated Protein|Leukemia-Associated Cell Surface Antigen p24|Leukemia Associated Cell Surface Antigen p24|Motility-Related Protein-1|Motility Related Protein 1|p24-CD9 Antigen|p24 CD9 Antigen|CD9 Antigen|Antigen, CD9|DRAP27 Protein
-D060265	Tetraspanin-25	Tetraspanin 25|Antigens, CD53|CD53 Antigens|CD53 Antigen|Antigen, CD53
+D060245	Tetraspanin 29	CD9 Antigen|Antigen, CD9|Antigens, CD9|CD9 Antigens|Leukemia-Associated Cell Surface Antigen p24|Leukemia Associated Cell Surface Antigen p24|DRAP27 Protein|Motility-Related Protein-1|Motility Related Protein 1|p24-CD9 Antigen|p24 CD9 Antigen|Tetraspanin-29|27 kDa Diphtheria Toxin Receptor-Associated Protein|27 kDa Diphtheria Toxin Receptor Associated Protein
+D060265	Tetraspanin 25	Antigens, CD53|CD53 Antigens|CD53 Antigen|Antigen, CD53|Tetraspanin-25
 D060285	Receptors, Autocrine Motility Factor	Tumor Autocrine Motility Factor Receptor|Receptor, Tumor Autocrine Motility Factor|Autocrine Motility Factor Receptor|AMF Receptor|Receptor, AMF
 D060305	Transition to Adult Care	Transfer from Pediatric to Adult Care|Pediatric Transition To Adult Care|Transferring to Adult Care|Transfer to Adult Care
 D060306	Magnetometry	
@@ -27844,12 +28257,12 @@ D060645	Scopulariopsis	Scopulariopses
 D060666	Airway Extubation	Airway Extubations|Extubation, Airway|Extubations, Airway
 D060685	Sense of Coherence	Coherence Sense|Salutogenesis|Salutogeneses
 D060705	Dyscalculia	Dyscalculias|Acalculia|Acalculias
-D060725	Uterine Retroversion	Retroversion, Uterine|Retroversions, Uterine|Uterine Retroversions|Tipped Uterus|Uterus, Tipped|Retroverted Uterus|Uterus, Retroverted
+D060725	Uterine Retroversion	Retroversion, Uterine|Retroversions, Uterine|Uterine Retroversions|Retroverted Uterus|Uterus, Retroverted|Tipped Uterus|Uterus, Tipped
 D060726	Torso	Torsos
 D060728	Reproductive Health	Health, Reproductive
 D060729	Coal Ash	Ash, Coal
 D060730	Glomerular Filtration Barrier	Barrier, Glomerular Filtration|Barriers, Glomerular Filtration|Filtration Barrier, Glomerular|Filtration Barriers, Glomerular|Glomerular Filtration Barriers
-D060731	Emergency Responders	Emergency Responder|Responder, Emergency|Responders, Emergency|Emergency First Responders|Emergency First Responder|First Responder, Emergency|First Responders, Emergency
+D060731	Emergency Responders	Emergency Responder|Responder, Emergency|Responders, Emergency|Emergency First Responders|Emergency First Responder|First Responder, Emergency|First Responders, Emergency|First Responders|First Responder|Responder, First|Responders, First
 D060733	Electromagnetic Radiation	Electromagnetic Waves|Electromagnetic Wave|Wave, Electromagnetic|Waves, Electromagnetic|Electromagnetic Energy|Electromagnetic Energies|Energies, Electromagnetic|Energy, Electromagnetic|Radiation, Electromagnetic
 D060734	Nacre	Mother of Pearl
 D060735	Pharmacovigilance	Pharmacovigilances
@@ -27931,7 +28344,7 @@ D061089	Radiotherapy, Image-Guided	Image-Guided Radiotherapies|Image-Guided Radi
 D061105	Peroxiredoxin III	Thioredoxin-Dependent Peroxide Reductase, Mitochondrial|Thioredoxin Dependent Peroxide Reductase, Mitochondrial|PRDX3 Peroxidase|Mitochondrial Thioredoxin-Dependent Antioxidant Protein SP-22|Mitochondrial Thioredoxin Dependent Antioxidant Protein SP 22|Peroxiredoxin 3
 D061106	Radiotherapy Setup Errors	Error, Radiotherapy Setup|Errors, Radiotherapy Setup|Radiotherapy Setup Error|Setup Error, Radiotherapy|Setup Errors, Radiotherapy
 D061107	Nucleoside Diphosphate Kinase D	Nucleoside Diphosphate Kinase, Mitochondrial|NM23-M4 Nucleoside Diphosphate Kinase|NM23 M4 Nucleoside Diphosphate Kinase
-D061108	Social Media	Media, Social|Social Medium|Mediums, Social|Social Mediums
+D061108	Social Media	Media, Social|Social Medium
 D061125	Genes, Chloroplast	Chloroplast Gene|Gene, Chloroplast|Chloroplast Genes
 D061145	Microvascular Decompression Surgery	Decompression Surgeries, Microvascular|Decompression Surgery, Microvascular|Microvascular Decompression Surgeries|Surgeries, Microvascular Decompression|Surgery, Microvascular Decompression
 D061146	Chlorophyll Binding Proteins	Chlorophyll Protein Complexes
@@ -27956,17 +28369,17 @@ D061215	Energy Drinks	Drink, Energy|Drinks, Energy|Energy Drink
 D061216	Potassium Ionophores	Ionophores, Potassium
 D061217	Weight Reduction Programs	Program, Weight Reduction|Programs, Weight Reduction|Reduction Program, Weight|Reduction Programs, Weight|Weight Reduction Program|Weight Loss Programs|Loss Program, Weight|Loss Programs, Weight|Program, Weight Loss|Programs, Weight Loss|Weight Loss Program
 D061218	Depressive Disorder, Treatment-Resistant	Depressive Disorder, Treatment Resistant|Depressive Disorders, Treatment-Resistant|Disorder, Treatment-Resistant Depressive|Disorders, Treatment-Resistant Depressive|Treatment-Resistant Depressive Disorder|Treatment-Resistant Depressive Disorders|Refractory Depression|Depression, Refractory|Depressions, Refractory|Refractory Depressions|Therapy-Resistant Depression|Depression, Therapy-Resistant|Depressions, Therapy-Resistant|Therapy Resistant Depression|Therapy-Resistant Depressions|Treatment Resistant Depression|Depression, Treatment Resistant|Depressions, Treatment Resistant|Resistant Depression, Treatment|Resistant Depressions, Treatment|Treatment Resistant Depressions
-D061219	Olfactory Nerve Injuries	Injuries, Olfactory Nerve|Injury, Olfactory Nerve|Nerve Injuries, Olfactory|Nerve Injury, Olfactory|Cranial Nerve I Injury|First Cranial Nerve Injuries|First Cranial Nerve Injury|Traumatic First-Nerve Palsy|Traumatic First Nerve Palsy|First-Nerve Trauma|First Nerve Trauma|First-Nerve Traumas|Trauma, First-Nerve|Traumas, First-Nerve|Injury, Cranial Nerve I|Injury, First Cranial Nerve|Olfactory Nerve Trauma|Nerve Trauma, Olfactory|Nerve Traumas, Olfactory|Olfactory Nerve Traumas|Trauma, Olfactory Nerve|Traumas, Olfactory Nerve|Olfactory Neuropathy, Traumatic|Neuropathies, Traumatic Olfactory|Neuropathy, Traumatic Olfactory|Olfactory Neuropathies, Traumatic|Traumatic Olfactory Neuropathies|Traumatic Olfactory Neuropathy|Olfactory Nerve Injury|First-Nerve Palsy, Traumatic|First Nerve Palsy, Traumatic|First-Nerve Palsies, Traumatic|Palsies, Traumatic First-Nerve|Palsy, Traumatic First-Nerve|Traumatic First-Nerve Palsies
+D061219	Olfactory Nerve Injuries	Injuries, Olfactory Nerve|Injury, Olfactory Nerve|Nerve Injuries, Olfactory|Nerve Injury, Olfactory|Olfactory Nerve Trauma|Nerve Trauma, Olfactory|Nerve Traumas, Olfactory|Olfactory Nerve Traumas|Trauma, Olfactory Nerve|Traumas, Olfactory Nerve|Olfactory Neuropathy, Traumatic|Neuropathies, Traumatic Olfactory|Neuropathy, Traumatic Olfactory|Olfactory Neuropathies, Traumatic|Traumatic Olfactory Neuropathies|Traumatic Olfactory Neuropathy|Cranial Nerve I Injury|Injury, Cranial Nerve I|First Cranial Nerve Injuries|First Cranial Nerve Injury|First-Nerve Palsy, Traumatic|First Nerve Palsy, Traumatic|First-Nerve Palsies, Traumatic|Palsies, Traumatic First-Nerve|Palsy, Traumatic First-Nerve|Traumatic First-Nerve Palsies|First-Nerve Trauma|First Nerve Trauma|First-Nerve Traumas|Trauma, First-Nerve|Traumas, First-Nerve|Traumatic First-Nerve Palsy|Traumatic First Nerve Palsy|Olfactory Nerve Injury|Injury, First Cranial Nerve
 D061220	Oculomotor Nerve Injuries	Injuries, Oculomotor Nerve|Injury, Oculomotor Nerve|Nerve Injuries, Oculomotor|Nerve Injury, Oculomotor|Oculomotor Nerve Trauma|Nerve Trauma, Oculomotor|Nerve Traumas, Oculomotor|Oculomotor Nerve Traumas|Trauma, Oculomotor Nerve|Traumas, Oculomotor Nerve|Oculomotor Neuropathy, Traumatic|Neuropathies, Traumatic Oculomotor|Neuropathy, Traumatic Oculomotor|Oculomotor Neuropathies, Traumatic|Traumatic Oculomotor Neuropathies|Traumatic Oculomotor Neuropathy|Cranial Nerve III Injury|Traumatic Third-Nerve Palsy|Traumatic Third Nerve Palsy|Injury, Third Cranial Nerve|Third Cranial Nerve Injuries|Third Cranial Nerve Injury|Third-Nerve Palsy, Traumatic|Palsies, Traumatic Third-Nerve|Palsy, Traumatic Third-Nerve|Third Nerve Palsy, Traumatic|Third-Nerve Palsies, Traumatic|Traumatic Third-Nerve Palsies|Third-Nerve Trauma|Third Nerve Trauma|Third-Nerve Traumas|Trauma, Third-Nerve|Traumas, Third-Nerve|Oculomotor Nerve Injury|Injury, Cranial Nerve III
-D061221	Trigeminal Nerve Injuries	Injuries, Trigeminal Nerve|Injury, Trigeminal Nerve|Nerve Injuries, Trigeminal|Nerve Injury, Trigeminal|Fifth Cranial Nerve Injuries|Fifth Cranial Nerve Injury|Fifth-Nerve Palsy, Traumatic|Fifth Nerve Palsy, Traumatic|Fifth-Nerve Palsies, Traumatic|Palsies, Traumatic Fifth-Nerve|Palsy, Traumatic Fifth-Nerve|Traumatic Fifth-Nerve Palsies|Trigeminal Neuropathy, Traumatic|Neuropathies, Traumatic Trigeminal|Neuropathy, Traumatic Trigeminal|Traumatic Trigeminal Neuropathies|Traumatic Trigeminal Neuropathy|Trigeminal Neuropathies, Traumatic|Injury, Cranial Nerve V|Injury, Fifth Cranial Nerve|Traumatic Fifth-Nerve Palsy|Traumatic Fifth Nerve Palsy|Trigeminal Nerve Injury|Trigeminal Nerve Trauma|Nerve Trauma, Trigeminal|Nerve Traumas, Trigeminal|Trauma, Trigeminal Nerve|Traumas, Trigeminal Nerve|Trigeminal Nerve Traumas|Cranial Nerve V Injury|Fifth-Nerve Trauma|Fifth Nerve Trauma|Fifth-Nerve Traumas|Trauma, Fifth-Nerve|Traumas, Fifth-Nerve
+D061221	Trigeminal Nerve Injuries	Injuries, Trigeminal Nerve|Injury, Trigeminal Nerve|Nerve Injuries, Trigeminal|Nerve Injury, Trigeminal|Trigeminal Nerve Trauma|Nerve Trauma, Trigeminal|Nerve Traumas, Trigeminal|Trauma, Trigeminal Nerve|Traumas, Trigeminal Nerve|Trigeminal Nerve Traumas|Trigeminal Neuropathy, Traumatic|Neuropathies, Traumatic Trigeminal|Neuropathy, Traumatic Trigeminal|Traumatic Trigeminal Neuropathies|Traumatic Trigeminal Neuropathy|Trigeminal Neuropathies, Traumatic|Cranial Nerve V Injury|Traumatic Fifth-Nerve Palsy|Traumatic Fifth Nerve Palsy|Injury, Fifth Cranial Nerve|Fifth Cranial Nerve Injuries|Fifth Cranial Nerve Injury|Fifth-Nerve Palsy, Traumatic|Fifth Nerve Palsy, Traumatic|Fifth-Nerve Palsies, Traumatic|Palsies, Traumatic Fifth-Nerve|Palsy, Traumatic Fifth-Nerve|Traumatic Fifth-Nerve Palsies|Fifth-Nerve Trauma|Fifth Nerve Trauma|Fifth-Nerve Traumas|Trauma, Fifth-Nerve|Traumas, Fifth-Nerve|Trigeminal Nerve Injury|Injury, Cranial Nerve V
 D061222	Lingual Nerve Injuries	Injuries, Lingual Nerve|Injury, Lingual Nerve|Nerve Injuries, Lingual|Nerve Injury, Lingual|Lingual Nerve Injury
-D061223	Vagus Nerve Injuries	Injuries, Vagus Nerve|Injury, Vagus Nerve|Nerve Injuries, Vagus|Nerve Injury, Vagus|Vagus Nerve Injury|Injury, Cranial Nerve X|Injury, Tenth Cranial Nerve|Tenth Cranial Nerve Injuries|Vagus Neuropathy, Traumatic|Neuropathies, Traumatic Vagus|Neuropathy, Traumatic Vagus|Traumatic Vagus Neuropathies|Traumatic Vagus Neuropathy|Vagus Neuropathies, Traumatic|Tenth-Nerve Palsy, Traumatic|Palsies, Traumatic Tenth-Nerve|Palsy, Traumatic Tenth-Nerve|Tenth Nerve Palsy, Traumatic|Tenth-Nerve Palsies, Traumatic|Traumatic Tenth-Nerve Palsies|Tenth-Nerve Trauma|Tenth Nerve Trauma|Tenth-Nerve Traumas|Trauma, Tenth-Nerve|Traumas, Tenth-Nerve|Traumatic Tenth-Nerve Palsy|Traumatic Tenth Nerve Palsy|Vagus Nerve Trauma|Nerve Trauma, Vagus|Nerve Traumas, Vagus|Trauma, Vagus Nerve|Traumas, Vagus Nerve|Vagus Nerve Traumas|Cranial Nerve X Injury|Tenth Cranial Nerve Injury
+D061223	Vagus Nerve Injuries	Injuries, Vagus Nerve|Injury, Vagus Nerve|Nerve Injuries, Vagus|Nerve Injury, Vagus|Vagus Nerve Injury|Vagus Neuropathy, Traumatic|Neuropathies, Traumatic Vagus|Neuropathy, Traumatic Vagus|Traumatic Vagus Neuropathies|Traumatic Vagus Neuropathy|Vagus Neuropathies, Traumatic|Cranial Nerve X Injury|Injury, Cranial Nerve X|Traumatic Tenth-Nerve Palsy|Traumatic Tenth Nerve Palsy|Tenth Cranial Nerve Injuries|Tenth Cranial Nerve Injury|Tenth-Nerve Palsy, Traumatic|Palsies, Traumatic Tenth-Nerve|Palsy, Traumatic Tenth-Nerve|Tenth Nerve Palsy, Traumatic|Tenth-Nerve Palsies, Traumatic|Traumatic Tenth-Nerve Palsies|Tenth-Nerve Trauma|Tenth Nerve Trauma|Tenth-Nerve Traumas|Trauma, Tenth-Nerve|Traumas, Tenth-Nerve|Vagus Nerve Trauma|Nerve Trauma, Vagus|Nerve Traumas, Vagus|Trauma, Vagus Nerve|Traumas, Vagus Nerve|Vagus Nerve Traumas|Injury, Tenth Cranial Nerve
 D061224	Laryngeal Nerve Injuries	Injuries, Laryngeal Nerve|Injury, Laryngeal Nerve|Laryngeal Nerve Injury|Nerve Injuries, Laryngeal|Nerve Injury, Laryngeal|Laryngeal Neuropathy, Traumatic|Laryngeal Neuropathies, Traumatic|Neuropathies, Traumatic Laryngeal|Neuropathy, Traumatic Laryngeal|Traumatic Laryngeal Neuropathies|Traumatic Laryngeal Neuropathy|Laryngeal Nerve Trauma|Laryngeal Nerve Traumas|Nerve Trauma, Laryngeal|Nerve Traumas, Laryngeal|Trauma, Laryngeal Nerve|Traumas, Laryngeal Nerve
 D061226	Recurrent Laryngeal Nerve Injuries	Recurrent Laryngeal Nerve Trauma|Recurrent Laryngeal Neuropathy, Traumatic|Recurrent Laryngeal Nerve Injury
-D061227	Accessory Nerve Injuries	Accessory Nerve Injury|Injuries, Accessory Nerve|Injury, Accessory Nerve|Nerve Injuries, Accessory|Nerve Injury, Accessory|Accessory Neuropathy, Traumatic|Accessory Neuropathies, Traumatic|Neuropathies, Traumatic Accessory|Neuropathy, Traumatic Accessory|Traumatic Accessory Neuropathies|Traumatic Accessory Neuropathy|Cranial Nerve XI Injury|Eleventh Cranial Nerve Injuries|Eleventh Cranial Nerve Injury|Traumatic Eleventh-Nerve Palsy|Traumatic Eleventh Nerve Palsy|Eleventh-Nerve Trauma|Eleventh Nerve Trauma|Eleventh-Nerve Traumas|Trauma, Eleventh-Nerve|Traumas, Eleventh-Nerve|Injury, Cranial Nerve XI|Injury, Eleventh Cranial Nerve|Spinal Accessory Nerve Injury|Spinal Accessory Nerve Trauma|Spinal Accessory Neuropathy, Traumatic|Accessory Nerve Trauma|Accessory Nerve Traumas|Nerve Trauma, Accessory|Nerve Traumas, Accessory|Trauma, Accessory Nerve|Traumas, Accessory Nerve|Eleventh-Nerve Palsy, Traumatic|Eleventh Nerve Palsy, Traumatic|Eleventh-Nerve Palsies, Traumatic|Palsies, Traumatic Eleventh-Nerve|Palsy, Traumatic Eleventh-Nerve|Traumatic Eleventh-Nerve Palsies
-D061228	Hypoglossal Nerve Injuries	Hypoglossal Nerve Injury|Injuries, Hypoglossal Nerve|Injury, Hypoglossal Nerve|Nerve Injuries, Hypoglossal|Nerve Injury, Hypoglossal|Hypoglossal Nerve Trauma|Hypoglossal Nerve Traumas|Nerve Trauma, Hypoglossal|Nerve Traumas, Hypoglossal|Trauma, Hypoglossal Nerve|Traumas, Hypoglossal Nerve|Hypoglossal Neuropathy, Traumatic|Hypoglossal Neuropathies, Traumatic|Neuropathies, Traumatic Hypoglossal|Neuropathy, Traumatic Hypoglossal|Traumatic Hypoglossal Neuropathies|Traumatic Hypoglossal Neuropathy|Injury, Cranial Nerve XII|Twelfth-Nerve Trauma|Trauma, Twelfth-Nerve|Traumas, Twelfth-Nerve|Twelfth Nerve Trauma|Twelfth-Nerve Traumas|Traumatic Twelfth-Nerve Palsy|Palsies, Traumatic Twelfth-Nerve|Palsy, Traumatic Twelfth-Nerve|Traumatic Twelfth Nerve Palsy|Traumatic Twelfth-Nerve Palsies|Twelfth-Nerve Palsies, Traumatic|Twelfth Cranial Nerve Injuries|Twelfth Cranial Nerve Injury|Twelfth-Nerve Palsy, Traumatic|Twelfth Nerve Palsy, Traumatic|Cranial Nerve XII Injury|Injury, Twelfth Cranial Nerve
+D061227	Accessory Nerve Injuries	Accessory Nerve Injury|Injuries, Accessory Nerve|Injury, Accessory Nerve|Nerve Injuries, Accessory|Nerve Injury, Accessory|Accessory Neuropathy, Traumatic|Accessory Neuropathies, Traumatic|Neuropathies, Traumatic Accessory|Neuropathy, Traumatic Accessory|Traumatic Accessory Neuropathies|Traumatic Accessory Neuropathy|Cranial Nerve XI Injury|Injury, Cranial Nerve XI|Injury, Eleventh Cranial Nerve|Spinal Accessory Neuropathy, Traumatic|Eleventh Cranial Nerve Injury|Eleventh-Nerve Palsy, Traumatic|Eleventh Nerve Palsy, Traumatic|Eleventh-Nerve Palsies, Traumatic|Palsies, Traumatic Eleventh-Nerve|Palsy, Traumatic Eleventh-Nerve|Traumatic Eleventh-Nerve Palsies|Eleventh-Nerve Trauma|Eleventh Nerve Trauma|Eleventh-Nerve Traumas|Trauma, Eleventh-Nerve|Traumas, Eleventh-Nerve|Traumatic Eleventh-Nerve Palsy|Traumatic Eleventh Nerve Palsy|Spinal Accessory Nerve Injury|Spinal Accessory Nerve Trauma|Accessory Nerve Trauma|Accessory Nerve Traumas|Nerve Trauma, Accessory|Nerve Traumas, Accessory|Trauma, Accessory Nerve|Traumas, Accessory Nerve|Eleventh Cranial Nerve Injuries
+D061228	Hypoglossal Nerve Injuries	Hypoglossal Nerve Injury|Injuries, Hypoglossal Nerve|Injury, Hypoglossal Nerve|Nerve Injuries, Hypoglossal|Nerve Injury, Hypoglossal|Hypoglossal Neuropathy, Traumatic|Hypoglossal Neuropathies, Traumatic|Neuropathies, Traumatic Hypoglossal|Neuropathy, Traumatic Hypoglossal|Traumatic Hypoglossal Neuropathies|Traumatic Hypoglossal Neuropathy|Cranial Nerve XII Injury|Injury, Cranial Nerve XII|Traumatic Twelfth-Nerve Palsy|Palsies, Traumatic Twelfth-Nerve|Palsy, Traumatic Twelfth-Nerve|Traumatic Twelfth Nerve Palsy|Traumatic Twelfth-Nerve Palsies|Twelfth-Nerve Palsies, Traumatic|Twelfth Cranial Nerve Injuries|Twelfth Cranial Nerve Injury|Twelfth-Nerve Palsy, Traumatic|Twelfth Nerve Palsy, Traumatic|Twelfth-Nerve Trauma|Trauma, Twelfth-Nerve|Traumas, Twelfth-Nerve|Twelfth Nerve Trauma|Twelfth-Nerve Traumas|Hypoglossal Nerve Trauma|Hypoglossal Nerve Traumas|Nerve Trauma, Hypoglossal|Nerve Traumas, Hypoglossal|Trauma, Hypoglossal Nerve|Traumas, Hypoglossal Nerve|Injury, Twelfth Cranial Nerve
 D061245	Axenic Culture	Culture, Axenic|Cultures, Axenic|Axenic Cultures
-D061247	Trochlear Nerve Injuries	Injuries, Trochlear Nerve|Injury, Trochlear Nerve|Nerve Injuries, Trochlear|Nerve Injury, Trochlear|Trochlear Nerve Injury|Fourth Cranial Nerve Injuries|Fourth Cranial Nerve Injury|Fourth-Nerve Palsy, Traumatic|Fourth Nerve Palsy, Traumatic|Fourth-Nerve Palsies, Traumatic|Palsies, Traumatic Fourth-Nerve|Palsy, Traumatic Fourth-Nerve|Traumatic Fourth-Nerve Palsies|Trochlear Neuropathy, Traumatic|Neuropathies, Traumatic Trochlear|Neuropathy, Traumatic Trochlear|Traumatic Trochlear Neuropathies|Traumatic Trochlear Neuropathy|Trochlear Neuropathies, Traumatic|Injury, Cranial Nerve IV|Injury, Fourth Cranial Nerve|Traumatic Fourth-Nerve Palsy|Traumatic Fourth Nerve Palsy|Trochlear Nerve Trauma|Nerve Trauma, Trochlear|Nerve Traumas, Trochlear|Trauma, Trochlear Nerve|Traumas, Trochlear Nerve|Trochlear Nerve Traumas|Cranial Nerve IV Injury|Fourth-Nerve Trauma|Fourth Nerve Trauma|Fourth-Nerve Traumas|Trauma, Fourth-Nerve|Traumas, Fourth-Nerve
+D061247	Trochlear Nerve Injuries	Injuries, Trochlear Nerve|Injury, Trochlear Nerve|Nerve Injuries, Trochlear|Nerve Injury, Trochlear|Trochlear Nerve Injury|Trochlear Neuropathy, Traumatic|Neuropathies, Traumatic Trochlear|Neuropathy, Traumatic Trochlear|Traumatic Trochlear Neuropathies|Traumatic Trochlear Neuropathy|Trochlear Neuropathies, Traumatic|Cranial Nerve IV Injury|Fourth Cranial Nerve Injuries|Traumatic Fourth-Nerve Palsy|Traumatic Fourth Nerve Palsy|Fourth-Nerve Palsy, Traumatic|Fourth Nerve Palsy, Traumatic|Fourth-Nerve Palsies, Traumatic|Palsies, Traumatic Fourth-Nerve|Palsy, Traumatic Fourth-Nerve|Traumatic Fourth-Nerve Palsies|Fourth-Nerve Trauma|Fourth Nerve Trauma|Fourth-Nerve Traumas|Trauma, Fourth-Nerve|Traumas, Fourth-Nerve|Injury, Cranial Nerve IV|Injury, Fourth Cranial Nerve|Trochlear Nerve Trauma|Nerve Trauma, Trochlear|Nerve Traumas, Trochlear|Trauma, Trochlear Nerve|Traumas, Trochlear Nerve|Trochlear Nerve Traumas|Fourth Cranial Nerve Injury
 D061249	Batch Cell Culture Techniques	Batch Culture|Batch Cultures|Culture, Batch|Cultures, Batch|Shake-Flask Culture|Culture, Shake-Flask|Cultures, Shake-Flask|Shake Flask Culture|Shake-Flask Cultures|Batch Culture Techniques|Batch Culture Technique|Culture Technique, Batch|Culture Techniques, Batch|Technique, Batch Culture|Techniques, Batch Culture
 D061250	Transferrins	
 D061251	Primary Cell Culture	Cell Culture, Primary|Cell Cultures, Primary|Primary Cell Cultures
@@ -27978,9 +28391,9 @@ D061268	Insulin Lispro	Lispro, Insulin|28(B)-Lys-29(B)-Pro-Insulin|28(B)-Lysine-
 D061269	DNA Transformation Competence	Transformation Competence, DNA|Competence, DNA Transformation
 D061270	Nasal Septal Perforation	Nasal Septal Perforations|Perforation, Nasal Septal|Perforations, Nasal Septal|Septal Perforation, Nasal|Septal Perforations, Nasal|Nasal Septum Perforation|Nasal Septum Perforations|Perforation, Nasal Septum|Perforations, Nasal Septum|Septum Perforation, Nasal|Septum Perforations, Nasal
 D061271	Acidobacteria	
-D061285	Vestibulocochlear Nerve Injuries	Injuries, Vestibulocochlear Nerve|Injury, Vestibulocochlear Nerve|Nerve Injuries, Vestibulocochlear|Nerve Injury, Vestibulocochlear|Vestibulocochlear Nerve Injury|Eighth Cranial Nerve Injuries|Eighth Cranial Nerve Injury|Eighth-Nerve Palsy, Traumatic|Eighth Nerve Palsy, Traumatic|Eighth-Nerve Palsies, Traumatic|Palsies, Traumatic Eighth-Nerve|Palsy, Traumatic Eighth-Nerve|Traumatic Eighth-Nerve Palsies|Vestibulocochlear Neuropathy, Traumatic|Neuropathies, Traumatic Vestibulocochlear|Neuropathy, Traumatic Vestibulocochlear|Traumatic Vestibulocochlear Neuropathies|Traumatic Vestibulocochlear Neuropathy|Vestibulocochlear Neuropathies, Traumatic|Injury, Cranial Nerve VIII|Injury, Eighth Cranial Nerve|Traumatic Eighth-Nerve Palsy|Traumatic Eighth Nerve Palsy|Vestibulocochlear Nerve Trauma|Nerve Trauma, Vestibulocochlear|Nerve Traumas, Vestibulocochlear|Trauma, Vestibulocochlear Nerve|Traumas, Vestibulocochlear Nerve|Vestibulocochlear Nerve Traumas|Cranial Nerve VIII Injury|Eighth-Nerve Trauma|Eighth Nerve Trauma|Eighth-Nerve Traumas|Trauma, Eighth-Nerve|Traumas, Eighth-Nerve
+D061285	Vestibulocochlear Nerve Injuries	Injuries, Vestibulocochlear Nerve|Injury, Vestibulocochlear Nerve|Nerve Injuries, Vestibulocochlear|Nerve Injury, Vestibulocochlear|Vestibulocochlear Nerve Injury|Vestibulocochlear Neuropathy, Traumatic|Neuropathies, Traumatic Vestibulocochlear|Neuropathy, Traumatic Vestibulocochlear|Traumatic Vestibulocochlear Neuropathies|Traumatic Vestibulocochlear Neuropathy|Vestibulocochlear Neuropathies, Traumatic|Cranial Nerve VIII Injury|Eighth Cranial Nerve Injuries|Traumatic Eighth-Nerve Palsy|Traumatic Eighth Nerve Palsy|Eighth-Nerve Palsy, Traumatic|Eighth Nerve Palsy, Traumatic|Eighth-Nerve Palsies, Traumatic|Palsies, Traumatic Eighth-Nerve|Palsy, Traumatic Eighth-Nerve|Traumatic Eighth-Nerve Palsies|Eighth-Nerve Trauma|Eighth Nerve Trauma|Eighth-Nerve Traumas|Trauma, Eighth-Nerve|Traumas, Eighth-Nerve|Injury, Cranial Nerve VIII|Injury, Eighth Cranial Nerve|Vestibulocochlear Nerve Trauma|Nerve Trauma, Vestibulocochlear|Nerve Traumas, Vestibulocochlear|Trauma, Vestibulocochlear Nerve|Traumas, Vestibulocochlear Nerve|Vestibulocochlear Nerve Traumas|Eighth Cranial Nerve Injury
 D061286	Osmometry	
-D061287	Glossopharyngeal Nerve Injuries	Glossopharyngeal Nerve Injury|Injuries, Glossopharyngeal Nerve|Injury, Glossopharyngeal Nerve|Nerve Injuries, Glossopharyngeal|Nerve Injury, Glossopharyngeal|Glossopharyngeal Nerve Trauma|Glossopharyngeal Nerve Traumas|Nerve Trauma, Glossopharyngeal|Nerve Traumas, Glossopharyngeal|Trauma, Glossopharyngeal Nerve|Traumas, Glossopharyngeal Nerve|Glossopharyngeal Neuropathy, Traumatic|Glossopharyngeal Neuropathies, Traumatic|Neuropathies, Traumatic Glossopharyngeal|Neuropathy, Traumatic Glossopharyngeal|Traumatic Glossopharyngeal Neuropathies|Traumatic Glossopharyngeal Neuropathy|Injury, Cranial Nerve IX|Traumatic Ninth-Nerve Palsy|Traumatic Ninth Nerve Palsy|Ninth Cranial Nerve Injuries|Ninth Cranial Nerve Injury|Ninth-Nerve Palsy, Traumatic|Ninth Nerve Palsy, Traumatic|Ninth-Nerve Palsies, Traumatic|Palsies, Traumatic Ninth-Nerve|Palsy, Traumatic Ninth-Nerve|Traumatic Ninth-Nerve Palsies|Ninth-Nerve Trauma|Ninth Nerve Trauma|Ninth-Nerve Traumas|Trauma, Ninth-Nerve|Traumas, Ninth-Nerve|Cranial Nerve IX Injury|Injury, Ninth Cranial Nerve
+D061287	Glossopharyngeal Nerve Injuries	Glossopharyngeal Nerve Injury|Injuries, Glossopharyngeal Nerve|Injury, Glossopharyngeal Nerve|Nerve Injuries, Glossopharyngeal|Nerve Injury, Glossopharyngeal|Glossopharyngeal Neuropathy, Traumatic|Glossopharyngeal Neuropathies, Traumatic|Neuropathies, Traumatic Glossopharyngeal|Neuropathy, Traumatic Glossopharyngeal|Traumatic Glossopharyngeal Neuropathies|Traumatic Glossopharyngeal Neuropathy|Cranial Nerve IX Injury|Ninth Cranial Nerve Injuries|Traumatic Ninth-Nerve Palsy|Traumatic Ninth Nerve Palsy|Ninth-Nerve Palsy, Traumatic|Ninth Nerve Palsy, Traumatic|Ninth-Nerve Palsies, Traumatic|Palsies, Traumatic Ninth-Nerve|Palsy, Traumatic Ninth-Nerve|Traumatic Ninth-Nerve Palsies|Ninth-Nerve Trauma|Ninth Nerve Trauma|Ninth-Nerve Traumas|Trauma, Ninth-Nerve|Traumas, Ninth-Nerve|Injury, Cranial Nerve IX|Injury, Ninth Cranial Nerve|Glossopharyngeal Nerve Trauma|Glossopharyngeal Nerve Traumas|Nerve Trauma, Glossopharyngeal|Nerve Traumas, Glossopharyngeal|Trauma, Glossopharyngeal Nerve|Traumas, Glossopharyngeal Nerve|Ninth Cranial Nerve Injury
 D061305	Lymphoscintigraphy	Lymphoscintigraphies
 D061306	Fibrobacteres	
 D061307	Human Umbilical Vein Endothelial Cells	Endothelial Cells, Human Umbilical Vein|HUVEC Cells|Cell, HUVEC|Cells, HUVEC|HUVEC Cell
@@ -28010,7 +28423,7 @@ D061389	Insulin, Regular, Pork	Insulin, Regular, Porcine|Porcine Insulin|Insulin
 D061405	Insulin, Lente	Lente Insulin
 D061406	Insulin, Ultralente	Ultralente Insulin
 D061466	Lopinavir	N-(4-(((2,6-dimethylphenoxy)acetyl)amino)-3-hydroxy-5-phenyl-1-(phenylmethyl)pentyl)tetrahydro-alpha-(1-methylethyl)-2-oxo-1(2H)-pydrimidineacetamide
-D061485	Tobacco Use Cessation Products	
+D061485	Tobacco Use Cessation Devices	
 D061505	Cell Surface Display Techniques	Cell Surface Display Technology
 D061525	Perforator Flap	Flap, Perforator|Flaps, Perforator|Perforator Flaps
 D061545	Carbonated Water	Carbonated Waters|Water, Carbonated|Waters, Carbonated|Soda Water|Soda Waters|Water, Soda|Waters, Soda
@@ -28023,14 +28436,14 @@ D061625	Immunoreceptor Tyrosine-Based Activation Motif	Immunoreceptor Tyrosine B
 D061626	Immunoreceptor Tyrosine-Based Inhibition Motif	Immunoreceptor Tyrosine Based Inhibition Motif|Immune Receptor Tyrosine-Based Inhibition Motif|Immune Receptor Tyrosine Based Inhibition Motif|Immuno-Receptor Tyrosine-Based Inhibition Motif|Immuno Receptor Tyrosine Based Inhibition Motif
 D061645	Abdominoplasty	Abdominoplasties
 D061646	Operative Time	Operative Times|Time, Operative|Times, Operative|Time Length of Surgery|Surgery Time Length|Surgery Time Lengths|Length of Operative Time|Operative Time Length|Operative Time Lengths|Time Length, Operative|Time Lengths, Operative|Surgical Time|Surgical Times|Time, Surgical|Times, Surgical
-D061665	Time-to-Treatment	Time-to-Treatments|Time to Treatment|Time to Treatments|Treatment, Time to|Treatments, Time to
+D061665	Time-to-Treatment	Time-to-Treatments|Time to Treatment|Time to Treatments
 D061685	Time-to-Pregnancy	Time to Pregnancy|Time-to-Pregnancies
 D061686	Premature Ejaculation	Ejaculation, Premature|Ejaculations, Premature|Premature Ejaculations|Ejaculatio Praecox|Ejaculatio Praecoxs|Praecox, Ejaculatio|Praecoxs, Ejaculatio
 D061705	Image-Guided Biopsy	Biopsies, Image-Guided|Biopsy, Image-Guided|Image Guided Biopsy|Image-Guided Biopsies|Imaging Guided Biopsy|Biopsies, Imaging Guided|Biopsy, Imaging Guided|Guided Biopsies, Imaging|Guided Biopsy, Imaging|Imaging Guided Biopsies
 D061725	Accelerometry	
 D061745	Antioxidant Response Elements	Antioxidant Response Element|Element, Antioxidant Response|Elements, Antioxidant Response|Response Element, Antioxidant|Response Elements, Antioxidant|Anti-Oxidant Response Elements|Anti Oxidant Response Elements|Anti-Oxidant Response Element|Element, Anti-Oxidant Response|Elements, Anti-Oxidant Response|Response Element, Anti-Oxidant|Response Elements, Anti-Oxidant
 D061765	Endoscopic Ultrasound-Guided Fine Needle Aspiration	Endoscopic Ultrasound Guided Fine Needle Aspiration|EUS-FNA
-D061766	Proton Therapy	Proton Therapies|Therapies, Proton|Therapy, Proton|Proton Beam Therapy|Beam Therapies, Proton|Beam Therapy, Proton|Proton Beam Therapies|Therapies, Proton Beam|Therapy, Proton Beam
+D061766	Proton Therapy	Proton Therapies|Therapies, Proton|Therapy, Proton|Proton Beam Therapy|Proton Beam Therapies|Therapies, Proton Beam|Therapy, Proton Beam|Proton Beam Radiation Therapy
 D061785	Transcription Initiation, Genetic	Genetic Transcription Initiation|Initiation, Genetic Transcription
 D061805	Transcription Elongation, Genetic	Elongation, Genetic Transcription|Genetic Transcription Elongation
 D061806	Transcription Termination, Genetic	Genetic Transcription Termination|Termination, Genetic Transcription
@@ -28097,7 +28510,7 @@ D062205	Strategic Stockpile	Stockpile, Strategic|Stockpiles, Strategic|Strategic
 D062206	Spatial Analysis	Analyses, Spatial|Analysis, Spatial|Spatial Analyses|Spacial Analysis|Analyses, Spacial|Analysis, Spacial|Spacial Analyses
 D062207	Brain-Computer Interfaces	Brain Computer Interfaces|Interface, Brain-Computer|Interfaces, Brain-Computer|Brain-Computer Interface|Brain Computer Interface
 D062209	Patient Handoff	Handoff, Patient|Handoffs, Patient|Patient Handoffs|Patient Hand Over|Hand Over, Patient|Hand Overs, Patient|Patient Hand Overs|Patient Sign Out|Sign Out, Patient|Sign Outs, Patient|Patient Signout|Patient Signouts|Signout, Patient|Signouts, Patient|Patient Signover|Patient Signovers|Signover, Patient|Signovers, Patient|Patient Hand Off|Hand Off, Patient|Hand Offs, Patient|Patient Hand Offs|Patient Sign Outs|Patient Handover|Handover, Patient|Handovers, Patient|Patient Handovers
-D062210	Personal Narratives	
+D062210	Personal Narrative	Personal Narratives
 D062211	Spatio-Temporal Analysis	Analyses, Spatio-Temporal|Analysis, Spatio-Temporal|Spatio Temporal Analysis|Spatio-Temporal Analyses|Spatial Temporal Analysis|Analyses, Spatial Temporal|Analysis, Spatial Temporal|Spatial Temporal Analyses|Temporal Analyses, Spatial|Temporal Analysis, Spatial|Spatiotemporal Analysis|Analyses, Spatiotemporal|Analysis, Spatiotemporal|Spatiotemporal Analyses
 D062245	RxNorm	
 D062265	Health Insurance Exchanges	Exchange, Health Insurance|Exchanges, Health Insurance|Health Insurance Exchange|Insurance Exchange, Health|Insurance Exchanges, Health|Health Insurance Marketplaces|Health Insurance Marketplace|Insurance Marketplace, Health|Insurance Marketplaces, Health|Marketplace, Health Insurance|Marketplaces, Health Insurance
@@ -28305,7 +28718,7 @@ D063465	Skin Cream	Cream, Skin|Creams, Skin|Skin Creams
 D063466	Respiratory Aspiration of Gastric Contents	
 D063485	Acanthocheilonemiasis	Acanthocheilonemiases
 D063486	Acanthocheilonema	Acanthocheilonemas
-D063487	Prescription Drug Misuse	Drug Misuse, Prescription|Misuse, Prescription Drug|Non-Medical Use of Prescription Drugs|Non Medical Use of Prescription Drugs|NMUPD|Prescription Medicine Misuse|Medicine Misuse, Prescription|Misuse, Prescription Medicine|Prescription Medicine Misuses
+D063487	Prescription Drug Misuse	Drug Misuse, Prescription|Misuse, Prescription Drug|NMUPD|Non-Medical Use of Prescription Drugs|Non Medical Use of Prescription Drugs|Prescription Medicine Misuse|Medicine Misuse, Prescription|Misuse, Prescription Medicine|Prescription Medicine Misuses
 D063505	Racism	Racial Bias|Bias, Racial|Racial Prejudice|Prejudice, Racial|Prejudices, Racial|Racial Prejudices|Racial Discrimination|Discrimination, Racial|Discriminations, Racial|Racial Discriminations
 D063506	Ageism	Age Discrimination|Age Discriminations|Discrimination, Age|Discriminations, Age
 D063507	Sexism	Sex Bias|Bias, Sex|Gender Bias|Bias, Gender
@@ -28327,7 +28740,7 @@ D063731	Mobile Applications	Application, Mobile|Applications, Mobile|Mobile Appl
 D063746	Methanocaldococcaceae	
 D063747	Methanocaldococcus	
 D063748	Bland White Garland Syndrome	ALCAPA Syndrome|ALCAPA Syndromes|Syndrome, ALCAPA|Bland-White-Garland Syndrome|Syndrome, Bland-White-Garland|ALCAPA
-D063766	Pediatric Obesity	Obesity, Pediatric
+D063766	Pediatric Obesity	Obesity, Pediatric|Childhood Onset Obesity|Obesity, Childhood Onset|Obesity in Childhood|Child Obesity|Obesity, Child|Childhood Obesity|Obesity, Childhood
 D063806	Myalgia	Muscle Pain|Pain, Muscle|Pains, Muscle|Muscle Soreness|Muscle Sorenesses|Soreness, Muscle
 D063807	Dandruff	Scurf
 D063809	Satellite Imagery	Imageries, Satellite|Imagery, Satellite|Satellite Imageries
@@ -28335,14 +28748,14 @@ D063826	Kosovo	Republic of Kosovo
 D063847	Mean Platelet Volume	Mean Platelet Volumes|Platelet Volume, Mean|Platelet Volumes, Mean|Volume, Mean Platelet|Volumes, Mean Platelet
 D063866	Medical Identity Theft	Identity Theft, Medical|Medical Identity Thefts|Theft, Medical Identity
 D063867	Identity Theft	Identity Thefts|Theft, Identity|Thefts, Identity
-D063868	Patient Outcome Assessment	Assessments, Patient Outcome|Outcome Assessments, Patient|Patient Outcome Assessments|Assessment, Patient Outcomes|Patient Outcomes Assessment|Outcomes Assessments, Patient|Patient-Centered Outcomes Research|Patient Centered Outcomes Research|Research, Patient-Centered Outcomes|Assessment, Patient Outcome|Outcome Assessment, Patient
+D063868	Patient Outcome Assessment	Assessments, Patient Outcome|Outcome Assessments, Patient|Patient Outcome Assessments|Patient-Centered Outcomes Research|Patient Centered Outcomes Research|Research, Patient-Centered Outcomes|Outcome Assessment, Patient|Outcomes Assessments, Patient|Assessment, Patient Outcome|Assessment, Patient Outcomes|Patient Outcomes Assessment
 D063886	Patient Discharge Summaries	Discharge Summaries, Patient|Discharge Summary, Patient|Patient Discharge Summary|Summaries, Patient Discharge|Summary, Patient Discharge
 D063906	Prisoners of War	War Prisoner|War Prisoners
 D063926	Drug Hypersensitivity Syndrome	Drug Hypersensitivity Syndromes|Hypersensitivity Syndrome, Drug|Hypersensitivity Syndromes, Drug|Syndrome, Drug Hypersensitivity|Syndromes, Drug Hypersensitivity|DRESS Syndrome|DRESS Syndromes|Drug Reaction with Eosinophilia and Systemic Symptoms|Drug Reaction with Eosinophilia and Systemic Symptoms Syndrome
 D063927	Lujo virus	
 D063928	Ependymoglial Cells	Cell, Ependymoglial|Cells, Ependymoglial|Ependymoglial Cell
-D063947	Slavery	Enslavement|Enslavements|Slaveholding|Slaveholdings
-D063948	Slaves	Slave|Enslaved Persons|Enslaved Person|Person, Enslaved|Persons, Enslaved
+D063947	Enslavement	Enslavements|Slaveholding|Slavery
+D063948	Enslaved Persons	Enslaved Person|Person, Enslaved|Persons, Enslaved|Slaves|Slave
 D063967	Material Safety Data Sheets	Material Safety Data Sheet
 D063986	Vascularized Composite Allotransplantation	Allotransplantation, Vascularized Composite|Composite Tissue Allotransplantation|Allotransplantation, Composite Tissue|Vascularized Composite Allografting|Allografting, Vascularized Composite|Composite Tissue Allografting|Allografting, Composite Tissue
 D063987	Hand Transplantation	Transplantation, Hand
@@ -28358,8 +28771,7 @@ D064006	Dodecenoyl-CoA Isomerase	Dodecenoyl CoA Isomerase|Isomerase, Dodecenoyl-
 D064007	Ataxia Telangiectasia Mutated Proteins	AT Mutated Protein|Mutated Protein, AT|Protein, AT Mutated|ATM Protein|A-T Protein|A T Protein|Protein, A-T
 D064008	Enoyl-CoA Hydratase 2	Enoyl CoA Hydratase 2|D-3-Hydroxyacyl-CoA Hydro-Lyase|D 3 Hydroxyacyl CoA Hydro Lyase|2-Enoyl-CoA Hydratase 2
 D064026	Calbindins	Calbindin
-D064027	Pteridophyta	Pteridophytas
-D064028	Tracheophyta	Tracheobionta
+D064028	Tracheophyta	Tracheobionta|Pteridophyta
 D064029	Peroxisomal Multifunctional Protein-2	Multifunctional Protein-2, Peroxisomal|Peroxisomal Multifunctional Protein 2|3-alpha,7-alpha,12-alpha-Trihydroxy-5-beta-Cholest-24-enoyl-CoA Hydratase|Peroxisomal Multifunctional Enzyme Type 2|17-beta-Hydroxysteroid Dehydrogenase 4|17 beta Hydroxysteroid Dehydrogenase 4|4, 17-beta-Hydroxysteroid Dehydrogenase|Dehydrogenase 4, 17-beta-Hydroxysteroid
 D064030	S100 Calcium Binding Protein G	Calbindin D9K|Calbindin-D9K|Calbindin 3
 D064032	Calbindin 2	Calretinin
@@ -28429,7 +28841,7 @@ D064202	O'nyong-nyong Virus	O'nyong-nyong Viruses|Virus, O'nyong-nyong|Viruses, 
 D064206	Aggregatibacter	
 D064207	Aggregatibacter aphrophilus	Haemophilus aphrophilus
 D064208	Aggregatibacter segnis	Haemophilus segnis
-D064209	Phytochemicals	Phytonutrient|Dietary Phytochemicals|Phytochemicals, Dietary|Phytonutrients|Plant-Derived Compounds|Compounds, Plant-Derived|Plant Derived Compounds|Phytochemical|Plant-Derived Chemicals|Chemicals, Plant-Derived|Plant Derived Chemicals
+D064209	Phytochemicals	Plant Bioactive Compounds|Bioactive Compounds, Plant|Compounds, Plant Bioactive|Plant Biologically Active Compounds|Bioactive Coumpounds, Plant|Coumpounds, Plant Bioactive|Plant Bioactive Coumpounds|Biologically Active Coumpounds, Plant|Plant-Derived Compounds|Compounds, Plant-Derived|Plant Derived Compounds|Phytonutrient|Plant-Derived Chemicals|Chemicals, Plant-Derived|Plant Derived Chemicals|Phytonutrients|Dietary Phytochemicals|Phytochemicals, Dietary|Phytochemical
 D064210	Secondary Metabolism	Metabolism, Secondary|Metabolisms, Secondary|Secondary Metabolisms
 D064211	Connectin	
 D064226	Prescription Drug Diversion	Diversion, Prescription Drug|Diversions, Prescription Drug|Drug Diversion, Prescription|Drug Diversions, Prescription|Prescription Drug Diversions|Controlled Substance Diversion|Controlled Substance Diversions|Diversion, Controlled Substance|Diversions, Controlled Substance|Substance Diversion, Controlled|Substance Diversions, Controlled
@@ -28450,9 +28862,9 @@ D064250	Hypertriglyceridemic Waist	Waist, Hypertriglyceridemic|Enlarged Waist El
 D064251	Multifunctional Enzymes	Enzymes, Multifunctional
 D064266	Preexisting Condition Coverage	Pre-Existing Condition Coverage|Pre-Existing Disease|Pre-Existing Diseases|Pre-Existing Disorder|Pre-Existing Disorders|Preexisting Condition|Preexisting Conditions|Preexisting Disease|Preexisting Diseases|Preexisting Disorder|Preexisting Disorders|Preexisting Illness|Preexisting Illnesses|Pre-Existing Condition|Pre-Existing Conditions|Pre-Existing Illness|Pre-Existing Illnesses
 D064267	Intrinsically Disordered Proteins	Unstructured Proteins|Natively Unfolded Proteins
-D064286	ATP Binding Cassette Transporter 1	ATP-Binding Cassette Sub-Family A Member 1|ATP Binding Cassette Sub Family A Member 1|CERP Protein|Protein, CERP|ABCA1 Protein|Protein, ABCA1|Cholesterol-Efflux Regulatory Protein|Cholesterol Efflux Regulatory Protein|Protein, Cholesterol-Efflux Regulatory|Regulatory Protein, Cholesterol-Efflux
+D064286	ATP Binding Cassette Transporter 1	ATP-Binding Cassette Sub-Family A Member 1|ATP Binding Cassette Sub Family A Member 1|ATP Binding Cassette Transporter, Subfamily A, Member 1|CERP Protein|ABCA1 Protein|Cholesterol-Efflux Regulatory Protein|Cholesterol Efflux Regulatory Protein
 D064306	Non-Nutritive Sweeteners	Non Nutritive Sweeteners|Sweeteners, Non-Nutritive|Artificial Sweeteners, Non-Nutritive|Artificial Sweeteners, Non Nutritive|Non-Nutritive Artificial Sweeteners|High-Intensity Sweeteners|High Intensity Sweeteners|Sweeteners, High-Intensity
-D064307	Microbiota	Microbiotas
+D064307	Microbiota	Microbiotas|Microbial Community|Community, Microbial|Microbial Communities|Microbial Community Composition|Community Composition, Microbial|Composition, Microbial Community|Microbial Community Compositions
 D064308	Ecological Parameter Monitoring	Monitoring, Ecological Parameter|Parameter Monitoring, Ecological
 D064326	MEF2 Transcription Factors	Transcription Factors, MEF2|Muscle Enhancer Factor-2|Enhancer Factor-2, Muscle|Muscle Enhancer Factor 2|Myocyte-Specific Enhancer-Binding Factor 2|Myocyte Specific Enhancer Binding Factor 2|Myocyte Enhancer Factor 2|Myocyte-Specific Enhancer Factor 2|Myocyte Specific Enhancer Factor 2|MEF2 Proteins|Muscle-Specific Enhancer Factor-2|Enhancer Factor-2, Muscle-Specific|Muscle Specific Enhancer Factor 2
 D064346	Sagittal Abdominal Diameter	Abdominal Diameter, Sagittal|Abdominal Diameters, Sagittal|Diameter, Sagittal Abdominal|Diameters, Sagittal Abdominal|Sagittal Abdominal Diameters|Abdominal Height|Height, Abdominal|Supine Abdominal Height|Abdominal Height, Supine|Height, Supine Abdominal
@@ -28513,7 +28925,7 @@ D064586	Selenic Acid	Acid, Selenic
 D064587	Osmoregulation	Osmotic Stress Regulating Pathway|Osmotic Stress Response|Osmotic Stress Responses|Response, Osmotic Stress|Responses, Osmotic Stress|Stress Response, Osmotic|Stress Responses, Osmotic
 D064588	Selenium Oxides	Oxides, Selenium
 D064590	Cool-Down Exercise	Cool Down Exercise|Cool-Down Exercises|Exercise, Cool-Down|Exercises, Cool-Down|Warming-Down Exercise|Exercise, Warming-Down|Exercises, Warming-Down|Warming Down Exercise|Warming-Down Exercises|Warm-Down Exercise|Exercise, Warm-Down|Exercises, Warm-Down|Warm Down Exercise|Warm-Down Exercises|Cooldown Exercise|Cooldown Exercises|Exercise, Cooldown|Exercises, Cooldown|Cooling-Down Exercise|Cooling Down Exercise|Cooling-Down Exercises|Exercise, Cooling-Down|Exercises, Cooling-Down
-D064591	Allografts	Allograft|Homologous Transplants|Homologous Transplant|Transplant, Homologous|Transplants, Homologous|Homografts|Homograft
+D064591	Allografts	Allograft|Allogeneic Transplants|Allogeneic Transplant|Transplant, Allogeneic|Transplants, Allogeneic|Allogeneic Grafts|Allogeneic Graft|Graft, Allogeneic|Grafts, Allogeneic|Homografts|Homograft|Homologous Transplants|Homologous Transplant|Transplant, Homologous|Transplants, Homologous
 D064592	Autografts	Autograft|Autologous Transplants|Autologous Transplant|Transplant, Autologous|Transplants, Autologous|Autotransplants|Autotransplant
 D064593	Heterografts	Heterograft|Xenografts|Xenograft
 D064594	Bone-Patellar Tendon-Bone Grafts	Bone Patellar Tendon Bone Grafts|Bone-Patellar Tendon-Bone Graft
@@ -28544,7 +28956,7 @@ D064701	Pediatric Nurse Practitioners	Nurse Practitioner, Pediatric|Nurse Practi
 D064702	International Classification of Functioning, Disability and Health	
 D064703	Family Nurse Practitioners	Family Nurse Practitioner|Nurse Practitioner, Family|Nurse Practitioners, Family
 D064704	Levofloxacin	Ofloxacin, (S)-Isomer
-D064705	Racepinephrine	Adrenaline, Racemic Mixture|Mixture Adrenaline, Racemic|Racemic Mixture Adrenaline|Epinephrine, Racemic Mixture|Mixture Epinephrine, Racemic|Racemic Mixture Epinephrine|Racemic Epinephrine|Epinephrine, Racemic|Racemic Adrenaline|Adrenaline, Racemic
+D064705	Racepinephrine	Adrenaline, Racemic Mixture|Racemic Mixture Adrenaline|Epinephrine, Racemic Mixture|Racemic Mixture Epinephrine|Racemic Epinephrine|Epinephrine, Racemic|Racemic Adrenaline|Adrenaline, Racemic
 D064706	Vocal Cord Dysfunction	Dysfunction, Vocal Cord|Dysfunctions, Vocal Cord|Vocal Cord Dysfunctions|Paradoxical Vocal Fold Motion|Paradoxical Vocal Fold Motion Disorder
 D064726	Triple Negative Breast Neoplasms	ER-Negative PR-Negative HER2-Negative Breast Neoplasms|ER Negative PR Negative HER2 Negative Breast Neoplasms|Triple-Negative Breast Cancer|Breast Cancer, Triple-Negative|Breast Cancers, Triple-Negative|Triple-Negative Breast Cancers|Triple-Negative Breast Neoplasm|Breast Neoplasm, Triple-Negative|Breast Neoplasms, Triple-Negative|Triple Negative Breast Neoplasm|Triple-Negative Breast Neoplasms|ER-Negative PR-Negative HER2-Negative Breast Cancer|ER Negative PR Negative HER2 Negative Breast Cancer|Triple Negative Breast Cancer
 D064727	Posterior Capsulotomy	Capsulotomies, Posterior|Capsulotomy, Posterior|Posterior Capsulotomies
@@ -28566,7 +28978,7 @@ D064788	Serving Size	Serving Sizes
 D064789	Immunity, Heterologous	Off Target Effects of Vaccines|Non-Target Heterologous Effects of Vaccines|Non Target Heterologous Effects of Vaccines|Non-Specific Effects of Vaccines|Non Specific Effects of Vaccines|Vaccines Non-Specific Effect|Vaccines Non-Specific Effects|Heterologous Immunity|Non-Targeted Immunity|Immunity, Non-Targeted|Non Targeted Immunity|Non-Specific Effects of Vaccine|Non Specific Effects of Vaccine|Vaccine Non-Specific Effect|Vaccine Non-Specific Effects|Non-Target Heterologous Effects of Vaccine|Non Target Heterologous Effects of Vaccine|Off Target Effects of Vaccine|Heterologous Effects of Vaccines|Vaccines Heterologous Effect|Vaccines Heterologous Effects|Heterologous Effects of Vaccine|Vaccine Heterologous Effect|Vaccine Heterologous Effects
 D064790	Clinical Laboratory Services	Clinical Laboratory Service|Laboratory Service, Clinical|Service, Clinical Laboratory|Services, Clinical Laboratory|Laboratory Services, Clinical
 D064791	Desoxycorticosterone Acetate	DOC-21-acetate|DOC 21 acetate|Deoxycorticosterone-21-acetate|Deoxycorticosterone 21 acetate|Desoxycorticosterone-21-acetate|Desoxycorticosterone 21 acetate|DOCA|Desoxycortone Acetate|Acetate, Desoxycortone
-D064792	Pragmatic Clinical Trials as Topic	Real World Clinical Trials|Naturalistic Randomized Clinical Trial|Pragmatic Trials|Trials, Pragmatic|Pragmatic Clinical Trials|Clinical Trials, Pragmatic|Trials, Pragmatic Clinical|Practical Clinical Trials|Clinical Trials, Practical|Trials, Practical Clinical
+D064792	Pragmatic Clinical Trials as Topic	Naturalistic Randomized Clinical Trial|Practical Clinical Trials|Clinical Trials, Practical|Trials, Practical Clinical|Pragmatic Trials|Trials, Pragmatic|Pragmatic Clinical Trials|Clinical Trials, Pragmatic|Trials, Pragmatic Clinical|Real World Clinical Trials
 D064793	Teratogenesis	
 D064794	Lorajmine	
 D064795	Intraoperative Neurophysiological Monitoring	Monitoring, Intraoperative Neurophysiological|Neurophysiological Monitoring, Intraoperative|Intraoperative Neurophysiologic Monitoring|Intraoperative Neurophysiologic Monitorings|Monitoring, Intraoperative Neurophysiologic|Monitorings, Intraoperative Neurophysiologic|Neurophysiologic Monitoring, Intraoperative|Neurophysiologic Monitorings, Intraoperative
@@ -28586,7 +28998,7 @@ D064828	Prolyl Hydroxylases	Hydroxylases, Prolyl|Prolyl Hydroxylase|Proline,2-Ox
 D064829	Alcohol Abstinence	Abstinence, Alcohol|Abstinences, Alcohol|Alcohol Abstinences
 D064830	Temperance Movement	Movement, Temperance|Movements, Temperance|Temperance Movements
 D064846	Sports for Persons with Disabilities	Sports for the Disabled|Adaptive Sports|Adaptive Sport|Sport, Adaptive|Sports, Adaptive
-D064847	Multimodal Imaging	Imaging, Multimodal|Imaging, Hybrid|Hybrid Imaging
+D064847	Multimodal Imaging	Imaging, Multimodal
 D064866	Mindfulness	
 D064867	Mesopotamia	
 D064868	Ethnic Violence	Violence, Ethnic
@@ -28659,13 +29071,13 @@ D065170	Pregnancy, Angular	Angular Pregnancies|Pregnancies, Angular|Angular Preg
 D065171	Estrogen Receptor Antagonists	Antagonists, Estrogen Receptor|Receptor Antagonists, Estrogen
 D065172	Pregnancy, Ovarian	Ovarian Pregnancies|Pregnancies, Ovarian|Ovarian Pregnancy
 D065173	Pregnancy, Cornual	Cornual Pregnancies|Cornual Pregnancy|Pregnancies, Cornual
-D065186	Interrupted Time Series Analysis	ITS Studies|Interrupted Time Series|Time Series, Interrupted
-D065187	Controlled Before-After Studies	Before-After Studies, Controlled|Before-After Study, Controlled|Controlled Before After Studies|Controlled Before-After Study|Controlled Before and After Studies|CBA Studies
+D065186	Interrupted Time Series Analysis	Interrupted Time Series|Time Series, Interrupted|ITS Studies
+D065187	Controlled Before-After Studies	Before-After Studies, Controlled|Before-After Study, Controlled|Controlled Before After Studies|Controlled Before-After Study|CBA Studies|Controlled Before and After Studies
 D065206	Extracellular Traps	Extracellular Trap|Trap, Extracellular|Traps, Extracellular|Extracellular DNA Traps|DNA Trap, Extracellular|DNA Traps, Extracellular|Extracellular DNA Trap|Trap, Extracellular DNA|Traps, Extracellular DNA
 D065207	Middle East Respiratory Syndrome Coronavirus	MERS-CoV|MERS Virus|MERS Viruses|Virus, MERS|Viruses, MERS|Middle East respiratory syndrome-related coronavirus|Middle East respiratory syndrome related coronavirus
 D065227	Transfusion Reaction	Transfusion Reactions|Blood Transfusion-Associated Adverse Reactions|Blood Transfusion Associated Adverse Reactions
 D065228	Non-Randomized Controlled Trials as Topic	Non Randomized Controlled Trials as Topic|Controlled Clinical Trials, Non-Randomized|Controlled Clinical Trials, Non Randomized|Quasi-Experimental Studies|Quasi Experimental Studies|Quasi-Experimental Study|Studies, Quasi-Experimental|Study, Quasi-Experimental|Clinical Trials, Nonrandomized|Clinical Trial, Nonrandomized|Nonrandomized Clinical Trial|Nonrandomized Clinical Trials|Trial, Nonrandomized Clinical|Trials, Nonrandomized Clinical|Controlled Clinical Trials, Nonrandomized|Clinical Trials, Non-Randomized|Clinical Trial, Non-Randomized|Clinical Trials, Non Randomized|Non-Randomized Clinical Trial|Non-Randomized Clinical Trials|Trial, Non-Randomized Clinical|Trials, Non-Randomized Clinical|Nonrandomized Controlled Trials as Topic
-D065246	Culturally Competent Care	Care, Culturally Competent|Cultural Care|Care, Cultural|Culturally Congruent Care|Care, Culturally Congruent|Cross-Cultural Care|Care, Cross-Cultural|Cross Cultural Care|Culturally Competent Health Care
+D065246	Culturally Competent Care	Care, Culturally Competent|Culturally Congruent Care|Care, Culturally Congruent|Culturally Competent Health Care|Cross-Cultural Care|Care, Cross-Cultural|Cross Cultural Care|Cultural Care|Care, Cultural
 D065260	Frankincense	Olibanum Resin|Resin, Olibanum|Frankincense Resin|Resin, Frankincense|Olibanum
 D065286	Prophylactic Surgical Procedures	Procedure, Prophylactic Surgical|Procedures, Prophylactic Surgical|Prophylactic Surgical Procedure|Surgical Procedure, Prophylactic|Surgical Procedures, Preventive|Surgical Procedures, Prophylactic|Preventive Surgical Procedures|Preventive Surgical Procedure|Procedure, Preventive Surgical|Procedures, Preventive Surgical|Surgical Procedure, Preventive
 D065287	Robotic Surgical Procedures	Procedure, Robotic Surgical|Procedures, Robotic Surgical|Robotic Surgical Procedure|Surgical Procedure, Robotic|Surgical Procedures, Robotic
@@ -28686,7 +29098,7 @@ D065366	Cryptoxanthins	Cryptoxanthin|Beta-Caroten-3-ol|Beta Caroten 3 ol
 D065386	Historically Controlled Study	Historically Controlled Studies|Studies, Historically Controlled|Study, Historically Controlled|Historical Controlled Study|Historical Controlled Studies|Studies, Historical Controlled|Study, Historical Controlled|Historical Control Study|Historical Control Studies|Studies, Historical Control|Study, Historical Control
 D065406	Laminoplasty	Laminoplasties|Laminaplasty|Laminaplasties
 D065426	Cytoreduction Surgical Procedures	Cytoreduction Surgical Procedure|Procedure, Cytoreduction Surgical|Surgical Procedure, Cytoreduction|Debulking Surgical Procedures|Debulking Surgical Procedure|Procedure, Debulking Surgical|Surgical Procedure, Debulking|Cytoreductive Surgery|Cytoreductive Surgeries|Surgery, Cytoreductive|Cytoreductive Surgical Procedures|Cytoreductive Surgical Procedure|Procedure, Cytoreductive Surgical|Surgical Procedure, Cytoreductive|Surgical Procedures, Cytoreductive
-D065427	Factor Xa Inhibitors	Inhibitors, Factor Xa|Direct Factor Xa Inhibitors
+D065427	Factor Xa Inhibitors	
 D065446	Premenstrual Dysphoric Disorder	Disorder, Premenstrual Dysphoric|Dysphoric Disorder, Premenstrual|Premenstrual Dysphoric Syndrome|Syndrome, Premenstrual Dysphoric
 D065447	Practice Management, Veterinary	Veterinary Practice Management
 D065466	Lysholm Knee Score	Lysholm Knee Scoring Scale|Lysholm Knee Scale
@@ -28757,7 +29169,7 @@ D065708	Porencephaly	Porencephalies|Encephaloclastic Porencephaly|Porencephaly, 
 D065709	Common Data Elements	Common Data Element|Data Element, Common|Data Elements, Common|Element, Common Data|Elements, Common Data
 D065710	Glossoptosis	Glossoptoses
 D065711	Broca Area	Area, Broca|Broca's Region|Broca Region|Brocas Region|Region, Broca's|Broca's Speech Area|Area, Broca's Speech|Broca Speech Area|Brocas Speech Area|Speech Area, Broca's|Broca's Area|Area, Broca's|Brocas Area
-D065726	Limbic Lobe	Limbic Lobes|Lobe, Limbic|Lobes, Limbic|Lobus Limbicus|Grande Lobe Limbique of Broca
+D065726	Limbic Lobe	Limbic Lobes|Lobe, Limbic|Lobes, Limbic|Grande Lobe Limbique of Broca|Lobus Limbicus
 D065727	Cytochrome P-450 CYP2C8	CYP2C8, Cytochrome P-450|Cytochrome P 450 CYP2C8|P-450 CYP2C8, Cytochrome|Cytochrome P450 MP-20|Cytochrome P450 MP 20|P450 MP-20, Cytochrome|Cytochrome P450, Family 2, Subfamily C, Polypeptide 8|S-Mephenytoin 4-Hydroxylase|4-Hydroxylase, S-Mephenytoin|S Mephenytoin 4 Hydroxylase|CYP2C8|CYPIIC8
 D065729	Cytochrome P-450 CYP2C9	CYP2C9, Cytochrome P-450|Cytochrome P 450 CYP2C9|P-450 CYP2C9, Cytochrome|Cytochrome P450 PB-1|Cytochrome P450 PB 1|P450 PB-1, Cytochrome|PB-1, Cytochrome P450|Cytochrome P450 MP-4|Cytochrome P450 MP 4|MP-4, Cytochrome P450|P450 MP-4, Cytochrome|Cytochrome P450 MP-8|Cytochrome P450 MP 8|MP-8, Cytochrome P450|P450 MP-8, Cytochrome|CYP2C9|CYPIIC9
 D065730	Limonene Hydroxylases	Hydroxylases, Limonene|Limonene Monooxygenases|Monooxygenases, Limonene
@@ -28859,15 +29271,15 @@ D066187	Basal Forebrain	Basal Forebrains|Forebrain, Basal|Forebrains, Basal|Pars
 D066188	Taiga	Taigas|Boreal Forest|Boreal Forests|Forest, Boreal|Forests, Boreal
 D066189	Missionaries	Missionary
 D066190	Allesthesia	Allesthesias|Alloesthesia|Alloesthesias|Allachesthesia|Allachesthesias
-D066191	Sensorimotor Cortex	Cortex, Sensorimotor|Cortices, Sensorimotor|Sensorimotor Cortices|Sensory Motor Area|Area, Sensory Motor|Areas, Sensory Motor|Motor Area, Sensory|Motor Areas, Sensory|Sensory Motor Areas|Sensory-Motor Area|Area, Sensory-Motor|Areas, Sensory-Motor|Sensory-Motor Areas|Sensory-Motor Cortex|Cortex, Sensory-Motor|Cortices, Sensory-Motor|Sensory-Motor Cortices|Sensorimotor Area|Area, Sensorimotor|Areas, Sensorimotor|Sensorimotor Areas|Sensory Motor Cortex|Cortex, Sensory Motor|Cortices, Sensory Motor|Motor Cortex, Sensory|Motor Cortices, Sensory|Sensory Motor Cortices
+D066191	Sensorimotor Cortex	Cortex, Sensorimotor|Cortices, Sensorimotor|Sensorimotor Cortices|Sensory Motor Area|Area, Sensory Motor|Areas, Sensory Motor|Motor Area, Sensory|Motor Areas, Sensory|Sensory Motor Areas|Sensory-Motor Cortex|Cortex, Sensory-Motor|Cortices, Sensory-Motor|Sensory-Motor Cortices|Sensory-Motor Area|Area, Sensory-Motor|Areas, Sensory-Motor|Sensory-Motor Areas|Sensorimotor Area|Area, Sensorimotor|Areas, Sensorimotor|Sensorimotor Areas|Sensory Motor Cortex|Cortex, Sensory Motor|Cortices, Sensory Motor|Motor Cortex, Sensory|Motor Cortices, Sensory|Sensory Motor Cortices
 D066192	Manufacturing Industry	Manufacturing Industries|Fabrication Industry|Fabrication Industries|Industries, Fabrication|Industry, Fabrication
 D066193	Cervical Cord	Cervical Cords|Cord, Cervical|Cords, Cervical|Cervical Spinal Cord|Cervical Spinal Cords|Cord, Cervical Spinal|Cords, Cervical Spinal|Spinal Cord, Cervical|Spinal Cords, Cervical
-D066194	Olfactory Cortex	Cortex, Olfactory|Olfactory Lobe|Lobe, Olfactory|Lobes, Olfactory|Olfactory Lobes|Paleopallium|Paleopalliums|Regio Olfactoria|Olfactoria, Regio|Olfactorias, Regio|Regio Olfactorias|Rhinencephalon|Rhinencephalons|Olfactory Brain|Brain, Olfactory|Brains, Olfactory|Olfactory Brains|Primary Olfactory Cortex|Cortex, Primary Olfactory|Cortices, Primary Olfactory|Olfactory Cortex, Primary|Olfactory Cortices, Primary|Primary Olfactory Cortices
-D066195	Piriform Cortex	Cortex, Piriform|Cortices, Piriform|Piriform Cortices|Piriform Area|Area, Piriform|Areas, Piriform|Piriform Areas|Prepiriform Cortex|Cortex, Prepiriform|Cortices, Prepiriform|Prepiriform Cortices|Pyriform Area|Area, Pyriform|Areas, Pyriform|Pyriform Areas|Prepyriform Cortex|Cortex, Prepyriform|Cortices, Prepyriform|Prepyriform Cortices|Prepyriform Region|Prepyriform Regions|Region, Prepyriform|Regions, Prepyriform|Pyriform Cortex|Cortex, Pyriform|Cortices, Pyriform|Pyriform Cortices|Cortex Piriformis|Cortex Piriformi|Piriformi, Cortex|Piriformis, Cortex|Prepyriform Area|Area, Prepyriform|Areas, Prepyriform|Prepyriform Areas
-D066208	Olfactory Tubercle	Olfactory Tubercles|Tubercle, Olfactory|Tubercles, Olfactory|Anterior Perforated Substance|Anterior Perforated Substances|Perforated Substance, Anterior|Perforated Substances, Anterior|Substance, Anterior Perforated|Substances, Anterior Perforated|Tuberculum Olfactorium|Olfactorium, Tuberculum|Olfactoriums, Tuberculum|Tuberculum Olfactoriums|Anterior Perforated Space
+D066194	Olfactory Cortex	Cortex, Olfactory|Olfactory Brain|Brain, Olfactory|Brains, Olfactory|Olfactory Brains|Regio Olfactoria|Olfactoria, Regio|Olfactorias, Regio|Regio Olfactorias|Paleopallium|Paleopalliums|Primary Olfactory Cortex|Cortex, Primary Olfactory|Cortices, Primary Olfactory|Olfactory Cortex, Primary|Olfactory Cortices, Primary|Primary Olfactory Cortices|Rhinencephalon|Rhinencephalons|Olfactory Lobe|Lobe, Olfactory|Lobes, Olfactory|Olfactory Lobes
+D066195	Piriform Cortex	Cortex, Piriform|Cortices, Piriform|Piriform Cortices|Cortex Piriformis|Cortex Piriformi|Piriformi, Cortex|Piriformis, Cortex|Piriform Area|Area, Piriform|Areas, Piriform|Piriform Areas|Pyriform Area|Area, Pyriform|Areas, Pyriform|Pyriform Areas|Prepiriform Cortex|Cortex, Prepiriform|Cortices, Prepiriform|Prepiriform Cortices|Pyriform Cortex|Cortex, Pyriform|Cortices, Pyriform|Pyriform Cortices|Prepyriform Area|Area, Prepyriform|Areas, Prepyriform|Prepyriform Areas|Prepyriform Cortex|Cortex, Prepyriform|Cortices, Prepyriform|Prepyriform Cortices|Prepyriform Region|Prepyriform Regions|Region, Prepyriform|Regions, Prepyriform
+D066208	Olfactory Tubercle	Olfactory Tubercles|Tubercle, Olfactory|Tubercles, Olfactory|Anterior Perforated Space|Tuberculum Olfactorium|Olfactorium, Tuberculum|Olfactoriums, Tuberculum|Tuberculum Olfactoriums|Anterior Perforated Substance|Anterior Perforated Substances|Perforated Substance, Anterior|Perforated Substances, Anterior|Substance, Anterior Perforated|Substances, Anterior Perforated
 D066209	Medical Writing	Medical Writings|Writing, Medical|Writings, Medical
 D066228	Vaginal Absorption	Absorption, Vaginal
-D066229	Speech Sound Disorder	Disorder, Speech Sound|Disorders, Speech Sound|Sound Disorder, Speech|Sound Disorders, Speech|Speech Sound Disorders|Phonological Disorder|Disorder, Phonological|Disorders, Phonological|Phonological Disorders
+D066229	Speech Sound Disorder	Disorder, Speech Sound|Disorders, Speech Sound|Speech Sound Disorders|Phonological Disorder|Disorder, Phonological|Disorders, Phonological|Phonological Disorders
 D066230	Patient-Specific Modeling	Modeling, Patient-Specific|Patient Specific Modeling|Patient-Specific Computational Modeling|Computational Modeling, Patient-Specific|Patient Specific Computational Modeling
 D066231	Surgeons	
 D066232	Pulmonary Elimination	Elimination, Pulmonary|Pulmonary Excretion|Excretion, Pulmonary
@@ -28878,12 +29290,12 @@ D066236	Bioresonance Therapy	Therapy, Bioresonance|Bio-Physical Information Ther
 D066237	Intestinal Elimination	Elimination, Intestinal|Intestinal Excretion|Excretion, Intestinal
 D066238	Cutaneous Elimination	Cutaneous Eliminations|Elimination, Cutaneous|Eliminations, Cutaneous|Cutaneous Excretion|Cutaneous Excretions|Excretion, Cutaneous|Excretions, Cutaneous
 D066239	Lacteal Elimination	Elimination, Lacteal|Eliminations, Lacteal|Lacteal Eliminations|Lacteal Excretion|Excretion, Lacteal|Excretions, Lacteal|Lacteal Excretions
-D066240	Anterior Cerebellar Commissure	Anterior Cerebellar Commissures|Cerebellar Commissure, Anterior|Cerebellar Commissures, Anterior|Commissure, Anterior Cerebellar|Commissures, Anterior Cerebellar|Anterior Commissure, Cerebellar|Anterior Commissures, Cerebellar|Cerebellar Anterior Commissure|Cerebellar Anterior Commissures|Commissure, Cerebellar Anterior|Commissures, Cerebellar Anterior|Anterior Commissure, Brain|Anterior Commissures, Brain|Brain Anterior Commissure|Brain Anterior Commissures|Commissure, Brain Anterior|Commissures, Brain Anterior
+D066240	Anterior Cerebellar Commissure	Anterior Cerebellar Commissures|Cerebellar Commissure, Anterior|Cerebellar Commissures, Anterior|Commissure, Anterior Cerebellar|Commissures, Anterior Cerebellar|Anterior Commissure, Brain|Anterior Commissures, Brain|Brain Anterior Commissure|Brain Anterior Commissures|Commissure, Brain Anterior|Commissures, Brain Anterior|Anterior Commissure, Cerebellar|Anterior Commissures, Cerebellar|Cerebellar Anterior Commissure|Cerebellar Anterior Commissures|Commissure, Cerebellar Anterior|Commissures, Cerebellar Anterior
 D066241	Carbon-13 Magnetic Resonance Spectroscopy	Carbon 13 Magnetic Resonance Spectroscopy|13C NMR
 D066243	Posterior Cerebellar Commissure	Cerebellar Commissure, Posterior|Cerebellar Commissures, Posterior|Commissure, Posterior Cerebellar|Commissures, Posterior Cerebellar|Posterior Cerebellar Commissures|Posterior Commissure, Cerebellar|Cerebellar Posterior Commissure|Cerebellar Posterior Commissures|Commissure, Cerebellar Posterior|Commissures, Cerebellar Posterior|Posterior Commissures, Cerebellar
 D066244	Proton Magnetic Resonance Spectroscopy	1H-MRS
 D066245	Telencephalic Commissures	Commissure, Telencephalic|Commissures, Telencephalic|Telencephalic Commissure|Forebrain Commissures|Commissure, Forebrain|Commissures, Forebrain|Forebrain Commissure
-D066246	ErbB Receptors	Receptors, ErbB|Receptors, Epidermal Growth Factor-Urogastrone|Receptors, Epidermal Growth Factor Urogastrone|Receptors, Epidermal Growth Factor|EGF Receptors|Receptors, EGF|Epidermal Growth Factor Receptor Family Proteins|HER Family Receptors|Family Receptors, HER|Receptors, HER Family|Erb-b2 Receptor Tyrosine Kinases|Erb b2 Receptor Tyrosine Kinases
+D066246	ErbB Receptors	Receptors, ErbB|Transforming Growth Factor alpha Receptor|Urogastrone Receptor|Receptor, TGF-alpha|Receptor, TGF alpha|Epidermal Growth Factor Receptor Kinase|Epidermal Growth Factor Receptor Protein-Tyrosine Kinase|Epidermal Growth Factor Receptor Protein Tyrosine Kinase|Receptor, Urogastrone|Receptor, Transforming-Growth Factor alpha|Receptor, Transforming Growth Factor alpha|TGF-alpha Receptor
 D066247	Receptor, ErbB-4	c-ErbB-4 Protein|c ErbB 4 Protein|Receptor Protein-tyrosine Kinase ErbB-4|Receptor Protein tyrosine Kinase ErbB 4|HER-4 Proto-oncogene Protein|HER 4 Proto oncogene Protein|Protein, HER-4 Proto-oncogene|Proto-oncogene Protein, HER-4|Proto-oncogene Protein HER-4|HER-4, Proto-oncogene Protein|Protein HER-4, Proto-oncogene|Proto oncogene Protein HER 4|v-erb-a Erythroblastic Leukemia Viral Oncogene Homolog 4 (avian) Protein|Receptor Tyrosine-protein Kinase ErbB-4|Receptor Tyrosine protein Kinase ErbB 4|ErbB-4 Receptor|ErbB 4 Receptor
 D066248	High Fructose Corn Syrup	Isoglucose|Maize Syrup|Syrup, Maize|Glucose-Fructose Syrup|Glucose Fructose Syrup|Syrup, Glucose-Fructose|Corn Sugar|Sugar, Corn|High-Fructose Maize Syrup|High Fructose Maize Syrup|Maize Syrup, High-Fructose|Syrup, High-Fructose Maize
 D066249	Craving	Cravings
@@ -28909,18 +29321,18 @@ D066268	Interpeduncular Nucleus	Nucleus, Interpeduncular|Nucleus Interpeduncular
 D066269	Social Theory	Social Theories|Theories, Social|Theory, Social|Sociological Theory|Sociological Theories|Theories, Sociological|Theory, Sociological
 D066270	Social Capital	Capital, Social
 D066271	External Capsule	Capsule, External|Capsules, External|External Capsules|Capsula Externa|Capsula Externas|Externa, Capsula|Externas, Capsula
-D066272	Basolateral Nuclear Complex	Basolateral Nuclear Complices|Nuclear Complex, Basolateral|Nuclear Complices, Basolateral|Deep Nuclei, Amygdaloid|Amygdaloid Deep Nuclei|Amygdaloid Deep Nucleus|Deep Nucleus, Amygdaloid|Basolateral Nuclear Group|Basolateral Nuclear Groups|Nuclear Group, Basolateral|Nuclear Groups, Basolateral|Deep Nuclei, Amygdala|Amygdala Deep Nuclei|Amygdala Deep Nucleus|Deep Nucleus, Amygdala|Amygdaloid Basolateral Complex|Amygdaloid Basolateral Complices|Basolateral Complex, Amygdaloid|Basolateral Complices, Amygdaloid|Basolateral Amygdala|Amygdala, Basolateral|Amygdalas, Basolateral|Basolateral Amygdalas
+D066272	Basolateral Nuclear Complex	Basolateral Nuclear Complices|Nuclear Complex, Basolateral|Nuclear Complices, Basolateral|Basolateral Nuclear Group|Basolateral Nuclear Groups|Nuclear Group, Basolateral|Nuclear Groups, Basolateral|Deep Nuclei, Amygdala|Amygdala Deep Nuclei|Amygdala Deep Nucleus|Deep Nucleus, Amygdala|Deep Nuclei, Amygdaloid|Amygdaloid Deep Nuclei|Amygdaloid Deep Nucleus|Deep Nucleus, Amygdaloid|Basolateral Amygdala|Amygdala, Basolateral|Amygdalas, Basolateral|Basolateral Amygdalas|Amygdaloid Basolateral Complex|Amygdaloid Basolateral Complices|Basolateral Complex, Amygdaloid|Basolateral Complices, Amygdaloid
 D066273	Diet, Western	Diets, Western|Western Diets|Western Dietary Pattern|Dietary Pattern, Western|Dietary Patterns, Western|Pattern, Western Dietary|Patterns, Western Dietary|Western Dietary Patterns|Diet, Occidental|Diets, Occidental|Occidental Diet|Occidental Diets|Western Diet|Meat-Sweet Diet|Diet, Meat-Sweet|Diets, Meat-Sweet|Meat Sweet Diet|Meat-Sweet Diets
-D066274	Central Amygdaloid Nucleus	Amygdaloid Nucleus, Central|Nucleus, Central Amygdaloid|Central Nucleus of the Amygdala|Central Nucleus of Amygdala|Amygdala Central Nucleus|Central Amygdala Nucleus|Amygdala Nucleus, Central|Nucleus, Central Amygdala|Central Amygdala|Amygdala, Central|Amygdalas, Central|Central Amygdalas
+D066274	Central Amygdaloid Nucleus	Amygdaloid Nucleus, Central|Nucleus, Central Amygdaloid|Central Amygdala|Amygdala, Central|Amygdalas, Central|Central Amygdalas|Central Nucleus of the Amygdala|Central Amygdala Nucleus|Amygdala Nucleus, Central|Nucleus, Central Amygdala|Central Nucleus of Amygdala|Amygdala Central Nucleus
 D066275	Health Information Exchange	Exchange, Health Information|Exchanges, Health Information|Health Information Exchanges|Information Exchange, Health|Information Exchanges, Health|Medical Information Exchange|Exchange, Medical Information|Exchanges, Medical Information|Information Exchange, Medical|Information Exchanges, Medical|Medical Information Exchanges
 D066276	Corticomedial Nuclear Complex	Nuclear Complex, Corticomedial|Superficial Nuclei, Amygdaloid|Amygdaloid Superficial Nuclei|Amygdaloid Superficial Nucleus|Nuclei, Amygdaloid Superficial|Nucleus, Amygdaloid Superficial|Superficial Nucleus, Amygdaloid|Corticomedial Nuclei Complex|Complex, Corticomedial Nuclei|Nuclei Complex, Corticomedial|Superficial Nuclei|Nuclei, Superficial|Nucleus, Superficial|Superficial Nucleus|Corticomedial Nuclei|Corticomedial Nucleus|Corticomedial Nuclear Group|Corticomedial Nuclear Groups|Nuclear Group, Corticomedial|Nuclear Groups, Corticomedial|Superficial Nuclei, Amygdala|Amygdala Superficial Nuclei|Amygdala Superficial Nucleus|Nuclei, Amygdala Superficial|Nucleus, Amygdala Superficial|Superficial Nucleus, Amygdala
 D066277	Periamygdaloid Cortex	Cortex, Periamygdaloid|Periamygdaloid Area
-D066278	Organum Vasculosum	Organum Vasculosums|Vasculosum, Organum|Vasculosums, Organum|Supraoptic Crest|Crest, Supraoptic|Crests, Supraoptic|Supraoptic Crests|Organum Vasculosum Laminae Terminalis|Organum Vasculosum of Lamina Terminalis
+D066278	Organum Vasculosum	Organum Vasculosums|Vasculosum, Organum|Vasculosums, Organum|Organum Vasculosum of Lamina Terminalis|Supraoptic Crest|Crest, Supraoptic|Crests, Supraoptic|Supraoptic Crests|Organum Vasculosum Laminae Terminalis
 D066279	Courage	Heroism|Bravery
 D066280	Circumventricular Organs	Circumventricular Organ|Organ, Circumventricular|Organs, Circumventricular
 D066288	Romanticism	
 D066289	Data Curation	Curation, Data
-D066290	Libraries, Special	Library, Special|Special Libraries|Special Library
+D066290	Libraries, Special	Special Libraries|Special Library
 D066291	Psychiatry in Literature	Literature, Psychiatry in|Literatures, Psychiatry in|Psychiatry in Literatures|in Literature, Psychiatry|in Literatures, Psychiatry
 D066292	Lipid Droplets	Droplet, Lipid|Droplets, Lipid|Lipid Droplet|Lipid Bodies|Lipid Body|Lipid Storage Bodies|Lipid Storage Body|Storage Bodies, Lipid|Storage Body, Lipid|Adiposomes|Adiposome
 D066293	Renshaw Cells	Cells, Renshaw|Spinal Cord Ventral Horn Interneuron Renshaw|Renshaw Cell|Cell, Renshaw|Renshaw Interneurons|Interneurons, Renshaw
@@ -28930,10 +29342,10 @@ D066296	Grounded Theory	Theory, Grounded
 D066297	Hermeneutics	Hermeneutic
 D066298	In Vitro Techniques	In Vitro Technique|Technique, In Vitro|Techniques, In Vitro|In Vitro as Topic
 D066300	Electronic Nicotine Delivery Systems	
-D066308	Public Service Announcements as Topic	Public Service Advertising as Topic|Public Service Ads as Topic
-D066309	Public Service Announcements	Public Service Ads|Public Service Advertising
+D066308	Public Service Announcements as Topic	Public Service Ads as Topic|Public Service Advertising as Topic
+D066309	Public Service Announcement	Public Service Advertising|Public Service Ads|Public Service Announcements
 D066310	Digital Divide	Divide, Digital
 D066328	Ventral Striatum	Striatum, Ventral
 D066329	Protein Aggregates	Aggregates, Protein
-D066330	Printing, Three-Dimensional	Printing, Three Dimensional|Printings, Three-Dimensional|Three-Dimensional Printings|3 Dimensional Printing|3 Dimensional Printings|Dimensional Printing, 3|Dimensional Printings, 3|Printing, 3 Dimensional|Printings, 3 Dimensional|3D Printing|3D Printings|Printing, 3D|Printings, 3D|Three Dimensional Printing|Dimensional Printing, Three|Dimensional Printings, Three|Printings, Three Dimensional|Three Dimensional Printings|Three-Dimensional Printing|3-Dimensional Printing|3-Dimensional Printings|Printing, 3-Dimensional|Printings, 3-Dimensional|3-D Printing|3 D Printing|3-D Printings|Printing, 3-D|Printings, 3-D
+D066330	Printing, Three-Dimensional	Printing, Three Dimensional|Printings, Three-Dimensional|Three-Dimensional Printings|3-Dimensional Printing|3 Dimensional Printing|3-Dimensional Printings|Printing, 3-Dimensional|Printings, 3-Dimensional|3-D Printing|3 D Printing|3-D Printings|Printing, 3-D|Printings, 3-D|Three-Dimensional Printing|Three Dimensional Printing|3D Printing|3D Printings|Printing, 3D|Printings, 3D
 D066331	Laser-Evoked Potentials	Laser Evoked Potentials|Laser-Evoked Potential|Potential, Laser-Evoked|Potentials, Laser-Evoked

--- a/indra/resources/update_resources.py
+++ b/indra/resources/update_resources.py
@@ -603,8 +603,8 @@ def update_lincs_proteins():
 
 
 def update_mesh_names():
-    url = 'ftp://nlmpubs.nlm.nih.gov/online/mesh/2018/xmlmesh/desc2018.gz'
-    desc_path = os.path.join(path, 'mesh_desc2018.gz')
+    url = 'ftp://nlmpubs.nlm.nih.gov/online/mesh/2019/xmlmesh/desc2019.gz'
+    desc_path = os.path.join(path, 'mesh_desc2019.gz')
     if not os.path.exists(desc_path):
         logging.info('Download MeSH descriptors from %s', url)
         urlretrieve(url, desc_path)
@@ -626,8 +626,8 @@ def update_mesh_names():
 
 
 def update_mesh_supplementary_names():
-    supp_url = 'ftp://nlmpubs.nlm.nih.gov/online/mesh/2018/xmlmesh/supp2018.gz'
-    supp_path = os.path.join(path, 'mesh_supp2018.gz')
+    supp_url = 'ftp://nlmpubs.nlm.nih.gov/online/mesh/2019/xmlmesh/supp2019.gz'
+    supp_path = os.path.join(path, 'mesh_supp2019.gz')
     if not os.path.exists(supp_path):
         logging.info('Download MeSH supplement from %s', supp_url)
         urlretrieve(supp_url, supp_path)

--- a/indra/tests/test_mesh.py
+++ b/indra/tests/test_mesh.py
@@ -72,7 +72,6 @@ def test_mesh_term_name_norm():
 def test_mesh_term_lookups():
     queries = {'Breast Cancer': ('D001943', 'Breast Neoplasms'),
                'Neoplasms': ('D009369', 'Neoplasms'),
-               'Colorectal Cancer': ('D015179', 'Colorectal Neoplasms'),
                'Intestinal Neoplasms': ('D007414', 'Intestinal Neoplasms'),
                'Carcinoma, Non-Small-Cell Lung':
                                 ('D002289', 'Carcinoma, Non-Small-Cell Lung'),

--- a/indra/tests/test_mesh.py
+++ b/indra/tests/test_mesh.py
@@ -79,8 +79,8 @@ def test_mesh_term_lookups():
                'Prostate Cancer': ('D011471', 'Prostatic Neoplasms')}
     for query_term, (correct_id, correct_name) in queries.items():
         mesh_id, mesh_name = mesh_client.get_mesh_id_name(query_term)
-        assert mesh_id == correct_id
-        assert mesh_name == correct_name
+        assert mesh_id == correct_id, (query_term, mesh_id, correct_id)
+        assert mesh_name == correct_name, (query_term, mesh_name, correct_name)
 
 
 def test_mesh_isa():


### PR DESCRIPTION
This PR updates the MeSH name/ID mapping files to their latest versions. In an attempt to fix the failing test_mesh_term_lookups test, I investigated both the downloadable dumps and the web service to see why  'Colorectal Cancer' does not map to  'D015179' (Colorectal Neoplasms) anymore. I found that 'Colorectal Cancer' has been removed as a term from D015179's descriptor and appears as a narrower synonym to it under the corresponding M heading (rather than the D descriptor). Similarly, the current web service does not return this mapping anymore.

Two confusing facts remain, however: (1) On the MeSh website, Colorectal Cancer still appears as a term for D015179 (https://meshb.nlm.nih.gov/record/ui?ui=D015179), and (2) Similar relationships, such as 'Prostate Cancer' as a term of D011471 (Prostatic Neoplasms) are still there, which seems to be somewhat inconsistent.