### PR TITLE
Wm docs

### DIFF
--- a/doc/tutorials/index.rst
+++ b/doc/tutorials/index.rst
@@ -7,3 +7,4 @@ Tutorials
    nl_modeling
    html_curation
    gene_network
+   wm_service

--- a/doc/tutorials/wm_service.rst
+++ b/doc/tutorials/wm_service.rst
@@ -66,8 +66,22 @@ feedback service with the following parameters:
 
 .. code-block:: sh
 
-    docker run -v -id -p 8001:8001 --entrypoint python labsyspharm/indra \
-    /sw/indra/indra/tools/live_curation.py
+    docker run -v -id -p 8001:8001 --env-file docker_variables --entrypoint \
+    python labsyspharm/indra /sw/indra/indra/tools/live_curation.py
+
+Here we use the tag :code:`--env-file` to provide a file containing
+environment variables to the docker. In this case, we need to provide
+:code:`AWS_ACCESS_KEY_ID` and :code:`AWS_SECRET_ACCESS_KEY` to allow the
+curation service to access corpora on S3. The file content should look like
+this:
+
+.. code-block:: sh
+
+    AWS_ACCESS_KEY_ID=<aws_access_key_id>
+    AWS_SECRET_ACCESS_KEY=<aws_secret_access_key>
+
+Replace :code:`<aws_access_key_id>` and :code:`<aws_secret_access_key>` with
+your aws access and secret keys.
 
 Using the live feedback service
 -------------------------------

--- a/doc/tutorials/wm_service.rst
+++ b/doc/tutorials/wm_service.rst
@@ -64,23 +64,16 @@ Setting up the live feedback service
 Assuming you already have the INDRA docker image, run the INDRA live
 feedback service with the following parameters:
 
-- :code:`<folder with corpus>` needs to be a folder in which you have the
-  corpus file. This folder will be mounted into the Docker container on the
-  :code:`/sw/mounted` path allowing the container to access both the corpus
-  file.
-- :code:`<corpus file>` needs to be the name of the corpus file in the
-  :code:`<folder with corpus>` folder.
-
 .. code-block:: sh
 
-    docker run -v <folder with corpus>:/sw/mounted -id -p 8001:8001 \
-    --entrypoint python labsyspharm/indra \
-    /sw/indra/indra/tools/live_curation.py --json /sw/mounted/<corpus file>
+    docker run -v -id -p 8001:8001 --entrypoint python labsyspharm/indra \
+    /sw/indra/indra/tools/live_curation.py
 
 Using the live feedback service
 -------------------------------
 Below each example uses the remote service, you can replace that IP with
-localhost to do the same locally.
+localhost to do the same locally. Replace :code:`<corpus-id>` with the ID of
+your corpus.
 
 Submit curations for a set of Statements in a corpus:
 

--- a/doc/tutorials/wm_service.rst
+++ b/doc/tutorials/wm_service.rst
@@ -95,6 +95,17 @@ Update beliefs of a corpus:
      "6f2b2d69-16af-40ea-aa03-9b3a9a1d2ac3": 0.6979166666666666,
      "727adb95-4890-4bbc-a985-fd985c355215": 0.6979166666666666}
 
+Update meta data for a corpus:
+
+.. code-block::
+
+    URL: http://54.84.114.146:8001/update_metadata
+    Method: POST with JSON content header
+    Input parameters: {"corpus_id": "<corpus-id>",
+     "meta_data": {"date": "2020-02-15",
+                   "updated": "2020-02-19",
+                   "tags": ["manual curation", "curated by Bob"]}}
+    Output: {}
 
 Reset all submitted curations so far:
 

--- a/doc/tutorials/wm_service.rst
+++ b/doc/tutorials/wm_service.rst
@@ -10,9 +10,13 @@ the following endpoints:
   reset_curation, update_beliefs, add_ontology_entry, reset_ontology,
   update_groundings.
 
