### PR TITLE
Sanitize TRIPS agent names

### DIFF
--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -2091,7 +2091,12 @@ def _get_db_mappings(dbname, dbid):
 
 
 def sanitize_trips_name(name):
-    name = name.replace('-PUNC-MINUS-', '-')
+    # Since TRIPS replaces dashes with something that contains dashes, and on
+    # top of that, adds arbitrary dashes between letters and numbers, this
+    # is a bit painful but works.
+    name = name.replace('-PUNC-MINUS-', '|DASH|')
+    name = name.replace('-', '')
+    name = name.replace('|DASH|', '-')
     return name
 
 

--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -1260,8 +1260,8 @@ class TripsProcessor(object):
             # agent name
             if agent_name is None:
                 name = term.find("name")
-                if name is not None:
-                    agent_name = name.text
+                if name is not None and name.text is not None:
+                    agent_name = sanitize_trips_name(name.text)
             # If after all of this, the agent name is still None
             # then we don't extract this term as an agent
             if agent_name is None:
@@ -2088,6 +2088,11 @@ def _get_db_mappings(dbname, dbid):
 
     # TODO: we could do some chemical mappings here i.e. CHEBI/PUBCHEM/CHEMBL
     return db_mappings
+
+
+def sanitize_trips_name(name):
+    name = name.replace('-PUNC-MINUS-', '-')
+    return name
 
 
 def _read_ncit_map():

--- a/indra/tests/test_trips.py
+++ b/indra/tests/test_trips.py
@@ -255,3 +255,4 @@ def test_no_shared_objects():
 def test_sanitize():
     assert sanitize_trips_name('SB-PUNC-MINUS-525334') == \
         'SB-525334'
+    assert sanitize_trips_name('MAP-2-K-1') == 'MAP2K1'

--- a/indra/tests/test_trips.py
+++ b/indra/tests/test_trips.py
@@ -1,9 +1,8 @@
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str
 import sys
 from os.path import dirname, join
 import indra.statements as ist
 from indra.sources import trips
+from indra.sources.trips.processor import sanitize_trips_name
 from indra.assemblers.pysb import PysbAssembler
 from indra.util import unicode_strs
 from nose.plugins.attrib import attr
@@ -251,3 +250,8 @@ def test_no_shared_objects():
     hedgehog1 = stmt1.agent_list()[0]
     hedgehog2 = stmt2.agent_list()[0]
     assert hedgehog1 is not hedgehog2
+
+
+def test_sanitize():
+    assert sanitize_trips_name('SB-PUNC-MINUS-525334') == \
+        'SB-525334'


### PR DESCRIPTION
This PR reverses some of the post-processing that TRIPS does on names it reports. Unfortunately there is no way to go back to the original capitalization of the word but at least the added dashes can be reverted.