### PR TITLE
Implement retaining molecular complexes in ISI reader

### DIFF
--- a/indra/sources/isi/processor.py
+++ b/indra/sources/isi/processor.py
@@ -151,6 +151,20 @@ class IsiProcessor(object):
         """
         return ist.Agent(agent_str, db_refs={'TEXT': agent_str})
 
+    def retain_molecular_complexes(self):
+        """Filter the statements to Complexes between molecular entities."""
+        self.statements = [s for s in self.statements
+                           if isinstance(s, ist.Complex) and
+                           all(is_molecular(m) for m in s.members)]
+
+
+def is_molecular(agent):
+    if agent is None:
+        return False
+    db, id = agent.get_grounding()
+    return (db is not None and db in {'HGNC', 'UP', 'CHEBI', 'PUBCHEM',
+                                      'UPPRO', 'FPLX'})
+
 
 # Load the mapping between ISI verb and INDRA statement type
 def _build_verb_statement_mapping():

--- a/indra/tests/test_isi.py
+++ b/indra/tests/test_isi.py
@@ -29,6 +29,8 @@ def test_process_complex():
     assert ev.text == 'Ras binds to Raf.'
     assert ev.annotations['interaction'] == ['binds', None, 'Ras', 'Raf']
     assert ev.annotations['source_id'] is not None
+    ip.retain_molecular_complexes()
+    assert ip.statements
 
 
 def test_process_phosphorylation():
@@ -57,3 +59,6 @@ def test_process_phosphorylation():
     assert ev.text == 'Ras phosphorylates Raf.'
     assert ev.annotations['interaction'] == ['phosphorylates', 'Ras', 'Raf']
     assert ev.annotations['source_id'] is not None
+
+    ip.retain_molecular_complexes()
+    assert not ip.statements


### PR DESCRIPTION
This PR adds an option in the ISI reader API to retain only Complex statements over grounded agents that are molecular.