-The instructions below run each Docker container with the `-d` option which
-will run containers in the background. You can list running containers with
-`docker ps` and stop a container with `docker stop <container id>`.
+The instructions below run each Docker container with the :code:`-d` option
+which will run containers in the background. You can list running containers
+with their ids using :code:`docker ps` and stop a container with
+
+.. code-block::
+
+    docker stop <container id>
 
 For interactive text reading, it makes sense to do an initial test reading
 before the demo so that Eidos loads the necessary resources. Subsequent

--- a/doc/tutorials/wm_service.rst
+++ b/doc/tutorials/wm_service.rst
@@ -1,14 +1,11 @@
-Summary
-=======
-These instructions allow you to have reading and assembly services running
-locally during the evaluation. With this setup, CauseMos can interact with
-the following endpoints:
+World Modelers INDRA service stack
+==================================
 
-- http://localhost:8000/reader/process_text to read text via
-  eidos/sofia/cwms and get back INDRA Statements
-- http://localhost:8001/action to do the following actions: submit_curation,
-  reset_curation, update_beliefs, add_ontology_entry, reset_ontology,
-  update_groundings.
+Setting up the services locally
+-------------------------------
+These instructions describe setting up and using the INDRA service stack
+for World Modelers applications, in particular, as a back-end for the
+CauseMos UI.
 
 The instructions below run each Docker container with the :code:`-d` option
 which will run containers in the background. You can list running containers
@@ -23,8 +20,8 @@ before the demo so that Eidos loads the necessary resources. Subsequent
 reading calls will be much faster.
 
 Setting up the Eidos service
-----------------------------
-Clone the Eidos repo and cd to Docker folder
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Clone the Eidos repo and cd to the Docker folder
 
 .. code-block:: sh
 
@@ -35,7 +32,7 @@ Build the Eidos docker image
 
 .. code-block:: sh
 
-    docker build -f Dockerfile . -t eidos-webservice
+    docker build -f DockerfileRunProd . -t eidos-webservice
 
 Run the Eidos web service and expose it on port 9000
 
@@ -45,7 +42,7 @@ Run the Eidos web service and expose it on port 9000
 
 
 Setting up the general INDRA service
-------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Pull the INDRA docker image from DockerHub
 
 .. code-block:: sh
@@ -56,24 +53,27 @@ Run the INDRA web service and expose it on port 8000
 
 .. code-block:: sh
 
-    docker run -id -p 8000:8080 --entrypoint python labsyspharm/indra \
-    /sw/indra/rest_api/api.py
+    docker run -id -p 8000:8080 --entrypoint gunicorn labsyspharm/indra:latest \
+        -w 1 -b :8000 -t 600 rest_api.api:app
 
-Setting up the live feedback service
-------------------------------------
+Note that the :code:`-w 1` parameter specifies one service worker which can
+be set to a higher number if needed.
+
+Setting up the INDRA live curation service
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Assuming you already have the INDRA docker image, run the INDRA live
 feedback service with the following parameters:
 
 .. code-block:: sh
 
-    docker run -v -id -p 8001:8001 --env-file docker_variables --entrypoint \
+    docker run -id -p 8001:8001 --env-file docker_variables --entrypoint \
     python labsyspharm/indra /sw/indra/indra/tools/live_curation.py
 
 Here we use the tag :code:`--env-file` to provide a file containing
 environment variables to the docker. In this case, we need to provide
 :code:`AWS_ACCESS_KEY_ID` and :code:`AWS_SECRET_ACCESS_KEY` to allow the
-curation service to access corpora on S3. The file content should look like
-this:
+curation service to access World Modelers corpora on S3.
+The file content should look like this:
 
 .. code-block:: sh
 
@@ -83,49 +83,55 @@ this:
 Replace :code:`<aws_access_key_id>` and :code:`<aws_secret_access_key>` with
 your aws access and secret keys.
 
