### PR TITLE
Add some new flexibility to the HTML assembler.

### DIFF
--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -148,14 +148,14 @@ class HtmlAssembler(object):
         agents = {}
         previous_stmt_set = set()
         for row in stmt_rows:
-            # Distinguish between the cases with
+            # Distinguish between the cases with source counts and without.
             if self.source_counts:
                 key, verb, stmts_group, tl_counts, src_counts = row
             else:
                 key, verb, stmts_group = row
                 src_counts = None
                 tl_counts = None
-            curr_stmt_set = {s.get_hash() for s in stmts}
+            curr_stmt_set = {s.get_hash() for s in stmts_group}
             if curr_stmt_set == previous_stmt_set:
                 continue
             else:

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -176,7 +176,8 @@ class HtmlAssembler(object):
 
                 # Try to accumulate db refs in the meta agents.
                 for ag in stmt.agent_list():
-
+                    if ag is None:
+                        continue
                     # Get the corresponding meta-agent
                     meta_ag = meta_agent_dict.get(ag.name)
                     if not meta_ag:

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -183,7 +183,13 @@ class HtmlAssembler(object):
             for stmt in stmts_group:
                 stmt_hash = stmt.get_hash(shallow=True)
                 for ag in stmt.agent_list():
-                    name_groundings[ag.name].update(ag.db_refs)
+                    for dbn, dbid in ag.db_refs.items():
+                        # If we've seen it before and don't agree, scrap it.
+                        existing_dbid = name_groundings[ag.name].get(dbn)
+                        if existing_dbid is not None and existing_dbid != dbid:
+                            name_groundings[ag.name].pop(dbn)
+                        elif existing_dbid is None:
+                            name_groundings[ag.name][dbn] = dbid
                 ev_list = self._format_evidence_text(stmt)
                 english = self._format_stmt_text(stmt)
                 if self.ev_totals:

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -197,19 +197,23 @@ class HtmlAssembler(object):
                     'source_count': self.source_counts.get(stmt_hash)})
 
             # Generate the short name for the statement and a unique key.
-            if with_grouping or not stmts[tl_key]['stmts_formatted']:
+            existing_list = stmts[tl_key]['stmts_formatted']
+            if with_grouping or not existing_list:
                 if with_grouping:
                     short_name = make_string_from_sort_key(key, verb)
                     short_name_key = str(uuid.uuid4())
                 else:
                     short_name = "All Statements Sub Group"
                     short_name_key = "all-statements-sub-group"
-                new_tpl = (short_name, short_name_key, stmt_info_list, src_counts)
-                stmts[tl_key]['stmts_formatted'].append(new_tpl)
+                new_dict = {'short_name': short_name,
+                            'short_name_key': short_name_key,
+                            'stmt_info_list': stmt_info_list,
+                            'src_counts': src_counts}
+                existing_list.append(new_dict)
             else:
-                stmts[tl_key]['stmts_formatted'][0][2].extend(stmt_info_list)
+                existing_list[0]['stmt_info_list'].extend(stmt_info_list)
                 if src_counts:
-                    stmts[tl_key]['stmts_formatted'][0][3].update(src_counts)
+                    existing_list[0]['src_counts'].update(src_counts)
 
         return stmts
 

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -2,24 +2,21 @@
 Format a set of INDRA Statements into an HTML-formatted report which also
 supports curation.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str
 
 import re
 import uuid
 import logging
 import itertools
-from collections import OrderedDict, defaultdict
-from os.path import abspath, dirname, join, exists, getmtime, sep
+from collections import OrderedDict
+from os.path import abspath, dirname, join
 
-from jinja2 import Environment, BaseLoader, TemplateNotFound, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader
 
 from indra.statements import *
 from indra.assemblers.english import EnglishAssembler
-from indra.databases import get_identifiers_url, hgnc_client, chebi_client
+from indra.databases import get_identifiers_url
 from indra.util.statement_presentation import group_and_sort_statements, \
-    make_string_from_sort_key, make_top_level_label_from_names_key, \
-    make_stmt_from_sort_key
+    make_top_level_label_from_names_key, make_stmt_from_sort_key
 
 logger = logging.getLogger(__name__)
 HERE = dirname(abspath(__file__))

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -190,7 +190,7 @@ class HtmlAssembler(object):
                     evidence_count_str = str(len(ev_list))
 
                 stmt_info_list.append({
-                    'hash': stmt_hash,
+                    'hash': str(stmt_hash),
                     'english': english,
                     'evidence': ev_list,
                     'evidence_count': evidence_count_str,
@@ -345,7 +345,7 @@ class HtmlAssembler(object):
                             'pmid': ev.pmid,
                             'text_refs': ev.text_refs,
                             'text': format_text,
-                            'source_hash': ev.source_hash })
+                            'source_hash': str(ev.source_hash) })
 
         return ev_list
 

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -136,7 +136,21 @@ class HtmlAssembler(object):
         self.statements += statements
 
     def make_json_model(self, with_grouping=True):
