### PR TITLE
Statement hash deserialization

### DIFF
--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -90,7 +90,7 @@ class IndraDBRestProcessor(object):
 
     def get_ev_count_by_hash(self, stmt_hash):
         """Get the total evidence count for a statement hash."""
-        return self.__evidence_counts.get(str(stmt_hash))
+        return self.__evidence_counts.get(str(stmt_hash), 0)
 
     def get_source_counts(self):
         """Get the source counts as a dict per statement hash."""
@@ -102,7 +102,7 @@ class IndraDBRestProcessor(object):
 
     def get_source_count_by_hash(self, stmt_hash):
         """Get the source counts for a given statement."""
-        return self.__source_counts.get(stmt_hash)
+        return self.__source_counts.get(stmt_hash, {})
 
     def get_ev_counts(self):
         """Get a dictionary of evidence counts."""

--- a/indra/statements/statements.py
+++ b/indra/statements/statements.py
@@ -513,6 +513,14 @@ class Statement(object):
         if not stmt_id:
             stmt_id = '%s' % uuid.uuid4()
         stmt.uuid = stmt_id
+        json_matches_hash = json_dict.get('matches_hash')
+        if json_matches_hash:
+            # This code is so central that we need to handle the corner case
+            # that a non-int string hash is there without erroring
+            try:
+                stmt._shallow_hash = int(json_matches_hash)
+            except ValueError:
+                pass
         return stmt
 
     def to_graph(self):

--- a/indra/tests/test_statements_serialization.py
+++ b/indra/tests/test_statements_serialization.py
@@ -266,6 +266,28 @@ def test_belief():
     assert jd2['belief'] == 0.5
 
 
+def test_hash():
+    # Check that the original matches hash is preserved to and from JSON
+    stmt = Phosphorylation(Agent('a'), Agent('b'), 'S', evidence=[ev])
+    sh = stmt.get_hash()
+    jd = stmt.to_json()
+    stmt_ret = Statement._from_json(jd)
+    assert stmt_ret._shallow_hash == sh
+
+    # Check that the JSON matches hash is set but when refreshed, is replaced
+    jd['matches_hash'] = '1234'
+    stmt_ret = Statement._from_json(jd)
+    assert stmt_ret._shallow_hash == 1234, stmt_ret._shallow_hash
+    assert stmt_ret.get_hash() == 1234
+    assert stmt_ret.get_hash(refresh=True) == sh
+
+    # Check handling of invalid matches hash in JSON
+    jd['matches_hash'] = 'abcde'
+    stmt_ret = Statement._from_json(jd)
+    assert stmt_ret._shallow_hash is None
+    assert stmt_ret.get_hash() == sh
+
+
 def test_time_context():
     tc = TimeContext(text='2018',
                      start=datetime.datetime(2018, 1, 1, 0, 0),


### PR DESCRIPTION
This PR makes an important addition/fix to JSON deserialization, namely, it deserializes the matches_hash into the Statement's _shallow_hash attribute. This means that when get_hash() on a deserialized Statement is called, the hash isn't recalculated but rather, the hash from the JSON is preserved. This is important especially in cases where the locally running version of INDRA is different from the version with which the JSON was produced, which would lead to inconsistencies when recalculating hashes. One example is `indra_db_rest` being used to query content and construct evidence counts, for which having consistent hashes is critical.