-Using the live feedback service
--------------------------------
-Below each example uses the remote service, you can replace that IP with
-localhost to do the same locally. Replace :code:`<corpus-id>` with the ID of
-your corpus.
+Using the services
+------------------
+Below, SERVICE_HOST should be replaced by the address of the server on which
+the services are running.
+
+Read a given text with a reader and return INDRA Statements (below, <reader>
+can be eidos, sofia or cwms):
+
+.. code-block::
+
+    URL: http://SERVICE_HOST:8000/<reader>/process_text
+    Method: POST with JSON content header
+    Input parameters: {"corpus_id": "<corpus-id>", "curations": {"38ce0c14-2c7e-4df8-bd53-3006afeaa193": 0}}
+    Output: {}
 
 Submit curations for a set of Statements in a corpus:
 
 .. code-block::
 
-    URL: http://54.84.114.146:8001/submit_curation
+    URL: http://SERVICE_HOST:8001/submit_curation
     Method: POST with JSON content header
     Input parameters: {"corpus_id": "<corpus-id>", "curations": {"38ce0c14-2c7e-4df8-bd53-3006afeaa193": 0}}
+    Output: {}
+
+Save curations for a given corpus on S3:
+
+.. code-block::
+
+    URL: http://SERVICE_HOST:8001/save_curation
+    Method: POST with JSON content header
+    Input parameters: {"corpus_id": "<corpus-id>"}
     Output: {}
 
 Update beliefs of a corpus:
 
 .. code-block::
 
-    URL: http://54.84.114.146:8001/update_beliefs
+    URL: http://SERVICE_HOST:8001/update_beliefs
     Method: POST with JSON content header
     Input parameters: {"corpus_id": "<corpus-id>"}
     Output: {"38ce0c14-2c7e-4df8-bd53-3006afeaa193": 0,
      "6f2b2d69-16af-40ea-aa03-9b3a9a1d2ac3": 0.6979166666666666,
      "727adb95-4890-4bbc-a985-fd985c355215": 0.6979166666666666}
 
-Update meta data for a corpus:
-
-.. code-block::
-
-    URL: http://54.84.114.146:8001/update_metadata
-    Method: POST with JSON content header
-    Input parameters: {"corpus_id": "<corpus-id>",
-     "meta_data": {"date": "2020-02-15",
-                   "updated": "2020-02-19",
-                   "tags": ["manual curation", "curated by Bob"]}}
-    Output: {}
-
 Reset all submitted curations so far:
 
 .. code-block::
 
-    URL: http://54.84.114.146:8001/reset_curation
+    URL: http://SERVICE_HOST:8001/reset_curation
     Method: POST with JSON content header
     Input parameters: {}
     Output: {}
@@ -134,7 +140,7 @@ Add a new ontology entry:
 
 .. code-block::
 
-    URL: http://54.84.114.146:8001/add_ontology_entry
+    URL: http://SERVICE_HOST:8001/add_ontology_entry
     Method: POST with JSON content header
     Input parameters: {"entry": "UN/animals/dog", "examples": ["dog", "canine", "puppy"]}
     Output: {}
@@ -143,7 +149,7 @@ Reset all customizations to the ontology so far:
 
 .. code-block::
 
-    URL: http://54.84.114.146:8001/reset_ontology
+    URL: http://SERVICE_HOST:8001/reset_ontology
     Method: POST with JSON content header
     Input parameters: {}
     Output: {}
@@ -152,7 +158,7 @@ Update groundings and re-assemble corpus based on current ontology:
 
 .. code-block::
 
-    URL: http://54.84.114.146:8001/update_groundings
+    URL: http://SERVICE_HOST:8001/update_groundings
     Method: POST with JSON content header
     Input parameters: {"corpus_id": "1"}
     Output: [{"type": "Influence", ...}] (INDRA Statements JSON)

--- a/doc/tutorials/wm_service.rst
+++ b/doc/tutorials/wm_service.rst
@@ -10,14 +10,7 @@ CauseMos UI.
 The instructions below run each Docker container with the :code:`-d` option
 which will run containers in the background. You can list running containers
 with their ids using :code:`docker ps` and stop a container with
-
-.. code-block::
-
-    docker stop <container id>
-
-For interactive text reading, it makes sense to do an initial test reading
-before the demo so that Eidos loads the necessary resources. Subsequent
-reading calls will be much faster.
+:code:`docker stop <container id>`.
 
 Setting up the Eidos service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/tutorials/wm_service.rst
