### PR TITLE
Add evidence source hashes to edges in PyBEL assembler

### DIFF
--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -431,11 +431,11 @@ def _combine_edge_data(relation, subj_edge, obj_edge, stmt_hash, evidences):
     for ev in evidences:
         edge_data_one = copy(edge_data)
         citation, evidence, annotations = _get_evidence(ev)
-        edge_data.update({
+        edge_data_one.update({
             pc.CITATION: citation,
             pc.EVIDENCE: evidence,
         })
-        edge_data[pc.ANNOTATIONS].update(annotations)
+        edge_data_one[pc.ANNOTATIONS].update(annotations)
         edge_data_list.append(edge_data_one)
     return edge_data_list
 

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -218,11 +218,11 @@ class PybelAssembler(object):
         else:
             with open(path, 'w') as fh:
                 if output_format == 'json':
-                    pybel.to_json_file(self.model, fh)
+                    pybel.to_nodelink_file(self.model, fh)
                 elif output_format == 'cx':
                     pybel.to_cx_file(self.model, fh)
                 else: # output_format == 'bel':
-                    pybel.to_bel(self.model, fh)
+                    pybel.to_bel_script(self.model, fh)
 
     def _add_nodes_edges(self, subj_agent, obj_agent, relation, stmt_hash,
                          evidences):

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -440,6 +440,7 @@ def _update_edge_data_from_evidence(evidence, edge_data):
 def _get_annotations_from_stmt(stmt):
     return {
         'stmt_hash': stmt.get_hash(refresh=True),
+        'uuid': stmt.uuid
     }
 
 

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -234,7 +234,11 @@ class PybelAssembler(object):
         self.model.add_node_from_data(subj_data)
         self.model.add_node_from_data(obj_data)
         edge_data_list = _combine_edge_data(
-            relation, subj_edge, obj_edge, stmt)
+            relation=relation,
+            subj_edge=subj_edge,
+            obj_edge=obj_edge,
+            stmt=stmt,
+        )
         for edge_data in edge_data_list:
             self.model.add_edge(subj_data, obj_data, **edge_data)
 
@@ -334,7 +338,10 @@ class PybelAssembler(object):
             subj_attr, subj_edge = _get_agent_node(stmt.subj)
             self.model.add_node_from_data(subj_attr)
             edge_data_list = _combine_edge_data(
-                pc.DIRECTLY_INCREASES, subj_edge, obj_edge, stmt,
+                relation=pc.DIRECTLY_INCREASES,
+                subj_edge=subj_edge,
+                obj_edge=obj_edge,
+                stmt=stmt,
             )
             for edge_data in edge_data_list:
                 self.model.add_edge(subj_attr, rxn_node_data, **edge_data)

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -590,7 +590,7 @@ def _get_evidence(evidence):
     pybel_ev[pc.CITATION] = citation
 
     annotations = {
-        'indra_evidence_hash': evidence.source_hash, 
+        'source_hash': evidence.get_source_hash(),
     }
     if evidence.source_api:
         annotations['source_api'] = evidence.source_api

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -589,7 +589,9 @@ def _get_evidence(evidence):
                     pc.CITATION_IDENTIFIER: cit_ref_str}
     pybel_ev[pc.CITATION] = citation
 
-    annotations = {}
+    annotations = {
+        'indra_evidence_hash': evidence.source_hash, 
+    }
     if evidence.source_api:
         annotations['source_api'] = evidence.source_api
     if evidence.source_id:

--- a/indra/explanation/reporting.py
+++ b/indra/explanation/reporting.py
@@ -168,7 +168,7 @@ def stmts_from_pybel_path(path, model, from_db=True, stmts=None):
         hashes = set()
         for j in range(len(edges)):
             try:
-                hashes.add(edges[j]['stmt_hash'])
+                hashes.add(edges[j]['annotations']['stmt_hash'])
             # partOf and hasVariant edges don't have hashes
             except KeyError:
                 continue

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -123,6 +123,7 @@ def test_modification_with_evidences():
     assert 'source_api' in edge_data[pc.ANNOTATIONS]
     assert edge_data[pc.ANNOTATIONS]['source_api'] == 'test'
     assert 'source_id' not in edge_data[pc.ANNOTATIONS]
+    assert 'source_hash' in edge_data[pc.ANNOTATIONS]
 
 
 def test_modification_with_mutation():

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -150,6 +150,7 @@ def test_activation():
         pc.OBJECT: {pc.MODIFIER: pc.ACTIVITY},
         pc.ANNOTATIONS: {
             'stmt_hash': hash1,
+            'uuid': stmt1.uuid,
         },
     }
     edge2 = {
@@ -158,6 +159,7 @@ def test_activation():
         pc.OBJECT: activity('kin'),
         pc.ANNOTATIONS: {
             'stmt_hash': hash2,
+            'uuid': stmt2.uuid,
         },
     }
     for stmt, edge in ((stmt1, edge1), (stmt2, edge2)):
