### PR TITLE
Refactor REACH API

### DIFF
--- a/doc/modules/sources/reach/index.rst
+++ b/doc/modules/sources/reach/index.rst
@@ -1,6 +1,9 @@
 REACH (:py:mod:`indra.sources.reach`)
 =====================================
 
+.. automodule:: indra.sources.reach
+    :members:
+
 REACH API (:py:mod:`indra.sources.reach.api`)
 ---------------------------------------------
 

--- a/doc/rest_api.rst
+++ b/doc/rest_api.rst
@@ -3,17 +3,17 @@ REST API
 
 Many functionalities of INDRA can be used via a REST API. This enables
 making use of INDRA's knowledge sources and assembly capabilities in a
-RESTful, platform independent fashion. The REST service
-is meant to be used locally (on a single machine or local network)
-and is currently not offered as a public web service by the creators of INDRA.
+RESTful, platform independent fashion. The REST service is available as a
+public web service and can also be run locally (on a single machine or local
+network).
 
 Installation
 ------------
-The REST service requires the `bottle` package to be installed in addition
-to all the other requirements of INDRA.
+Running the REST service requires the `bottle` package to be installed in
+addition to all the other requirements of INDRA.
 
-Launching the REST service
---------------------------
+Launching the REST service (locally)
+------------------------------------
 The REST service can be launched by running `api.py` in the `rest_api` folder
 within `indra`.
 
@@ -22,4 +22,3 @@ Documentation
 The specific end-points and input/output parameters offered by the REST API
 are documented in `rest_api/docs/index.html`, which is accessible locally
 within the `indra` folder.
-