+++ b/doc/tutorials/wm_service.rst
@@ -1,5 +1,5 @@
 Summary
--------
+=======
 These instructions allow you to have reading and assembly services running
 locally during the evaluation. With this setup, CauseMos can interact with
 the following endpoints:

--- a/doc/tutorials/wm_service.rst
+++ b/doc/tutorials/wm_service.rst
@@ -39,40 +39,6 @@ Run the Eidos web service and expose it on port 9000
     docker run -id -p 9000:9000 eidos-webservice
 
 
-Building an Eidos JAR
----------------------
-In addition, for the live curation service (in particular, to support
-real-time regrounding), a JAR-packaged version of Eidos needs to be
-available. In the top-level Eidos folder, run
-
-.. code-block:: sh
-
-    sbt assembly
-
-to obtain a file called something like `target/scala-2.12/eidos-assembly-0.2
-.3-SNAPSHOT.jar`. We will refer to this file in later sections as the Eidos
-JAR. Note the following details:
-
-- Eidos needs to be configured to use grounding, and one of two large
-  word2vec files needs to be made available to Eidos. The commands to do
-  this are:
-
-.. code-block:: sh
-
-    wget https://s3.amazonaws.com/world-modelers/data/vectors.txt
-    mv vectors.txt src/main/resources/org/clulab/wm/eidos/english/w2v/
-    sed -i 's/useW2V = false/useW2V = true/' src/main/resources/eidos.conf
-    sed -i 's/useW2V = false/useW2V = true/' src/main/resources/reference.conf
-    sed -i 's/glove.840B.300d.txt/vectors.txt/' src/main/resources/eidos.conf
-
-
-- Running :code:`sbt assembly` may fail with an out of memory error, if this
-  happens, run it again with an extra flag to allocate more memory, like
-  :code:`sbt -J-Xmx8G assembly`.
-- Note that it is also possible to obtain the Eidos JAR from a running
-  instance of the Eidos service Docker container using :code:`docker cp`
-  thereby avoiding having to build it manually.
-
 Setting up the general INDRA service
 ------------------------------------
 Pull the INDRA docker image from DockerHub

