### PR TITLE
Handle NDEx API failures

### DIFF
--- a/indra/assemblers/cx/assembler.py
+++ b/indra/assemblers/cx/assembler.py
@@ -345,19 +345,20 @@ class CxAssembler(object):
         network_id = ndex_client.create_network(cx_str, ndex_cred, private)
         if network_id and style:
             template_id = None if style == 'default' else style
-            nretries = 5
+            nretries = 3
             for retry_idx in range(nretries):
                 time.sleep(3)
                 try:
                     ndex_client.set_style(network_id, ndex_cred, template_id)
                     break
                 except Exception:
+                    msg = 'Style setting failed, '
                     if retry_idx + 1 < nretries:
-                        logger.info('Style setting failed, retrying %d '
-                                    'more times' % (nretries - (retry_idx+1)))
+                        logger.info(msg + 'retrying %d more times' %
+                                    (nretries - (retry_idx+1)))
                     else:
-                        logger.info('Style setting failed, the network will '
-                                    'be missing style information.')
+                        logger.info(msg + 'the network will be missing style '
+                                    'information.')
         return network_id
 
     def set_context(self, cell_type):

--- a/indra/assemblers/cx/assembler.py
+++ b/indra/assemblers/cx/assembler.py
@@ -345,8 +345,19 @@ class CxAssembler(object):
         network_id = ndex_client.create_network(cx_str, ndex_cred, private)
         if network_id and style:
             template_id = None if style == 'default' else style
-            time.sleep(0.5)
-            ndex_client.set_style(network_id, ndex_cred, template_id)
+            nretries = 5
+            for retry_idx in range(nretries):
+                time.sleep(3)
+                try:
+                    ndex_client.set_style(network_id, ndex_cred, template_id)
+                    break
+                except Exception:
+                    if retry_idx + 1 < nretries:
+                        logger.info('Style setting failed, retrying %d '
+                                    'more times' % (nretries - (retry_idx+1)))
+                    else:
+                        logger.info('Style setting failed, the network will '
+                                    'be missing style information.')
         return network_id
 
     def set_context(self, cell_type):

--- a/indra/databases/ndex_client.py
+++ b/indra/databases/ndex_client.py
@@ -195,7 +195,7 @@ def update_network(cx_str, network_id, ndex_cred=None):
                }
     logger.info('Updating NDEx network (%s) profile to %s',
                 network_id, profile)
-    profile_retries = 5
+    profile_retries = 3
     for _ in range(profile_retries):
         try:
             time.sleep(5)
@@ -223,7 +223,8 @@ def set_style(network_id, ndex_cred=None, template_id=None):
     """
     if not template_id:
         template_id = "ea4ea3b7-6903-11e7-961c-0ac135e8bacf"
-
+    logger.info('Setting network style based on template: %s' %
+                template_id)
     server = 'http://public.ndexbio.org'
     username, password = get_default_ndex_cred(ndex_cred)
 


### PR DESCRIPTION
This PR implements some wait-and-retry strategies for handling failures from the NDEx server which have to do with attempting to manipulate the network too soon after upload.