-        """Return the JSON used to create the HTML display."""
+        """Return the JSON used to create the HTML display.
+
+        Parameters
+        ----------
+        with_grouping : bool
+            If True, statements will be grouped under multiple sub-headings. If
+            False, all headings will be collapsed into one on every level, with
+            all statements placed under a single heading.
+
+        Returns
+        -------
+        json : dict
+            A complexly structured JSON dict containing grouped statements and
+            various metadata.
+        """
         # Get an iterator over the statements, carefully grouped.
         stmt_rows = group_and_sort_statements(
             self.statements,
@@ -287,6 +301,21 @@ class HtmlAssembler(object):
 
     def make_model(self, template=None, with_grouping=True, **template_kwargs):
         """Return the assembled HTML content as a string.
+
+        Parameters
+        ----------
+        template : a Template object
+            Manually pass a Jinja template to be used in generating the HTML.
+            The template is responsible for rendering essentially the output of
+            `make_json_model`.
+        with_grouping : bool
+            If True, statements will be grouped under multiple sub-headings. If
+            False, all headings will be collapsed into one on every level, with
+            all statements placed under a single heading.
+
+        All other keyword arguments are passed along to the template. If you
+        are using a custom template with args that are not passed below, this
+        is how you pass them.
 
         Returns
         -------

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -237,7 +237,7 @@ class HtmlAssembler(object):
                                  'names': tl_names}
                 if tl_label:
                     stmts[tl_key]['label'] = tl_label
-            else:
+            elif with_grouping:
                 for name, existing_ag in agents[tl_key].items():
                     new_ag = tl_agents.get(name)
                     if new_ag is None:

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -115,13 +115,15 @@ class HtmlAssembler(object):
     """
 
     def __init__(self, statements=None, summary_metadata=None, ev_totals=None,
-                 source_counts=None, title='INDRA Results', db_rest_url=None):
+                 source_counts=None, curation_dict=None, title='INDRA Results',
+                 db_rest_url=None):
         self.title = title
         self.statements = [] if statements is None else statements
         self.metadata = {} if summary_metadata is None \
             else summary_metadata
         self.ev_totals = {} if ev_totals is None else ev_totals
         self.source_counts = {} if source_counts is None else source_counts
+        self.curation_dict = {} if curation_dict is None else curation_dict
         self.db_rest_url = db_rest_url
         self.model = None
 
@@ -271,8 +273,7 @@ class HtmlAssembler(object):
         with open(fname, 'wb') as fh:
             fh.write(self.model.encode('utf-8'))
 
-    @staticmethod
-    def _format_evidence_text(stmt):
+    def _format_evidence_text(self, stmt):
         """Returns evidence metadata with highlighted evidence text.
 
         Parameters
@@ -341,11 +342,14 @@ class HtmlAssembler(object):
                                                       ev.text)]
                 format_text = tag_text(ev.text, indices)
 
+            has_curation = ((stmt.get_hash(), ev.source_hash)
+                            in self.curation_dict.keys())
             ev_list.append({'source_api': source_api,
                             'pmid': ev.pmid,
                             'text_refs': ev.text_refs,
                             'text': format_text,
-                            'source_hash': str(ev.source_hash) })
+                            'source_hash': str(ev.source_hash),
+                            'has_curation': has_curation})
 
         return ev_list
 

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -135,14 +135,8 @@ class HtmlAssembler(object):
         """
         self.statements += statements
 