--- a/doc/tutorials/wm_service.rst
+++ b/doc/tutorials/wm_service.rst
@@ -1,0 +1,169 @@
+Summary
+-------
+These instructions allow you to have reading and assembly services running
+locally during the evaluation. With this setup, CauseMos can interact with
+the following endpoints:
+
+- http://localhost:8000/reader/process_text to read text via
+  eidos/sofia/cwms and get back INDRA Statements
+- http://localhost:8001/action to do the following actions: submit_curation,
+  reset_curation, update_beliefs, add_ontology_entry, reset_ontology,
+  update_groundings.
+
+The instructions below run each Docker container with the `-d` option which
+will run containers in the background. You can list running containers with
+`docker ps` and stop a container with `docker stop <container id>`.
+
+For interactive text reading, it makes sense to do an initial test reading
+before the demo so that Eidos loads the necessary resources. Subsequent
+reading calls will be much faster.
+
+Setting up the Eidos service
+----------------------------
+Clone the Eidos repo and cd to Docker folder
+
+.. code-block:: sh
+
+    git clone https://github.com/clulab/eidos.git
+    cd eidos/Docker
+
+Build the Eidos docker image
+.. code-block:: sh
+
+    docker build -f Dockerfile . -t eidos-webservice
+
+Run the Eidos web service and expose it on port 9000
+
+.. code-block:: sh
+
+    docker run -id -p 9000:9000 eidos-webservice
+
+
+Building an Eidos JAR
+---------------------
+In addition, for the live curation service (in particular, to support
+real-time regrounding), a JAR-packaged version of Eidos needs to be
+available. In the top-level Eidos folder, run
+
+.. code-block:: sh
+
+    sbt assembly
+
+to obtain a file called something like `target/scala-2.12/eidos-assembly-0.2
+.3-SNAPSHOT.jar`. We will refer to this file in later sections as the Eidos
+JAR. Note the following details:
+
+- Eidos needs to be configured to use grounding, and one of two large
+  word2vec files needs to be made available to Eidos. The commands to do
+  this are:
+
+.. code-block:: sh
+
+    wget https://s3.amazonaws.com/world-modelers/data/vectors.txt
+    mv vectors.txt src/main/resources/org/clulab/wm/eidos/english/w2v/
+    sed -i 's/useW2V = false/useW2V = true/' src/main/resources/eidos.conf
+    sed -i 's/useW2V = false/useW2V = true/' src/main/resources/reference.conf
+    sed -i 's/glove.840B.300d.txt/vectors.txt/' src/main/resources/eidos.conf
+
+
+- Running :code:`sbt assembly` may fail with an out of memory error, if this
+  happens, run it again with an extra flag to allocate more memory, like
+  :code:`sbt -J-Xmx8G assembly`.
+- Note that it is also possible to obtain the Eidos JAR from a running
+  instance of the Eidos service Docker container using :code:`docker cp`
+  thereby avoiding having to build it manually.
+
+Setting up the general INDRA service
+------------------------------------
+Pull the INDRA docker image from DockerHub
+
+.. code-block:: sh
+
+    docker pull labsyspharm/indra
+
+Run the INDRA web service and expose it on port 8000
+
+.. code-block:: sh
+
+    docker run -id -p 8000:8080 --entrypoint python labsyspharm/indra /sw/indra/rest_api/api.py
+
+Setting up the live feedback service
+------------------------------------
+Assuming you already have the INDRA docker image and the Eidos JAR, run the
+INDRA live feedback service with the following parameters:
+
+- :code:`<folder with corpus>` needs to be a folder in which you have the
+  corpus file as well as the Eidos JAR. This folder will be mounted into the
+  Docker container on the :code:`/sw/mounted` path allowing the container to
+  access both the corpus file, and the Eidos JAR.
+- :code:`<corpus file>` needs to be the name of the corpus file in the
+  :code:`<folder with corpus>` folder.
+
+.. code-block:: sh
+
+    docker run -v <folder with corpus>:/sw/mounted -id \
+      -p 8001:8001 -e EIDOSPATH=/sw/mounted/eidos-assembly-0.2.3-SNAPSHOT.jar \
+      --entrypoint python labsyspharm/indra \
+      /sw/indra/indra/tools/live_curation.py --json /sw/mounted/<corpus file>
+
+Using the live feedback service
+-------------------------------
+Below each example uses the remote service, you can replace that IP with
+localhost to do the same locally.
+
+Submit curations for a set of Statements in a corpus:
+
+.. code-block::
+
+    URL: http://54.84.114.146:8001/submit_curation
+    Method: POST with JSON content header
+    Input parameters: {"corpus_id": "1", "curations": {"38ce0c14-2c7e-4df8-bd53-3006afeaa193": 0}}
+    Output: {}
+
+Update beliefs of a corpus:
+
+.. code-block::
+
+    URL: http://54.84.114.146:8001/update_beliefs
+    Method: POST with JSON content header
+    Input parameters: {"corpus_id": "1"}
+    Output: {"38ce0c14-2c7e-4df8-bd53-3006afeaa193": 0,
+     "6f2b2d69-16af-40ea-aa03-9b3a9a1d2ac3": 0.6979166666666666,
+     "727adb95-4890-4bbc-a985-fd985c355215": 0.6979166666666666}
+
+
+Reset all submitted curations so far:
+
+.. code-block::
+
+    URL: http://54.84.114.146:8001/reset_curation
+    Method: POST with JSON content header
+    Input parameters: {}
+    Output: {}
+
+Add a new ontology entry:
+
+.. code-block::
+
+    URL: http://54.84.114.146:8001/add_ontology_entry
+    Method: POST with JSON content header
+    Input parameters: {"entry": "UN/animals/dog", "examples": ["dog", "canine", "puppy"]}
+    Output: {}
+
+Reset all customizations to the ontology so far:
+
+.. code-block::
+
+    URL: http://54.84.114.146:8001/reset_ontology
+    Method: POST with JSON content header
+    Input parameters: {}
+    Output: {}
+
+Update groundings and re-assemble corpus based on current ontology:
+
+.. code-block::
+
+    URL: http://54.84.114.146:8001/update_groundings
+    Method: POST with JSON content header
+    Input parameters: {"corpus_id": "1"}
+    Output: [{"type": "Influence", ...}] (INDRA Statements JSON)

