### PR TITLE
Location fixes

### DIFF
--- a/indra/sources/sparser/processor.py
+++ b/indra/sources/sparser/processor.py
@@ -249,7 +249,11 @@ def fix_json_stmt(json_stmt):
                     loc = None
                 else:
                     loc = go_client.get_valid_location(loc)
-                json_stmt[loc_param] = loc
+                    if not loc:
+                        loc = None
+            else:
+                loc = None
+            json_stmt[loc_param] = loc
         # Skip Translocation with both locations None
         if (json_stmt.get('from_location') is None
                 and json_stmt.get('to_location') is None):

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -141,6 +141,13 @@ def map_grounding(stmts_in, **kwargs):
                          use_adeft=kwargs.get('use_adeft', True),
                          gilda_mode=kwargs.get('gilda_mode', None))
     stmts_out = gm.map_stmts(stmts_in, do_rename=do_rename)
+    # Patch wrong locations in Translocation statements
+    for stmt in stmts_out:
+        if isinstance(stmt, Translocation):
+            if not stmt.from_location:
+                stmt.from_location = None
+            if not stmt.to_location:
+                stmt.to_location = None
     dump_pkl = kwargs.get('save')
     if dump_pkl:
         dump_statements(stmts_out, dump_pkl)


### PR DESCRIPTION
This PR fixes wrong from and to locations in Translocation statements produced by sparser (`{}` instead of None) in sparser processor for new statements and in `map_grounding` for existing statements.