### PR TITLE
Agent coordinates in English and HTML assemblers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ indra/benchmarks/assembly_eval/batch4/trips
 indra/benchmarks/assembly_eval/batch4/reach
 models/fallahi_eval/output
 indra/sources/eidos/cache/geonames/index/
+indra/tests/tempfile.html
 
 # Other
 *.txt

--- a/indra/assemblers/english/__init__.py
+++ b/indra/assemblers/english/__init__.py
@@ -1,1 +1,1 @@
-from .assembler import EnglishAssembler
+from .assembler import EnglishAssembler, AgentWithCoordinates, SentenceBuilder

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -20,6 +20,10 @@ class EnglishAssembler(object):
         A list of INDRA Statements to assemble.
     model : str
         The assembled sentences as a single string.
+    stmt_agents : list[list[AgentWithCoordinates]]
+        A list containing lists of AgentWithCoordinates objects for each of
+        the assembled statements. Coordinates represent the location of
+        agents in the model.
     """
     def __init__(self, stmts=None):
         if stmts is None:

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -193,9 +193,9 @@ class SentenceBuilder():
             for ag in self.agents:
                 ag.update_coords(len(element))
         elif isinstance(element, AgentWithCoordinates):
-            self.sentence = element.agent_str + current_sentence
+            self.sentence = element.agent_str + ' ' + current_sentence
             for ag in self.agents:
-                ag.update_coords(len(element.agent_str))
+                ag.update_coords(len(element.agent_str) + 1)
             self.agents.insert(0, element)
 
     def append_as_list(self, lst, oxford=True):
@@ -596,7 +596,7 @@ def _make_sentence(txt):
 
 
 def _get_is_direct(stmt):
-    """Return True if there is evidence that the statement is direct.
+    """Return True if there is any evidence that the statement is direct.
 
     If any of the evidences associated with the statement
     indicates a direct interaction then we assume the interaction
@@ -617,7 +617,7 @@ def _get_is_direct(stmt):
 
 
 def _get_is_hypothesis(stmt):
-    """Return True if there is evidence that the statement is hypothetical.
+    """Return True if there is only evidence that the statement is hypothetical.
 
     If all of the evidences associated with the statement
     indicate a hypothetical interaction then we assume the interaction

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -83,6 +83,68 @@ class EnglishAssembler(object):
             return ''
 
 
+class AgentWithCoordinates():
+    def __init__(self, agent_str, name, coords=None):
+        self.agent_str = agent_str
+        self.name = name
+        self.coords = coords if coords else (
+            agent_str.find(name), agent_str.find(name) + len(name))
+
+    def update_coords(self, shift_by):
+        current_coords = self.coords
+        self.coords = (current_coords[0] + shift_by,
+                       current_coords[1] + shift_by)
+
+
+class SentenceBuilder():
+    def __init__(self):
+        self.elements = []
+        self.sentence = ''
+
+    def append(self, element):
+        if isinstance(element, str):
+            self.sentence += element
+        elif isinstance(element, AgentWithCoordinates):
+            element.update_coords(len(self.sentence))
+            self.sentence += element.agent_str
+        self.elements.append(element)
+
+    def prepend(self, element):
+        current_sentence = self.sentence
+        if isinstance(element, str):
+            self.sentence = element + current_sentence
+        elif isinstance(element, AgentWithCoordinates):
+            self.sentence = element.agent_str + current_sentence
+            for el in self.elements:
+                if isinstance(el, AgentWithCoordinates):
+                    el.update_coords(len(element.agent_str))
+        self.elements.insert(0, element)
+
+    def append_as_list(self, lst, oxford=True):
+        """Join a list of words in a gramatically correct way."""
+        if len(lst) > 2:
+            for el in lst[:-1]:
+                self.append(el)
+                self.append(', ')
+            if oxford:
+                self.append(',')
+            self.append(' and ')
+            self.append(lst[-1])
+        elif len(lst) == 2:
+            self.append(lst[0])
+            self.append(' and ')
+            self.append(lst[1])
+        elif len(lst) == 1:
+            self.append(lst[0])
+
+    def append_as_sentence(self, lst):
+        for el in lst:
+            self.append(el)
+
+    def make_sentence(self):
+        self.sentence = _make_sentence(self.sentence)
+
+
 def _assemble_agent_str(agent):
     """Assemble an Agent object to text."""
     agent_str = agent.name

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -58,6 +58,7 @@ class EnglishAssembler(object):
         # Keep track of current length of the model text.
         text_length = 0
         for stmt in self.statements:
+            sb = None
             # Get a SentenceBuilder object per statement
             if isinstance(stmt, ist.Modification):
                 sb = _assemble_modification(stmt)

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -93,7 +93,7 @@ class EnglishAssembler(object):
                 for ag in sb.agents:
                     ag.update_coords(text_length)
                 self.stmt_agents.append(sb.agents)
-                # Update the length of the text by adding a length of new
+                # Update the length of the text by adding the length of the new
                 # sentence and a space.
                 text_length += (len(sb.sentence) + 1)
             else:
@@ -190,6 +190,8 @@ class SentenceBuilder():
         current_sentence = self.sentence
         if isinstance(element, str):
             self.sentence = element + current_sentence
+            for ag in self.agents:
+                ag.update_coords(len(element))
         elif isinstance(element, AgentWithCoordinates):
             self.sentence = element.agent_str + current_sentence
             for ag in self.agents:
@@ -205,8 +207,8 @@ class SentenceBuilder():
             A list of elements to append. Elements in this list represent a
             sequence and grammar standards require the use of appropriate
             punctuation and conjunction to connect them (e.g. [ag1, ag2, ag3]).
-        oxford : bool
-            Whether to use oxford grammar standards.
+        oxford : Optional[bool]
+            Whether to use oxford grammar standards. Default: True
         """
         if len(lst) > 2:
             for el in lst[:-1]:
@@ -225,6 +227,7 @@ class SentenceBuilder():
 
     def append_as_sentence(self, lst):
         """Append a list of elements by concatenating them together.
+
         Note: a list of elements here are parts of sentence that do not
         represent a sequence and do not need to have extra punctuation or
         conjunction between them.
@@ -360,7 +363,7 @@ def english_join(lst):
 
 
 def _join_list(lst, oxford=True):
-    """Join a list of words in a gramatically correct way."""
+    """Join a list of words in a grammatically correct way."""
     if len(lst) > 2:
         s = ', '.join(lst[:-1])
         if oxford:
@@ -593,11 +596,13 @@ def _make_sentence(txt):
 
 
 def _get_is_direct(stmt):
-    '''Returns true if there is evidence that the statement is a direct
-    interaction. If any of the evidences associated with the statement
-    indicates a direct interatcion then we assume the interaction
+    """Return True if there is evidence that the statement is direct.
+
+    If any of the evidences associated with the statement
+    indicates a direct interaction then we assume the interaction
     is direct. If there is no evidence for the interaction being indirect