--- a/indra/sources/reach/__init__.py
+++ b/indra/sources/reach/__init__.py
@@ -1,3 +1,123 @@
+"""
+REACH is a biology-oriented machine reading system which uses a cascade of
+grammars to extract biological mechanisms from free text.
+
+To cover a wide range of use cases and scenarios, there are currently 4
+different ways in which INDRA can use REACH.
+
+
+1. INDRA communicating with a remote REACH API Server (:py:mod:`indra.sources.reach.api`)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Setup and usage: Does not require any additional setup after installing INDRA.
+
+Read text using the default values for `offline` and `url` parameters.
+
+.. code-block:: python
+
+   from indra.sources import reach
+   rp = reach.process_text('MEK binds ERK')
+
+It is also possible to read NXML (string or file) and process text of a paper
+given its PMC ID or PubMed ID.
+
+Advantages:
+
+* Does not require setting up the pyjnius Python-Java bridge
+* Does not require assembling a REACH JAR file
+
+Disadvantages:
+
+* No control on which REACH version is used to run the service
+* Difficulties processing NXML-formatted text have been observed in the past
+
+2. INDRA communicating with a locally running REACH API Server (:py:mod:`indra.sources.reach.api`)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Setup and usage: Clone and run REACH web server.
+
+.. code-block:: bash
+
+    git clone https://github.com/clulab/reach.git
+    cd reach
+    sbt 'run-main org.clulab.reach.export.server.ApiServer'
+
+Then read text by specifying the url parameter when using
+`indra.sources.reach.process_text`.
+
+.. code-block:: python
+
+   from indra.sources import reach
+   rp = reach.process_text('MEK binds ERK',
+                           url='http://localhost:8080/api/text')
+
+It is also possible to read NXML (string or file) and process text of a paper
+given its PMC ID or PubMed ID.
+
+Advantages:
+
+* Control the REACH version used to run the service
+* Does not require setting up the pyjnius Python-Java bridge
+* Does not require assembling a REACH JAR file
+
+Disadvantages:
+
+* First request might be time-consuming as REACH is loading additional
+resources.
+
+3. INDRA using a REACH JAR directly through a Python-Java bridge (:py:mod:`indra.sources.reach.reader`)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Setup and usage:
+
+First, the REACH system and its dependencies need to be packaged as a fat JAR:
+
+.. code-block:: bash
+
+    git clone https://github.com/clulab/reach.git
+    cd reach
+    sbt assembly
+
+This creates a JAR file in reach/target/scala[version]/reach-[version].jar.
+Set the absolute path to this file on the REACHPATH environmental variable
+and then append REACHPATH to the CLASSPATH environmental variable (entries
+are separated by colons).
+
+The `pyjnius` package needs to be set up and be operational. For more details,
+see :ref:`pyjniussetup` setup instructions in the documentation.
+
+Then, reading can be done simply using the `indra.sources.reach.process_text`
+function with offline option.
+
+.. code-block:: python
+
+   from indra.sources import reach
+   rp = reach.process_text('MEK binds ERK', offline=True)
+
+
+Advantages:
+
+* Doesn't require running a separate process for REACH and INDRA
+* Having a single REACH JAR file makes this solution portable
+
+Disadvantages:
+
+* Requires configuring pyjnius which is often difficult
+* Requires building a large REACH JAR file which can be time consuming
+* The ReachReader instance needs to be instantiated every time a new INDRA
+  session is started which is time consuming.
+
+4. Use REACH separately to produce output files and then process those with INDRA
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In this usage mode REACH is not directly invoked by INDRA. Rather, REACH
+is set up and run idenpendently of INDRA to produce JSON-LD output files
+for a set of text content.
+One can then use :py:mod:`indra.sources.reach.api.process_json_file`
+in INDRA to process the JSON-LD output files.
+"""
+
+
 from .api import (process_pmc,
                   process_pubmed_abstract,
                   process_text,

--- a/indra/sources/reach/__init__.py
+++ b/indra/sources/reach/__init__.py
@@ -5,36 +5,11 @@ grammars to extract biological mechanisms from free text.
 To cover a wide range of use cases and scenarios, there are currently 4
 different ways in which INDRA can use REACH.
 
-
-1. INDRA communicating with a remote REACH API Server (:py:mod:`indra.sources.reach.api`)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Setup and usage: Does not require any additional setup after installing INDRA.
-
-Read text using the default values for `offline` and `url` parameters.
-
-.. code-block:: python
-
-   from indra.sources import reach
-   rp = reach.process_text('MEK binds ERK')
-
-It is also possible to read NXML (string or file) and process text of a paper
-given its PMC ID or PubMed ID.
-
-Advantages:
-
-* Does not require setting up the pyjnius Python-Java bridge
-* Does not require assembling a REACH JAR file
-
-Disadvantages:
-
-* No control on which REACH version is used to run the service
-* Difficulties processing NXML-formatted text have been observed in the past
-
-2. INDRA communicating with a locally running REACH API Server (:py:mod:`indra.sources.reach.api`)
+1. INDRA communicating with a locally running REACH API Server (:py:mod:`indra.sources.reach.api`)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Setup and usage: Clone and run REACH web server.
+Setup and usage: Follow standard instructions to install SBT. Clone REACH and
+run REACH web server.
 
 .. code-block:: bash
 
@@ -63,14 +38,47 @@ Advantages:
 Disadvantages:
 
 * First request might be time-consuming as REACH is loading additional
-resources.
+  resources.
+* Only endpoints exposed by the REACH web server are available, i.e., no
+  full object-level access to REACH components.
 
-3. INDRA using a REACH JAR directly through a Python-Java bridge (:py:mod:`indra.sources.reach.reader`)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+2. INDRA communicating with a remote REACH API Server (:py:mod:`indra.sources.reach.api`)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Setup and usage: Does not require any additional setup after installing INDRA.
+
+Read text using the default values for `offline` and `url` parameters.
+
+.. code-block:: python
+
+   from indra.sources import reach
+   rp = reach.process_text('MEK binds ERK')
+
+It is also possible to read NXML (string or file) and process text of a paper
+given its PMC ID or PubMed ID.
+
+Advantages:
+
+* Does not require setting up the pyjnius Python-Java bridge
+* Does not require assembling a REACH JAR file or installing REACH at all
+  locally
+* Suitable for initial prototyping or integration testing
+
+Disadvantages:
+
+* Cannot handle high-throughput reading workflows due to limited server
+  resources.
+* No control on which REACH version is used to run the service.
+* Difficulties processing NXML-formatted text have been observed in the past.
+
+3. INDRA using a REACH JAR through a Python-Java bridge (:py:mod:`indra.sources.reach.reader`)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Setup and usage:
 
-First, the REACH system and its dependencies need to be packaged as a fat JAR:
+Follow standard instructions for installing SBT. First, the REACH system and
+its dependencies need to be packaged as a fat JAR:
 
 .. code-block:: bash
 
@@ -86,8 +94,8 @@ are separated by colons).
 The `pyjnius` package needs to be set up and be operational. For more details,
 see :ref:`pyjniussetup` setup instructions in the documentation.
 
-Then, reading can be done simply using the `indra.sources.reach.process_text`
-function with offline option.
+Then, reading can be done using the `indra.sources.reach.process_text`
+function with the offline option.
 
 .. code-block:: python
 
@@ -98,11 +106,14 @@ function with offline option.
 Advantages:
 
 * Doesn't require running a separate process for REACH and INDRA
-* Having a single REACH JAR file makes this solution portable
+* Having a single REACH JAR file makes this solution easily portable
+* Through jnius, all classes in REACH become available for programmatic
+  access
+
 
 Disadvantages:
 
