### PR TITLE
Improvements in UPPRO handling

### DIFF
--- a/indra/databases/__init__.py
+++ b/indra/databases/__init__.py
@@ -95,6 +95,10 @@ def get_identifiers_url(db_name, db_id):
             url = 'http://www.lncrnadb.org/%s/' % db_id
     elif db_name == 'TEXT':
         return None
+    # TODO: we should return the parent UniProt ID here but only once that
+    # can be obtained from protmapper in a faster way
+    elif db_name == 'UPPRO':
+        return None
     else:
         logger.warning('Unhandled name space %s' % db_name)
         url = None

--- a/indra/statements/agent.py
+++ b/indra/statements/agent.py
@@ -19,8 +19,8 @@ from .resources import get_valid_residue, get_valid_location, activity_types, \
 logger = logging.getLogger(__name__)
 
 
-default_ns_order = ['FPLX', 'HGNC', 'UP', 'CHEBI', 'GO', 'MESH', 'DOID', 'HP',
-                    'EFO']
+default_ns_order = ['FPLX', 'UPPRO', 'HGNC', 'UP', 'CHEBI', 'GO', 'MESH',
+                    'DOID', 'HP', 'EFO']
 
 
 @python_2_unicode_compatible

--- a/indra/tests/test_groundingmapper.py
+++ b/indra/tests/test_groundingmapper.py
@@ -554,3 +554,11 @@ def test_gilda_disambiguation():
         annotations
     assert annotations['agents']['gilda'][0] is None
     assert annotations['agents']['gilda'][1] is not None
+
+
+def test_uppro_fallback():
+    # This UP chain has no name currently so we can test that the fallback
+    # to naming by the UP ID is working
+    ag = Agent('x', db_refs={'UP': 'Q6IE75', 'UPPRO': 'PRO_0000383648'})
+    standardize_agent_name(ag)
+    assert ag.name == 'Bace2'

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -1050,3 +1050,23 @@ def test_matches_key_fun():
     stmts = run_preassembly([e1, e2, e3], matches_fun=event_location_matches,
                             refinement_fun=event_location_refinement)
     assert len(stmts) == 2, stmts
+
+
+def test_uppro_assembly():
+    ag1 = Agent('x', db_refs={'UP': 'P01019', 'UPPRO': 'PRO_0000032457'})
+    ag2 = Agent('y', db_refs={'UP': 'P01019', 'UPPRO': 'PRO_0000032458'})
+    assert ag1.get_grounding() == ('UPPRO', ag1.db_refs['UPPRO'])
+    assert ag2.get_grounding() == ('UPPRO', ag2.db_refs['UPPRO'])
+    stmt1 = Phosphorylation(None, ag1)
+    stmt2 = Phosphorylation(None, ag2)
+    assert stmt1.matches_key() != stmt2.matches_key()
+    pa = Preassembler(hierarchies, [stmt1, stmt2])
+    unique_stmts = pa.combine_duplicates()
+    assert len(unique_stmts) == 2, unique_stmts
+
+    from indra.tools import assemble_corpus as ac
+    stmts = ac.map_grounding([stmt1, stmt2])
+    pa = Preassembler(hierarchies, stmts)
+    unique_stmts = pa.combine_duplicates()
+    assert len(unique_stmts) == 2
+


### PR DESCRIPTION
This PR makes some improvements to the way UPPRO groundings are handled. First, I realized that UPPRO has to be prioritized in get_grounding for preassembly to differentiate based on it. Second, name standardization is improved such that if there's no name for a feature, the parent gene/protein's name is standardized to. Third, we handle UPPRO in get_identifiers_url, though for the time being just return None because there is no direct link to UniProt features, and getting the parent protein's ID is not desirable in this context unless some optimizations are implemented in protmapper.