-    then we default to direct.'''
+    then we default to direct.
+    """
     any_indirect = False
     for ev in stmt.evidence:
         if ev.epistemics.get('direct') is True:
@@ -612,10 +617,12 @@ def _get_is_direct(stmt):
 
 
 def _get_is_hypothesis(stmt):
-    """Returns true if there is evidence that the statement is only
-    hypothetical. If all of the evidences associated with the statement
+    """Return True if there is evidence that the statement is hypothetical.
+
+    If all of the evidences associated with the statement
     indicate a hypothetical interaction then we assume the interaction
-    is hypothetical."""
+    is hypothetical.
+    """
     for ev in stmt.evidence:
         if not ev.epistemics.get('hypothesis') is True:
             return True

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -110,6 +110,8 @@ class AgentWithCoordinates():
         Full English description of an agent.
     name : str
         Name of an agent.
+    db_refs : dict
+        Dictionary of database identifiers associated with this agent.
     coords : tuple(int)
         A tuple of integers representing coordinates of agent name in a text.
         If not provided, coords will be set to coordinates of name in

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -143,6 +143,13 @@ class AgentWithCoordinates():
         self.coords = (current_coords[0] + shift_by,
                        current_coords[1] + shift_by)
 
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        return 'AgentWithCoordinates(%s (%s), coords=%s)' % (
+            self.agent_str, self.name, self.coords)
+
 
 class SentenceBuilder():
     """Builds a sentence from agents and strings.

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -27,6 +27,7 @@ class EnglishAssembler(object):
         else:
             self.statements = stmts
         self.model = None
+        sb.coords = []
 
     def add_statements(self, stmts):
         """Add INDRA Statements to the assembler's list of statements.
@@ -52,31 +53,33 @@ class EnglishAssembler(object):
         stmt_strs = []
         for stmt in self.statements:
             if isinstance(stmt, ist.Modification):
-                stmt_strs.append(_assemble_modification(stmt))
+                sb = _assemble_modification(stmt)
             elif isinstance(stmt, ist.Autophosphorylation):
-                stmt_strs.append(_assemble_autophosphorylation(stmt))
+                sb = _assemble_autophosphorylation(stmt)
             elif isinstance(stmt, ist.Association):
-                stmt_strs.append(_assemble_association(stmt))
+                sb = _assemble_association(stmt)
             elif isinstance(stmt, ist.Complex):
-                stmt_strs.append(_assemble_complex(stmt))
+                sb = _assemble_complex(stmt)
             elif isinstance(stmt, ist.Influence):
-                stmt_strs.append(_assemble_influence(stmt))
+                sb = _assemble_influence(stmt)
             elif isinstance(stmt, ist.RegulateActivity):
-                stmt_strs.append(_assemble_regulate_activity(stmt))
+                sb = _assemble_regulate_activity(stmt)
             elif isinstance(stmt, ist.RegulateAmount):
-                stmt_strs.append(_assemble_regulate_amount(stmt))
+                sb = _assemble_regulate_amount(stmt)
             elif isinstance(stmt, ist.ActiveForm):
-                stmt_strs.append(_assemble_activeform(stmt))
+                sb = _assemble_activeform(stmt)
             elif isinstance(stmt, ist.Translocation):
-                stmt_strs.append(_assemble_translocation(stmt))
+                sb = _assemble_translocation(stmt)
             elif isinstance(stmt, ist.Gef):
-                stmt_strs.append(_assemble_gef(stmt))
+                sb = _assemble_gef(stmt)
             elif isinstance(stmt, ist.Gap):
-                stmt_strs.append(_assemble_gap(stmt))
+                sb = _assemble_gap(stmt)
             elif isinstance(stmt, ist.Conversion):
-                stmt_strs.append(_assemble_conversion(stmt))
+                sb = _assemble_conversion(stmt)
             else:
                 logger.warning('Unhandled statement type: %s.' % type(stmt))
+            stmt_strs.append(sb.sentence)
+            self.coords.append(sb.coords)
         if stmt_strs:
             return ' '.join(stmt_strs)
         else:

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -27,7 +27,7 @@ class EnglishAssembler(object):
         else:
             self.statements = stmts
         self.model = None
-        sb.coords = []
+        self.stmt_agents = []
 
     def add_statements(self, stmts):
         """Add INDRA Statements to the assembler's list of statements.
@@ -51,6 +51,7 @@ class EnglishAssembler(object):
             periods at the end.
         """
         stmt_strs = []
+        text_length = 0
         for stmt in self.statements:
             if isinstance(stmt, ist.Modification):
                 sb = _assemble_modification(stmt)
@@ -78,8 +79,14 @@ class EnglishAssembler(object):
                 sb = _assemble_conversion(stmt)
             else:
                 logger.warning('Unhandled statement type: %s.' % type(stmt))
+            if sb:
             stmt_strs.append(sb.sentence)
-            self.coords.append(sb.coords)
+                for ag in sb.agents:
+                    ag.update_coords(text_length)
+                self.stmt_agents.append(sb.agents)
+                text_length += (len(sb.sentence) + 1)
+            else:
+                self.stmt_agents.append([])
         if stmt_strs:
             return ' '.join(stmt_strs)
         else:

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -80,7 +80,7 @@ class EnglishAssembler(object):
             else:
                 logger.warning('Unhandled statement type: %s.' % type(stmt))
             if sb:
-            stmt_strs.append(sb.sentence)
+                stmt_strs.append(sb.sentence)
                 for ag in sb.agents:
                     ag.update_coords(text_length)
                 self.stmt_agents.append(sb.agents)
@@ -346,7 +346,7 @@ def _assemble_association(stmt):
     sb = SentenceBuilder()
     sb.append(member_strs[0])
     sb.append(' is associated with ')
-    sb.append_list(member_strs[1:])
+    sb.append_as_list(member_strs[1:])
     sb.make_sentence()
     return sb
 
@@ -357,7 +357,7 @@ def _assemble_complex(stmt):
     sb = SentenceBuilder()
     sb.append(member_strs[0])
     sb.append(' binds ')
-    sb.append_list(member_strs[1:])
+    sb.append_as_list(member_strs[1:])
     sb.make_sentence()
     return sb
 
@@ -391,7 +391,7 @@ def _assemble_regulate_activity(stmt):
     sb = SentenceBuilder()
     sb.append_as_sentence([subj_str, rel_str, obj_str])
     sb.make_sentence()
-    return _make_sentence(stmt_str)
+    return sb
 
 
 def _assemble_regulate_amount(stmt):

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -101,7 +101,7 @@ class AgentWithCoordinates():
 
 class SentenceBuilder():
     def __init__(self):
-        self.elements = []
+        self.agents = []
         self.sentence = ''
 
     def append(self, element):
@@ -110,7 +110,7 @@ class SentenceBuilder():
         elif isinstance(element, AgentWithCoordinates):
             element.update_coords(len(self.sentence))
             self.sentence += element.agent_str
-        self.elements.append(element)
+            self.agents.append(element)
 
     def prepend(self, element):
         current_sentence = self.sentence
@@ -118,10 +118,9 @@ class SentenceBuilder():
             self.sentence = element + current_sentence
         elif isinstance(element, AgentWithCoordinates):
             self.sentence = element.agent_str + current_sentence
-            for el in self.elements:
-                if isinstance(el, AgentWithCoordinates):
-                    el.update_coords(len(element.agent_str))
-        self.elements.insert(0, element)
+            for ag in self.agents:
+                ag.update_coords(len(element.agent_str))
+            self.agents.insert(0, element)
 
     def append_as_list(self, lst, oxford=True):
         """Join a list of words in a gramatically correct way."""

--- a/indra/assemblers/english/assembler.py
+++ b/indra/assemblers/english/assembler.py
@@ -117,9 +117,10 @@ class AgentWithCoordinates():
         EnglishAssembler, the coords represent the location of agent name in
         the SentenceBuilder.sentence or EnglishAssembler.model.
     """
-    def __init__(self, agent_str, name, coords=None):
+    def __init__(self, agent_str, name, db_refs, coords=None):
         self.agent_str = agent_str
         self.name = name
+        self.db_refs = db_refs
         self.coords = coords if coords else (
             agent_str.find(name), agent_str.find(name) + len(name))
 
@@ -242,7 +243,7 @@ def _assemble_agent_str(agent):
 
     # Only do the more detailed assembly for molecular agents
     if not isinstance(agent, ist.Agent):
-        return AgentWithCoordinates(agent_str, agent.name)
+        return AgentWithCoordinates(agent_str, agent.name, agent.db_refs)
 
     # Handle mutation conditions
     if agent.mutations:
@@ -270,7 +271,7 @@ def _assemble_agent_str(agent):
         agent_str += ' in the ' + agent.location
 
     if not agent.mods and not agent.bound_conditions and not agent.activity:
-        return AgentWithCoordinates(agent_str, agent.name)
+        return AgentWithCoordinates(agent_str, agent.name, agent.db_refs)
 
     # Handle bound conditions
     bound_to = [bc.agent.name for bc in
@@ -331,7 +332,7 @@ def _assemble_agent_str(agent):
             prefix = pre_prefix + 'inactive'
         agent_str = prefix + ' ' + agent_str
 
-    return AgentWithCoordinates(agent_str, agent.name)
+    return AgentWithCoordinates(agent_str, agent.name, agent.db_refs)
 
 
 def english_join(lst):

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -525,7 +525,7 @@ def id_url(ag):
                     'IP', 'PF', 'NXPFA',
                     'MIRBASEM', 'MIRBASE',
                     'NCIT',
-                    'UN', 'HUME', 'CWMS', 'SOFIA'):
+                    'WM', 'UN', 'HUME', 'CWMS', 'SOFIA'):
         if db_name in ag.db_refs:
             # Handle a special case where a list of IDs is given
             if isinstance(ag.db_refs[db_name], list):
@@ -533,7 +533,7 @@ def id_url(ag):
                 if db_name == 'CHEBI':
                     if not db_id.startswith('CHEBI'):
                         db_id = 'CHEBI:%s' % db_id
-                elif db_name in ('UN', 'HUME'):
+                elif db_name in ('UN', 'WM', 'HUME'):
                     db_id = db_id[0]
             else:
                 db_id = ag.db_refs[db_name]
@@ -589,7 +589,7 @@ def tag_text(text, tag_info_list):
     format_text = ''
     start_pos = 0
     for i, j, ag_text, tag_start, tag_close in tag_info_list:
-        # Capitalize if it's a beginnine of a sentence
+        # Capitalize if it's the beginning of a sentence
         if i == 0:
             ag_text = ag_text[0].upper() + ag_text[1:]
         # Add the text before this agent, if any

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -290,7 +290,7 @@ class HtmlAssembler(object):
                         if isinstance(dbid, set):
                             logger.info("Removing %s from top level refs "
                                         "due to multiple matches: %s"
-                                           % (dbn, dbid))
+                                        % (dbn, dbid))
                             del ag.db_refs[dbn]
                 tl_label = make_top_level_label_from_names_key(tlg['names'])
                 tl_label = re.sub("<b>(.*?)</b>", r"\1", tl_label)
@@ -406,10 +406,10 @@ def _format_evidence_text(stmt, curation_dict=None, correct_tags=None):
     for ix, ev in enumerate(stmt.evidence):
         # Expand the source api to include the sub-database
         if ev.source_api == 'biopax' and \
-           'source_sub_id' in ev.annotations and \
-           ev.annotations['source_sub_id']:
-           source_api = '%s:%s' % (ev.source_api,
-                                   ev.annotations['source_sub_id'])
+                'source_sub_id' in ev.annotations and \
+                ev.annotations['source_sub_id']:
+            source_api = '%s:%s' % (ev.source_api,
+                                    ev.annotations['source_sub_id'])
         else:
             source_api = ev.source_api
         # Prepare the evidence text
@@ -438,8 +438,7 @@ def _format_evidence_text(stmt, curation_dict=None, correct_tags=None):
                 # Build up a set of indices
                 indices += [(m.start(), m.start() + len(ag_text),
                              ag_text, tag_start, tag_close)
-                             for m in re.finditer(re.escape(ag_text),
-                                                  ev.text)]
+                            for m in re.finditer(re.escape(ag_text), ev.text)]
             format_text = tag_text(ev.text, indices)
 
         curation_key = (stmt.get_hash(), ev.source_hash)

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -369,7 +369,7 @@ class HtmlAssembler(object):
             fh.write(self.model.encode('utf-8'))
 
 
-def _format_evidence_text(stmt, curation_dict=None):
+def _format_evidence_text(stmt, curation_dict=None, correct_tags=None):
     """Returns evidence metadata with highlighted evidence text.
 
     Parameters
@@ -388,6 +388,8 @@ def _format_evidence_text(stmt, curation_dict=None):
     """
     if curation_dict is None:
         curation_dict = {}
+    if correct_tags is None:
+        correct_tags = ['correct']
 
     def get_role(ag_ix):
         if isinstance(stmt, Complex) or \
@@ -441,13 +443,19 @@ def _format_evidence_text(stmt, curation_dict=None):
             format_text = tag_text(ev.text, indices)
 
         curation_key = (stmt.get_hash(), ev.source_hash)
-        num_curations = len(curation_dict.get(curation_key, []))
+        curations = curation_dict.get(curation_key, [])
+        num_curations = len(curations)
+        num_correct = len([cur for cur in curations if cur.tag in correct_tags])
+        num_incorrect = num_curations - num_correct
         ev_list.append({'source_api': source_api,
                         'pmid': ev.pmid,
                         'text_refs': ev.text_refs,
                         'text': format_text,
                         'source_hash': str(ev.source_hash),
-                        'num_curations': num_curations})
+                        'num_curations': num_curations,
+                        'num_correct': num_correct,
+                        'num_incorrect': num_incorrect
+                        })
 
     return ev_list
 

--- a/indra/explanation/reporting.py
+++ b/indra/explanation/reporting.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from indra.sources.indra_db_rest.api import get_statements_by_hash
 from indra.statements import *
 from indra.assemblers.english.assembler import _assemble_agent_str, \
-    _make_sentence
+    SentenceBuilder
 
 
 def stmts_from_pysb_path(path, model, stmts):
@@ -93,6 +93,7 @@ PybelEdge = namedtuple(
 def pybel_edge_to_english(pybel_edge):
     source_str = _assemble_agent_str(pybel_edge.source)
     target_str = _assemble_agent_str(pybel_edge.target)
+    sb = SentenceBuilder()
     if pybel_edge.relation == 'partOf':
         if pybel_edge.reverse:
             rel_str = ' has a component '
@@ -103,8 +104,9 @@ def pybel_edge_to_english(pybel_edge):
             rel_str = ' is a variant of '
         else:
             rel_str = ' has a variant '
-    edge_str = source_str + rel_str + target_str
-    return _make_sentence(edge_str)
+    sb.append_as_sentence([source_str, rel_str, target_str])
+    sb.make_sentence()
+    return sb.sentence
 
 
 def stmts_from_pybel_path(path, model, from_db=True, stmts=None):

--- a/indra/tests/test_english_assembler.py
+++ b/indra/tests/test_english_assembler.py
@@ -512,6 +512,13 @@ def test_sentence_builder():
     sb.append(ac)
     assert len(sb.agents) == 1
     assert sb.sentence == 'BRAF'
+
     sb.prepend('phosphorylated ')
     assert sb.sentence == 'phosphorylated BRAF'
     assert sb.agents[0].coords == (15, 19), sb.agents[0].coords
+
+    sb.prepend(ea.AgentWithCoordinates('active KRAS', 'KRAS', {}))
+    assert sb.sentence == 'active KRAS phosphorylated BRAF', sb.sentence
+    assert sb.agents[0].name == 'KRAS'
+    assert sb.agents[1].name == 'BRAF'
+    assert sb.agents[1].coords == (27, 31), sb.agents[1].coords

--- a/indra/tests/test_english_assembler.py
+++ b/indra/tests/test_english_assembler.py
@@ -2,7 +2,7 @@ import indra.assemblers.english.assembler as ea
 from indra.statements import *
 
 
-def _sustring_by_coords(text, coords):
+def _substring_by_coords(text, coords):
     return text[coords[0]:coords[1]]
 
 
@@ -11,7 +11,7 @@ def test_agent_basic():
     assert isinstance(ag, ea.AgentWithCoordinates)
     print(ag.agent_str)
     assert ag.agent_str == 'EGFR'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_mod():
@@ -20,7 +20,7 @@ def test_agent_mod():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'phosphorylated EGFR'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_mod2():
@@ -29,7 +29,7 @@ def test_agent_mod2():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'tyrosine-phosphorylated EGFR'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_mod3():
@@ -38,7 +38,7 @@ def test_agent_mod3():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'EGFR phosphorylated on Y1111'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_mods():
@@ -48,7 +48,7 @@ def test_agent_mods():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'EGFR phosphorylated on Y1111 and Y1234'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_mods2():
@@ -58,7 +58,7 @@ def test_agent_mods2():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'EGFR phosphorylated on Y1111 and tyrosine'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_mods3():
@@ -77,7 +77,7 @@ def test_agent_mods_pos_only():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'EGFR phosphorylated on amino acid 1111'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_bound():
@@ -86,7 +86,7 @@ def test_agent_bound():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'EGFR bound to EGF'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_not_bound():
@@ -95,7 +95,7 @@ def test_agent_not_bound():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'EGFR not bound to EGF'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_bound_two():
@@ -105,7 +105,7 @@ def test_agent_bound_two():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'EGFR bound to EGF and EGFR'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_bound_three():
@@ -116,7 +116,7 @@ def test_agent_bound_three():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'EGFR bound to EGF, EGFR, and GRB2'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_bound_mixed():
@@ -126,7 +126,7 @@ def test_agent_bound_mixed():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'EGFR bound to EGF and not bound to EGFR'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_phos_noenz():
@@ -135,7 +135,7 @@ def test_phos_noenz():
     sb = ea._assemble_modification(st)
     print(sb.sentence)
     assert sb.sentence == 'MAP2K1 is phosphorylated.'
-    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
+    assert _substring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
 
 
 def test_phos_noenz2():
@@ -144,7 +144,7 @@ def test_phos_noenz2():
     sb = ea._assemble_modification(st)
     print(sb.sentence)
     assert sb.sentence == 'MAP2K1 is phosphorylated on serine.'
-    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
+    assert _substring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
 
 
 def test_phos_noenz3():
@@ -153,7 +153,7 @@ def test_phos_noenz3():
     sb = ea._assemble_modification(st)
     print(sb.sentence)
     assert sb.sentence == 'MAP2K1 is phosphorylated on S222.'
-    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
+    assert _substring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
 
 
 def test_phos_enz():
@@ -163,8 +163,8 @@ def test_phos_enz():
     sb = ea._assemble_modification(st)
     print(sb.sentence)
     assert sb.sentence == 'BRAF phosphorylates MAP2K1 on S222.'
-    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'BRAF'
-    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'MAP2K1'
+    assert _substring_by_coords(sb.sentence, sb.agents[0].coords) == 'BRAF'
+    assert _substring_by_coords(sb.sentence, sb.agents[1].coords) == 'MAP2K1'
 
 
 def test_phos_indirect():
@@ -175,8 +175,8 @@ def test_phos_indirect():
     sb = ea._assemble_modification(st)
     print(sb.sentence)
     assert sb.sentence == 'BRAF leads to the phosphorylation of MAP2K1 on S222.'
-    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'BRAF'
-    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'MAP2K1'
+    assert _substring_by_coords(sb.sentence, sb.agents[0].coords) == 'BRAF'
+    assert _substring_by_coords(sb.sentence, sb.agents[1].coords) == 'MAP2K1'
 
 
 def test_phos_enz2():
@@ -186,8 +186,8 @@ def test_phos_enz2():
     sb = ea._assemble_modification(st)
     print(sb.sentence)
     assert sb.sentence == 'PP2A dephosphorylates MAP2K1 on S222.'
-    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'PP2A'
-    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'MAP2K1'
+    assert _substring_by_coords(sb.sentence, sb.agents[0].coords) == 'PP2A'
+    assert _substring_by_coords(sb.sentence, sb.agents[1].coords) == 'MAP2K1'
 
 
 def test_dephos_no_residue():
@@ -197,8 +197,8 @@ def test_dephos_no_residue():
     sb = ea._assemble_modification(st)
     print(sb.sentence)
     assert sb.sentence == 'PP2A dephosphorylates MAP2K1 at position 222.'
-    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'PP2A'
-    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'MAP2K1'
+    assert _substring_by_coords(sb.sentence, sb.agents[0].coords) == 'PP2A'
+    assert _substring_by_coords(sb.sentence, sb.agents[1].coords) == 'MAP2K1'
 
 
 def test_ubiq_stmt():
@@ -206,8 +206,8 @@ def test_ubiq_stmt():
     sb = ea._assemble_modification(st)
     print(sb.sentence)
     assert sb.sentence == 'X ubiquitinates Y.'
-    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'X'
-    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'Y'
+    assert _substring_by_coords(sb.sentence, sb.agents[0].coords) == 'X'
+    assert _substring_by_coords(sb.sentence, sb.agents[1].coords) == 'Y'
 
 
 def test_deubiq_stmt():
@@ -215,8 +215,8 @@ def test_deubiq_stmt():
     sb = ea._assemble_modification(st)
     print(sb.sentence)
     assert sb.sentence == 'X deubiquitinates Y.'
-    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'X'
-    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'Y'
+    assert _substring_by_coords(sb.sentence, sb.agents[0].coords) == 'X'
+    assert _substring_by_coords(sb.sentence, sb.agents[1].coords) == 'Y'
 
 
 def test_deubiq_noenz():
@@ -224,7 +224,7 @@ def test_deubiq_noenz():
     sb = ea._assemble_modification(st)
     print(sb.sentence)
     assert sb.sentence == 'Y is deubiquitinated.'
-    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'Y'
+    assert _substring_by_coords(sb.sentence, sb.agents[0].coords) == 'Y'
 
 
 def test_complex_one():
@@ -234,8 +234,8 @@ def test_complex_one():
     sb = ea._assemble_complex(st)
     print(sb.sentence)
     assert sb.sentence == 'MAP2K1 binds BRAF.'
-    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
-    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'BRAF'
+    assert _substring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
+    assert _substring_by_coords(sb.sentence, sb.agents[1].coords) == 'BRAF'
 
 
 def test_complex_more():
@@ -246,9 +246,9 @@ def test_complex_more():
     sb = ea._assemble_complex(st)
     print(sb.sentence)
     assert sb.sentence == 'MAP2K1 binds BRAF and RAF1.'
-    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
-    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'BRAF'
-    assert _sustring_by_coords(sb.sentence, sb.agents[2].coords) == 'RAF1'
+    assert _substring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
+    assert _substring_by_coords(sb.sentence, sb.agents[1].coords) == 'BRAF'
+    assert _substring_by_coords(sb.sentence, sb.agents[2].coords) == 'RAF1'
 
 
 def test_assemble_one():
@@ -272,11 +272,11 @@ def test_assemble_more():
     print(s)
     assert s == \
         'PP2A dephosphorylates MAP2K1 on S222. MAP2K1 binds BRAF and RAF1.'
-    assert _sustring_by_coords(s, e.stmt_agents[0][0].coords) == 'PP2A'
-    assert _sustring_by_coords(s, e.stmt_agents[0][1].coords) == 'MAP2K1'
-    assert _sustring_by_coords(s, e.stmt_agents[1][0].coords) == 'MAP2K1'
-    assert _sustring_by_coords(s, e.stmt_agents[1][1].coords) == 'BRAF'
-    assert _sustring_by_coords(s, e.stmt_agents[1][2].coords) == 'RAF1'
+    assert _substring_by_coords(s, e.stmt_agents[0][0].coords) == 'PP2A'
+    assert _substring_by_coords(s, e.stmt_agents[0][1].coords) == 'MAP2K1'
+    assert _substring_by_coords(s, e.stmt_agents[1][0].coords) == 'MAP2K1'
+    assert _substring_by_coords(s, e.stmt_agents[1][1].coords) == 'BRAF'
+    assert _substring_by_coords(s, e.stmt_agents[1][2].coords) == 'RAF1'
 
 
 def test_autophos():
@@ -318,7 +318,7 @@ def test_agent_loc():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'BRAF in the cytoplasm'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'BRAF'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'BRAF'
 
 
 def test_agent_mut():
@@ -326,7 +326,7 @@ def test_agent_mut():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'BRAF-V600E'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'BRAF'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'BRAF'
 
 
 def test_agent_mut_plus():
@@ -335,7 +335,7 @@ def test_agent_mut_plus():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'BRAF-V600E in the nucleus'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'BRAF'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'BRAF'
 
 
 def test_agent_activity():
@@ -343,7 +343,7 @@ def test_agent_activity():
     ag = ea._assemble_agent_str(a)
     print(ag.agent_str)
     assert ag.agent_str == 'active BRAF'
-    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'BRAF'
+    assert _substring_by_coords(ag.agent_str, ag.coords) == 'BRAF'
 
 
 def test_agent_activity_stmt():
@@ -355,8 +355,8 @@ def test_agent_activity_stmt():
     s = e.make_model()
     print(s)
     assert s == 'Active BRAF activates MAP2K1.'
-    assert _sustring_by_coords(s, e.stmt_agents[0][0].coords) == 'BRAF'
-    assert _sustring_by_coords(s, e.stmt_agents[0][1].coords) == 'MAP2K1'
+    assert _substring_by_coords(s, e.stmt_agents[0][0].coords) == 'BRAF'
+    assert _substring_by_coords(s, e.stmt_agents[0][1].coords) == 'MAP2K1'
 
 
 def test_translocation():
@@ -368,22 +368,22 @@ def test_translocation():
     e.add_statements([st1])
     s = e.make_model()
     assert s == 'FOXO3A translocates.'
-    assert _sustring_by_coords(s, e.stmt_agents[0][0].coords) == 'FOXO3A'
+    assert _substring_by_coords(s, e.stmt_agents[0][0].coords) == 'FOXO3A'
     e = ea.EnglishAssembler()
     e.add_statements([st2])
     s = e.make_model()
     assert s == 'FOXO3A translocates from the cytoplasm.'
-    assert _sustring_by_coords(s, e.stmt_agents[0][0].coords) == 'FOXO3A'
+    assert _substring_by_coords(s, e.stmt_agents[0][0].coords) == 'FOXO3A'
     e = ea.EnglishAssembler()
     e.add_statements([st3])
     s = e.make_model()
     assert s == 'FOXO3A translocates to the nucleus.'
-    assert _sustring_by_coords(s, e.stmt_agents[0][0].coords) == 'FOXO3A'
+    assert _substring_by_coords(s, e.stmt_agents[0][0].coords) == 'FOXO3A'
     e = ea.EnglishAssembler()
     e.add_statements([st4])
     s = e.make_model()
     assert s == 'FOXO3A translocates from the cytoplasm to the nucleus.'
-    assert _sustring_by_coords(s, e.stmt_agents[0][0].coords) == 'FOXO3A'
+    assert _substring_by_coords(s, e.stmt_agents[0][0].coords) == 'FOXO3A'
 
 
 def test_gef():
@@ -504,3 +504,14 @@ def _stmt_to_text(st):
     s = e.make_model()
     print(s)
     return s
+
+
+def test_sentence_builder():
+    sb = ea.SentenceBuilder()
+    ac = ea.AgentWithCoordinates('BRAF', 'BRAF', {})
+    sb.append(ac)
+    assert len(sb.agents) == 1
+    assert sb.sentence == 'BRAF'
+    sb.prepend('phosphorylated ')
+    assert sb.sentence == 'phosphorylated BRAF'
+    assert sb.agents[0].coords == (15, 19), sb.agents[0].coords

--- a/indra/tests/test_english_assembler.py
+++ b/indra/tests/test_english_assembler.py
@@ -2,94 +2,110 @@ import indra.assemblers.english.assembler as ea
 from indra.statements import *
 
 
+def _sustring_by_coords(text, coords):
+    return text[coords[0]:coords[1]]
+
+
 def test_agent_basic():
-    s = ea._assemble_agent_str(Agent('EGFR'))
-    print(s)
-    assert (s == 'EGFR')
+    ag = ea._assemble_agent_str(Agent('EGFR'))
+    assert isinstance(ag, ea.AgentWithCoordinates)
+    print(ag.agent_str)
+    assert ag.agent_str == 'EGFR'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_mod():
     mc = ModCondition('phosphorylation')
     a = Agent('EGFR', mods=mc)
-    s = ea._assemble_agent_str(a)
-    print(s)
-    assert (s == 'phosphorylated EGFR')
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'phosphorylated EGFR'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_mod2():
     mc = ModCondition('phosphorylation', 'tyrosine')
     a = Agent('EGFR', mods=mc)
-    s = ea._assemble_agent_str(a)
-    print(s)
-    assert (s == 'tyrosine-phosphorylated EGFR')
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'tyrosine-phosphorylated EGFR'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_mod3():
     mc = ModCondition('phosphorylation', 'tyrosine', '1111')
     a = Agent('EGFR', mods=mc)
-    s = ea._assemble_agent_str(a)
-    print(s)
-    assert (s == 'EGFR phosphorylated on Y1111')
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'EGFR phosphorylated on Y1111'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_mods():
     mc1 = ModCondition('phosphorylation', 'tyrosine', '1111')
     mc2 = ModCondition('phosphorylation', 'tyrosine', '1234')
     a = Agent('EGFR', mods=[mc1, mc2])
-    s = ea._assemble_agent_str(a)
-    print(s)
-    assert (s == 'EGFR phosphorylated on Y1111 and Y1234')
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'EGFR phosphorylated on Y1111 and Y1234'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_mods2():
     mc1 = ModCondition('phosphorylation', 'tyrosine', '1111')
     mc2 = ModCondition('phosphorylation', 'tyrosine')
     a = Agent('EGFR', mods=[mc1, mc2])
-    s = ea._assemble_agent_str(a)
-    print(s)
-    assert (s == 'EGFR phosphorylated on Y1111 and tyrosine')
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'EGFR phosphorylated on Y1111 and tyrosine'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_mods3():
     mc1 = ModCondition('phosphorylation', 'tyrosine', '1111')
     mc2 = ModCondition('phosphorylation')
     a = Agent('EGFR', mods=[mc1, mc2])
-    s = ea._assemble_agent_str(a)
-    print(s)
-    assert (s == 'EGFR phosphorylated on Y1111 and an unknown residue')
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'EGFR phosphorylated on Y1111 and an unknown residue'
+    assert ag.agent_str[ag.coords[0]:ag.coords[1]] == 'EGFR'
 
 
 def test_agent_mods_pos_only():
     mc1 = ModCondition('phosphorylation', None, '1111')
     a = Agent('EGFR', mods=[mc1])
-    s = ea._assemble_agent_str(a)
-    print(s)
-    assert (s == 'EGFR phosphorylated on amino acid 1111')
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'EGFR phosphorylated on amino acid 1111'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_bound():
     bc = BoundCondition(Agent('EGF'), True)
     a = Agent('EGFR', bound_conditions=[bc])
-    s = ea._assemble_agent_str(a)
-    print(s)
-    assert (s == 'EGFR bound to EGF')
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'EGFR bound to EGF'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_not_bound():
     bc = BoundCondition(Agent('EGF'), False)
     a = Agent('EGFR', bound_conditions=[bc])
-    s = ea._assemble_agent_str(a)
-    print(s)
-    assert (s == 'EGFR not bound to EGF')
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'EGFR not bound to EGF'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_bound_two():
     bc = BoundCondition(Agent('EGF'), True)
     bc2 = BoundCondition(Agent('EGFR'), True)
     a = Agent('EGFR', bound_conditions=[bc, bc2])
-    s = ea._assemble_agent_str(a)
-    print(s)
-    assert (s == 'EGFR bound to EGF and EGFR')
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'EGFR bound to EGF and EGFR'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_bound_three():
@@ -97,51 +113,58 @@ def test_agent_bound_three():
     bc2 = BoundCondition(Agent('EGFR'), True)
     bc3 = BoundCondition(Agent('GRB2'), True)
     a = Agent('EGFR', bound_conditions=[bc, bc2, bc3])
-    s = ea._assemble_agent_str(a)
-    print(s)
-    assert (s == 'EGFR bound to EGF, EGFR, and GRB2')
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'EGFR bound to EGF, EGFR, and GRB2'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_agent_bound_mixed():
     bc = BoundCondition(Agent('EGF'), True)
     bc2 = BoundCondition(Agent('EGFR'), False)
     a = Agent('EGFR', bound_conditions=[bc, bc2])
-    s = ea._assemble_agent_str(a)
-    print(s)
-    assert (s == 'EGFR bound to EGF and not bound to EGFR')
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'EGFR bound to EGF and not bound to EGFR'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'EGFR'
 
 
 def test_phos_noenz():
     a = Agent('MAP2K1')
     st = Phosphorylation(None, a)
-    s = ea._assemble_modification(st)
-    print(s)
-    assert s == 'MAP2K1 is phosphorylated.'
+    sb = ea._assemble_modification(st)
+    print(sb.sentence)
+    assert sb.sentence == 'MAP2K1 is phosphorylated.'
+    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
 
 
 def test_phos_noenz2():
     a = Agent('MAP2K1')
     st = Phosphorylation(None, a, 'serine')
-    s = ea._assemble_modification(st)
-    print(s)
-    assert s == 'MAP2K1 is phosphorylated on serine.'
+    sb = ea._assemble_modification(st)
+    print(sb.sentence)
+    assert sb.sentence == 'MAP2K1 is phosphorylated on serine.'
+    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
 
 
 def test_phos_noenz3():
     a = Agent('MAP2K1')
     st = Phosphorylation(None, a, 'serine', '222')
-    s = ea._assemble_modification(st)
-    print(s)
-    assert s == 'MAP2K1 is phosphorylated on S222.'
+    sb = ea._assemble_modification(st)
+    print(sb.sentence)
+    assert sb.sentence == 'MAP2K1 is phosphorylated on S222.'
+    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
 
 
 def test_phos_enz():
     a = Agent('MAP2K1')
     b = Agent('BRAF')
     st = Phosphorylation(b, a, 'serine', '222')
-    s = ea._assemble_modification(st)
-    print(s)
-    assert s == 'BRAF phosphorylates MAP2K1 on S222.'
+    sb = ea._assemble_modification(st)
+    print(sb.sentence)
+    assert sb.sentence == 'BRAF phosphorylates MAP2K1 on S222.'
+    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'BRAF'
+    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'MAP2K1'
 
 
 def test_phos_indirect():
@@ -149,57 +172,70 @@ def test_phos_indirect():
     b = Agent('BRAF')
     ev = Evidence(epistemics={'direct': False})
     st = Phosphorylation(b, a, 'serine', '222', evidence=[ev])
-    s = ea._assemble_modification(st)
-    print(s)
-    assert s == 'BRAF leads to the phosphorylation of MAP2K1 on S222.'
+    sb = ea._assemble_modification(st)
+    print(sb.sentence)
+    assert sb.sentence == 'BRAF leads to the phosphorylation of MAP2K1 on S222.'
+    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'BRAF'
+    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'MAP2K1'
 
 
 def test_phos_enz2():
     a = Agent('MAP2K1')
     b = Agent('PP2A')
     st = Dephosphorylation(b, a, 'serine', '222')
-    s = ea._assemble_modification(st)
-    print(s)
-    assert s == 'PP2A dephosphorylates MAP2K1 on S222.'
+    sb = ea._assemble_modification(st)
+    print(sb.sentence)
+    assert sb.sentence == 'PP2A dephosphorylates MAP2K1 on S222.'
+    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'PP2A'
+    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'MAP2K1'
 
 
 def test_dephos_no_residue():
     a = Agent('MAP2K1')
     b = Agent('PP2A')
     st = Dephosphorylation(b, a, None, '222')
-    s = ea._assemble_modification(st)
-    print(s)
-    assert s == 'PP2A dephosphorylates MAP2K1 at position 222.'
+    sb = ea._assemble_modification(st)
+    print(sb.sentence)
+    assert sb.sentence == 'PP2A dephosphorylates MAP2K1 at position 222.'
+    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'PP2A'
+    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'MAP2K1'
 
 
 def test_ubiq_stmt():
     st = Ubiquitination(Agent('X'), Agent('Y'))
-    s = ea._assemble_modification(st)
-    print(s)
-    assert s == 'X ubiquitinates Y.'
+    sb = ea._assemble_modification(st)
+    print(sb.sentence)
+    assert sb.sentence == 'X ubiquitinates Y.'
+    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'X'
+    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'Y'
 
 
 def test_deubiq_stmt():
     st = Deubiquitination(Agent('X'), Agent('Y'))
-    s = ea._assemble_modification(st)
-    print(s)
-    assert s == 'X deubiquitinates Y.'
+    sb = ea._assemble_modification(st)
+    print(sb.sentence)
+    assert sb.sentence == 'X deubiquitinates Y.'
+    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'X'
+    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'Y'
 
 
 def test_deubiq_noenz():
     st = Deubiquitination(None, Agent('Y'))
-    s = ea._assemble_modification(st)
-    print(s)
-    assert s == 'Y is deubiquitinated.'
+    sb = ea._assemble_modification(st)
+    print(sb.sentence)
+    assert sb.sentence == 'Y is deubiquitinated.'
+    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'Y'
 
 
 def test_complex_one():
     a = Agent('MAP2K1')
     b = Agent('BRAF')
     st = Complex([a, b])
-    s = ea._assemble_complex(st)
-    print(s)
-    assert s == 'MAP2K1 binds BRAF.'
+    sb = ea._assemble_complex(st)
+    print(sb.sentence)
+    assert sb.sentence == 'MAP2K1 binds BRAF.'
+    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
+    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'BRAF'
 
 
 def test_complex_more():
@@ -207,9 +243,12 @@ def test_complex_more():
     b = Agent('BRAF')
     c = Agent('RAF1')
     st = Complex([a, b, c])
-    s = ea._assemble_complex(st)
-    print(s)
-    assert s == 'MAP2K1 binds BRAF and RAF1.'
+    sb = ea._assemble_complex(st)
+    print(sb.sentence)
+    assert sb.sentence == 'MAP2K1 binds BRAF and RAF1.'
+    assert _sustring_by_coords(sb.sentence, sb.agents[0].coords) == 'MAP2K1'
+    assert _sustring_by_coords(sb.sentence, sb.agents[1].coords) == 'BRAF'
+    assert _sustring_by_coords(sb.sentence, sb.agents[2].coords) == 'RAF1'
 
 
 def test_assemble_one():
@@ -233,6 +272,11 @@ def test_assemble_more():
     print(s)
     assert s == \
         'PP2A dephosphorylates MAP2K1 on S222. MAP2K1 binds BRAF and RAF1.'
+    assert _sustring_by_coords(s, e.stmt_agents[0][0].coords) == 'PP2A'
+    assert _sustring_by_coords(s, e.stmt_agents[0][1].coords) == 'MAP2K1'
+    assert _sustring_by_coords(s, e.stmt_agents[1][0].coords) == 'MAP2K1'
+    assert _sustring_by_coords(s, e.stmt_agents[1][1].coords) == 'BRAF'
+    assert _sustring_by_coords(s, e.stmt_agents[1][2].coords) == 'RAF1'
 
 
 def test_autophos():
@@ -271,27 +315,35 @@ def test_regulateamount():
 
 def test_agent_loc():
     a = Agent('BRAF', location='cytoplasm')
-    print(ea._assemble_agent_str(a))
-    assert ea._assemble_agent_str(a) == 'BRAF in the cytoplasm'
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'BRAF in the cytoplasm'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'BRAF'
 
 
 def test_agent_mut():
     a = Agent('BRAF', mutations=[MutCondition('600','V', 'E')])
-    print(ea._assemble_agent_str(a))
-    assert ea._assemble_agent_str(a) == 'BRAF-V600E'
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'BRAF-V600E'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'BRAF'
 
 
 def test_agent_mut_plus():
     a = Agent('BRAF', mutations=[MutCondition('600','V', 'E')],
               location='nucleus')
-    print(ea._assemble_agent_str(a))
-    assert ea._assemble_agent_str(a) == 'BRAF-V600E in the nucleus'
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'BRAF-V600E in the nucleus'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'BRAF'
 
 
 def test_agent_activity():
     a = Agent('BRAF', activity=ActivityCondition('activity', True))
-    print(ea._assemble_agent_str(a))
-    assert ea._assemble_agent_str(a) == 'active BRAF'
+    ag = ea._assemble_agent_str(a)
+    print(ag.agent_str)
+    assert ag.agent_str == 'active BRAF'
+    assert _sustring_by_coords(ag.agent_str, ag.coords) == 'BRAF'
 
 
 def test_agent_activity_stmt():
@@ -303,6 +355,8 @@ def test_agent_activity_stmt():
     s = e.make_model()
     print(s)
     assert s == 'Active BRAF activates MAP2K1.'
+    assert _sustring_by_coords(s, e.stmt_agents[0][0].coords) == 'BRAF'
+    assert _sustring_by_coords(s, e.stmt_agents[0][1].coords) == 'MAP2K1'
 
 
 def test_translocation():
@@ -314,18 +368,22 @@ def test_translocation():
     e.add_statements([st1])
     s = e.make_model()
     assert s == 'FOXO3A translocates.'
+    assert _sustring_by_coords(s, e.stmt_agents[0][0].coords) == 'FOXO3A'
     e = ea.EnglishAssembler()
     e.add_statements([st2])
     s = e.make_model()
     assert s == 'FOXO3A translocates from the cytoplasm.'
+    assert _sustring_by_coords(s, e.stmt_agents[0][0].coords) == 'FOXO3A'
     e = ea.EnglishAssembler()
     e.add_statements([st3])
     s = e.make_model()
     assert s == 'FOXO3A translocates to the nucleus.'
+    assert _sustring_by_coords(s, e.stmt_agents[0][0].coords) == 'FOXO3A'
     e = ea.EnglishAssembler()
     e.add_statements([st4])
     s = e.make_model()
     assert s == 'FOXO3A translocates from the cytoplasm to the nucleus.'
+    assert _sustring_by_coords(s, e.stmt_agents[0][0].coords) == 'FOXO3A'
 
 
 def test_gef():

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -1,7 +1,8 @@
 import re
 from indra.statements import *
+from indra.assemblers.english import AgentWithCoordinates
 from indra.assemblers.html.assembler import HtmlAssembler, tag_text, loader, \
-    _format_evidence_text
+    _format_evidence_text, tag_agents
 
 
 def make_stmt():
@@ -16,6 +17,17 @@ def make_stmt():
     return st
 
 
+def make_bad_stmt():
+    subj = None  # None agent
+    # Agent without name and several matches in db_refs
+    ras = Agent('', db_refs={'FPLX': {'RAS', 'Ras'}, 'TEXT': 'RAS'})
+    ev = Evidence(text="Ras is phosphorylated",
+                  source_api='test', pmid='1234',
+                  annotations={'agents': {'raw_text': [None, None]}})  # no raw
+    st = Phosphorylation(subj, ras, 'tyrosine', '32', evidence=[ev])
+    return st
+
+
 def test_format_evidence_text():
     stmt = make_stmt()
     ev_list = _format_evidence_text(stmt)
@@ -23,7 +35,8 @@ def test_format_evidence_text():
     ev = ev_list[0]
     assert isinstance(ev, dict)
     assert set(ev.keys()) == {'source_api', 'text_refs', 'text', 'source_hash',
-                              'pmid', 'num_curations'}
+                              'pmid', 'num_curations', 'num_correct',
+                              'num_incorrect'}
     assert ev['source_api'] == 'test'
     assert ev['text_refs']['PMID'] == '1234567'
     assert ev['text'] == ('We noticed that the '
@@ -42,6 +55,40 @@ def test_assembler():
     # content matches
     template, _, _ = loader.get_source(None, 'indra/template.html')
     assert result.startswith(template[0:100])
+    # Make sure assembler works with other parameters provided
+    stmt2 = make_bad_stmt()
+    ha = HtmlAssembler(
+        source_counts={stmt.get_hash(): {'test': 1},
+                       stmt2.get_hash(): {'test': 1}},
+        ev_totals={stmt.get_hash(): 1, stmt2.get_hash(): 1},
+        db_rest_url='test.db.url')
+    ha.add_statements([stmt, stmt2])
+    result = ha.make_model(with_grouping=True)
+    assert isinstance(result, str)
+    result = ha.make_model(with_grouping=False)
+    assert isinstance(result, str)
+    # Make sure warning can be appended
+    ha.append_warning('warning')
+    assert ('\t<span style="color:red;">(CAUTION: warning occurred when '
+            'creating this page.)</span>' in ha.model)
+    # Make sure model is created before saving
+    ha = HtmlAssembler([stmt])
+    assert not ha.model
+    ha.save_model('tempfile.html')
+    assert ha.model
+
+
+def test_tag_agents():
+    # tag_agents input can be either regular agents or agents with coordinates
+    english = 'SRC phosphorylates RAS on Y32.'
+    src = Agent('SRC', db_refs={'HGNC': '11283'})
+    ras = Agent('RAS', db_refs={'FPLX': 'RAS'})
+    src_with_coords = AgentWithCoordinates(
+        'SRC', 'SRC', db_refs={'HGNC': '11283'}, coords=(0, 3))
+    ras_with_coords = AgentWithCoordinates(
+        'RAS', 'RAS', db_refs={'FPLX': 'RAS'}, coords=(19, 22))
+    assert tag_agents(english, [src, ras]) == tag_agents(
+        english, [src_with_coords, ras_with_coords])
 
 
 def test_tag_text():
@@ -53,7 +100,7 @@ def test_tag_text():
         tag_close = "</%s>" % span
         indices += [(m.start(), m.start() + len(span), span,
                      tag_start, tag_close)
-                     for m in re.finditer(re.escape(span), text)]
+                    for m in re.finditer(re.escape(span), text)]
     tagged_text = tag_text(text, indices)
     print(tagged_text)
     assert tagged_text == '<FooBarBaz>FooBarBaz</FooBarBaz> binds ' \


### PR DESCRIPTION
This PR updates EnglishAssembler and HtmlAssembler code. AgentWithCoordinates and SentenceBuilder classes are added in English assembler to store the (relative) location of agent in text. The result of EnglishAssembler.make_model() is unchanged which ensures that no changes are needed in any downstream applications, but the EnglishAssembler object contains the AgentWithCoordinates objects to keep track of agents' coordinates. HTML assembler is using the new structure of EnglishAssembler to tag the agents in statement text (previous version of matching the agent names with regex is also supported for statements that could not be assembled with EnglishAssembler).