### PR TITLE
Tweak aws util: run_in_batch

### DIFF
--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -111,8 +111,6 @@ class BatchMonitor(object):
         while True:
             pre_run = []
             self.job_id_list = get_ids(self.job_list)
-            logger.info("Specifically tracked jobs: %s"
-                        % len(self.job_id_list))
             for status in ('SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING'):
                 pre_run += self.get_jobs_by_status(status)
             running = self.get_jobs_by_status('RUNNING')
@@ -126,9 +124,11 @@ class BatchMonitor(object):
                 self.get_dict_of_job_tuples(pre_run + running)
             )
 
-            logger.info('(%d s)=(pre: %d, running: %d, failed: %d, done: %d)'
+            logger.info('(%d s)=(tracking: %d, pre: %d, running: %d, '
+                        'failed: %d, done: %d)'
                         % ((datetime.now() - self.start_time).seconds,
-                           len(pre_run), len(running), len(failed), len(done)))
+                           len(self.job_id_list), len(pre_run), len(running),
+                           len(failed), len(done)))
 
             # Check the logs for new output, and possibly terminate some jobs.
             stalled_jobs = self.check_logs(running, idle_log_timeout)

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -131,7 +131,7 @@ class BatchMonitor(object):
                            len(pre_run), len(running), len(failed), len(done)))
 
             # Check the logs for new output, and possibly terminate some jobs.
-            stalled_jobs = self.check_logs(running)
+            stalled_jobs = self.check_logs(running, idle_log_timeout)
             if idle_log_timeout is not None:
                 if kill_on_log_timeout:
                     # Keep track of terminated jobs so we don't send a
@@ -232,7 +232,7 @@ class BatchMonitor(object):
                     if job_def['jobId'] in self.job_id_list]
         return jobs
 
-    def check_logs(self, job_defs):
+    def check_logs(self, job_defs, idle_log_timeout):
         """Updates the job_log_dict."""
         stalled_jobs = set()
 
@@ -264,7 +264,7 @@ class BatchMonitor(object):
                     logger.warning(('Job \'%s\' has not produced output for '
                                     '%d seconds.')
                                    % (job_def['jobName'], check_dt.seconds))
-                    if check_dt.seconds > self.idle_log_timeout:
+                    if check_dt.seconds > idle_log_timeout:
                         logger.warning("Job \'%s\' has stalled."
                                        % job_def['jobName'])
                         stalled_jobs.add(jid)

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -172,6 +172,7 @@ class BatchMonitor(object):
                     log_name = self._get_log_name(stash_log_method,
                                                   job_log.job_name, 'RUNNING')
                     job_log.dump(log_name)
+                    job_log.clear_lines()
 
             sleep(poll_interval)
 
@@ -192,6 +193,7 @@ class BatchMonitor(object):
             log_name = self._get_log_name(stash_log_method, job_log.job_name,
                                           label)
             job_log.dump(log_name)
+            job_log.clear_lines()
 
         result_record['terminated'] = terminated_jobs
         result_record['failed'] = failed
@@ -254,7 +256,7 @@ class BatchMonitor(object):
                 job_log.get_lines()
                 post_len = len(job_log)
 
-                if pre_len == post_len:
+                if post_len and pre_len == post_len:
                     # If the job log hasn't changed, announce as such, and
                     # check to see if it has been the same for longer than
                     # stall time.
@@ -266,10 +268,6 @@ class BatchMonitor(object):
                         logger.warning("Job \'%s\' has stalled."
                                        % job_def['jobName'])
                         stalled_jobs.add(jid)
-
-                # Dump the log lines as we go, reducing RAM usage.
-                job_log.dump()
-                job_log.clear_lines()
             except Exception as e:
                 # Sometimes due to sync et al. issues, a part of this will fail
                 # Such things are usually transitory issues so we keep trying.
@@ -390,7 +388,7 @@ class Submitter(object):
         else:
             self.readers = readers
         self.project_name = project_name
-        self.job_list = None
+        self.job_list = []
         self.options = options
         self.ids_per_job = None
         self.running = None
@@ -451,8 +449,6 @@ class Submitter(object):
         job_list : list[str]
             A list of job id strings.
         """
-        self.job_list = []
-
         # stash this for later.
         self.ids_per_job = ids_per_job
 

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from indra.literature import elsevier_client as ec
 from indra.literature.elsevier_client import _ensure_api_keys
 from indra.tools.reading.readers import get_reader_classes
-from indra.tools.reading.util import get_s3_job_prefix, get_s3_and_job_prefixes
+from indra.tools.reading.util import get_s3_job_log_prefix, get_s3_and_job_prefixes
 from indra.util.aws import tag_instance, get_batch_command, kill_all, get_ids,\
     JobLog
 
@@ -221,8 +221,8 @@ class BatchMonitor(object):
             raise ValueError("You cannot stash logs without specifying a base "
                              "directory for the logs: log_base.")
         if stash_log_method == 's3':
-            s3_prefix = get_s3_job_prefix(self.log_base, job_name,
-                                          job_queue=self.queue_name)
+            s3_prefix = get_s3_job_log_prefix(self.log_base, job_name,
+                                              job_queue=self.queue_name)
             log_name = (label + '_' if label else '') + log_name
             log_name = 's3:%s/%s%s' % (bucket_name, s3_prefix, log_name)
         elif stash_log_method == 'local':

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -40,7 +40,7 @@ class BatchMonitor(object):
         If you choose to dump logs on s3, this will be the s3 prefix. Note that
         a trailing '/' is NOT assumed.
     """