-    def make_model(self, template=None, **template_kwargs):
-        """Return the assembled HTML content as a string.
-
-        Returns
-        -------
-        str
-            The assembled HTML as a string.
-        """
+    def make_json_model(self):
+        """Return the JSON used to create the HTML display."""
         # Get an iterator over the statements, carefully grouped.
         stmt_rows = group_and_sort_statements(
             self.statements,
@@ -204,6 +198,18 @@ class HtmlAssembler(object):
 
             new_tpl = (short_name, short_name_key, stmt_info_list, src_counts)
             tl_stmts[tl_key]['stmts_formatted'].append(new_tpl)
+
+        return tl_stmts
+
+    def make_model(self, template=None, **template_kwargs):
+        """Return the assembled HTML content as a string.
+
+        Returns
+        -------
+        str
+            The assembled HTML as a string.
+        """
+        tl_stmts = self.make_json_model()
 
         metadata = {k.replace('_', ' ').title(): v
                     for k, v in self.metadata.items()

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -202,15 +202,16 @@ class HtmlAssembler(object):
                     for dbn, dbid in ag.db_refs.items():
                         if dbn == 'TEXT':
                             continue
-                        existing_dbid = meta_ag.db_refs.get(dbn)
-                        if existing_dbid is not None and existing_dbid != dbid:
+                        meta_dbid = meta_ag.db_refs.get(dbn)
+                        if isinstance(meta_dbid, set):
+                            # If we've already marked this one add to the set.
+                            meta_ag.db_refs[dbn].add(dbid)
+                        elif meta_dbid is not None and meta_dbid != dbid:
                             # If we've seen it before and don't agree, mark it.
                             meta_ag.db_refs[dbn] = {meta_ag.db_refs[dbn], dbid}
-                        elif existing_dbid is None:
+                        elif meta_dbid is None:
                             # Otherwise, add it.
                             meta_ag.db_refs[dbn] = dbid
-                        elif isinstance(existing_dbid, set):
-                            meta_ag.db_refs[dbn].add(dbid)
 
                 # Format some strings nicely.
                 ev_list = self._format_evidence_text(stmt)

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -151,6 +151,7 @@ class HtmlAssembler(object):
 
         # Do some extra formatting.
         tl_stmts = OrderedDict()
+        previous_stmt_set = set()
         for row in stmt_rows:
             # Distinguish between the cases with
             if self.source_counts:
@@ -159,6 +160,11 @@ class HtmlAssembler(object):
                 key, verb, stmts = row
                 src_counts = None
                 tl_counts = None
+            curr_stmt_set = {s.get_hash() for s in stmts}
+            if curr_stmt_set == previous_stmt_set:
+                continue
+            else:
+                previous_stmt_set = curr_stmt_set
 
             names = key[1]
             tl_key = '-'.join([str(name) for name in names])

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -368,27 +368,31 @@ class HtmlAssembler(object):
         english = ea.make_model()
         if not english:
             english = str(stmt)
-        indices = []
-        for ag in stmt.agent_list():
-            if ag is None or not ag.name:
-                continue
-            url = id_url(ag)
-            if url is None:
-                continue
-            # Build up a set of indices
-            tag_start = "<a href='%s'>" % url
-            tag_close = "</a>"
-            found = False
-            for m in re.finditer(re.escape(ag.name), english):
-                index = (m.start(), m.start() + len(ag.name), ag.name,
-                         tag_start, tag_close)
-                indices.append(index)
-                found = True
-            if not found and \
-                    english.startswith(re.escape(ag.name).capitalize()):
-                index = (0, len(ag.name), ag.name, tag_start, tag_close)
-                indices.append(index)
-        return tag_text(english, indices)
+        return tag_agents(english, stmt.agent_list())
+
+
+def tag_agents(english, agents):
+    indices = []
+    for ag in agents:
+        if ag is None or not ag.name:
+            continue
+        url = id_url(ag)
+        if url is None:
+            continue
+        # Build up a set of indices
+        tag_start = "<a href='%s' target='_blank'>" % url
+        tag_close = "</a>"
+        found = False
+        for m in re.finditer(re.escape(ag.name), english):
+            index = (m.start(), m.start() + len(ag.name), ag.name,
+                     tag_start, tag_close)
+            indices.append(index)
+            found = True
+        if not found and \
+                english.startswith(re.escape(ag.name).capitalize()):
+            index = (0, len(ag.name), ag.name, tag_start, tag_close)
+            indices.append(index)
+    return tag_text(english, indices)
 
 
 def id_url(ag):

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -206,6 +206,8 @@ class HtmlAssembler(object):
 
             # Clean out invalid fields from the meta agents.
             for ag in meta_agents:
+                if ag is None:
+                    continue
                 for dbn, dbid in list(ag.db_refs.items()):
                     if isinstance(dbid, set):
                         logger.warning("Removing %s from refs due to too many "

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -163,20 +163,6 @@ class HtmlAssembler(object):
             else:
                 previous_stmt_set = curr_stmt_set
 
-            names = key[1]
-            if with_grouping:
-                tl_key = '-'.join([str(name) for name in names])
-                tl_label = make_top_level_label_from_names_key(names)
-            else:
-                tl_key = 'all-statements'
-                tl_label = 'All Statements'
-
-            if tl_key not in stmts.keys():
-                stmts[tl_key] = {'html_key': str(uuid.uuid4()),
-                                 'label': tl_label,
-                                 'source_counts': tl_counts,
-                                 'stmts_formatted': []}
-
             # We will keep track of some of the meta data for this stmt group.
             # NOTE: Much of the code relies heavily on the fact that the Agent
             # objects in `meta_agents` are references to the Agent's in the
@@ -239,6 +225,22 @@ class HtmlAssembler(object):
                         logger.warning("Removing %s from refs due to too many "
                                        "matches: %s" % (dbn, dbid))
                         del ag.db_refs[dbn]
+
+            names = key[1]
+            if with_grouping:
+                tl_key = '-'.join([str(name) for name in names])
+                tl_label = make_top_level_label_from_names_key(names)
+                tl_label = re.sub("<b>(.*?)</b>", r"\1", tl_label)
+                tl_label = tag_agents(tl_label, meta_agents)
+            else:
+                tl_key = 'all-statements'
+                tl_label = 'All Statements'
+
+            if tl_key not in stmts.keys():
+                stmts[tl_key] = {'html_key': str(uuid.uuid4()),
+                                 'label': tl_label,
+                                 'source_counts': tl_counts,
+                                 'stmts_formatted': []}
 
             # Generate the short name for the statement and a unique key.
             existing_list = stmts[tl_key]['stmts_formatted']

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -210,8 +210,8 @@ class HtmlAssembler(object):
                     continue
                 for dbn, dbid in list(ag.db_refs.items()):
                     if isinstance(dbid, set):
-                        logger.warning("Removing %s from refs due to too many "
-                                       "matches: %s" % (dbn, dbid))
+                        logger.info("Removing %s from refs due to too many "
+                                    "matches: %s" % (dbn, dbid))
                         del ag.db_refs[dbn]
 
             # Update the top level grouping.
@@ -274,8 +274,8 @@ class HtmlAssembler(object):
                 for ag in tl_agents:
                     for dbn, dbid in list(ag.db_refs.items()):
                         if isinstance(dbid, set):
-                            logger.warning("Removing %s from top level refs "
-                                           "due to multiple matches: %s"
+                            logger.info("Removing %s from top level refs "
+                                        "due to multiple matches: %s"
                                            % (dbn, dbid))
                             del ag.db_refs[dbn]
                 tl_label = make_top_level_label_from_names_key(tlg['names'])

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -167,7 +167,8 @@ class HtmlAssembler(object):
             # Statement object `meta_stmts`.
             meta_agents = []
             meta_stmt = make_stmt_from_sort_key(key, verb, meta_agents)
-            meta_agent_dict = {ag.name: ag for ag in meta_agents}
+            meta_agent_dict = {ag.name: ag for ag in meta_agents
+                               if ag is not None}
 
             # This will now be ordered by prevalence and entity pairs.
             stmt_info_list = []

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -338,7 +338,7 @@ class HtmlAssembler(object):
             fh.write(self.model.encode('utf-8'))
 
 
-def _format_evidence_text(stmt, curation_dict):
+def _format_evidence_text(stmt, curation_dict=None):
     """Returns evidence metadata with highlighted evidence text.
 
     Parameters
@@ -355,6 +355,8 @@ def _format_evidence_text(stmt, curation_dict):
         Evidence objects. The text entry of the dict includes
         `<span>` tags identifying the agents referenced by the Statement.
     """
+    if curation_dict is None:
+        curation_dict = {}
 
     def get_role(ag_ix):
         if isinstance(stmt, Complex) or \

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -342,14 +342,14 @@ class HtmlAssembler(object):
                                                       ev.text)]
                 format_text = tag_text(ev.text, indices)
 
-            has_curation = ((stmt.get_hash(), ev.source_hash)
-                            in self.curation_dict.keys())
+            curation_key = (stmt.get_hash(), ev.source_hash)
+            num_curations = len(self.curation_dict.get(curation_key, []))
             ev_list.append({'source_api': source_api,
                             'pmid': ev.pmid,
                             'text_refs': ev.text_refs,
                             'text': format_text,
                             'source_hash': str(ev.source_hash),
-                            'has_curation': has_curation})
+                            'num_curations': num_curations})
 
         return ev_list
 

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -291,25 +291,25 @@
       <div class="group-shown" id="tl-{{ results['html_key'] }}_group">
     {% endif %}
         <div class="container nvp">
