### PR TITLE
Filter incorrect evidences

### DIFF
--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -735,10 +735,16 @@ def test_filter_by_curation():
     assert len(all_incorrect_two_cur) == 2
     assert new_st1 not in all_incorrect_two_cur
     # Correct curation cancels out incorrect
+    assert len(new_st1.evidence) == 2
     correct_incorrect = ac.filter_by_curation(
         stmts_in, [cur1, cur2, cur3, cur4], 'all', update_belief=False)
     assert len(correct_incorrect) == 3, len(correct_incorrect)
     assert new_st1 in correct_incorrect
+    # new_st1.evidence[1] should be filtered out because there's only incorrect
+    # curation(cur2), new_st1.evidence[0] stays because correct cancels out
+    # incorrect (cur1, cur3)
+    assert len(new_st1.evidence) == 1
+    assert new_st1.evidence[0].source_api == 'assertion'
     assert all(st.belief != 1 for st in correct_incorrect)
     # Optionally update belief to 1 for correct curation
     new_belief = ac.filter_by_curation(

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -1774,18 +1774,48 @@ def filter_by_curation(stmts_in, curations, incorrect_policy='any',
     # not intersect.
     correct = {c.pa_hash for c in curations if c.tag in correct_tags}
     incorrect = {c.pa_hash for c in curations if c.pa_hash not in correct}
+    # Store evidence level curations for overall correct statements
+    correct_stmt_evid = {}
+    for c in curations:
+        if c.pa_hash in correct:
+            if c.pa_hash not in correct_stmt_evid:
+                correct_stmt_evid[c.pa_hash] = defaultdict(set)
+            if c.tag in correct_tags:
+                correct_stmt_evid[c.pa_hash]['correct'].add(c.source_hash)
+            else:
+                correct_stmt_evid[c.pa_hash]['incorrect'].add(c.source_hash)
     stmts_out = []
     logger.info('Filtering %d statements with %s incorrect curations...' %
                 (len(stmts_in), incorrect_policy))
+
+    def _is_incorrect(stmt_hash, evid_hash):
+        # Evidence is incorrect if it was only curated as incorrect
+        if evid_hash in correct_stmt_evid[stmt_hash]['incorrect'] and \
+                evid_hash not in correct_stmt_evid[stmt_hash]['correct']:
+            return True
+        return False
+
+    def process_and_append(stmt, stmt_list):
+        # Filter out incorrect evidences for correct statements
+        if stmt.get_hash() in correct_stmt_evid:
+            evidence = []
+            for evid in stmt.evidence:
+                if _is_incorrect(stmt.get_hash(), evid.get_source_hash()):
+                    continue
+                else:
+                    evidence.append(evid)
+            stmt.evidence = evidence
+        # Set belief to one for statements with correct curations
+        if update_belief and stmt.get_hash() in correct:
+            stmt.belief = 1
+        stmt_list.append(stmt)
+
     if incorrect_policy == 'any':
         # Filter statements that have SOME incorrect and NO correct curations
         # (i.e. their hashes are in incorrect set)
         for stmt in stmts_in:
             if stmt.get_hash() not in incorrect:
-                stmts_out.append(stmt)
-            # Set belief to one for statements with correct curations
-            if update_belief and stmt.get_hash() in correct:
-                stmt.belief = 1
+                process_and_append(stmt, stmts_out)
     elif incorrect_policy == 'all':
         # Filter out statements in which ALL evidences are curated
         # as incorrect.
@@ -1802,10 +1832,7 @@ def filter_by_curation(stmts_in, curations, incorrect_policy='any',
                     incorrect_stmt_evid[stmt.get_hash()]):
                 continue
             else:
-                stmts_out.append(stmt)
-            # Set belief to one for statements with correct curations
-            if update_belief and stmt.get_hash() in correct:
-                stmt.belief = 1
+                process_and_append(stmt, stmts_out)
     logger.info('%d statements after filter...' % len(stmts_out))
     return stmts_out
 


### PR DESCRIPTION
This PR extends assemble corpus filter_by_curation function. If the statement has both correct and incorrect evidences, it is considered correct overall, but incorrect evidences are removed.