-    def __init__(self, queue_name, job_base=None, log_base=None, job_list=None):
+    def __init__(self, queue_name, job_list=None, job_base=None, log_base=None):
 
         self.start_time = datetime.now()
         self.queue_name = queue_name

--- a/indra/tools/reading/submit_reading_pipeline.py
+++ b/indra/tools/reading/submit_reading_pipeline.py
@@ -218,8 +218,8 @@ class BatchMonitor(object):
         if stash_log_method == 's3':
             s3_prefix = get_s3_job_prefix(self.log_base, job_name,
                                           job_queue=self.queue_name)
-            log_name = label + '_' if label else '' + log_name
-            log_name = 's3:%s/%s/%s' % (bucket_name, s3_prefix, log_name)
+            log_name = (label + '_' if label else '') + log_name
+            log_name = 's3:%s/%s%s' % (bucket_name, s3_prefix, log_name)
         elif stash_log_method == 'local':
             prefix = self.log_base
             if prefix is None:

--- a/indra/tools/reading/util/__init__.py
+++ b/indra/tools/reading/util/__init__.py
@@ -1,9 +1,9 @@
-def get_s3_root(s3_base, job_queue="run_db_reading_queue"):
+def get_s3_log_prefix(s3_base, job_queue="run_db_reading_queue"):
     return s3_base + 'logs/%s/' % job_queue
 
 
-def get_s3_job_prefix(s3_base, job_name, job_queue="run_db_reading_queue"):
-    s3_root = get_s3_root(s3_base, job_queue)
+def get_s3_job_log_prefix(s3_base, job_name, job_queue="run_db_reading_queue"):
+    s3_root = get_s3_log_prefix(s3_base, job_queue)
     return s3_root + '%s/' % job_name
 
 

