### PR TITLE
Update RLIMS-P API to changes in their REST service

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -305,7 +305,7 @@ MOCK_MODULES = [
     'pybel', 'pybel.constants', 'pybel.struct', 'pybel.canonicalize',
     'pybel.language', 'pybel.dsl', 'pybel.resources',
     'pybel.resources.definitions',
-    'pybel.resources.definitions.definitions',
+    'pybel.resources.definitions.definitions', 'pybel.utils',
     'pygraphviz', 'jnius', 'jnius_config', 'flask',
     'objectpath', 'lxml', 'lxml.etree', 'lxml.builder',
     'functools32', 'ndex2', 'ndex2.client', 'ndex2.nice_cx_network',

--- a/indra/sources/rlimsp/api.py
+++ b/indra/sources/rlimsp/api.py
@@ -22,11 +22,10 @@ class RLIMSP_Error(Exception):
 def process_from_webservice(id_val, id_type='pmcid', source='pmc'):
     """Return an output from RLIMS-p for the given PubMed ID or PMC ID.
 
-    The web service is documented at: https://research.bioinformatics.udel.
-    edu/itextmine/api/. The /data/rlims URL endpoint is extended with
-    three additional elements /{collection}/{key}/{value} where
-    collection is "medline" or "pmc", key is "pmid" or "pmcid", and
-    value is a specific PMID or PMCID.
+    The web service is documented at: https://research.bioinformatics.udel.edu/itextmine/api/.
+    The /data/rlims URL endpoint is extended with three additional elements:
+    /{collection}/{key}/{value} where collection is "medline" or "pmc", key is
+    "pmid" or "pmcid", and value is a specific PMID or PMCID.
 
     Parameters
     ----------
@@ -36,7 +35,7 @@ def process_from_webservice(id_val, id_type='pmcid', source='pmc'):
     id_type : Optional[str]
         Either 'pmid' or 'pmcid'. The default is 'pmcid'. Corresponds to the
         "key" argument of the REST API.
-    source : str
+    source : Optional[str]
         Either 'pmc' or 'medline', whether you want pmc fulltext or medline
         abstracts. Corresponds to the "collection" argument of the REST API.
 

--- a/indra/sources/rlimsp/api.py
+++ b/indra/sources/rlimsp/api.py
@@ -19,24 +19,26 @@ class RLIMSP_Error(Exception):
     pass
 
 
-def process_from_webservice(id_val, id_type='pmcid', source='pmc',
-                            with_grounding=True):
+def process_from_webservice(id_val, id_type='pmcid', source='pmc'):
     """Return an output from RLIMS-p for the given PubMed ID or PMC ID.
+
+    The web service is documented at: https://research.bioinformatics.udel.
+    edu/itextmine/api/. The /data/rlims URL endpoint is extended with
+    three additional elements /{collection}/{key}/{value} where
+    collection is "medline" or "pmc", key is "pmid" or "pmcid", and
+    value is a specific PMID or PMCID.
 
     Parameters
     ----------
     id_val : str
-        A PMCID, with the prefix PMC, or pmid, with no prefix, of the paper to
-        be "read".
-    id_type : str
-        Either 'pmid' or 'pmcid'. The default is 'pmcid'.
+        A PMCID, with the prefix PMC, or PMID, with no prefix, of the paper to
+        be "read". Corresponds to the "value" argument of the REST API.
+    id_type : Optional[str]
+        Either 'pmid' or 'pmcid'. The default is 'pmcid'. Corresponds to the
+        "key" argument of the REST API.
     source : str
         Either 'pmc' or 'medline', whether you want pmc fulltext or medline
-        abstracts.
-    with_grounding : bool
-        The RLIMS-P web service provides two endpoints, one pre-grounded, the
-        other not so much. The grounded endpoint returns far less content, and
-        may perform some grounding that can be handled by the grounding mapper.
+        abstracts. Corresponds to the "collection" argument of the REST API.
 
     Returns
     -------
@@ -44,12 +46,7 @@ def process_from_webservice(id_val, id_type='pmcid', source='pmc',
         An RlimspProcessor which contains a list of extracted INDRA Statements
         in its statements attribute.
     """
-    if with_grounding:
-        fmt = '%s.normed/%s/%s'
-    else:
-        fmt = '%s/%s/%s'
-
-    resp = requests.get(RLIMSP_URL + fmt % (source, id_type, id_val))
+    resp = requests.get(RLIMSP_URL + '%s/%s/%s' % (source, id_type, id_val))
 
     if resp.status_code != 200:
         raise RLIMSP_Error("Bad status code: %d - %s"

--- a/indra/tests/test_rlimsp.py
+++ b/indra/tests/test_rlimsp.py
@@ -1,10 +1,11 @@
 import os
 from indra.sources import rlimsp
 
+
 def test_simple_usage():
     rp = rlimsp.process_from_webservice('PMC3717945')
     stmts = rp.statements
-    assert len(stmts) == 6, len(stmts)
+    assert len(stmts) == 33, len(stmts)
     for s in stmts:
         assert len(s.evidence) == 1, "Wrong amount of evidence."
         ev = s.evidence[0]
@@ -13,46 +14,15 @@ def test_simple_usage():
         assert 'trigger' in ev.annotations.keys()
 
 
-def test_ungrounded_usage():
-    rp = rlimsp.process_from_webservice('PMC3717945', with_grounding=False)
-    assert len(rp.statements) == 33, len(rp.statements)
-
-
 def test_ungrounded_endpoint_with_pmids():
     pmid_list = ['16403219', '22258404', '16961925', '22096607']
     stmts = []
     for pmid in pmid_list:
-        rp = rlimsp.process_from_webservice(pmid, id_type='pmid',
-                                            with_grounding=False)
+        rp = rlimsp.process_from_webservice(pmid, id_type='pmid')
         assert len(rp.statements) > 10, len(rp.statements)
         stmts.extend(rp.statements)
     assert len(stmts) == 394, len(stmts)
     return
-
-
-def test_grounded_endpoint_with_pmids():
-    pmid_list = ['16403219', '22258404', '16961925', '22096607']
-    stmts = []
-    for pmid in pmid_list:
-        rp = rlimsp.process_from_webservice(pmid, id_type='pmid')
-        assert len(rp.statements), len(rp.statements)
-        stmts.extend(rp.statements)
-    assert len(stmts) > 10, len(stmts)
-
-
-def test_ungrounded_endpoint_with_pmids_on_medline():
-    pmid_list = ['16403219', '22258404', '16961925', '22096607']
-    for pmid in pmid_list:
-        rp = rlimsp.process_from_webservice(pmid, id_type='pmid',
-                                            source='medline')
-
-
-def test_grounded_endpoint_with_pmids_on_medline():
-    pmid_list = ['16403219', '22258404', '16961925', '22096607']
-    for pmid in pmid_list:
-        rp = rlimsp.process_from_webservice(pmid, id_type='pmid',
-                                            source='medline',
-                                            with_grounding=False)
 
 
 def test_tyrosine_grounding():


### PR DESCRIPTION
This PR removes the with_grounding setting which called the service with a .normed URL that no longer exists - results are now grounded by default.