--- a/doc/tutorials/wm_service.rst
+++ b/doc/tutorials/wm_service.rst
@@ -81,7 +81,7 @@ Submit curations for a set of Statements in a corpus:
 
     URL: http://54.84.114.146:8001/submit_curation
     Method: POST with JSON content header
-    Input parameters: {"corpus_id": "1", "curations": {"38ce0c14-2c7e-4df8-bd53-3006afeaa193": 0}}
+    Input parameters: {"corpus_id": "<corpus-id>", "curations": {"38ce0c14-2c7e-4df8-bd53-3006afeaa193": 0}}
     Output: {}
 
 Update beliefs of a corpus:
@@ -90,7 +90,7 @@ Update beliefs of a corpus:
 
     URL: http://54.84.114.146:8001/update_beliefs
     Method: POST with JSON content header
-    Input parameters: {"corpus_id": "1"}
+    Input parameters: {"corpus_id": "<corpus-id>"}
     Output: {"38ce0c14-2c7e-4df8-bd53-3006afeaa193": 0,
      "6f2b2d69-16af-40ea-aa03-9b3a9a1d2ac3": 0.6979166666666666,
      "727adb95-4890-4bbc-a985-fd985c355215": 0.6979166666666666}

--- a/doc/tutorials/wm_service.rst
+++ b/doc/tutorials/wm_service.rst
@@ -32,6 +32,7 @@ Clone the Eidos repo and cd to Docker folder
     cd eidos/Docker
 
 Build the Eidos docker image
+
 .. code-block:: sh
 
     docker build -f Dockerfile . -t eidos-webservice
@@ -55,26 +56,26 @@ Run the INDRA web service and expose it on port 8000
 
 .. code-block:: sh
 
-    docker run -id -p 8000:8080 --entrypoint python labsyspharm/indra /sw/indra/rest_api/api.py
+    docker run -id -p 8000:8080 --entrypoint python labsyspharm/indra \
+    /sw/indra/rest_api/api.py
 
 Setting up the live feedback service
 ------------------------------------
-Assuming you already have the INDRA docker image and the Eidos JAR, run the
-INDRA live feedback service with the following parameters:
+Assuming you already have the INDRA docker image, run the INDRA live
+feedback service with the following parameters:
 
 - :code:`<folder with corpus>` needs to be a folder in which you have the
-  corpus file as well as the Eidos JAR. This folder will be mounted into the
-  Docker container on the :code:`/sw/mounted` path allowing the container to
-  access both the corpus file, and the Eidos JAR.
+  corpus file. This folder will be mounted into the Docker container on the
+  :code:`/sw/mounted` path allowing the container to access both the corpus
+  file.
 - :code:`<corpus file>` needs to be the name of the corpus file in the
   :code:`<folder with corpus>` folder.
 
 .. code-block:: sh
 
-    docker run -v <folder with corpus>:/sw/mounted -id \
-      -p 8001:8001 -e EIDOSPATH=/sw/mounted/eidos-assembly-0.2.3-SNAPSHOT.jar \
-      --entrypoint python labsyspharm/indra \
-      /sw/indra/indra/tools/live_curation.py --json /sw/mounted/<corpus file>
+    docker run -v <folder with corpus>:/sw/mounted -id -p 8001:8001 \
+    --entrypoint python labsyspharm/indra \
+    /sw/indra/indra/tools/live_curation.py --json /sw/mounted/<corpus file>
 
 Using the live feedback service
 -------------------------------

--- a/indra/tools/live_curation.py
+++ b/indra/tools/live_curation.py
@@ -766,18 +766,19 @@ def update_groundings():
 
 @app.route('/update_metadata', methods=['POST'])
 def update_metadata():