-* Requires configuring pyjnius which is often difficult
+* Requires configuring pyjnius which is often difficult (e.g., on Windows)
 * Requires building a large REACH JAR file which can be time consuming
 * The ReachReader instance needs to be instantiated every time a new INDRA
   session is started which is time consuming.
@@ -111,10 +122,15 @@ Disadvantages:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In this usage mode REACH is not directly invoked by INDRA. Rather, REACH
-is set up and run idenpendently of INDRA to produce JSON-LD output files
-for a set of text content.
-One can then use :py:mod:`indra.sources.reach.api.process_json_file`
-in INDRA to process the JSON-LD output files.
+is set up and run independent of INDRA to produce output files
+for a set of text content. For more information on running REACH on a set of
+text or NXML files, see the REACH README and documentation at:
+https://github.com/clulab/reach. Note that INDRA uses the `fries` output format
+produced by REACH.
+
+Once REACH output has been obtained in the `fries` JSON format, once can
+use :py:mod:`indra.sources.reach.api.process_json_file`
+in INDRA to process the JSON files.
 """
 
 

--- a/indra/sources/reach/__init__.py
+++ b/indra/sources/reach/__init__.py
@@ -5,11 +5,11 @@ grammars to extract biological mechanisms from free text.
 To cover a wide range of use cases and scenarios, there are currently 4
 different ways in which INDRA can use REACH.
 
-1. INDRA communicating with a locally running REACH API Server (:py:mod:`indra.sources.reach.api`)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. INDRA communicating with a locally running REACH Server (:py:mod:`indra.sources.reach.api`)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Setup and usage: Follow standard instructions to install SBT. Clone REACH and
-run REACH web server.
+Setup and usage: Follow standard instructions to install
+`SBT <www.scala-sbt.org>`_. Then clone REACH and run the REACH web server.
 
 .. code-block:: bash
 
@@ -26,14 +26,18 @@ Then read text by specifying the url parameter when using
    rp = reach.process_text('MEK binds ERK',
                            url='http://localhost:8080/api/text')
 
-It is also possible to read NXML (string or file) and process text of a paper
-given its PMC ID or PubMed ID.
+It is also possible to read NXML (string or file) and process the text of a
+paper given its PMC ID or PubMed ID using other API methods in
+:py:mod:`indra.sources.reach.api`.
 
 Advantages:
 
-* Control the REACH version used to run the service
-* Does not require setting up the pyjnius Python-Java bridge
-* Does not require assembling a REACH JAR file
+* Does not require setting up the pyjnius Python-Java bridge.
+* Does not require assembling a REACH JAR file.
+* Allows local control the REACH version and configuration used to run the
+  service.
+* REACH is running in a separate process and therefore does not need to
+  be initialized if a new Python session is started.
 
 Disadvantages:
 
@@ -43,8 +47,8 @@ Disadvantages:
   full object-level access to REACH components.
 
 
-2. INDRA communicating with a remote REACH API Server (:py:mod:`indra.sources.reach.api`)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2. INDRA communicating with the UA REACH Server (:py:mod:`indra.sources.reach.api`)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Setup and usage: Does not require any additional setup after installing INDRA.
 
@@ -55,22 +59,24 @@ Read text using the default values for `offline` and `url` parameters.
    from indra.sources import reach
    rp = reach.process_text('MEK binds ERK')
 
-It is also possible to read NXML (string or file) and process text of a paper
-given its PMC ID or PubMed ID.
+It is also possible to read NXML (string or file) and process the content of
+a paper given its PMC ID or PubMed ID using other functions in
+:py:mod:`indra.sources.reach.api`.
 
 Advantages:
 
-* Does not require setting up the pyjnius Python-Java bridge
+* Does not require setting up the pyjnius Python-Java bridge.
 * Does not require assembling a REACH JAR file or installing REACH at all
-  locally
-* Suitable for initial prototyping or integration testing
+  locally.
+* Suitable for initial prototyping or integration testing.
 
 Disadvantages:
 
 * Cannot handle high-throughput reading workflows due to limited server
   resources.
-* No control on which REACH version is used to run the service.
-* Difficulties processing NXML-formatted text have been observed in the past.
+* No control over which REACH version is used to run the service.
+* Difficulties processing NXML-formatted text (request times out) have been
+  observed in the past.
 
 3. INDRA using a REACH JAR through a Python-Java bridge (:py:mod:`indra.sources.reach.reader`)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -102,19 +108,22 @@ function with the offline option.
    from indra.sources import reach
    rp = reach.process_text('MEK binds ERK', offline=True)
 
+Other functions in :py:mod:`indra.sources.reach.api` can also be used
+with the offline option to invoke local, JAR-based reading.
+
 
 Advantages:
 
-* Doesn't require running a separate process for REACH and INDRA
-* Having a single REACH JAR file makes this solution easily portable
+* Doesn't require running a separate process for REACH and INDRA.
+* Having a single REACH JAR file makes this solution easily portable.
 * Through jnius, all classes in REACH become available for programmatic
-  access
+  access.
 
 
 Disadvantages:
 
-* Requires configuring pyjnius which is often difficult (e.g., on Windows)
-* Requires building a large REACH JAR file which can be time consuming
+* Requires configuring pyjnius which is often difficult (e.g., on Windows).
+  Therefore this usage mode is generally not recommended.
 * The ReachReader instance needs to be instantiated every time a new INDRA
   session is started which is time consuming.
 
@@ -122,15 +131,15 @@ Disadvantages:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In this usage mode REACH is not directly invoked by INDRA. Rather, REACH
-is set up and run independent of INDRA to produce output files
+is set up and run independently of INDRA to produce output files
 for a set of text content. For more information on running REACH on a set of
-text or NXML files, see the REACH README and documentation at:
+text or NXML files, see the REACH documentation at:
 https://github.com/clulab/reach. Note that INDRA uses the `fries` output format
 produced by REACH.
 
-Once REACH output has been obtained in the `fries` JSON format, once can
+Once REACH output has been obtained in the `fries` JSON format, one can
 use :py:mod:`indra.sources.reach.api.process_json_file`
-in INDRA to process the JSON files.
+in INDRA to process each JSON file.
 """
 
 

