### PR TITLE
One-statement-per-line in live curation corpus

### DIFF
--- a/indra/statements/io.py
+++ b/indra/statements/io.py
@@ -64,13 +64,16 @@ def stmts_from_json(json_in, on_missing_support='handle'):
     return stmts
 
 
-def stmts_from_json_file(fname):
+def stmts_from_json_file(fname, format='json'):
     """Return a list of statements loaded from a JSON file.
 
     Parameters
     ----------
     fname : str
         Path to the JSON file to load statements from.
+    format : Optional[str]
+        One of 'json' to assume regular JSON formatting or
+        'jsonl' assuming each statement is on a new line.
 
     Returns
     -------
@@ -78,10 +81,14 @@ def stmts_from_json_file(fname):
         The list of INDRA Statements loaded from the JSOn file.
     """
     with open(fname, 'r') as fh:
-        return stmts_from_json(json.load(fh))
+        if format == 'json':
+            return stmts_from_json(json.load(fh))
+        else:
+            return stmts_from_json([json.loads(line)
+                                    for line in fh.readlines()])
 
 
-def stmts_to_json_file(stmts, fname, **kwargs):
+def stmts_to_json_file(stmts, fname, format='json', **kwargs):
     """Serialize a list of INDRA Statements into a JSON file.
 
     Parameters
@@ -90,9 +97,18 @@ def stmts_to_json_file(stmts, fname, **kwargs):
         The list of INDRA Statements to serialize into the JSON file.
     fname : str
         Path to the JSON file to serialize Statements into.
+    format : Optional[str]
+        One of 'json' to use regular JSON with indent=1 formatting or
+        'jsonl' to put each statement on a new line without indents.
     """
+    sj = stmts_to_json(stmts, **kwargs)
     with open(fname, 'w') as fh:
-        json.dump(stmts_to_json(stmts, **kwargs), fh, indent=1)
+        if format == json:
+            json.dump(sj, fh, indent=1)
+        else:
+            for json_stmt in sj:
+                json.dump(json_stmt, fh)
+                fh.write('\n')
 
 
 def stmts_to_json(stmts_in, use_sbo=False, matches_fun=None):

--- a/indra/statements/io.py
+++ b/indra/statements/io.py
@@ -103,7 +103,7 @@ def stmts_to_json_file(stmts, fname, format='json', **kwargs):
     """
     sj = stmts_to_json(stmts, **kwargs)
     with open(fname, 'w') as fh:
-        if format == json:
+        if format == 'json':
             json.dump(sj, fh, indent=1)
         else:
             for json_stmt in sj:

--- a/indra/tests/test_statements_serialization.py
+++ b/indra/tests/test_statements_serialization.py
@@ -377,3 +377,10 @@ def test_file_serialization():
     stmts_to_json_file([stmt], 'test_indra_stmts.json')
     stmts = stmts_from_json_file('test_indra_stmts.json')
     assert stmts[0].matches(stmt)
+
+
+def test_file_serialization_json_lines():
+    stmt = IncreaseAmount(Agent('a'), Agent('b'), evidence=[ev])
+    stmts_to_json_file([stmt], 'test_indra_stmts.json', format='jsonl')
+    stmts = stmts_from_json_file('test_indra_stmts.json', format='jsonl')
+    assert stmts[0].matches(stmt)

--- a/indra/tools/live_curation/corpus.py
+++ b/indra/tools/live_curation/corpus.py
@@ -116,7 +116,7 @@ class Corpus(object):
             # Structure and upload assembled statements
             self._s3_put_file(s3,
                               sts,
-                              '\n'.join(json.dumps(jo, indent=1) for jo in
+                              '\n'.join(json.dumps(jo) for jo in
                                         _stmts_dict_to_json(self.statements)),
                               bucket)
 

--- a/indra/tools/live_curation/corpus.py
+++ b/indra/tools/live_curation/corpus.py
@@ -3,6 +3,7 @@ import boto3
 import logging
 from os import environ
 from indra.statements import stmts_to_json, stmts_from_json
+from indra.statements.io import stmts_to_json_file
 from . import file_defaults, InvalidCorpusError, CACHE, default_bucket, \
     default_key_base, default_profile
 from .util import _stmts_dict_to_json, _json_to_stmts_dict, _json_dumper, \
@@ -329,3 +330,17 @@ class Corpus(object):
         if local_file.is_file():
             return _json_loader(local_file.as_posix())
         return None
+
+    def to_json_file(self, fname, w_newlines=False):
+        """Dump the statements to a file in json format
+
+        Parameters
+        ----------
+        fname : str
+            A valid file path
+        w_newlines : bool
+            If True, the statements will be separated by newlines in the
+            file. Default: False.
+        """
+        stmts_to_json_file(stmts=self.statements, fname=fname,
+                           format='jsonl' if w_newlines else 'json')

--- a/indra/tools/live_curation/corpus.py
+++ b/indra/tools/live_curation/corpus.py
@@ -225,7 +225,8 @@ class Corpus(object):
             if cache:
                 json_stmts = self._load_from_cache(sts) or []
             if not json_stmts:
-                raw_str = s3.get_object(Bucket=bucket, Key=sts)['Body'].read()
+                raw_str = s3.get_object(Bucket=bucket, Key=sts)[
+                    'Body'].read().decode()
                 if len(raw_str.split('\n')) > 1:
                     json_stmts = [json.loads(s) for s in raw_str.split('\n')]
                 else:

--- a/indra/tools/live_curation/corpus.py
+++ b/indra/tools/live_curation/corpus.py
@@ -342,5 +342,6 @@ class Corpus(object):
             If True, the statements will be separated by newlines in the
             file. Default: False.
         """
-        stmts_to_json_file(stmts=self.statements, fname=fname,
+        stmts_to_json_file(stmts=[s for _, s in self.statements.items()],
+                           fname=fname,
                            format='jsonl' if w_newlines else 'json')

--- a/indra/tools/live_curation/corpus.py
+++ b/indra/tools/live_curation/corpus.py
@@ -337,9 +337,14 @@ class Corpus(object):
 
         # Load json object
         if local_file.is_file():
-            if local_file.as_posix().endswith(file_defaults['sts'] + '.json'):
-                return stmts_from_json_file(local_file.as_posix(),
-                                            format='jsonl')
+            if local_file.as_posix().endswith(
+                    '/' + file_defaults['sts'] + '.json'):
+                with open(local_file.as_posix(), 'r') as fh:
+                    all_lines = fh.readlines()
+                    if len(all_lines) > 1:
+                        return [json.loads(s) for s in all_lines]
+                    else:
+                        return json.loads(all_lines[0])
             else:
                 return _json_loader(local_file.as_posix())
         return None


### PR DESCRIPTION
This PR implements a JSON output format in which one statement is serialized per line to allow line-based streaming of INDRA statements. This is applied in the Corpus class of the live curation tool for storing assembled statements.