### PR TITLE
Fix embedded amount regulation inside activation from REACH

### DIFF
--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -200,7 +200,8 @@ class ReachProcessor(object):
             if theme is None:
                 continue
             theme_agent, theme_coords = self._get_agent_from_entity(theme)
-            qstr = "$.events.frames[(@.type is 'regulation') and " + \
+            qstr = "$.events.frames[((@.type is 'regulation') or "\
+                   "(@.type is 'activation')) and " + \
                    "(@.arguments[0].arg is '%s')]" % frame_id
             reg_res = self.tree.execute(qstr)
             for reg in reg_res:
@@ -217,7 +218,7 @@ class ReachProcessor(object):
                               context=context, epistemics=epistemics)
                 args = [controller_agent, theme_agent, ev]
                 subtype = reg.get('subtype')
-                if subtype == 'positive-regulation':
+                if subtype.startswith('positive'):
                     st = IncreaseAmount(*args)
                 else:
                     st = DecreaseAmount(*args)
@@ -273,6 +274,7 @@ class ReachProcessor(object):
                           pmid=self.citation, annotations=annotations,
                           context=context, epistemics=epistemics)
             args = r['arguments']
+            controller_agent = None
             for a in args:
                 if self._get_arg_type(a) == 'controller':
                     controller_agent, controller_coords = \
@@ -281,6 +283,8 @@ class ReachProcessor(object):
                     controlled = a['arg']
             controlled_agent, controlled_coords = \
                 self._get_agent_from_entity(controlled)
+            if controller_agent is None or controlled_agent is None:
+                continue
             annotations['agents']['coords'] = [controller_coords,
                                                controlled_coords]
             if r['subtype'] == 'positive-activation':