--- a/indra/sources/reach/api.py
+++ b/indra/sources/reach/api.py
@@ -344,23 +344,16 @@ def process_json_str(json_str, citation=None):
         A ReachProcessor containing the extracted INDRA Statements
         in rp.statements.
     """
-    if not isinstance(json_str, str):
-        raise TypeError('{} is {} instead of {}'.format(json_str,
-                                                        json_str.__class__,
-                                                        str))
-
-    json_str = json_str.replace('frame-id', 'frame_id')
-    json_str = json_str.replace('argument-label', 'argument_label')
-    json_str = json_str.replace('object-meta', 'object_meta')
-    json_str = json_str.replace('doc-id', 'doc_id')
-    json_str = json_str.replace('is-hypothesis', 'is_hypothesis')
-    json_str = json_str.replace('is-negated', 'is_negated')
-    json_str = json_str.replace('is-direct', 'is_direct')
-    json_str = json_str.replace('found-by', 'found_by')
+    fields = ['frame-id', 'argument-label', 'object-meta',
+              'doc-id', 'is-hypothesis', 'is-negated',
+              'is-direct', 'found-by']
+    for field in fields:
+        json_str = json_str.replace(field, field.replace('-', '_'))
     try:
         json_dict = json.loads(json_str)
-    except ValueError:
+    except ValueError as e:
         logger.error('Could not decode JSON string.')
+        logger.exception(e)
         return None
     rp = ReachProcessor(json_dict, citation)
     rp.get_modifications()

--- a/indra/sources/reach/api.py
+++ b/indra/sources/reach/api.py
@@ -155,9 +155,9 @@ def process_text(text, citation=None, offline=False, url=reach_text_url,
         in rp.statements.
     """
     if offline:
-        json_str = get_json_str_offline(text, 'text')
+        json_str = _get_json_str_offline(text, 'text')
     else:
-        json_str = text_to_json_str_online(text, url, timeout)
+        json_str = _text_to_json_str_online(text, url, timeout)
 
     if json_str:
         with open(output_fname, 'wb') as fh:
@@ -196,17 +196,17 @@ def process_nxml_str(nxml_str, citation=None, offline=False,
         in rp.statements.
     """
     if offline:
-        json_str = get_json_str_offline(nxml_str, 'nxml')
+        json_str = _get_json_str_offline(nxml_str, 'nxml')
     else:
         if url == reach_nxml_url:
             logger.warning('Remote REACH webservice might get stuck when ' +
                            'processing NXML. Running local instance of REACH' +
                            ' is recommended.')
-            json_str = nxml_to_json_str_remote(nxml_str, url)
+            json_str = _nxml_to_json_str_remote(nxml_str, url)
         else:
             with open('temp_file.nxml', 'wb') as f:
                 f.write(nxml_str.encode('utf-8'))
-            json_str = nxml_file_to_json_str_local('temp_file.nxml', url)
+            json_str = _nxml_file_to_json_str_local('temp_file.nxml', url)
 
     if json_str:
         with open(output_fname, 'wb') as fh:
@@ -250,7 +250,7 @@ def process_nxml_file(file_name, citation=None, offline=False,
             return process_nxml_str(nxml_str, citation, offline=offline,
                                     url=url, output_fname=output_fname)
 
-    json_str = nxml_file_to_json_str_local(file_name, url)
+    json_str = _nxml_file_to_json_str_local(file_name, url)
     if json_str:
         with open(output_fname, 'wb') as fh:
             fh.write(json_str)
@@ -333,7 +333,7 @@ def process_json_str(json_str, citation=None):
     return rp
 
 
-def get_json_str_offline(content, content_type='text'):
+def _get_json_str_offline(content, content_type='text'):
     """Return a json string by processing the given text with offline
     REACH reader.
 
@@ -381,7 +381,7 @@ def get_json_str_offline(content, content_type='text'):
     return json_str
 
 
-def text_to_json_str_online(text, url=reach_text_url, timeout=None):
+def _text_to_json_str_online(text, url=reach_text_url, timeout=None):
     """Return a json string by processing the given text with online REACH API.
 
     Parameters
@@ -415,7 +415,7 @@ def text_to_json_str_online(text, url=reach_text_url, timeout=None):
     return json_str
 
 
-def nxml_to_json_str_remote(nxml_str, url=reach_nxml_url):
+def _nxml_to_json_str_remote(nxml_str, url=reach_nxml_url):
     """Return a json string by processing the given NXML string with remote
     REACH webservice.
 
@@ -446,7 +446,7 @@ def nxml_to_json_str_remote(nxml_str, url=reach_nxml_url):
     return json_str
 
 
-def nxml_file_to_json_str_local(file_name, url=local_nxml_url):
+def _nxml_file_to_json_str_local(file_name, url=local_nxml_url):
     """Return a json string by processing the given NXML file with locally
     running instance of REACH webservice.
 

--- a/indra/sources/reach/api.py
+++ b/indra/sources/reach/api.py
@@ -79,7 +79,7 @@ def process_pmc(pmc_id, offline=False, url=reach_nxml_url,
     return rp
 
 
-def process_pubmed_abstract(pubmed_id, offline=False, url=reach_nxml_url,
+def process_pubmed_abstract(pubmed_id, offline=False, url=reach_text_url,
                             output_fname=default_output_fname, **kwargs):
     """Return a ReachProcessor by processing an abstract with a given Pubmed id.
 
@@ -199,10 +199,13 @@ def process_nxml_str(nxml_str, citation=None, offline=False,
         json_str = get_json_str_offline(nxml_str, 'nxml')
     else:
         if url == reach_nxml_url:
+            logger.warning('Remote REACH webservice might get stuck when ' +
+                           'processing NXML. Running local instance of REACH' +
+                           ' is recommended.')
             json_str = nxml_to_json_str_remote(nxml_str, url)
         else:
             with open('temp_file.nxml', 'wb') as f:
-                f.write(nxml_str)
+                f.write(nxml_str.encode('utf-8'))
             json_str = nxml_file_to_json_str_local('temp_file.nxml', url)
 
     if json_str:
@@ -439,8 +442,8 @@ def nxml_to_json_str_remote(nxml_str, url=reach_nxml_url):
         logger.error('Could not process NXML via REACH service.'
                      + 'Status code: %d' % res.status_code)
         return None
-    json_str = res.text
-    return res.text
+    json_str = res.content
+    return json_str
 
 
 def nxml_file_to_json_str_local(file_name, url=local_nxml_url):
@@ -462,13 +465,13 @@ def nxml_file_to_json_str_local(file_name, url=local_nxml_url):
     with open(file_name, 'rb') as f:
         try:
             res = requests.post(url, files={'file': f})
-    except requests.exceptions.RequestException as e:
-        logger.error('Could not connect to REACH service:')
-        logger.error(e)
-        return None
+        except requests.exceptions.RequestException as e:
+            logger.error('Could not connect to REACH service:')
+            logger.error(e)
+            return None
     if res.status_code != 200:
         logger.error('Could not process NXML via REACH service.'
                      + 'Status code: %d' % res.status_code)
         return None
-    json_str = res.text
-    return res.text
+    json_str = res.content
+    return json_str

--- a/indra/sources/reach/api.py
+++ b/indra/sources/reach/api.py
@@ -405,7 +405,7 @@ def _read_content_offline(content, content_type='text'):
         else:
             raise ValueError('Invalid content_type: %s' % content_type)
     except JavaException as e:
-        logger.error('Could not process %d.' % content_type)
+        logger.error('Could not process %s.' % content_type)
         logger.error(e)
         return None
     # REACH version < 1.3.3

--- a/indra/sources/reach/api.py
+++ b/indra/sources/reach/api.py
@@ -4,7 +4,6 @@ Many file formats are supported. Many will run reach.
 """
 import json
 import logging
-import os
 import requests
 
 from indra.literature import id_lookup
@@ -403,6 +402,8 @@ def _read_content_offline(content, content_type='text'):
             result_map = api_ruler.annotateText(content, 'fries')
         elif content_type == 'nxml':
             result_map = api_ruler.annotateNxml(content, 'fries')
+        else:
+            raise ValueError('Invalid content_type: %s' % content_type)
     except JavaException as e:
         logger.error('Could not process %d.' % content_type)
         logger.error(e)

--- a/indra/sources/reach/api.py
+++ b/indra/sources/reach/api.py
@@ -2,9 +2,6 @@
 
 Many file formats are supported. Many will run reach.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str, bytes
-
 import json
 import logging
 import os
@@ -15,10 +12,6 @@ import indra.literature.pmc_client as pmc_client
 import indra.literature.pubmed_client as pubmed_client
 from .processor import ReachProcessor
 
-try:  # Python 2
-    basestring
-except NameError:  # Python 3
-    basestring = str
 
 logger = logging.getLogger(__name__)
 

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -136,6 +136,7 @@ def test_parse_site_multiple():
 def test_phosphorylate():
     for offline in offline_modes:
         rp = reach.process_text('MEK1 phosphorylates ERK2.', offline=offline)
+        assert rp is not None
         assert len(rp.statements) == 1
         s = rp.statements[0]
         assert (s.enz.name == 'MAP2K1')
@@ -147,6 +148,7 @@ def test_indirect_phosphorylate():
     txt = 'DUSP decreases the phosphorylation of ERK.'
     for offline in offline_modes:
         rp = reach.process_text(txt, offline=offline)
+        assert rp is not None
         assert len(rp.statements) == 1
         s = rp.statements[0]
         assert isinstance(s, Dephosphorylation)
@@ -159,6 +161,7 @@ def test_regulate_amount():
     for offline in offline_modes:
         rp = reach.process_text('ERK increases the transcription of DUSP.',
                                 offline=offline)
+        assert rp is not None
         assert len(rp.statements) == 1
         s = rp.statements[0]
         assert isinstance(s, IncreaseAmount)
@@ -179,6 +182,7 @@ def test_multiple_enzymes():
     for offline in offline_modes:
         rp = reach.process_text('MEK1 and MEK2 phosphorylate ERK1.',
                                 offline=offline)
+        assert rp is not None
         assert len(rp.statements) == 2
         s = rp.statements[0]
         if s.enz.name == 'MAP2K1':
@@ -194,6 +198,7 @@ def test_multiple_enzymes():
 def test_activate():
     for offline in offline_modes:
         rp = reach.process_text('HRAS activates BRAF.', offline=offline)
+        assert rp is not None
         assert len(rp.statements) == 1
         s = rp.statements[0]
         assert (s.subj.name == 'HRAS')
@@ -205,6 +210,7 @@ def test_reg_amount_complex_controller():
     txt = 'The FOS-JUN complex increases the amount of ZEB2.'
     for offline in offline_modes:
         rp = reach.process_text(txt, offline=offline)
+        assert rp is not None
         assert len(rp.statements) == 2
         cplx = [s for s in rp.statements if isinstance(s, Complex)][0]
         regam = [s for s in rp.statements if isinstance(s, IncreaseAmount)][0]
@@ -216,6 +222,7 @@ def test_reg_amount_complex_controller():
 def test_bind():
     for offline in offline_modes:
         rp = reach.process_text('MEK1 binds ERK2.', offline=offline)
+        assert rp is not None
         assert len(rp.statements) == 1
         assert unicode_strs(rp.statements)
 
@@ -223,6 +230,7 @@ def test_bind():
 def test_be_grounding():
     for offline in offline_modes:
         rp = reach.process_text('MEK activates ERK.', offline=offline)
+        assert rp is not None
         assert len(rp.statements) == 1
         assert unicode_strs(rp.statements)
         if offline is True:
@@ -234,6 +242,7 @@ def test_be_grounding():
 def test_activity():
     for offline in offline_modes:
         rp = reach.process_text('MEK1 activates ERK2.', offline=offline)
+        assert rp is not None
         assert len(rp.statements) == 1
         assert unicode_strs(rp.statements)
 
@@ -242,6 +251,7 @@ def test_mutation():
     for offline in offline_modes:
         rp = reach.process_text('BRAF(V600E) phosphorylates MEK.',
                                 offline=offline)
+        assert rp is not None
         assert len(rp.statements) == 1
         braf = rp.statements[0].enz
         assert braf.name == 'BRAF'
@@ -272,6 +282,7 @@ def test_parse_mutation():
 def test_process_unicode():
     for offline in offline_modes:
         rp = reach.process_text('MEK1 binds ERK2\U0001F4A9.', offline=offline)
+        assert rp is not None
         assert unicode_strs(rp.statements)
 
 
@@ -279,6 +290,7 @@ def test_process_unicode():
 def test_process_pmc():
     for offline in offline_modes:
         rp = reach.process_pmc('PMC4338247', offline=offline)
+        assert rp is not None
         for stmt in rp.statements:
             assert_pmid(stmt)
         assert unicode_strs(rp.statements)
@@ -287,6 +299,7 @@ def test_process_pmc():
 def test_process_unicode_abstract():
     for offline in offline_modes:
         rp = reach.process_pubmed_abstract('27749056', offline=offline)
+        assert rp is not None
         assert unicode_strs(rp.statements)
 
 
@@ -294,6 +307,7 @@ def test_hgnc_from_up():
     for offline in offline_modes:
         rp = reach.process_text('MEK1 phosphorylates ERK2.',
                                 offline=offline)
+        assert rp is not None
         assert len(rp.statements) == 1
         st = rp.statements[0]
         (map2k1, mapk1) = st.agent_list()
@@ -364,6 +378,7 @@ def test_get_agent_coordinates_phosphorylation():
                  'MEK that is phosphorylated phosphorylates ERK.')
     for offline in offline_modes:
         rp = reach.process_text(test_case, offline=offline)
+        assert rp is not None
         stmt = rp.statements[0]
         annotations = stmt.evidence[0].annotations
 
@@ -375,6 +390,7 @@ def test_get_agent_coordinates_activation():
     test_case = 'MEK1 activates ERK2'
     for offline in offline_modes:
         rp = reach.process_text(test_case, offline=offline)
+        assert rp is not None
         stmt = rp.statements[0]
         annotations = stmt.evidence[0].annotations
         coords = [(0, 4), (15, 19)]
@@ -385,6 +401,7 @@ def test_get_agent_coordinates_regulate_amount():
     test_case = 'ERK increases the transcription of DUSP'
     for offline in offline_modes:
         rp = reach.process_text(test_case, offline=offline)
+        assert rp is not None
         stmt = rp.statements[0]
         annotations = stmt.evidence[0].annotations
         coords = [(0, 3), (35, 39)]
@@ -395,6 +412,7 @@ def test_get_agent_coordinates_binding():
     test_case = 'Everyone has observed that MEK1 binds ERK2'
     for offline in offline_modes:
         rp = reach.process_text(test_case, offline=offline)
+        assert rp is not None
         stmt = rp.statements[0]
         annotations = stmt.evidence[0].annotations
         coords = [(27, 31), (38, 42)]
@@ -407,6 +425,7 @@ def test_get_agent_coordinates_translocation():
                  'translocates to the nucleus promotes cell growth.')
     for offline in offline_modes:
         rp = reach.process_text(test_case, offline=offline)
+        assert rp is not None
         stmt = [stmt for stmt in rp.statements if
                 isinstance(stmt, Translocation)][0]
         annotations = stmt.evidence[0].annotations
@@ -421,8 +440,11 @@ def test_get_agent_coordinates_phosphorylation_missing_controller():
                  'function cooperatively')
     for offline in offline_modes:
         rp = reach.process_text(test_case, offline=offline)
-        stmt = [stmt for stmt in rp.statements if
-                isinstance(stmt, Phosphorylation)][0]
+        assert rp is not None
+        phos_stmts = [stmt for stmt in rp.statements if
+                      isinstance(stmt, Phosphorylation)]
+        assert phos_stmts, rp.statements
+        stmt = phos_stmts[0]
         annotations = stmt.evidence[0].annotations
         coords = [None, (57, 60)]
         assert annotations['agents']['coords'] == coords
@@ -432,6 +454,7 @@ def test_amount_embedded_in_activation():
     here = os.path.dirname(os.path.abspath(__file__))
     test_file = os.path.join(here, 'reach_act_amt.json')
     rp = reach.process_json_file(test_file)
+    assert rp is not None
     assert len(rp.statements) == 1
     assert isinstance(rp.statements[0], IncreaseAmount)
     assert rp.statements[0].subj is not None

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -19,7 +19,7 @@ import indra.tools.assemble_corpus as ac
 from indra.databases import cbio_client
 from indra.sources.indra_db_rest import get_statements
 from indra.sources.ndex_cx.api import process_ndex_network
-
+from indra.sources.reach.api import reach_nxml_url, reach_text_url
 from indra.belief.wm_scorer import get_eidos_scorer
 from indra.preassembler.ontology_mapper import OntologyMapper, wm_ontomap
 
@@ -109,7 +109,7 @@ def reach_process_text():
     body = json.loads(response)
     text = body.get('text')
     offline = True if body.get('offline') else False
-    url = body.get('url')
+    url = body.get('url', reach_text_url)
     rp = reach.process_text(text, offline=offline, url=url)
     return _stmts_from_proc(rp)
 
@@ -136,7 +136,7 @@ def reach_process_pmc():
     response = request.body.read().decode('utf-8')
     body = json.loads(response)
     pmcid = body.get('pmcid')
-    url = body.get('url')
+    url = body.get('url', reach_nxml_url)
     rp = reach.process_pmc(pmcid, url=url)
     return _stmts_from_proc(rp)
 

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -703,4 +703,4 @@ def get_evidence_for_stmts():
 app = default_app()
 
 if __name__ == '__main__':
-    run(app, host='0.0.0.0', port='8081')
+    run(app, host='0.0.0.0', port='8080')

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -109,7 +109,8 @@ def reach_process_text():
     body = json.loads(response)
     text = body.get('text')
     offline = True if body.get('offline') else False
-    rp = reach.process_text(text, offline=offline)
+    url = body.get('url')
+    rp = reach.process_text(text, offline=offline, url=url)
     return _stmts_from_proc(rp)
 
 
@@ -135,7 +136,8 @@ def reach_process_pmc():
     response = request.body.read().decode('utf-8')
     body = json.loads(response)
     pmcid = body.get('pmcid')
-    rp = reach.process_pmc(pmcid)
+    url = body.get('url')
+    rp = reach.process_pmc(pmcid, url=url)
     return _stmts_from_proc(rp)
 
 ##################
@@ -701,4 +703,4 @@ def get_evidence_for_stmts():
 app = default_app()
 
 if __name__ == '__main__':
-    run(app, host='0.0.0.0', port='8080')
+    run(app, host='0.0.0.0', port='8081')

--- a/rest_api/docs/api_spec.js
+++ b/rest_api/docs/api_spec.js
@@ -176,10 +176,10 @@ var api_spec = {
         "parameters": [
           {
             "in": "body",
-            "name": "textObj",
+            "name": "textUrlObj",
             "description": "An object with keys of \"text\", referencing a string of text to be processed by REACH, and \"url\", referencing a url of REACH API to send request to.",
             "schema": {
-              "$ref": "#/definitions/textObj"
+              "$ref": "#/definitions/textUrlObj"
             }
           }
         ],
@@ -244,10 +244,10 @@ var api_spec = {
         "parameters": [
           {
             "in": "body",
-            "name": "pmcid",
+            "name": "pmcIDUrl",
             "description": "An object with keys of \"pmcid\", referencing a string that contains the PMCID of the publication, and \"url\", referencing a url of REACH API to send request to.",
             "schema": {
-              "$ref": "#/definitions/pmcID"
+              "$ref": "#/definitions/pmcIDUrl"
             }
           }
         ],

--- a/rest_api/docs/api_spec.js
+++ b/rest_api/docs/api_spec.js
@@ -177,7 +177,7 @@ var api_spec = {
           {
             "in": "body",
             "name": "textObj",
-            "description": "An object with a key of \"text\" referencing a string of text to be processed by REACH.",
+            "description": "An object with keys of \"text\", referencing a string of text to be processed by REACH, and \"url\", referencing a url of REACH API to send request to.",
             "schema": {
               "$ref": "#/definitions/textObj"
             }
@@ -245,7 +245,7 @@ var api_spec = {
           {
             "in": "body",
             "name": "pmcid",
-            "description": "An object with a key of \"pmcid\" referencing a string that contains the PMCID of the publication.",
+            "description": "An object with keys of \"pmcid\", referencing a string that contains the PMCID of the publication, and \"url\", referencing a url of REACH API to send request to.",
             "schema": {
               "$ref": "#/definitions/pmcID"
             }
@@ -927,6 +927,23 @@ var api_spec = {
         }
       }
     },
+    "pmcIDUrl": {
+      "type": "object",
+      "required": [
+        "pmcid",
+        "url"
+      ],
+      "properties": {
+        "pmcid": {
+          "type": "string",
+          "example": "5148607"
+        },
+        "url": {
+          "type": "string",
+          "example": "http://localhost:8080/api/uploadFile"
+        }
+      }
+    },
     "textObj": {
       "type": "object",
       "required": [
@@ -965,6 +982,23 @@ var api_spec = {
         "auth": {
           "type": "list",
           "example": ['USER', 'PASS']
+        }
+      }
+    },
+    "textUrlObj": {
+      "type": "object",
+      "required": [
+        "text",
+        "url"
+      ],
+      "properties": {
+        "text": {
+          "type": "string",
+          "example": "GRB2 binds SHC."
+        },
+        "url": {
+          "type": "string",
+          "example": "http://localhost:8080/api/text"
         }
       }
     },


### PR DESCRIPTION
This PR refactors `Indra.sources.reach.api` making it possible to run REACH with locally run service, remote service, or local JAR file using the same API. Reusable parts of code have been refactored to separate helper functions. PR also documents different ways to run REACH with INDRA.