### PR TITLE
Nlm2text update

### DIFF
--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -156,6 +156,11 @@ def extract_paragraphs(xml_string):
     All tags are removed from each paragraph in the list that is returned.
     LaTeX surrounded by <tex-math> tags is removed entirely.
 
+    Note: Some articles contain subarticles which are processed slightly
+    differently from the article body. Only text from the body element
+    of a subarticle is included, and all unwanted elements are excluded
+    along with their captions. Boxed-text elements are excluded as well.
+
     Parameters
     ----------
     xml_string : str

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -129,59 +129,21 @@ def extract_text(xml_string):
         return None
 
 
-def _select_main_article_front(xml_string):
-    """Return front of NLM XML string
+def _select_from_top_level(xml_string, tag):
+    """Return top level elements from an NLM XML article
 
     Parameters
     ----------
     xml_str : str
-        A valid NLM XML string
+        A valid NLM XML string for an entire article
 
     list
-        List containing lxml Element of front section of main article
+        List containing lxml Element objects of selected top level elements
     """
     output = []
     tree = etree.fromstring(xml_string.encode('utf-8'))
-    front_xpath = _namespace_unaware_xpath('article', 'front')
+    front_xpath = _namespace_unaware_xpath(tag)
     for element in tree.xpath(front_xpath):
-        output.append(element)
-    return output
-
-
-def _select_main_article_body(xml_string):
-    """Return body of NLM XML string
-
-    Parameters
-    ----------
-    xml_str : str
-        A valid NLM XML string
-
-    list
-        List containing lxml Element of main body.
-    """
-    output = []
-    tree = etree.fromstring(xml_string.encode('utf-8'))
-    body_xpath = _namespace_unaware_xpath('article', 'body')
-    for element in tree.xpath(body_xpath):
-        output.append(element)
-    return output
-
-
-def _select_subarticles(xml_string):
-    """Return sub-articles of NLM XML string
-
-    Parameters
-    ----------
-    xml_str : str
-        A valid NLM XML string
-
-    list
-        List containing lxml Element of front section of main article
-    """
-    output = []
-    tree = etree.fromstring(xml_string.encode('utf-8'))
-    sub_article_xpath = _namespace_unaware_xpath('article', 'sub-article')
-    for element in tree.xpath(sub_article_xpath):
         output.append(element)
     return output
 

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -400,6 +400,7 @@ def _retain_only_pars(tree):
     for element in tree.getiterator():
         if element.tag == 'title':
             element.tag = 'p'
+    for element in tree.getiterator():
         parent = element.getparent()
         if parent is not None and element.tag != 'p':
             etree.strip_tags(element.getparent(), element.tag)

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -245,3 +245,10 @@ def filter_pmids(pmid_list, source_type):
             pmids_fulltext_dict[source_type] = fulltext_list
     return list(set(pmid_list).intersection(
                                 pmids_fulltext_dict.get(source_type)))
+
+
+def _namespace_unaware_xpath(tag_list, from_root=True):
+    out = '' if from_root else '/'
+    for tag in tag_list:
+        out += "/*[local-name()='%s']" % tag
+    return out

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -177,13 +177,19 @@ def extract_paragraphs(xml_string):
     _remove_elements_by_tag(tree, 'tex-math')
     # Strip out all content in unwanted elements except the captions
     _replace_unwanted_elements_with_their_captions(tree)
-    # First process front element
+    # First process front element. Titles alt-titles and abstracts
+    # are pulled from here.
     front_elements = _select_from_top_level(tree, 'front')
     for element in front_elements:
         output.extend(_extract_from_front(element))
+    # All paragraphs except those in unwanted elements are extracted
+    # from the article body
     body_elements = _select_from_top_level(tree, 'body')
     for element in body_elements:
         output.extend(_extract_from_body(element))
+    # Only the body sections of subarticles are processed. All
+    # unwanted elements are removed entirely, including captions.
+    # Even boxed-text elements are removed.
     subarticles = _select_from_top_level(tree, 'sub-article')
     for element in subarticles:
         output.extend(_extract_from_subarticle(element))

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -173,6 +173,10 @@ def extract_paragraphs(xml_string):
     """
     output = []
     tree = etree.fromstring(xml_string.encode('utf-8'))
