### PR TITLE
Grounding map extension

### DIFF
--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -344,6 +344,18 @@ def test_map_grounding_user_map():
     assert st_out[0].subj.db_refs.get('XXX') == 'YYY'
     assert st_out[0].obj.db_refs.get('FPLX') == 'ERK'
     assert st_out[0].obj.name == 'ERK'
+    gm = {'ERK': {'FPLX': 'ERK_TEST'}}
+    st_out = ac.map_grounding([st], grounding_map=gm,
+                              grounding_map_policy='extend')
+    assert len(st_out) == 1
+    assert st_out[0].subj.db_refs.get('FPLX') == 'MEK'
+    assert st_out[0].obj.db_refs.get('FPLX') == 'ERK_TEST'
+    st_out = ac.map_grounding([st])
+    # Make sure the extension to the default grounding map doesn't persist
+    assert len(st_out) == 1
+    assert st_out[0].subj.db_refs.get('FPLX') == 'MEK'
+    assert st_out[0].obj.db_refs.get('FPLX') == 'ERK'
+    assert st_out[0].obj.name == 'ERK'
 
 
 def test_map_sequence():

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -109,6 +109,9 @@ def map_grounding(stmts_in, **kwargs):
         imported and used locally.
     save : Optional[str]
         The name of a pickle file to save the results (stmts_out) into.
+    grounding_map_policy : Optional[str]
+        If a grounding map is provided, use the policy to extend or replace
+        a default grounding map. Default: 'replace'.
 
     Returns
     -------
@@ -121,7 +124,12 @@ def map_grounding(stmts_in, **kwargs):
     logger.info('Mapping grounding on %d statements...' % len(stmts_in))
     do_rename = kwargs.get('do_rename', True)
     ignores = kwargs.get('ignores', default_ignores)
-    gm = kwargs.get('grounding_map', default_grounding_map)
+    gm = kwargs.get('grounding_map')
+    if not gm:
+        gm = default_grounding_map
+    elif kwargs.get('grounding_map_policy') == 'extend':
+        default_grounding_map.update(gm)
+        gm = default_grounding_map
     misgm = kwargs.get('misgrounding_map', default_misgrounding_map)
     agent_map = kwargs.get('agent_map', default_agent_map)
     gm = GroundingMapper(gm, agent_map=agent_map,

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -128,8 +128,9 @@ def map_grounding(stmts_in, **kwargs):
     if not gm:
         gm = default_grounding_map
     elif kwargs.get('grounding_map_policy') == 'extend':
-        default_grounding_map.update(gm)
-        gm = default_grounding_map
+        default_gm = {k: v for (k, v) in default_grounding_map.items()}
+        default_gm.update(gm)
+        gm = default_gm
     misgm = kwargs.get('misgrounding_map', default_misgrounding_map)
     agent_map = kwargs.get('agent_map', default_agent_map)
     gm = GroundingMapper(gm, agent_map=agent_map,


### PR DESCRIPTION
This PR adds an option in assemble_corpus.map_grounding function to extend the default grounding map with a custom one. 

By default the function will continue to either use a default map if no map is provided or to replace it with a new map if it's provided. To extend the default map, grounding_map_policy should be set to 'extend'.