-        {% for short_name, short_name_key, stmt_info_list, src_counts in results['stmts_formatted'] %}
+        {% for group_dict in results['stmts_formatted'] %}
           {% set i_type = loop.index0 %}
           {% if results['stmts_formatted']|length > 1 %}
             <div class="row group_heading"
-               onclick="toggler('{{ short_name_key }}');"
-               id="{{ short_name_key }}_heading">
+               onclick="toggler('{{ group_dict['short_name_key'] }}');"
+               id="{{ group_dict['short_name_key'] }}_heading">
               <div class="col nvp">
-                <h5 class="align-middle">{{ short_name }}</h5>
+                <h5 class="align-middle">{{ group_dict['short_name'] }}</h5>
               </div>
               <div class="col text-right nvp">
-                {{ badges(src_counts) }}
+                {{ badges(group_dict['src_counts']) }}
               </div>
             </div>
-            <div class="row group" id="{{ short_name_key }}_group">
+            <div class="row group" id="{{ group_dict['short_name_key'] }}_group">
           {% else %}
-            <div class="row group-shown" id="{{ short_name_key }}_group">
+            <div class="row group-shown" id="{{ group_dict['short_name_key'] }}_group">
           {% endif %}
               <div class="container nvp">
-              {% for stmt_info in stmt_info_list %}
+              {% for stmt_info in group_dict['stmt_info_list'] %}
                 {% set i_stmt = loop.index0 %}
                 <a name="{{ stmt_info['hash'] }}"></a>
                 <div class="row statement">

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -1,8 +1,7 @@
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str
 import re
 from indra.statements import *