@@ -195,6 +197,7 @@ def test_direct_activation():
         pc.ANNOTATIONS: {
             'stmt_hash': hash1,
             'source_hash': stmt1_ev.get_source_hash(),
+            'uuid': stmt1.uuid
         },
     }
     edge2 = {
@@ -209,6 +212,7 @@ def test_direct_activation():
         pc.ANNOTATIONS: {
             'stmt_hash': hash2,
             'source_hash': stmt1_ev.get_source_hash(),
+            'uuid': stmt2.uuid
         },
     }
     for stmt, expected_edge in ((stmt1, edge1), (stmt2, edge2)):
@@ -234,6 +238,7 @@ def test_inhibition():
         pc.OBJECT: activity('kin'),
         pc.ANNOTATIONS: {
             'stmt_hash': stmt_hash,
+            'uuid': stmt.uuid,
         },
     }
     pba = pa.PybelAssembler([stmt])
@@ -303,6 +308,7 @@ def test_gef():
         pc.OBJECT: activity('gtp'),
         pc.ANNOTATIONS: {
             'stmt_hash': stmt_hash,
+            'uuid': stmt.uuid,
         },
     }
     assert edge_data == edge, edge_data
@@ -334,6 +340,7 @@ def test_gap():
         pc.OBJECT: activity('gtp'),
         pc.ANNOTATIONS: {
             'stmt_hash': stmt_hash,
+            'uuid': stmt.uuid,
         },
     }
     assert edge_data == edge, edge_data
@@ -435,7 +442,8 @@ def test_autophosphorylation():
     edge_dicts = list(belgraph.get_edge_data(egfr_dsl,
                                              egfr_phos_node).values())
     assert {pc.RELATION: pc.DIRECTLY_INCREASES,
-            pc.ANNOTATIONS: {'stmt_hash': stmt_hash}} \
+            pc.ANNOTATIONS: {'stmt_hash': stmt_hash,
+                             'uuid': stmt.uuid}} \
         in edge_dicts
 
     # Test an autophosphorylation with a bound condition
@@ -479,6 +487,7 @@ def test_bound_condition():
              pc.OBJECT: activity('gtp'),
              pc.ANNOTATIONS: {
                  'stmt_hash': stmt_hash,
+                 'uuid': stmt.uuid,
              },
         },
     )