+    # Strip out comments
+    comments = tree.xpath('//comment()')
+    for element in comments:
+        element.getparent().remove(element)
     # Remove namespaces if any exist
     if tree.tag.startswith('{'):
         for element in tree.getiterator():

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -162,6 +162,31 @@ def extract_titles(xml_string):
     return output
 
 
+def select_abstracts(xml_string):
+    """Return list of abstract elements from NLM XML string
+
+    Parameters
+    ----------
+    xml_str : str
+        A valid NLM XML string
+
+    Returns
+    -------
+    list of str
+        List of string representations of abstract elements from
+        input XML
+    """
+    output = []
+    tree = etree.fromstring(xml_string.encode('utf-8'))
+    abstract_path_elements = ['front', 'article-meta', 'abstract']
+    abstract_xpath = '/'
+    for tag in abstract_path_elements:
+        abstract_xpath += "/*[local-name()='%s']" % tag
+    for element in tree.xpath(abstract_xpath):
+        output.append(etree.tostring(element, encoding='unicode'))
+    return output
+
+
 def extract_paragraphs(xml_string):
     """Returns list of paragraphs in an NLM XML.
 

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -412,7 +412,7 @@ def _pull_nested_paragraphs_to_top(tree):
     """
     # First identify all paragraphs nested within child paragraphs of the root
     nested_paragraphs = tree.xpath('./p/p')
-    # The tree is flattened from the top down. 
+    # The tree is flattened from the top down.
     while nested_paragraphs:
         last = None
         old_parent = None
@@ -430,13 +430,7 @@ def _pull_nested_paragraphs_to_top(tree):
 
 
 def _extract_paragraphs_from_tree(tree):
-    # In NLM xml, all plaintext is within <p> tags and <title> tags.
-    # There can be formatting tags nested within these tags, but no
-    # unwanted elements such as figures and tables appear nested
-    # within <p> tags and <title> tags. xpath local-name()= syntax
-    # is used to ignore namespaces in the NLM XML. Only elements
-    # directly under the input element are included to avoid
-    # duplication for nested paragraphs.
+    """Preprocess tree and return it's paragraphs."""
     _retain_only_pars(tree)
     _pull_nested_paragraphs_to_top(tree)
     paragraphs = []
@@ -447,4 +441,5 @@ def _extract_paragraphs_from_tree(tree):
 
 
 def _xpath_union(*xpath_list):
+    """Form union of xpath expressions"""
     return ' | '.join(xpath_list)

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -110,7 +110,12 @@ def get_xml(pmc_id):
 
 
 def extract_text(xml_string):
-    """Get text from the body of the given NLM XML string.
+    """Get plaintext from the body of the given NLM XML string.
+
+    This plaintext consists of all paragraphs returned by
+    indra.literature.pmc_client.extract_paragraphs separated
+    by newlines and then finally terminated by a newline.
+    See the DocString of extract_paragraphs for more information.
 
     Parameters
     ----------

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -308,12 +308,17 @@ def _extract_from_front(front_element):
 
 def _extract_from_body(body_element):
     """Return list of paragraphs from main article body of NLM XML
+
+    See DocString for extract_paragraphs for more info
     """
     return _extract_paragraphs_from_tree(body_element)
 
 
 def _extract_from_subarticle(subarticle_element):
-    """Return list of relevant paragraphs from a subarticle"""
+    """Return list of relevant paragraphs from a subarticle
+
+    See DocString for extract_paragraphs for more info.
+    """
     # Get only body element
     body = subarticle_element.xpath('./body')
     if not body:
@@ -329,15 +334,13 @@ def _extract_from_subarticle(subarticle_element):
 def _remove_elements_by_tag(tree, *tags):
     """Remove elements with given tags
 
+    Removes all element along with all of its content.
+    Modifies input tree inplace
+
     Parameters
     ----------
-    xml_str : str
-        String of valid NLM XML
-
-    Returns
-    -------
-    str
-        Copy of input XML string  with desired elements removed
+    tree : :py:class:`lxml.etree._Element`
+        etree element for valid NLM XML
     """
     bad_xpath = _xpath_union(*['.//%s' % tag for tag in tags])
     for element in tree.xpath(bad_xpath):
@@ -345,7 +348,15 @@ def _remove_elements_by_tag(tree, *tags):
 
 
 def _replace_unwanted_elements_with_their_captions(tree):
