### PR TITLE
Modelchecker

### DIFF
--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -322,11 +322,14 @@ class ModelChecker(object):
         sources = []
         for source, path_length in self._find_sources(target, input_set):
             # Path already includes an edge from targets to common target, so
-            # we need to subtract one edge to only include meaningful paths
-            # that include at least one more edge. In case of loops, we are
+            # we need to subtract one edge. In case of loops, we are
             # already missing one edge, there's no need to subtract one more.
             if not loop:
                 path_length = path_length - 1
+            # There might be a case when sources and targets contain the same
+            # nodes (e.g. different agent state in PyBEL networks) that would
+            # show up as paths of length 0. We only want to include meaningful
+            # paths that contain at least one edge.
             if path_length > 0:
                 pm = PathMetric(source, target, path_length)
                 path_metrics.append(pm)

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -327,11 +327,11 @@ class ModelChecker(object):
         for source, path_length in self._find_sources(obj, subj):
             # Path already includes edge from common source (if it exists) to
             # the sources and from targets to common target, so we need to
-            # only include meaningful paths that include at least on more edge
-            if subj:
-                path_length = path_length - 2
-            else:
+            # only include meaningful paths that include at least one more edge
+            if not subj or loop:
                 path_length = path_length - 1
+            else:
+                path_length = path_length - 2
             if path_length > 0:
                 pm = PathMetric(source, obj, path_length)
                 path_metrics.append(pm)
@@ -348,10 +348,10 @@ class ModelChecker(object):
             return pr
         elif path_metrics:
             if min(path_lengths) <= max_path_length:
-                if subj:
-                    search_path_length = min(path_lengths) + 2
-                else:
+                if not subj or loop:
                     search_path_length = min(path_lengths) + 1
+                else:
+                    search_path_length = min(path_lengths) + 2
                 pr = PathResult(True, 'PATHS_FOUND',
                                 max_paths, max_path_length)
                 pr.path_metrics = path_metrics

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -170,7 +170,7 @@ class ModelChecker(object):
         """
         self.statements += stmts
 
-    def check_model(self, max_paths=1, max_path_length=7):
+    def check_model(self, max_paths=1, max_path_length=5):
         """Check all the statements added to the ModelChecker.
 
         Parameters
@@ -328,8 +328,13 @@ class ModelChecker(object):
             # Path already includes edge from common source (if it exists) to
             # the sources and from targets to common target, so we need to
             # only include meaningful paths that include at least on more edge
-            if (input_set and path_length > 2) or \
-                    (not input_set and path_length > 1):
+            # if (input_set and path_length > 2) or \
+            #         (not input_set and path_length > 1):
+            if input_set:
+                path_length = path_length - 2
+            else:
+                path_length = path_length - 1
+            if path_length > 0:
                 pm = PathMetric(source, obj, path_length)
                 path_metrics.append(pm)
                 path_lengths.append(path_length)
@@ -345,6 +350,10 @@ class ModelChecker(object):
             return pr
         elif path_metrics:
             if min(path_lengths) <= max_path_length:
+                if input_set:
+                    search_path_length = min(path_lengths) + 2
+                else:
+                    search_path_length = min(path_lengths) + 1
                 pr = PathResult(True, 'PATHS_FOUND',
                                 max_paths, max_path_length)
                 pr.path_metrics = path_metrics
@@ -352,7 +361,7 @@ class ModelChecker(object):
                 # Try to find paths of fixed length using sources found above
                 for source in sources:
                     path_iter = get_path_iter(self.graph, source, obj,
-                                              min(path_lengths), loop)
+                                              search_path_length, loop)
                     for path in path_iter:
                         pr.add_path(tuple(path))
                         # Do not get next path if reached max_paths

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -444,8 +444,8 @@ def test_distinguish_path_polarity1():
     assert path_results[1].paths == [(('A_activate_B', 0), ('B_dephos_C', 0),
                                       ('C_T185_p_obs', 1))]
     assert path_results[2].paths == [], path_results[2].paths
-    assert path_results[3].paths == [(('B_dephos_C', 0), ('C_T185_p_obs', 1))]
-
+    assert path_results[3].paths == \
+        [(('B_dephos_C', 0), ('C_T185_p_obs', 1))], path_results[3].paths
 
 @with_model
 def test_distinguish_path_polarity2():
@@ -809,7 +809,7 @@ def test_check_rule_subject1():
     checks = mc.check_model()
     assert len(checks) == 1
     assert checks[0][0] == stmt_to_check
-    assert checks[0][1].paths == []
+    assert checks[0][1].paths == [], checks[0][1].paths
 
 
 def test_gef_activation():
@@ -1583,7 +1583,7 @@ def test_pybel_path():
     assert results[1][1].paths[0] == ((a, 0), (b, 0), (d, 1), (e, 1))
     # Fail cases
     assert results[2][1].result_code == 'NO_PATHS_FOUND'
-    assert results[3][1].result_code == 'SUBJECT_NOT_FOUND'
+    assert results[3][1].result_code == 'SUBJECT_NOT_FOUND', results[3]
     assert results[4][1].result_code == 'OBJECT_NOT_FOUND'
     assert results[5][1].result_code == 'STATEMENT_TYPE_NOT_HANDLED'
     # Loop paths


### PR DESCRIPTION
This PR is updating the ModelChecker class. Getting the input set is moved to the check_statement method level allowing to get all potential input nodes at once along with all potential target nodes. Dummy edges (from common source to all sources and from all targets to common target) are then added, used to simplify path search and removed after the search is finished. This approach will ensure that all sources and all targets are considered when searching for paths. One limitation is that the PathMetrics will report actual source as the source and the dummy node (common target) as a target. 