-    if request.json is None:
-        abort(Response('Missing application/json header.', 415))
+    # if request.json is None:
+    #     abort(Response('Missing application/json header.', 415))
 
-    try:
-        # Get input parameters
-        corpus_id = request.json.get('corpus_id')
-        meta_data = request.json.get('meta_data')
-        curator.update_metadata(corpus_id, meta_data, save_to_cache=True)
-    except InvalidCorpusError:
-        abort(Response('The corpus_id "%s" is unknown.' % corpus_id, 400))
-        return
-    return jsonify({})
+    # try:
+    #     # Get input parameters
+    #     corpus_id = request.json.get('corpus_id')
+    #     meta_data = request.json.get('meta_data')
+    #     curator.update_metadata(corpus_id, meta_data, save_to_cache=True)
+    # except InvalidCorpusError:
+    #     abort(Response('The corpus_id "%s" is unknown.' % corpus_id, 400))
+    #     return
+    logger.info('Update metadata is currently disabled')
+    return jsonify({'result': 'endpoint disabled'})
 
 
 @app.route('/save_curation', methods=['POST'])

--- a/indra/tools/live_curation.py
+++ b/indra/tools/live_curation.py
@@ -475,7 +475,7 @@ class LiveCurator(object):
         for corpus_id, corpus in self.corpora.items():
             corpus.curations = {}
 
-    def get_corpus(self, corpus_id, check_s3=False, use_cache=True):
+    def get_corpus(self, corpus_id, check_s3=True, use_cache=True):
         """Return a corpus given an ID.
 
         If the corpus ID cannot be found, an InvalidCorpusError is raised.
@@ -486,7 +486,7 @@ class LiveCurator(object):
             The ID of the corpus to return.
         check_s3 : bool
             If True, look on S3 for the corpus if it's not currently loaded.
-            Default: False.
+            Default: True
         use_cache : bool
             If True, look in local cache before trying to find corpus on s3.
             If True while check_s3 if False, this option will be ignored.
@@ -499,6 +499,8 @@ class LiveCurator(object):
         """
         logger.info('Getting corpus "%s"' % corpus_id)
         corpus = self.corpora.get(corpus_id)
+        if corpus:
+            logger.info('Found corpus loaded in memory')
         if check_s3 and corpus is None:
             logger.info('Corpus not loaded, looking on S3')
             corpus = Corpus.load_from_s3(s3key=corpus_id,

--- a/indra/tools/live_curation.py
+++ b/indra/tools/live_curation.py
@@ -296,7 +296,11 @@ class Corpus(object):
                     meta_json = json.loads(s3.get_object(
                         Bucket=bucket, Key=meta)['Body'].read())
             except Exception as e:
-                logger.warning('No meta data found')
+                if isinstance(e, s3.exceptions.NoSuchKey):
+                    logger.warning('No meta data found on s3')
+                else:
+                    logger.warning('No meta data found')
+                meta_json = {}
             self.meta_data = meta_json
 
         except Exception as e:

--- a/indra/tools/live_curation.py
+++ b/indra/tools/live_curation.py
@@ -806,12 +806,15 @@ if __name__ == '__main__':
     parser.add_argument('--meta-json', help='Meta data json file')
     parser.add_argument('--corpus_id')
     parser.add_argument('--host', default='0.0.0.0')
+    parser.add_argument('--eidos-url', default='http://localhost:9000')
     parser.add_argument('--port', default=8001, type=int)
     parser.add_argument('--aws-cred', type=str, default='default',
                         help='The name of the credential set to use when '
                              'connecting to AWS services. If the name is not '
                              'found in your AWS config, `[default]`  is used.')
     args = parser.parse_args()
+
+    curator.eidos_url = args.eidos_url
 
     # Load corpus from S3 if corpus ID is provided
     if args.corpus_id and not args.json and not args.pickle:


### PR DESCRIPTION
This PR adds a tutorial for how to run the WM Live Curation Service locally using docker containers.

Changes:
- Add `doc/tutorials/wm_service.rst`
- Fix a minor bug in `indra/tools/live_curation.py`
- Read environment variables before checking aws profiles