### PR TITLE
Add VirHostNet API/processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Biological pathway databases:
 | HPRD                       | [`indra.sources.hprd`](https://indra.readthedocs.io/en/latest/modules/sources/hprd/index.html) | http://www.hprd.org          |                   |
 | TRRUST                     | [`indra.sources.trrust`](https://indra.readthedocs.io/en/latest/modules/sources/trrust.html) | https://www.grnpedia.org/trrust/          |                   |
 | Phospho.ELM                | [`indra.sources.phosphoelm`](https://indra.readthedocs.io/en/latest/modules/sources/phosphoelm/index.html) | http://phospho.elm.eu.org/ |
+| VirHostNet                | [`indra.sources.virhostnet`](https://indra.readthedocs.io/en/latest/modules/sources/virhostnet/index.html) | http://virhostnet.prabi.fr/ |
 
 Custom knowledge bases:
 

--- a/doc/modules/sources/index.rst
+++ b/doc/modules/sources/index.rst
@@ -42,6 +42,7 @@ Standard Molecular Pathway Databases
    hprd/index
    trrust
    phosphoelm/index
+   virhostnet/index
 
 Custom Knowledge Bases
 ----------------------

--- a/doc/modules/sources/virhostnet/index.rst
+++ b/doc/modules/sources/virhostnet/index.rst
@@ -1,0 +1,17 @@
+VirHostNet (:py:mod:`indra.sources.virhostnet`)
+===============================================
+
+.. automodule:: indra.sources.virhostnet
+    :members:
+
+VirHostNet API (:py:mod:`indra.sources.virhostnet.api`)
+-------------------------------------------------------
+
+.. automodule:: indra.sources.virhostnet.api
+    :members:
+
+VirHostNet Processor (:py:mod:`indra.sources.virhostnet.processor`)
+-------------------------------------------------------------------
+
+.. automodule:: indra.sources.virhostnet.processor
+    :members:

--- a/indra/preassembler/grounding_mapper/standardize.py
+++ b/indra/preassembler/grounding_mapper/standardize.py
@@ -167,10 +167,15 @@ def standardize_agent_name(agent, standardize_refs=True):
         If True, this function assumes that the Agent's db_refs need to
         be standardized, e.g., HGNC mapped to UP.
         Default: True
+
+    Returns
+    -------
+    bool
+        True if a new name was set, False otherwise.
     """
     # We return immediately for None Agents
     if agent is None:
-        return
+        return False
 
     if standardize_refs:
         agent.db_refs = standardize_db_refs(agent.db_refs)
@@ -183,18 +188,20 @@ def standardize_agent_name(agent, standardize_refs=True):
         feature_name = name_from_grounding('UPPRO', agent.db_refs['UPPRO'])
         if feature_name:
             agent.name = feature_name
-            return
+            return True
 
     # If there's no grounding then we can't do more to standardize the
     # name and return
     if not db_ns or not db_id:
-        return
+        return False
 
     # If there is grounding available, we can try to get the standardized name
     # and in the rare case that we don't get it, we don't set it.
     standard_name = name_from_grounding(db_ns, db_id)
     if standard_name:
         agent.name = standard_name
+        return True
+    return False
 
 
 def name_from_grounding(db_ns, db_id):

--- a/indra/resources/default_belief_probs.json
+++ b/indra/resources/default_belief_probs.json
@@ -25,7 +25,8 @@
     "geneways": 0.05,
     "tees": 0.05,
     "phosphoelm": 0.01,
-    "hypothes.is": 0.01
+    "hypothes.is": 0.01,
+    "virhostnet": 0.01
   },
   "rand": {
     "eidos": 0.3,
@@ -53,6 +54,7 @@
     "geneways": 0.3,
     "tees": 0.3,
     "phosphoelm": 0.1,
-    "hypothes.is": 0.1
+    "hypothes.is": 0.1,
+    "virhostnet": 0.3
   }
 }

--- a/indra/sources/virhostnet/__init__.py
+++ b/indra/sources/virhostnet/__init__.py
@@ -1,0 +1,3 @@
+"""This module implements an API for VirHostNet 2.0
+(http://virhostnet.prabi.fr/)."""
+from .api import *

--- a/indra/sources/virhostnet/api.py
+++ b/indra/sources/virhostnet/api.py
@@ -8,7 +8,7 @@ vhn_url = ('http://virhostnet.prabi.fr:9090/psicquic/webservices/current/'\
 data_columns = [
     'host_grounding', 'vir_grounding', 'host_mnemonic', 'vir_mnemonic',
     'host_mnemonic2', 'vir_mnemonic2', 'exp_method',
-    'not_sure', 'publication', 'host_tax', 'vir_tax',
+    'dash', 'publication', 'host_tax', 'vir_tax',
     'int_type', 'source', 'source_id', 'score'
 ]
 

--- a/indra/sources/virhostnet/api.py
+++ b/indra/sources/virhostnet/api.py
@@ -1,15 +1,31 @@
 import pandas
+from .processor import VirhostnetProcessor
 
 vhn_url = ('http://virhostnet.prabi.fr:9090/psicquic/webservices/current/'\
            'search/query/*')
 
 
+data_columns = [
+    'host_grounding', 'vir_grounding', 'host_mnemonic', 'vir_mnemonic',
+    'host_mnemonic2', 'vir_mnemonic2', 'exp_method',
+    'not_sure', 'publication', 'host_tax', 'vir_tax',
+    'int_type', 'source', 'source_id', 'score'
+]
+
+
 def process_from_web():
-    df = pandas.read_csv(vhn_url)
+    df = pandas.read_csv(vhn_url, delimiter='\t', names=data_columns,
+                         header=None)
     return process_df(df)
 
 
-def process_df():
+def process_tsv(fname):
+    df = pandas.read_csv(fname, delimiter='\t', names=data_columns,
+                         header=None)
+    return process_df(df)
+
+
+def process_df(df):
     vp = VirhostnetProcessor(df)
     vp.extract_statements()
     return vp

--- a/indra/sources/virhostnet/api.py
+++ b/indra/sources/virhostnet/api.py
@@ -1,0 +1,15 @@
+import pandas
+
+vhn_url = ('http://virhostnet.prabi.fr:9090/psicquic/webservices/current/'\
+           'search/query/*')
+
+
+def process_from_web():
+    df = pandas.read_csv(vhn_url)
+    return process_df(df)
+
+
+def process_df():
+    vp = VirhostnetProcessor(df)
+    vp.extract_statements()
+    return vp

--- a/indra/sources/virhostnet/api.py
+++ b/indra/sources/virhostnet/api.py
@@ -7,7 +7,7 @@ from .processor import VirhostnetProcessor
 logger = logging.getLogger(__name__)
 
 
-vhn_url = ('http://virhostnet.prabi.fr:9090/psicquic/webservices/current/'\
+vhn_url = ('http://virhostnet.prabi.fr:9090/psicquic/webservices/current/'
            'search/query/')
 
 
@@ -19,7 +19,7 @@ data_columns = [
 ]
 
 
-def process_from_web(query=None):
+def process_from_web(query=None, up_web_fallback=False):
     """Process host-virus interactions from the VirHostNet website.
 
     Parameters
@@ -41,10 +41,10 @@ def process_from_web(query=None):
     logger.info('Processing VirHostNet data from %s' % url)
     df = pandas.read_csv(url, delimiter='\t', names=data_columns,
                          header=None)
-    return process_df(df)
+    return process_df(df, up_web_fallback=up_web_fallback)
 
 
-def process_tsv(fname):
+def process_tsv(fname, up_web_fallback=False):
     """Process a TSV data file obtained from VirHostNet.
 
     Parameters
@@ -61,10 +61,10 @@ def process_tsv(fname):
     """
     df = pandas.read_csv(fname, delimiter='\t', names=data_columns,
                          header=None)
-    return process_df(df)
+    return process_df(df, up_web_fallback=up_web_fallback)
 
 
-def process_df(df):
+def process_df(df, up_web_fallback=False):
     """Process a VirHostNet pandas DataFrame.
 
     Parameters
@@ -79,6 +79,6 @@ def process_df(df):
         A VirhostnetProcessor object which contains a list of extracted
         INDRA Statements in its statements attribute.
     """
-    vp = VirhostnetProcessor(df)
+    vp = VirhostnetProcessor(df, up_web_fallback=up_web_fallback)
     vp.extract_statements()
     return vp

--- a/indra/sources/virhostnet/api.py
+++ b/indra/sources/virhostnet/api.py
@@ -1,3 +1,5 @@
+__all__ = ['process_from_web', 'process_tsv', 'process_df']
+
 import pandas
 import logging
 from .processor import VirhostnetProcessor

--- a/indra/sources/virhostnet/api.py
+++ b/indra/sources/virhostnet/api.py
@@ -1,8 +1,12 @@
 import pandas
+import logging
 from .processor import VirhostnetProcessor
 
+logger = logging.getLogger(__name__)
+
+
 vhn_url = ('http://virhostnet.prabi.fr:9090/psicquic/webservices/current/'\
-           'search/query/*')
+           'search/query/')
 
 
 data_columns = [
@@ -13,19 +17,66 @@ data_columns = [
 ]
 
 
-def process_from_web():
-    df = pandas.read_csv(vhn_url, delimiter='\t', names=data_columns,
+def process_from_web(query=None):
+    """Process host-virus interactions from the VirHostNet website.
+
+    Parameters
+    ----------
+    query : Optional[str]
+        A query that constrains the results to a given subset of the VirHostNet
+        database. Example: "taxid:2697049" to search for interactions for
+        SARS-CoV-2. If not provided, By default, the "*" query is used which
+        returns the full database.
+
+    Returns
+    -------
+    VirhostnetProcessor
+        A VirhostnetProcessor object which contains a list of extracted
+        INDRA Statements in its statements attribute.
+    """
+    # Search for everything to get the full download by default
+    url = vhn_url + ('*' if query is None else query)
+    logger.info('Processing VirHostNet data from %s' % url)
+    df = pandas.read_csv(url, delimiter='\t', names=data_columns,
                          header=None)
     return process_df(df)
 
 
 def process_tsv(fname):
+    """Process a TSV data file obtained from VirHostNet.
+
+    Parameters
+    ----------
+    fname : str
+        The path to the VirHostNet tabular data file (in the same format as
+        the web service).
+
+    Returns
+    -------
+    VirhostnetProcessor
+        A VirhostnetProcessor object which contains a list of extracted
+        INDRA Statements in its statements attribute.
+    """
     df = pandas.read_csv(fname, delimiter='\t', names=data_columns,
                          header=None)
     return process_df(df)
 
 
 def process_df(df):
+    """Process a VirHostNet pandas DataFrame.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        A DataFrame representing VirHostNet interactions (in the same format as
+        the web service).
+
+    Returns
+    -------
+    VirhostnetProcessor
+        A VirhostnetProcessor object which contains a list of extracted
+        INDRA Statements in its statements attribute.
+    """
     vp = VirhostnetProcessor(df)
     vp.extract_statements()
     return vp

--- a/indra/sources/virhostnet/processor.py
+++ b/indra/sources/virhostnet/processor.py
@@ -1,0 +1,21 @@
+from indra.statements import Agent
+
+
+class VirhostnetProcessor():
+    def __init__(self, df):
+        self.df = df
+        self.statements = []
+
+    def extract_statements(self):
+        for _, row in self.df.iterrows():
+            host_up, vir_up, _, _, _, _, host_tax, vir_tax, psi_mi_pa, \
+                psi_mi_vhn, vhn_ids, score = row
+            stmt = process_row(host_up, vir_up, host_tax, vir_tax, psi_mi_pa,
+                               psi_mi_vhn, vhn_ids, score)
+            if stmt:
+                self.statements.append(stmt)
+
+
+def process_row(host_up, vir_up, host_tax, vir_tax, psi_mi_pa, psi_mi_vhn,
+                vhn_ids, score):
+    return None

--- a/indra/sources/virhostnet/processor.py
+++ b/indra/sources/virhostnet/processor.py
@@ -1,6 +1,5 @@
 import re
 import logging
-from indra.databases import uniprot_client
 from indra.statements import Agent, Complex, Evidence
 from indra.preassembler.grounding_mapper import standardize_agent_name
 
@@ -9,6 +8,20 @@ logger = logging.getLogger(__name__)
 
 
 class VirhostnetProcessor:
+    """A processor that takes a pandas DataFrame and extracts INDRA Statements.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        A pandas DataFrame representing VirHostNet interactions.
+
+    Attributes
+    ----------
+    df : pandas.DataFrame
+        A pandas DataFrame representing VirHostNet interactions.
+    statements : list[indra.statements.Statement]
+        A list of INDRA Statements extracted from the DataFrame.
+    """
     def __init__(self, df):
         self.df = df
         self.statements = []
@@ -21,6 +34,7 @@ class VirhostnetProcessor:
 
 
 def process_row(row):
+    """Process one row of the DataFrame into an INDRA Statement."""
     host_agent = get_agent_from_grounding(row['host_grounding'])
     vir_agent = get_agent_from_grounding(row['vir_grounding'])
 
@@ -60,6 +74,7 @@ def process_row(row):
 
 
 def get_agent_from_grounding(grounding):
+    """Return an INDRA Agent based on a grounding annotation."""
     db_ns, db_id = grounding.split(':')
     # Assume UniProt or RefSeq IDs
     assert db_ns in {'uniprotkb', 'refseq', 'ddbj/embl/genbank'}, db_ns
@@ -81,6 +96,7 @@ def get_agent_from_grounding(grounding):
 
 
 def parse_psi_mi(psi_mi_str):
+    """Parse a PSI-MI annotation into an ID and name pair."""
     # Example: psi-mi:"MI:0018"(two hybrid)
     match = re.match(r'psi-mi:"(.+)"\((.+)\)', psi_mi_str)
     mi_id, name = match.groups()
@@ -88,6 +104,7 @@ def parse_psi_mi(psi_mi_str):
 
 
 def parse_text_refs(text_ref_str):
+    """Parse a text reference annotation into a text_refs dict."""
     tr_ns, tr_id = text_ref_str.split(':')
     assert tr_ns == 'pubmed', text_ref_str
     if re.match(r'^\d+$', tr_id):
@@ -102,6 +119,7 @@ def parse_text_refs(text_ref_str):
 
 
 def parse_source_ids(source_id_str):
+    """Parse VirHostNet source id annotations into a dict."""
     ids = source_id_str.split('|')
     assert len(ids) == 2
     ids_dict = {id.split(':')[0]: id.split(':')[1] for id in ids}

--- a/indra/tests/test_virhostnet.py
+++ b/indra/tests/test_virhostnet.py
@@ -1,0 +1,79 @@
+from indra.statements import Complex
+from indra.sources import virhostnet
+from indra.sources.virhostnet.api import data_columns
+from indra.sources.virhostnet.processor import parse_psi_mi, parse_source_ids, \
+    parse_text_refs, get_agent_from_grounding, process_row
+
+
+def test_get_agent_from_grounding():
+    ag = get_agent_from_grounding('uniprotkb:P15056')
+    assert ag.name == 'BRAF'
+    assert ag.db_refs['UP'] == 'P15056', ag.db_refs
+
+    ag = get_agent_from_grounding('uniprotkb:P15056-PRO_0000085665')
+    # This is the name of the chain in UniProt, it will have to be uncommented
+    # once normalization for chains is merged
+    # assert ag.name == 'Serine/threonine-protein kinase B-raf'
+    assert ag.name == 'BRAF'
+    assert ag.db_refs['UP'] == 'P15056'
+    assert ag.db_refs['UPPRO'] == 'PRO_0000085665'
+
+    ag = get_agent_from_grounding('refseq:NP_828867')
+    assert ag.db_refs['REFSEQ_PROT'] == 'NP_828867'
+
+
+def test_parse_text_refs():
+    tr = parse_text_refs('pubmed:22046132')
+    assert tr['PMID'] == '22046132'
+
+    tr = parse_text_refs('pubmed:https(//doi.org/10.1101/2020.03.22.002386)')
+    assert tr['DOI'] == '10.1101/2020.03.22.002386'
+
+
+def test_parse_source_ids():
+    sd = parse_source_ids('virhostnet-rid:2564|virhostnet-nrid:2199')
+    assert sd == {'virhostnet-rid': '2564',
+                  'virhostnet-nrid': '2199'}
+
+
+def test_parse_psi_mi():
+    res = parse_psi_mi('psi-mi:"MI:0915"(physical association)')
+    assert len(res) == 2, res
+    assert res[0] == 'MI:0915', res
+    assert res[1] == 'physical association'
+
+
+def test_process_row():
+    test_row_str = ('uniprotkb:Q6P5R6	uniprotkb:Q1K9H5	'
+                    'uniprotkb:RL22L_HUMAN	uniprotkb:Q1K9H5_I33A0	'
+                    'uniprotkb:RL22L_HUMAN	uniprotkb:Q1K9H5_I33A0	'
+                    'psi-mi:"MI:0004"(affinity chromatography technology)	'
+                    '-	pubmed:26651948	taxid:9606	taxid:381518	'
+                    'psi-mi:"MI:0915"(physical association)	'
+                    'psi-mi:"MI:1114"(virhostnet)	'
+                    'virhostnet-rid:19809|virhostnet-nrid:18603	'
+                    'virhostnet-miscore:0.32715574')
+    row = {k: v for k, v in zip(data_columns, test_row_str.split('\t'))}
+    stmt = process_row(row)
+    assert isinstance(stmt, Complex)
+    host_ag = stmt.members[0]
+    assert host_ag.name == 'RPL22L1'
+    vir_ag = stmt.members[1]
+    # This is unreviewed so we currently can't get its name
+    assert vir_ag.name == 'Q1K9H5'
+    assert len(stmt.evidence) == 1
+    ev = stmt.evidence[0]
+    assert ev.source_api == 'virhostnet'
+    assert ev.source_id == '19809'
+    assert ev.pmid == '26651948'
+    assert ev.text_refs == {'PMID': '26651948'}
+    assert ev.annotations['host_tax'] == '9606'
+    assert ev.annotations['vir_tax'] == '381518'
+    assert ev.annotations['score'] == 0.32715574
+    assert ev.annotations['int_type'] == {'id': 'MI:0915',
+                                          'name': 'physical association'}
+    assert ev.annotations['virhostnet-rid'] == '19809'
+    assert ev.annotations['virhostnet-nrid'] == '18603'
+    assert ev.annotations['exp_method'] == {'id': 'MI:0004',
+                                            'name': ('affinity chromatography '
+                                                     'technology')}

--- a/indra/tests/test_virhostnet.py
+++ b/indra/tests/test_virhostnet.py
@@ -1,8 +1,40 @@
+import pandas
+from nose.plugins.attrib import attr
 from indra.statements import Complex
 from indra.sources import virhostnet
 from indra.sources.virhostnet.api import data_columns
 from indra.sources.virhostnet.processor import parse_psi_mi, parse_source_ids, \
     parse_text_refs, get_agent_from_grounding, process_row
+
+
+test_row_str = ('uniprotkb:Q6P5R6	uniprotkb:Q1K9H5	'
+                'uniprotkb:RL22L_HUMAN	uniprotkb:Q1K9H5_I33A0	'
+                'uniprotkb:RL22L_HUMAN	uniprotkb:Q1K9H5_I33A0	'
+                'psi-mi:"MI:0004"(affinity chromatography technology)	'
+                '-	pubmed:26651948	taxid:9606	taxid:381518	'
+                'psi-mi:"MI:0915"(physical association)	'
+                'psi-mi:"MI:1114"(virhostnet)	'
+                'virhostnet-rid:19809|virhostnet-nrid:18603	'
+                'virhostnet-miscore:0.32715574')
+test_row = {k: v for k, v in zip(data_columns, test_row_str.split('\t'))}
+test_df = pandas.DataFrame.from_dict({k: [v] for k, v in test_row.items()})
+
+
+@attr('webservice', 'slow')
+def test_process_from_web():
+    vp = virhostnet.process_from_web(query='pubmed:8553588')
+    assert len(vp.statements) == 5, len(vp.statements)
+    assert all(isinstance(st, Complex) for st in vp.statements)
+    assert all(stmt.members[1].db_refs['REFSEQ_PROT'] == 'NP_040311'
+               for stmt in vp.statements)
+    assert all(stmt.evidence[0].pmid == '8553588'
+               for stmt in vp.statements)
+
+
+def test_process_df():
+    vp = virhostnet.process_df(test_df)
+    assert len(vp.statements) == 1
+    _assert_test_stmt(vp.statements[0])
 
 
 def test_get_agent_from_grounding():
@@ -44,17 +76,11 @@ def test_parse_psi_mi():
 
 
 def test_process_row():
-    test_row_str = ('uniprotkb:Q6P5R6	uniprotkb:Q1K9H5	'
-                    'uniprotkb:RL22L_HUMAN	uniprotkb:Q1K9H5_I33A0	'
-                    'uniprotkb:RL22L_HUMAN	uniprotkb:Q1K9H5_I33A0	'
-                    'psi-mi:"MI:0004"(affinity chromatography technology)	'
-                    '-	pubmed:26651948	taxid:9606	taxid:381518	'
-                    'psi-mi:"MI:0915"(physical association)	'
-                    'psi-mi:"MI:1114"(virhostnet)	'
-                    'virhostnet-rid:19809|virhostnet-nrid:18603	'
-                    'virhostnet-miscore:0.32715574')
-    row = {k: v for k, v in zip(data_columns, test_row_str.split('\t'))}
-    stmt = process_row(row)
+    stmt = process_row(test_row)
+    _assert_test_stmt(stmt)
+
+
+def _assert_test_stmt(stmt):
     assert isinstance(stmt, Complex)
     host_ag = stmt.members[0]
     assert host_ag.name == 'RPL22L1'
@@ -77,3 +103,4 @@ def test_process_row():
     assert ev.annotations['exp_method'] == {'id': 'MI:0004',
                                             'name': ('affinity chromatography '
                                                      'technology')}
+

--- a/indra/tests/test_virhostnet.py
+++ b/indra/tests/test_virhostnet.py
@@ -43,10 +43,9 @@ def test_get_agent_from_grounding():
     assert ag.db_refs['UP'] == 'P15056', ag.db_refs
 
     ag = get_agent_from_grounding('uniprotkb:P15056-PRO_0000085665')
-    # This is the name of the chain in UniProt, it will have to be uncommented
-    # once normalization for chains is merged
-    # assert ag.name == 'Serine/threonine-protein kinase B-raf'
-    assert ag.name == 'BRAF'
+    # This is the name of the chain in UniProt which takes precedence
+    # if we have a feature ID
+    assert ag.name == 'Serine/threonine-protein kinase B-raf'
     assert ag.db_refs['UP'] == 'P15056'
     assert ag.db_refs['UPPRO'] == 'PRO_0000085665'
 

--- a/indra/tests/test_virhostnet.py
+++ b/indra/tests/test_virhostnet.py
@@ -104,3 +104,16 @@ def _assert_test_stmt(stmt):
                                             'name': ('affinity chromatography '
                                                      'technology')}
 
+
+def test_get_uppro_name():
+    ag = get_agent_from_grounding('uniprotkb:Q32ZE1-PRO_0000435839')
+    assert ag.db_refs['UP'] == 'Q32ZE1'
+    assert ag.db_refs['UPPRO'] == 'PRO_0000435839'
+    assert ag.name == 'Non-structural protein 4A'
+
+
+def test_name_web_fallback():
+    ag = get_agent_from_grounding('uniprotkb:Q174W8', up_web_fallback=False)
+    assert ag.name == 'Q174W8'
+    ag = get_agent_from_grounding('uniprotkb:Q174W8', up_web_fallback=True)
+    assert ag.name == 'GPRFZ2'

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ def main():
                     'indra.sources.sparser', 'indra.sources.tas',
                     'indra.sources.tees',
                     'indra.sources.trips', 'indra.sources.trrust',
+                    'indra.sources.virhostnet',
                     'indra.resources', 'indra.statements',
                     'indra.tests', 'indra.tests.test_obo_clients',
                     'indra.tools', 'indra.tools.machine', 'indra.util'],


### PR DESCRIPTION
This PR adds an API and processor for VirHostNet which currently has ~38k host-virus physical protein interactions. Some complications in the processor include the fact that:
- Many of the viral proteins that appear are unreviewed, for which we don't have resource-file based support in the UniProt client, and therefore don't do name standardization.
- Some of the proteins come with RefSeq IDs for which we don't do db_refs and name standardization.
- Initially, for both of the above, the agent name is set to the identifier which may not be ideal.