### PR TITLE
Allow processing Eidos output into Activation/Inhibition

### DIFF
--- a/indra/sources/eidos/__init__.py
+++ b/indra/sources/eidos/__init__.py
@@ -146,4 +146,4 @@ in INDRA to process the JSON-LD output files.
 """
 
 from .api import process_text, process_json_str, process_json_file, \
-    process_json, reground_texts, initialize_reader
+    process_json, reground_texts, initialize_reader, process_json_bio

--- a/indra/sources/eidos/__init__.py
+++ b/indra/sources/eidos/__init__.py
@@ -146,4 +146,5 @@ in INDRA to process the JSON-LD output files.
 """
 
 from .api import process_text, process_json_str, process_json_file, \
-    process_json, reground_texts, initialize_reader, process_json_bio
+    process_json, reground_texts, initialize_reader, process_json_bio, \
+    process_text_bio

--- a/indra/sources/eidos/api.py
+++ b/indra/sources/eidos/api.py
@@ -46,6 +46,14 @@ def process_text(text, save_json='eidos_output.json',
         An EidosProcessor containing the extracted INDRA Statements in its
         statements attribute.
     """
+    json_dict = _run_eidos_on_text(text, save_json, webservice)
+    if json_dict:
+        return process_json(json_dict, grounding_ns=grounding_ns)
+    return None
+
+
+def _run_eidos_on_text(text, save_json='eidos_output.json',
+                       webservice=None):
     if not webservice:
         if eidos_reader is None:
             logger.error('Eidos reader is not available.')
@@ -55,10 +63,10 @@ def process_text(text, save_json='eidos_output.json',
         if webservice.endswith('/'):
             webservice = webservice[:-1]
         json_dict = eidos_client.process_text(text, webservice=webservice)
-    if save_json:
+    if json_dict and save_json:
         with open(save_json, 'wt') as fh:
             json.dump(json_dict, fh, indent=2)
-    return process_json(json_dict, grounding_ns=grounding_ns)
+    return json_dict
 
 
 def process_json_file(file_name, grounding_ns=None):
@@ -164,19 +172,10 @@ def process_text_bio(text, save_json='eidos_output.json', webservice=None):
         An EidosProcessor containing the extracted INDRA Statements in its
         statements attribute.
     """
-    if not webservice:
-        if eidos_reader is None:
-            logger.error('Eidos reader is not available.')
-            return None
-        json_dict = eidos_reader.process_text(text)
-    else:
-        if webservice.endswith('/'):
-            webservice = webservice[:-1]
-        json_dict = eidos_client.process_text(text, webservice=webservice)
-    if save_json:
-        with open(save_json, 'wt') as fh:
-            json.dump(json_dict, fh, indent=2)
-    return process_json_bio(json_dict)
+    json_dict = _run_eidos_on_text(text, save_json, webservice)
+    if json_dict:
+        return process_json_bio(json_dict)
+    return None
 
 
 def process_json_bio(json_dict):

--- a/indra/sources/eidos/api.py
+++ b/indra/sources/eidos/api.py
@@ -192,19 +192,15 @@ def process_json_bio(json_dict):
         A EidosProcessor containing the extracted INDRA Statements
         in its statements attribute.
     """
-    import gilda
     from indra.preassembler.grounding_mapper.standardize \
         import standardize_agent_name
+    from indra.preassembler.grounding_mapper.gilda import get_grounding
     from indra.statements import Agent, Activation, Inhibition
 
     def get_agent(concept, context=None):
         txt = concept.name
-        matches = gilda.ground(txt, context=context)
-        if not matches:
-            return None
-        gr = (matches[0].term.db, matches[0].term.id)
-        agent = Agent(concept.name, db_refs={gr[0]: gr[1],
-                                             'TEXT': concept.name})
+        gr, _ = get_grounding(txt, context=context, mode='local')
+        agent = Agent(concept.name, db_refs={'TEXT': concept.name, **gr})
         standardize_agent_name(agent, standardize_refs=True)
         return agent
 

--- a/indra/tests/test_eidos.py
+++ b/indra/tests/test_eidos.py
@@ -52,6 +52,15 @@ def test_process_text():
     # assert len(stmt.obj.db_refs['UN']) > 5
 
 
+def test_process_text_bio():
+    ep = eidos.process_text_bio('virus increases death')
+    assert ep is not None
+    assert len(ep.statements) == 1
+    stmt = ep.statements[0]
+    from indra.statements import Activation
+    assert isinstance(stmt, Activation)
+
+
 def test_process_polarity():
     test_jsonld = os.path.join(path_this, 'eidos_neg_event.json')
     ep = eidos.process_json_file(test_jsonld)


### PR DESCRIPTION
This PR adds new endpoints in the Eidos API to post-process INDRA Statements from EIdos output into grounded Activation/Inhibition statements, applicable to biology content.