### PR TITLE
Don't count TEXT_NORM namespace as grounded

### DIFF
--- a/indra/databases/__init__.py
+++ b/indra/databases/__init__.py
@@ -93,7 +93,7 @@ def get_identifiers_url(db_name, db_id):
             url = 'http://www.lncrnadb.org/search/?q=%s' % db_id
         else:  # Assmuing HGNC symbol
             url = 'http://www.lncrnadb.org/%s/' % db_id
-    elif db_name == 'TEXT':
+    elif db_name == 'TEXT' or db_name == 'TEXT_NORM':
         return None
     # TODO: we should return the parent UniProt ID here but only once that
     # can be obtained from protmapper in a faster way

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -596,7 +596,7 @@ def filter_by_type(stmts_in, stmt_type, **kwargs):
 
 def _agent_is_grounded(agent, score_threshold):
     grounded = True
-    db_names = list(set(agent.db_refs.keys()) - set(['TEXT']))
+    db_names = list(set(agent.db_refs.keys()) - set(['TEXT', 'TEXT_NORM']))
     # If there are no entries at all other than possibly TEXT
     if not db_names:
         grounded = False


### PR DESCRIPTION
Amends `_agent_is_grounded` in assemble_corpus to exclude 'TEXT_NORM' as a namespace considered as a grounding. Allows for filtering out ungrounded Eidos statements after entity text normalization.