-from indra.assemblers.html.assembler import HtmlAssembler, tag_text, loader
+from indra.assemblers.html.assembler import HtmlAssembler, tag_text, loader, \
+    _format_evidence_text
 
 
 def make_stmt():
@@ -19,7 +18,7 @@ def make_stmt():
 
 def test_format_evidence_text():
     stmt = make_stmt()
-    ev_list = HtmlAssembler._format_evidence_text(stmt)
+    ev_list = _format_evidence_text(stmt)
     assert len(ev_list) == 1
     ev = ev_list[0]
     assert isinstance(ev, dict)

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -23,7 +23,7 @@ def test_format_evidence_text():
     ev = ev_list[0]
     assert isinstance(ev, dict)
     assert set(ev.keys()) == {'source_api', 'text_refs', 'text', 'source_hash',
-                              'pmid'}
+                              'pmid', 'num_curations'}
     assert ev['source_api'] == 'test'
     assert ev['text_refs']['PMID'] == '1234567'
     assert ev['text'] == ('We noticed that the '

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -148,7 +148,7 @@ def group_and_sort_statements(stmt_list, ev_totals=None, source_counts=None):
     return sorted_groups
 
 
-def make_stmt_from_sort_key(key, verb):
+def make_stmt_from_sort_key(key, verb, agents=None):
     """Make a Statement from the sort key.
 
     Specifically, the sort key used by `group_and_sort_statements`.
@@ -160,19 +160,25 @@ def make_stmt_from_sort_key(key, verb):
 
     StmtClass = get_statement_by_name(verb)
     inps = list(key[1])
+    if agents is None:
+        agents = []
     if verb == 'Complex':
-        stmt = StmtClass([make_agent(name) for name in inps])
+        agents.extend([make_agent(name) for name in inps])
+        stmt = StmtClass(agents[:])
     elif verb == 'Conversion':
-        stmt = StmtClass(make_agent(inps[0]),
-                         [make_agent(name) for name in inps[1]],
-                         [make_agent(name) for name in inps[2]])
+        names_from = [make_agent(name) for name in inps[1]]
+        names_to = [make_agent(name) for name in inps[2]]
+        agents.extend(names_from + names_to)
+        stmt = StmtClass(make_agent(inps[0]), names_from, names_to)
     elif verb == 'ActiveForm' or verb == 'HasActivity':
-        stmt = StmtClass(make_agent(inps[0]), inps[1], inps[2])
+        agents.extend([make_agent(inps[0])])
+        stmt = StmtClass(agents[0], inps[1], inps[2])
     elif verb == 'Influence':
-        stmt = Influence(Event(make_agent(inps[0])),
-                         Event(make_agent(inps[1])))
+        agents.extend([make_agent(inp) for inp in inps[:2]])
+        stmt = Influence(*[Event(ag) for ag in agents])
     else:
-        stmt = StmtClass(*[make_agent(name) for name in inps])
+        agents.extend([make_agent(name) for name in inps])
+        stmt = StmtClass(*agents)
     return stmt
 
 


### PR DESCRIPTION
This PR allows the dict-and-list structure that is sent to Jinja to be returned directly for use in new applications. This PR also makes changes fixing a prior bug where the same content could sometimes appear twice, and allows headings to have labeled named entities at every level of the drop-down.

(As of PR, some testing needed before merge)