### PR TITLE
Update to PyBEL Model Checker

### DIFF
--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -263,7 +263,6 @@ class ModelChecker(object):
         """
         # Get the input set (signed rules or names for source nodes)
         input_set, result_code = self.process_subject(subj)
-        print(input_set, result_code)
         if result_code:
             return self.make_false_result(result_code,
                                           max_paths, max_path_length)

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -229,6 +229,10 @@ class ModelChecker(object):
             if result.path_found:
                 logger.info('Found paths for %s' % stmt)
                 return result
+        # Return the result if the subject/input rules were not found
+        if result.result_code in [
+                'SUBJECT_NOT_FOUND', 'INPUT_RULES_NOT_FOUND']:
+            return result
         # If we got here, then there was no path for any observable
         logger.info('No paths found for %s' % stmt)
         return self.make_false_result('NO_PATHS_FOUND',
@@ -259,10 +263,10 @@ class ModelChecker(object):
         """
         # Get the input set (signed rules or names for source nodes)
         input_set, result_code = self.process_subject(subj)
+        print(input_set, result_code)
         if result_code:
             return self.make_false_result(result_code,
                                           max_paths, max_path_length)
-
         # # -- Route to the path sampling function --
         # NOTE this is not generic at this point!
         # if self.do_sampling:

--- a/indra/explanation/model_checker/pybel.py
+++ b/indra/explanation/model_checker/pybel.py
@@ -68,16 +68,16 @@ class PybelModelChecker(ModelChecker):
             target_polarity = 1 if isinstance(stmt, DecreaseAmount) else 0
         elif isinstance(stmt, Influence):
             target_polarity = 1 if stmt.overall_polarity() == -1 else 0
-        subj_nodes = self.get_nodes(subj, self.graph, 0)
-        if not subj_nodes:
-            return (None, None, 'SUBJECT_NOT_FOUND')
         obj_nodes = self.get_nodes(obj, self.graph, target_polarity)
         if not obj_nodes:
             return (None, None, 'OBJECT_NOT_FOUND')
-        return (subj_nodes, obj_nodes, None)
+        return ([subj], obj_nodes, None)
 
     def process_subject(self, subj):
-        return [subj], None
+        subj_nodes = self.get_nodes(subj, self.graph, 0)
+        if not subj_nodes:
+            return (None, 'SUBJECT_NOT_FOUND')
+        return subj_nodes, None
 
     def get_nodes(self, agent, graph, target_polarity):
         # This import is done here rather than at the top level to avoid


### PR DESCRIPTION
This PR makes a change to PyBEL ModelChecker that will guarantee finding the actual minimum available path length in the model and improve the chances of getting the same paths (it is still not completely deterministic as the order of paths of the same length varies, but it solves the issue of getting a path longer than yesterday that was observed before).

The main change is moving a call to `get_nodes` method from `process_statement` to `process_subject`. PyBEL ModelChecker was by mistake configured to return a set of subject nodes in `process_statement` and then a list containing one subject node in `process_subject` while the correct way would be to get a set of nodes in `process_subject` step. The difference is critical, because the next steps of finding the minimum path length and finding the paths of that length are run only for the sources returned by `process_subject` (e.g. input rules in PySB). That means we were finding the minimum path length for only one of the potential subject nodes at a time instead of all available subject nodes (and the choice of that one node was random as set of given nodes is not ordered) causing jumps in minimum path length (and therefore new, often longer paths).