--- a/indra/tools/reading/util/__init__.py
+++ b/indra/tools/reading/util/__init__.py
@@ -1,0 +1,17 @@
+def get_s3_root(s3_base, job_queue="run_db_reading_queue"):
+    return s3_base + 'logs/%s/' % job_queue
+
+
+def get_s3_job_prefix(s3_base, job_name, job_queue="run_db_reading_queue"):
+    s3_root = get_s3_root(s3_base, job_queue)
+    return s3_root + '%s/' % job_name
+
+
+def get_s3_and_job_prefixes(base_name, group_name=None):
+    """Returns the s3 prefix and job prefix."""
+    if not group_name:
+        s3_base = base_name
+        job_base = base_name
+    else:
+        s3_base, job_base = [group_name + d + base_name for d in ['/', '_']]
+    return 'reading_results/' + s3_base + '/', job_base

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -259,7 +259,8 @@ class JobLog(object):
                         self.lines.append(line)
                         self.latest_timestamp = \
                             (datetime.fromtimestamp(evt['timestamp']/1000)
-                                     .astimezone(timezone.utc))
+                                     .astimezone(timezone.utc)
+                                     .replace(tzinfo=None))
                         self.__len += 1
                         if self.verbose:
                             logger.info('%d %s' % (len(self.lines), line))

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -480,7 +480,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.task == 'run_in_batch':
-        ret_code = run_in_batch(args.command.split(' '), args.project,
+        ret_code = run_in_batch(args.command.split(), args.project,
                                 args.purpose)
         if ret_code is 0:
             logger.info('Job endend well.')

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -188,6 +188,11 @@ class JobLog(object):
         self.latest_timestamp = None
         self.lines = []
         self.nextToken = None
+        self.__len = 0
+        return
+
+    def __len__(self):
+        return self.__len
 
     def clear_lines(self):
         self.lines = []
@@ -218,6 +223,9 @@ class JobLog(object):
                     for evt in events:
                         line = '%s: %s\n' % (evt['timestamp'], evt['message'])
                         self.lines.append(line)
+                        self.latest_timestamp = \
+                            datetime.fromtimestamp(evt['timestamp'])
+                        self.__len += 1
                         if self.verbose:
                             logger.info('%d %s' % (len(self.lines), line))
                 self.nextToken = response.get('nextForwardToken')
@@ -228,8 +236,8 @@ def dump_logs(job_queue='run_reach_queue', job_status='RUNNING'):
     """Write logs for all jobs with given the status to files."""
     jobs = get_jobs(job_queue, job_status)
     for job in jobs:
-        job_log = JobLog(job)
-        job_log.dump()
+        log = JobLog(job)
+        log.dump()
 
 
 def get_date_from_str(date_str):

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -258,7 +258,7 @@ class JobLog(object):
                         line = '%s: %s\n' % (evt['timestamp'], evt['message'])
                         self.lines.append(line)
                         self.latest_timestamp = \
-                            datetime.fromtimestamp(evt['timestamp'])
+                            datetime.fromtimestamp(evt['timestamp']/1000)
                         self.__len += 1
                         if self.verbose:
                             logger.info('%d %s' % (len(self.lines), line))

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -197,13 +197,17 @@ class JobLog(object):
     def clear_lines(self):
         self.lines = []
 
-    def dump(self):
+    def dump(self, out_file=None):
         """Dump the logs in their entirety to the specified file."""
-        self.get_lines()
-        out_file = '%s_%s.log' % (self.job_name, self.job_id)
+        if not out_file:
+            out_file = '%s_%s.log' % (self.job_name, self.job_id)
         with open(out_file, 'wt') as f:
             for line in self.lines:
                 f.write(line)
+        return
+
+    def dumps(self):
+        return ''.join(self.lines)
 
     def get_lines(self):
         kwargs = {'logGroupName': self.log_group_name,
@@ -237,6 +241,7 @@ def dump_logs(job_queue='run_reach_queue', job_status='RUNNING'):
     jobs = get_jobs(job_queue, job_status)
     for job in jobs:
         log = JobLog(job)
+        log.get_lines()
         log.dump()
 
 

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -141,6 +141,7 @@ def get_batch_command(command_list, project=None, purpose=None):
 def run_in_batch(command_list, project, purpose):
     from subprocess import call
     tag_myself(project, purpose=purpose)
+    logger.info("Running command list: %s" % str(command_list))
     logger.info('\n'+20*'='+' Begin Primary Command Output '+20*'='+'\n')
     ret_code = call(command_list)
     logger.info('\n'+21*'='+' End Primary Command Output '+21*'='+'\n')

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -221,7 +221,7 @@ class JobLog(object):
             # Find the largest part number among the current suffixes
             if append:
                 max_num = 0
-                for key in iter_s3_keys(s3, bucket, prefix):
+                for key in iter_s3_keys(s3, bucket, prefix, do_retry=False):
                     if key[len(prefix):].startswith(self._suffix_base):
                         num = int(key[len(prefix + self._suffix_base):])
                         if max_num > num:

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -214,15 +214,16 @@ class JobLog(object):
             s3 = boto3.client('s3')
 
             # Find the largest part number among the current suffixes
+            suffix_base = '/part_'
             max_num = 0
             for key in iter_s3_keys(s3, bucket, prefix):
-                if key[len(prefix):].startswith('.'):
-                    num = int(key[len(prefix + '.'):])
+                if key[len(prefix):].startswith(suffix_base):
+                    num = int(key[len(prefix + suffix_base):])
                     if max_num > num:
                         max_num = num
 
             # Create the new suffix, and dump the lines to s3.
-            new_suffix = '.%d' % (max_num + 1)
+            new_suffix = suffix_base + str(max_num + 1)
             s3.put_object(Bucket=bucket, Key=prefix + new_suffix,
                           Body=''.join(self.lines))
         else:

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -258,8 +258,8 @@ class JobLog(object):
                         line = '%s: %s\n' % (evt['timestamp'], evt['message'])
                         self.lines.append(line)
                         self.latest_timestamp = \
-                            datetime.fromtimestamp(evt['timestamp']/1000,
-                                                   tz=timezone.utc)
+                            (datetime.fromtimestamp(evt['timestamp']/1000)
+                                     .astimezone(timezone.utc))
                         self.__len += 1
                         if self.verbose:
                             logger.info('%d %s' % (len(self.lines), line))

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -204,13 +204,13 @@ class JobLog(object):
         kwargs = {'logGroupName': self.log_group_name,
                   'logStreamName': self.log_stream_name,
                   'startFromHead': True}
-        if self.nextToken is not None:
-            kwargs['nextToken'] = self.nextToken
         while True:
+            if self.nextToken is not None:
+                kwargs['nextToken'] = self.nextToken
             response = self.logs_client.get_log_events(**kwargs)
             # If we've gotten all the events already, the nextForwardToken for
             # this call will be the same as the last one
-            if response.get('nextForwardToken') == kwargs.get('nextToken'):
+            if response.get('nextForwardToken') == self.nextToken:
                 break
             else:
                 events = response.get('events')

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -258,7 +258,8 @@ class JobLog(object):
                         line = '%s: %s\n' % (evt['timestamp'], evt['message'])
                         self.lines.append(line)
                         self.latest_timestamp = \
-                            datetime.fromtimestamp(evt['timestamp']/1000)
+                            datetime.fromtimestamp(evt['timestamp']/1000,
+                                                   tz=timezone.utc)
                         self.__len += 1
                         if self.verbose:
                             logger.info('%d %s' % (len(self.lines), line))


### PR DESCRIPTION
Make tiny changes to the `run_in_batch` functionality of the aws util: specifically, ensure that a trailing space, or the presence of multiple spaces do not mess up the command list.