-    """Replace an element with its captions"""
+    """Replace all unwanted elements with their captions
+
+    Modifies input tree inplace.
+
+    Parameters
+    ----------
+    tree : :py:class:`lxml.etree._Element`
+        etree element for valid NLM XML
+    """
     floats_xpath = "//*[@position='float']"
     figs_xpath = './/fig'
     tables_xpath = './/table-wrap'
@@ -366,7 +377,19 @@ def _replace_unwanted_elements_with_their_captions(tree):
 
 
 def _retain_only_pars(tree):
-    """Strip out all tags except title and p tags"""
+    """Strip out all tags except title and p tags
+
+    Function also changes title tags into p tags. This is a helpful
+    preprocessing step that makes it easier to extract paragraphs in
+    the order of a pre-ordered traversal.
+
+    Modifies input tree inplace.
+
+    Parameters
+    ----------
+    tree : :py:class:`lxml.etree._Element`
+        etree element for valid NLM XML
+    """
     for element in tree.xpath('.//*'):
         if element.tag == 'title':
             element.tag = 'p'
@@ -376,8 +399,20 @@ def _retain_only_pars(tree):
 
 
 def _pull_nested_paragraphs_to_top(tree):
-    """Flatten nexted paragraphs in pre-ordered traversal"""
+    """Flatten nested paragraphs in pre-ordered traversal
+
+    Requires _retain_only_pars to be run first.
+
+    Modifies input tree inplace.
+
+    Parameters
+    ----------
+    tree : :py:class:`lxml.etree._Element`
+        etree element for valid NLM XML
+    """
+    # First identify all paragraphs nested within child paragraphs of the root
     nested_paragraphs = tree.xpath('./p/p')
+    # The tree is flattened from the top down. 
     while nested_paragraphs:
         last = None
         old_parent = None

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -129,6 +129,35 @@ def extract_text(xml_string):
         return None
 
 
+def extract_titles(xml_string):
+    """Get list containing article title and also alt title if one exists
+
+    Parameters
+    ----------
+    xml_string : str
+        String containing valid NLM XML
+
+    Returns
+    -------
+    list of str
+        Singleton list containing article title, or a two element
+        list containing the article title and the alt title if
+        the latter exists.
+    """
+    output = []
+    tree = etree.fromstring(xml_string.encode('utf-8'))
+    title_path = '//front/article-meta/title-group'
+    for element_name in ['article-title', 'alt-title']:
+        elements = tree.xpath(os.path.join(title_path, element_name))
+        # Although there should be exaclty one article-title and at most one
+        # alt title we handle this as if there could any number of each as
+        # a guard against unusual input. The only assumption made is that
+        # article-titles appear before alt-titles
+        for element in elements:
+            output.append(' '.join(element.itertext()))
+    return output
+
+
 def extract_paragraphs(xml_string):
     """Returns list of paragraphs in an NLM XML.
 

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -145,14 +145,15 @@ def extract_paragraphs(xml_string):
     tree = etree.fromstring(xml_string.encode('utf-8'))
 
     paragraphs = []
-    # In NLM xml, all plaintext is within <p> tags, and is the only thing
-    # that can be contained in <p> tags. To handle to possibility of namespaces
-    # uses regex to search for tags either of the form 'p' or '{<namespace>}p'
-    for element in tree.iter():
-        if isinstance(element.tag, basestring) and \
-           re.search('(^|})[p|title]$', element.tag) and element.text:
-            paragraph = ' '.join(element.itertext())
-            paragraphs.append(paragraph)
+    # In NLM xml, all plaintext is within <p> tags and <title> tags.
+    # There can be formatting tags nested within these tags, but no
+    # unwanted elements such as figures and tables appear nested
+    # within <p> tags and <title> tags. xpath local-name()= syntax
+    # is used to ignore namespaces in the NLM XML
+    for element in tree.xpath("//*[local-name()='p'] | "
+                              "//*[local-name()='title']"):
+        paragraph = ' '.join(element.itertext())
+        paragraphs.append(paragraph)
     return paragraphs
 
 

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -270,3 +270,7 @@ def _namespace_unaware_xpath(*tag_list, direct_only=True):
     for tag in tag_list:
         out += "/*[local-name()='%s']" % tag
     return out
+
+
+def _xpath_union(*xpath_list):
+    return ' | '.join(xpath_list)

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -188,7 +188,17 @@ def _extract_from_body(body_element):
 
 
 def _extract_from_subarticle(subarticle_element):
-    return ''
+    """Return list of relevant paragraphs from a subarticle"""
+    # Get only body element
+    body = subarticle_element.xpath(_namespace_unaware_xpath('body'))
+    if not body:
+        return []
+    body = body[0]
+    # Remove float elements. From observation these do not appear to
+    # contain any meaningful information within sub-articles.
+    for element in body.xpath(".//*[@position='float']"):
+        element.getparent().remove(element)
+    return _extract_paragraphs_from_tree(body)
 
 
 def _extract_paragraphs_from_tree(tree):

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -247,8 +247,26 @@ def filter_pmids(pmid_list, source_type):
                                 pmids_fulltext_dict.get(source_type)))
 
 
-def _namespace_unaware_xpath(tag_list, from_root=True):
-    out = '' if from_root else '/'
+def _namespace_unaware_xpath(*tag_list, direct_only=True):
+    """Create a namespace unaware xpath from a list of tags
+
+    Created xpaths always start with current node, node from
+    root of tree
+
+    Parameters
+    ----------
+    *tag_list
+        Variable length argument list of str. Contains tags for
+        constructing xpath
+    direct_only : Optional[bool]
+        If True, xpath only selects nodes directly beneath the
+        current node. Otherwise any descendents of the current
+        node can be selected. Default: True
+    """
+    if direct_only:
+        out = '.'
+    else:
+        out = './'
     for tag in tag_list:
         out += "/*[local-name()='%s']" % tag
     return out

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -146,9 +146,13 @@ def extract_titles(xml_string):
     """
     output = []
     tree = etree.fromstring(xml_string.encode('utf-8'))