@@ -504,6 +513,7 @@ def test_transphosphorylation():
         pc.RELATION: pc.DIRECTLY_INCREASES,
         pc.ANNOTATIONS: {
             'stmt_hash': stmt_hash,
+            'uuid': stmt.uuid,
         },
     }, edge_data
 

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Tests for the PyBEL assembler."""
+
 import json
 import networkx as nx
 import pybel.constants as pc
@@ -197,7 +198,7 @@ def test_direct_activation():
         pc.ANNOTATIONS: {
             'stmt_hash': hash1,
             'source_hash': stmt1_ev.get_source_hash(),
-            'uuid': stmt1.uuid
+            'uuid': stmt1.uuid,
         },
     }
     edge2 = {
@@ -212,7 +213,7 @@ def test_direct_activation():
         pc.ANNOTATIONS: {
             'stmt_hash': hash2,
             'source_hash': stmt1_ev.get_source_hash(),
-            'uuid': stmt2.uuid
+            'uuid': stmt2.uuid,
         },
     }
     for stmt, expected_edge in ((stmt1, edge1), (stmt2, edge2)):

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -148,13 +148,17 @@ def test_activation():
     edge1 = {
         pc.RELATION: pc.INCREASES,
         pc.OBJECT: {pc.MODIFIER: pc.ACTIVITY},
-        'annotations': {'stmt_hash': hash1}
+        pc.ANNOTATIONS: {
+            'stmt_hash': hash1,
+        },
     }
     edge2 = {
         pc.RELATION: pc.INCREASES,
         pc.SUBJECT: activity('kin'),
         pc.OBJECT: activity('kin'),
-        'annotations': {'stmt_hash': hash2}
+        pc.ANNOTATIONS: {
+            'stmt_hash': hash2,
+        },
     }
     for stmt, edge in ((stmt1, edge1), (stmt2, edge2)):
         pba = pa.PybelAssembler([stmt])
@@ -188,8 +192,10 @@ def test_direct_activation():
             pc.CITATION_DB: pc.CITATION_TYPE_PUBMED,
             pc.CITATION_IDENTIFIER: '1234',
         },
-        'annotations': {'stmt_hash': hash1,
-                        'source_hash': stmt1_ev.get_source_hash()}
+        pc.ANNOTATIONS: {
+            'stmt_hash': hash1,
+            'source_hash': stmt1_ev.get_source_hash(),
+        },
     }
     edge2 = {
         pc.RELATION: pc.DIRECTLY_INCREASES,
@@ -200,8 +206,10 @@ def test_direct_activation():
             pc.CITATION_DB: pc.CITATION_TYPE_PUBMED,
             pc.CITATION_IDENTIFIER: '1234',
         },
-        'annotations': {'stmt_hash': hash2,
-                        'source_hash': stmt1_ev.get_source_hash()}
+        pc.ANNOTATIONS: {
+            'stmt_hash': hash2,
+            'source_hash': stmt1_ev.get_source_hash(),
+        },
     }
     for stmt, expected_edge in ((stmt1, edge1), (stmt2, edge2)):
         pba = pa.PybelAssembler([stmt])
@@ -224,7 +232,9 @@ def test_inhibition():
         pc.RELATION: pc.DECREASES,
         pc.SUBJECT: activity('kin'),
         pc.OBJECT: activity('kin'),
-        'annotations': {'stmt_hash': stmt_hash}
+        pc.ANNOTATIONS: {
+            'stmt_hash': stmt_hash,
+        },
     }
     pba = pa.PybelAssembler([stmt])
     belgraph = pba.make_model()
@@ -291,7 +301,9 @@ def test_gef():
         pc.RELATION: pc.DIRECTLY_INCREASES,
         pc.SUBJECT: activity('gef'),
         pc.OBJECT: activity('gtp'),
-        'annotations': {'stmt_hash': stmt_hash}
+        pc.ANNOTATIONS: {
+            'stmt_hash': stmt_hash,
+        },
     }
     assert edge_data == edge, edge_data
 
@@ -320,7 +332,9 @@ def test_gap():
         pc.RELATION: pc.DIRECTLY_DECREASES,
         pc.SUBJECT: activity('gap'),
         pc.OBJECT: activity('gtp'),
-        'annotations': {'stmt_hash': stmt_hash}
+        pc.ANNOTATIONS: {
+            'stmt_hash': stmt_hash,
+        },
     }
     assert edge_data == edge, edge_data
 
@@ -421,7 +435,7 @@ def test_autophosphorylation():
     edge_dicts = list(belgraph.get_edge_data(egfr_dsl,
                                              egfr_phos_node).values())
     assert {pc.RELATION: pc.DIRECTLY_INCREASES,
-            'annotations': {'stmt_hash': stmt_hash}} \
+            pc.ANNOTATIONS: {'stmt_hash': stmt_hash}} \
         in edge_dicts
 
     # Test an autophosphorylation with a bound condition
@@ -457,12 +471,17 @@ def test_bound_condition():
     assert kras_node in belgraph
     assert (egfr_grb2_sos1_phos_complex_dsl, kras_node) in belgraph.edges()
 
-    edge_data = (egfr_grb2_sos1_phos_complex_dsl, kras_node,
-                 {
-                     pc.RELATION: pc.DIRECTLY_INCREASES,
-                     pc.OBJECT: activity('gtp'),
-                     'annotations': {'stmt_hash': stmt_hash}
-                 })
+    edge_data = (
+        egfr_grb2_sos1_phos_complex_dsl,
+        kras_node,
+        {
+             pc.RELATION: pc.DIRECTLY_INCREASES,
+             pc.OBJECT: activity('gtp'),
+             pc.ANNOTATIONS: {
+                 'stmt_hash': stmt_hash,
+             },
+        },
+    )
     belgraph_edges = belgraph.edges(data=True)
     assert edge_data in belgraph_edges, belgraph_edges
 
@@ -483,9 +502,9 @@ def test_transphosphorylation():
     edge_data = get_edge_data(belgraph, egfr_dimer_node, egfr_phos_node)
     assert edge_data == {
         pc.RELATION: pc.DIRECTLY_INCREASES,
-        'annotations': {
-            'stmt_hash': stmt_hash
-        }
+        pc.ANNOTATIONS: {
+            'stmt_hash': stmt_hash,
+        },
     }, edge_data
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[testenv:pybel]
+commands =
+    nosetests indra.tests.test_pybel_api
+    nosetests indra.tests.test_pybel_assembler
+    nosetests indra.tests.test_model_checker
+deps =
+    nose
+extras =
+    bel
+    explanation


### PR DESCRIPTION
This PR isn't done yet, but it will make some improvements for the rational enrichment package.

- [x] Update export functions (5bc73624)
- [x] Add source hash of evidence to PyBEL edge data dictionary
- [x] Add ability to output ungrounded entities (this might be useful in a curation setting; b0cdba58)