### PR TITLE
Site mapper invalid position check

### DIFF
--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -234,6 +234,13 @@ class SiteMapper(ProtMapper):
         mapped_statements = []
 
         for stmt in stmts:
+            # Check for errors in the position str
+            if isinstance(stmt, (Modification, SelfModification)) and \
+                    stmt.residue is not None and stmt.position is not None \
+                    and str(int(float(stmt.position))) != stmt.position:
+                logger.warning('%s has an invalid value for position: "%s".' %
+                               (str(stmt), stmt.position))
+                continue
             mapped_stmt = self.map_stmt_sites(stmt)
             # If we got a MappedStatement as a return value, we add that to the
             # list of mapped statements, otherwise, the original Statement is

--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -224,6 +224,8 @@ class SiteMapper(ProtMapper):
 
         for stmt in stmts:
             # Check for errors in the position str
+            # TODO: this could also be used on agent conditions, here
+            # it's only applied to statement position arguments
             if isinstance(stmt, (Modification, SelfModification)) and \
                     not _valid_position_str(stmt.position):
                 continue

--- a/indra/tests/test_sitemapper.py
+++ b/indra/tests/test_sitemapper.py
@@ -213,6 +213,18 @@ def test_site_map_within_bound_condition():
     validate_mapk1(mapped_s.obj.bound_conditions[0].agent)
 
 
+def test_invalid_position():
+    stmt = Phosphorylation._from_json({
+        'enz': {'name': 'CFD'},
+        'sub': {'name': 'HP'},
+        'residue': 'F',
+        'position': '2.59'
+    })
+    valid, mapped = sm.map_sites(stmts=[stmt])
+    assert not valid
+    assert not mapped
+
+
 def get_invalid_mapks():
     """A handy function for getting the invalid MAPK agents we want."""
     mapk1_invalid = Agent('MAPK1',

--- a/indra/tests/test_sitemapper.py
+++ b/indra/tests/test_sitemapper.py
@@ -1,9 +1,8 @@
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import dict, str
 from protmapper import MappedSite
 from indra.statements import *
 from indra.util import unicode_strs
 from indra.preassembler.sitemapper import default_mapper as sm, MappedStatement
+from indra.preassembler.sitemapper import _valid_position_str
 
 
 def test_check_agent_mod():
@@ -223,6 +222,15 @@ def test_invalid_position():
     valid, mapped = sm.map_sites(stmts=[stmt])
     assert not valid
     assert not mapped
+
+
+def test_valid_pos_str():
+    assert _valid_position_str('5') is True
+    assert _valid_position_str('005') is False
+    assert _valid_position_str('5.5') is False
+    assert _valid_position_str('xxx') is False
+    assert _valid_position_str(None) is True
+    assert _valid_position_str('') is False
 
 
 def get_invalid_mapks():


### PR DESCRIPTION
This PR adds a filter in the SiteMapper class that checks for invalid values of `position` in `Modification` and `SelfModification` statements.