-    title_path = '//front/article-meta/title-group'
-    for element_name in ['article-title', 'alt-title']:
-        elements = tree.xpath(os.path.join(title_path, element_name))
+    title_group_path_elements = ['front', 'article-meta', 'title-group']
+    title_group_xpath = '/'
+    for tag in title_group_path_elements:
+        title_group_xpath += "/*[local-name()='%s']" % tag
+    for tag in ['article-title', 'alt-title']:
+        title_xpath = title_group_xpath + "/*[local-name()='%s']" % tag
+        elements = tree.xpath(title_xpath)
         # Although there should be exaclty one article-title and at most one
         # alt title we handle this as if there could any number of each as
         # a guard against unusual input. The only assumption made is that

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -137,6 +137,25 @@ def extract_text(xml_string):
 def extract_paragraphs(xml_string):
     """Returns list of paragraphs in an NLM XML.
 
+    This returns a list of the plaintexts for each paragraph and title in
+    the input XML, excluding some paragraphs with text that should not
+    be relevant to biomedical text processing.
+
+    Relevant text includes titles, abstracts, and the contents of many body
+    paragraphs. Within figures, tables, and floating elements, only captions
+    are retained (One exception is that all paragraphs within floating
+    boxed-text elements are retained. These elements often contain short
+    summaries enriched with useful information.) Due to captions, nested
+    paragraphs can appear in an NLM XML document. Occasionally there are
+    multiple levels of nesting. If nested paragraphs appear in the input
+    document their texts are returned in a pre-ordered traversal. The text
+    within child paragraphs is not included in the output associated to the
+    parent. Each parent appears in the output before its children. All children
+    of an element appear before the elements following sibling.
+
+    All tags are removed from each paragraph in the list that is returned.
+    LaTeX surrounded by <tex-math> tags is removed entirely.
+
     Parameters
     ----------
     xml_string : str
@@ -145,7 +164,7 @@ def extract_paragraphs(xml_string):
     Returns
     -------
     list of str
-        List of extracted paragraphs in an NLM XML
+        List of extracted paragraphs from the input NLM XML
     """
     output = []
     tree = etree.fromstring(xml_string.encode('utf-8'))

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -234,7 +234,17 @@ def filter_pmids(pmid_list, source_type):
 
 
 def _select_from_top_level(tree, tag):
-    """Return top level elements from an NLM XML tree
+    """Select direct children of the article element of a tree by tag.
+
+    Different versions of NLM XML place the article element in different
+    places. We cannot rely on a hard coded path to the article element.  This
+    helper function helps select top level elements beneath article from their
+    tag name. We use this to pull out the front, body, and sub-article elements
+    of an article.
+
+    An assumption is made that there is only one article element in the input
+    XML tree. If this is not the case, only the firt article will be
+    processed.
 
     Parameters
     ----------