--- a/indra/tests/reach_act_amt.json
+++ b/indra/tests/reach_act_amt.json
@@ -1,0 +1,484 @@
+{
+  "events" : {
+    "frames" : [ {
+      "frame-id" : "evem-api1789-UAZ-r1-Reach-0-11103",
+      "text" : "levels of p53",
+      "arguments" : [ {
+        "text" : "p53",
+        "argument-type" : "entity",
+        "type" : "theme",
+        "object-type" : "argument",
+        "index" : 0,
+        "arg" : "ment-api1789-UAZ-r1-Reach-0-139368"
+      } ],
+      "type" : "amount",
+      "frame-type" : "event-mention",
+      "subtype" : "amount",
+      "is-direct" : false,
+      "end-pos" : {
+        "reference" : "pass-api1789-UAZ-r1-Reach",
+        "offset" : 13,
+        "object-type" : "relative-pos"
+      },
+      "trigger" : "levels",
+      "object-type" : "frame",
+      "start-pos" : {
+        "reference" : "pass-api1789-UAZ-r1-Reach",
+        "offset" : 0,
+        "object-type" : "relative-pos"
+      },
+      "sentence" : "sent-api1789-UAZ-r1-Reach-0",
+      "found-by" : "amount_1",
+      "verbose-text" : "levels of p53 mediating DNA damage genes"
+    }, {
+      "frame-id" : "evem-api1789-UAZ-r1-Reach-0-11104",
+      "text" : "levels of p53-mediating DNA damage",
+      "arguments" : [ {
+        "text" : "levels of p53",
+        "argument-type" : "event",
+        "type" : "controlled",
+        "object-type" : "argument",
+        "index" : 0,
+        "arg" : "evem-api1789-UAZ-r1-Reach-0-11103"
+      }, {
+        "text" : "DNA damage",
+        "argument-type" : "entity",
+        "type" : "controller",
+        "object-type" : "argument",
+        "index" : 0,
+        "arg" : "ment-api1789-UAZ-r1-Reach-0-139369"
+      } ],
+      "type" : "activation",
+      "frame-type" : "event-mention",
+      "subtype" : "positive-activation",
+      "is-direct" : false,
+      "end-pos" : {
+        "reference" : "pass-api1789-UAZ-r1-Reach",
+        "offset" : 34,
+        "object-type" : "relative-pos"
+      },
+      "trigger" : "mediating",
+      "object-type" : "frame",
+      "start-pos" : {
+        "reference" : "pass-api1789-UAZ-r1-Reach",
+        "offset" : 0,
+        "object-type" : "relative-pos"
+      },
+      "sentence" : "sent-api1789-UAZ-r1-Reach-0",
+      "found-by" : "Positive_activation_syntax_1_verb",
+      "verbose-text" : "levels of p53 mediating DNA damage genes"
+    } ],
+    "object-type" : "frame-collection",
+    "object-meta" : {
+      "processing-end" : "2020-01-18T22:42:19Z",
+      "doc-id" : "api1789",
+      "component-type" : "machine",
+      "component" : "Reach",
+      "processing-start" : "2020-01-18T22:42:18Z",
+      "object-type" : "meta-info",
+      "organization" : "UAZ"
+    }
+  },
+  "entities" : {
+    "frames" : [ {
+      "text" : "p53",
+      "frame-id" : "ment-api1789-UAZ-r1-Reach-0-139368",
+      "type" : "protein",
+      "frame-type" : "entity-mention",
+      "end-pos" : {
+        "reference" : "pass-api1789-UAZ-r1-Reach",
+        "offset" : 13,
+        "object-type" : "relative-pos"
+      },
+      "xrefs" : [ {
+        "namespace" : "uniprot",
+        "species" : "homo sapiens",
+        "object-type" : "db-reference",
+        "id" : "P04637"
+      } ],
+      "object-type" : "frame",
+      "start-pos" : {
+        "reference" : "pass-api1789-UAZ-r1-Reach",
+        "offset" : 10,
+        "object-type" : "relative-pos"
+      },
+      "sentence" : "sent-api1789-UAZ-r1-Reach-0",
+      "alt-xrefs" : [ {
+        "namespace" : "uniprot",
+        "species" : "homo sapiens",
+        "object-type" : "db-reference",
+        "id" : "P04637"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "human",
+        "object-type" : "db-reference",
+        "id" : "P04637"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "arabidopsis thaliana",
+        "object-type" : "db-reference",
+        "id" : "Q42578"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "barbel",
+        "object-type" : "db-reference",
+        "id" : "Q9W678"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "barbus barbus",
+        "object-type" : "db-reference",
+        "id" : "Q9W678"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bec",
+        "object-type" : "db-reference",
+        "id" : "Q288N7"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bec-nb",
+        "object-type" : "db-reference",
+        "id" : "Q8JN60"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "beluga whale",
+        "object-type" : "db-reference",
+        "id" : "Q8SPZ3"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bovine enteric calicivirus nb",
+        "object-type" : "db-reference",
+        "id" : "Q8JN60"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bovine enteric calicivirus newbury agent-1",
+        "object-type" : "db-reference",
+        "id" : "Q288N7"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "canis familiaris",
+        "object-type" : "db-reference",
+        "id" : "Q29537"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "canis lupus familiaris",
+        "object-type" : "db-reference",
+        "id" : "Q29537"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "channel catfish",
+        "object-type" : "db-reference",
+        "id" : "O93379"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "chinese hamster",
+        "object-type" : "db-reference",
+        "id" : "O09185"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "common tree shrew",
+        "object-type" : "db-reference",
+        "id" : "Q9TTA1"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "congo puffer",
+        "object-type" : "db-reference",
+        "id" : "Q9W679"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "crab-eating macaque",
+        "object-type" : "db-reference",
+        "id" : "P56423"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "cricetulus barabensis griseus",
+        "object-type" : "db-reference",
+        "id" : "O09185"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "cricetulus griseus",
+        "object-type" : "db-reference",
+        "id" : "O09185"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "cynomolgus monkey",
+        "object-type" : "db-reference",
+        "id" : "P56423"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "cyprinus barbus",
+        "object-type" : "db-reference",
+        "id" : "Q9W678"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "delphinapterus leucas",
+        "object-type" : "db-reference",
+        "id" : "Q8SPZ3"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "dog",
+        "object-type" : "db-reference",
+        "id" : "Q29537"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "equus caballus",
+        "object-type" : "db-reference",
+        "id" : "P79892"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "european flounder",
+        "object-type" : "db-reference",
+        "id" : "O12946"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "green swordtail",
+        "object-type" : "db-reference",
+        "id" : "O57538"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "horse",
+        "object-type" : "db-reference",
+        "id" : "P79892"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "ictalurus punctatus",
+        "object-type" : "db-reference",
+        "id" : "O93379"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "isolate bovine/uk/newbury1/1976",
+        "object-type" : "db-reference",
+        "id" : "Q288N7"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "isolate bovine/united states/nebraska/1980",
+        "object-type" : "db-reference",
+        "id" : "Q8JN60"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "japanese killifish",
+        "object-type" : "db-reference",
+        "id" : "P79820"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "japanese macaque",
+        "object-type" : "db-reference",
+        "id" : "P61260"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "japanese rice fish",
+        "object-type" : "db-reference",
+        "id" : "P79820"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "macaca fascicularis",
+        "object-type" : "db-reference",
+        "id" : "P56423"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "macaca fuscata fuscata",
+        "object-type" : "db-reference",
+        "id" : "P61260"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "macaca mulatta",
+        "object-type" : "db-reference",
+        "id" : "P56424"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "mouse",
+        "object-type" : "db-reference",
+        "id" : "P02340"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "mouse-ear cress",
+        "object-type" : "db-reference",
+        "id" : "Q42578"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "mus musculus",
+        "object-type" : "db-reference",
+        "id" : "P02340"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "oncorhynchus mykiss",
+        "object-type" : "db-reference",
+        "id" : "P25035"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "oryzias latipes",
+        "object-type" : "db-reference",
+        "id" : "P79820"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "pig",
+        "object-type" : "db-reference",
+        "id" : "Q9TUB2"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "platichthys flesus",
+        "object-type" : "db-reference",
+        "id" : "O12946"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "platypoecilus maculatus",
+        "object-type" : "db-reference",
+        "id" : "Q92143"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "pleuronectes flesus",
+        "object-type" : "db-reference",
+        "id" : "O12946"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "rainbow trout",
+        "object-type" : "db-reference",
+        "id" : "P25035"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "rat",
+        "object-type" : "db-reference",
+        "id" : "P10361"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "rattus norvegicus",
+        "object-type" : "db-reference",
+        "id" : "P10361"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "rhesus macaque",
+        "object-type" : "db-reference",
+        "id" : "P56424"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "salmo gairdneri",
+        "object-type" : "db-reference",
+        "id" : "P25035"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "silurus punctatus",
+        "object-type" : "db-reference",
+        "id" : "O93379"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "southern platyfish",
+        "object-type" : "db-reference",
+        "id" : "Q92143"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "sus scrofa",
+        "object-type" : "db-reference",
+        "id" : "Q9TUB2"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "tetraodon miurus",
+        "object-type" : "db-reference",
+        "id" : "Q9W679"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "tupaia belangeri",
+        "object-type" : "db-reference",
+        "id" : "Q9TTA1"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "tupaia glis belangeri",
+        "object-type" : "db-reference",
+        "id" : "Q9TTA1"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "xiphophorus helleri",
+        "object-type" : "db-reference",
+        "id" : "O57538"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "xiphophorus maculatus",
+        "object-type" : "db-reference",
+        "id" : "Q92143"
+      } ]
+    }, {
+      "text" : "DNA damage",
+      "frame-id" : "ment-api1789-UAZ-r1-Reach-0-139369",
+      "type" : "bioprocess",
+      "frame-type" : "entity-mention",
+      "end-pos" : {
+        "reference" : "pass-api1789-UAZ-r1-Reach",
+        "offset" : 34,
+        "object-type" : "relative-pos"
+      },
+      "xrefs" : [ {
+        "namespace" : "mesh",
+        "species" : "human",
+        "object-type" : "db-reference",
+        "id" : "D004249"
+      } ],
+      "object-type" : "frame",
+      "start-pos" : {
+        "reference" : "pass-api1789-UAZ-r1-Reach",
+        "offset" : 24,
+        "object-type" : "relative-pos"
+      },
+      "sentence" : "sent-api1789-UAZ-r1-Reach-0",
+      "alt-xrefs" : [ {
+        "namespace" : "mesh",
+        "species" : "human",
+        "object-type" : "db-reference",
+        "id" : "D004249"
+      } ]
+    } ],
+    "object-type" : "frame-collection",
+    "object-meta" : {
+      "processing-end" : "2020-01-18T22:42:19Z",
+      "doc-id" : "api1789",
+      "component-type" : "machine",
+      "component" : "Reach",
+      "processing-start" : "2020-01-18T22:42:18Z",
+      "object-type" : "meta-info",
+      "organization" : "UAZ"
+    }
+  },
+  "sentences" : {
+    "frames" : [ {
+      "text" : "levels of p53-mediating DNA damage genes",
+      "frame-id" : "pass-api1789-UAZ-r1-Reach",
+      "section-id" : "NoSection",
+      "frame-type" : "passage",
+      "is-title" : false,
+      "section-name" : "NoSection",
+      "object-type" : "frame",
+      "index" : "Reach",
+      "object-meta" : {
+        "component" : "nxml2fries",
+        "object-type" : "meta-info"
+      }
+    }, {
+      "text" : "levels of p53 mediating DNA damage genes",
+      "frame-id" : "sent-api1789-UAZ-r1-Reach-0",
+      "passage" : "pass-api1789-UAZ-r1-Reach",
+      "frame-type" : "sentence",
+      "end-pos" : {
+        "reference" : "pass-api1789-UAZ-r1-Reach",
+        "offset" : 40,
+        "object-type" : "relative-pos"
+      },
+      "object-type" : "frame",
+      "start-pos" : {
+        "reference" : "pass-api1789-UAZ-r1-Reach",
+        "offset" : 0,
+        "object-type" : "relative-pos"
+      },
+      "object-meta" : {
+        "component" : "BioNLPProcessor",
+        "object-type" : "meta-info"
+      }
+    } ],
+    "object-type" : "frame-collection",
+    "object-meta" : {
+      "processing-end" : "2020-01-18T22:42:19Z",
+      "doc-id" : "api1789",
+      "component-type" : "machine",
+      "component" : "Reach",
+      "processing-start" : "2020-01-18T22:42:18Z",
+      "object-type" : "meta-info",
+      "organization" : "UAZ"
+    }
+  }
+}

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str
-import unittest
+import os
 from nose.plugins.attrib import attr
 from indra.sources import reach
 from indra.sources.reach.processor import ReachProcessor
@@ -428,3 +426,13 @@ def test_get_agent_coordinates_phosphorylation_missing_controller():
         annotations = stmt.evidence[0].annotations
         coords = [None, (57, 60)]
         assert annotations['agents']['coords'] == coords
+
+
+def test_amount_embedded_in_activation():
+    here = os.path.dirname(os.path.abspath(__file__))
+    test_file = os.path.join(here, 'reach_act_amt.json')
+    rp = reach.process_json_file(test_file)
+    assert len(rp.statements) == 1
+    assert isinstance(rp.statements[0], IncreaseAmount)
+    assert rp.statements[0].subj is not None
+    assert rp.statements[0].obj is not None


### PR DESCRIPTION
This PR resolves #1028 by handling a special case of an amount event being the controlled argument of an activation event (previously, amount events only ever appeared as controlled arguments of regulation events).