@@ -246,7 +256,9 @@ def _select_from_top_level(tree, tag):
     Returns
     -------
     list
-        List containing lxml Element objects of selected top level elements
+        List containing lxml Element objects of selected top level elements.
+        Typically there is only one front and one body that are direct chilren
+        of the article element, but there can be multiple subarticles.
     """
     if tree.tag == 'article':
         article = tree
@@ -254,8 +266,7 @@ def _select_from_top_level(tree, tag):
         article = tree.xpath('.//article')
         if not len(article):
             raise ValueError('Input XML contains no article element')
-        # We make the assumption each NLM XML contains only one article element.
-        # If this is not the case, then only the first article will be processed
+        # Assume there is only one article
         article = article[0]
     output = []
     xpath = './%s' % tag

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import re
+import copy
 import logging
 import os.path
 import requests
@@ -456,6 +457,7 @@ def _pull_nested_paragraphs_to_top(tree):
 
 def _extract_paragraphs_from_tree(tree):
     """Preprocess tree and return it's paragraphs."""
+    tree = copy.deepcopy(tree)
     _retain_only_pars(tree)
     _pull_nested_paragraphs_to_top(tree)
     paragraphs = []

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -202,17 +202,38 @@ def extract_paragraphs(xml_string):
     """
     tree = etree.fromstring(xml_string.encode('utf-8'))
 
+def _extract_paragraphs_from_tree(tree):
     paragraphs = []
     # In NLM xml, all plaintext is within <p> tags and <title> tags.
     # There can be formatting tags nested within these tags, but no
     # unwanted elements such as figures and tables appear nested
     # within <p> tags and <title> tags. xpath local-name()= syntax
     # is used to ignore namespaces in the NLM XML
-    for element in tree.xpath("//*[local-name()='p'] | "
-                              "//*[local-name()='title']"):
+    pars_xpath = _xpath_union(_namespace_unaware_xpath('p', direct_only=False),
+                              _namespace_unaware_xpath('title',
+                                                       direct_only=False))
+    for element in tree.xpath(pars_xpath):
         paragraph = ' '.join(element.itertext())
         paragraphs.append(paragraph)
     return paragraphs
+
+
+def extract_paragraphs(xml_string):
+    """Returns list of paragraphs in an NLM XML.
+
+    Parameters
+    ----------
+    xml_string : str
+        String containing valid NLM XML.
+
+    Returns
+    -------
+    list of str
+        List of extracted paragraphs in an NLM XML
+    """
+    tree = etree.fromstring(xml_string.encode('utf-8'))
+
+    return _extract_paragraphs_from_tree(tree)
 
 
 def filter_pmids(pmid_list, source_type):

--- a/indra/tests/test_adeft_tools.py
+++ b/indra/tests/test_adeft_tools.py
@@ -25,7 +25,7 @@ def test_universal_extract_paragraphs_pmc():
     pmc_id = 'PMC3262597'
     xml_str = pmc_client.get_xml(pmc_id)
     paragraphs = universal_extract_paragraphs(xml_str)
-    assert len(paragraphs) > 1
+    assert len(paragraphs) > 1, paragraphs
 
 
 @attr('webservice')

--- a/indra/tests/test_pmc_client.py
+++ b/indra/tests/test_pmc_client.py
@@ -107,4 +107,5 @@ def test_extract_text():
     xml_str = pmc_client.get_xml(pmc_id)
     text = pmc_client.extract_text(xml_str)
     assert text is not None
+    assert 'RAS VS BRAF ONCOGENES AND TARGETED THERAPIES' in text
     assert unicode_strs(text)


### PR DESCRIPTION
This PR addresses some problems with our tool to extract raw text from NLM XML. Previously, some unwanted non-natural language content such as that within tables was being included. Large tables an choke some machine reading systems, causing them to hang or crash. Pieces of non-natural language content are also a source of spurious statements.

Also, text is now only extracted from the abstract and title sections, from paragraphs in the main article body, and from the bodies of any included sub-articles. There are often blocks of text outside of the main article body such as author statements and acknowledgements that are not relevant for text mining applications.

In addition, a bug that was causing duplication of content within nested paragraphs has been corrected.
