### PR TITLE
Add bioRxiv (and medRxiv) client

### DIFF
--- a/doc/modules/literature/index.rst
+++ b/doc/modules/literature/index.rst
@@ -16,6 +16,12 @@ Pubmed Central client (:py:mod:`indra.literature.pmc_client`)
 .. automodule:: indra.literature.pmc_client
     :members:
 
+bioRxiv client (:py:mod:`indra.literature.biorxiv_client`)
+----------------------------------------------------------
+
+.. automodule:: indra.literature.biorxiv_client
+    :members:
+
 CrossRef client (:py:mod:`indra.literature.crossref_client`)
 ------------------------------------------------------------
 

--- a/indra/literature/biorxiv_client.py
+++ b/indra/literature/biorxiv_client.py
@@ -1,3 +1,5 @@
+"""A client to obtain metadata and text content from bioRxiv
+(and to some extent medRxiv) preprints."""
 import re
 import logging
 import requests

--- a/indra/literature/biorxiv_client.py
+++ b/indra/literature/biorxiv_client.py
@@ -87,8 +87,8 @@ def get_formats(pub):
         (in case of pdf, xml, txt) as the value.
     """
     formats = {}
-    if 'rel_base' in pub:
-        formats['abstract'] = pub['rel_abstract']
+    if 'rel_abs' in pub:
+        formats['abstract'] = pub['rel_abs']
     # The publication JSON does not contain enough information generally
     # to identify the URL for the various formats. Therefore we have to
     # load the landing page for the article and parse out various URLs
@@ -217,8 +217,30 @@ def get_text_from_rxiv_text(rxiv_text):
 
 
 if __name__ == '__main__':
-    covid19_pubs = get_collection_pubs(covid19_collection_id)
-    abs = get_pub_content(covid19_pubs[0], 'abstract')
-    pdf = get_pub_content(covid19_pubs[0], 'pdf')
-
+    import os
+    import json
+    fname = 'covid19_pubs.json'
+    if os.path.exists(fname):
+        with open(fname, 'r') as fh:
+            covid19_pubs = json.load(fh)
+    else:
+        covid19_pubs = get_collection_pubs(covid19_collection_id)
+        with open(fname, 'w') as fh:
+            json.dump(covid19_pubs, fh)
+    contents = {}
+    for pub in covid19_pubs:
+        doi = pub['rel_doi']
+        formats = get_formats(pub)
+        if 'txt' in formats:
+            print('Getting text for %s' % doi)
+            txt = get_content_from_pub_json(pub, 'txt')
+        elif 'xml' in formats:
+            print('Getting xml for %s' % doi)
+            txt = get_content_from_pub_json(pub, 'xml')
+        else:
+            print('Getting abstract for %s' % doi)
+            txt = get_content_from_pub_json(pub, 'abstract')
+        contents[doi] = txt
+    with open('covid19_contents', 'w') as fh:
+        json.dump(contents, fh)
 

--- a/indra/literature/biorxiv_client.py
+++ b/indra/literature/biorxiv_client.py
@@ -1,4 +1,4 @@
-import json
+import re
 import logging
 import requests
 
@@ -13,15 +13,7 @@ bio_content_url = 'https://www.biorxiv.org/content/'
 med_content_url = 'https://www.medrxiv.org/content/'
 
 
-format_map = {
-    'xml': 'source.xml',
-    'txt': 'full',
-    'pdf': 'full.pdf',
-    'abstract': ''
-}
-
-
-def get_collection_dois(collection_id):
+def get_collection_pubs(collection_id):
     """Get list of DOIs from a biorxiv/medrxiv collection.
 
     Parameters
@@ -36,8 +28,9 @@ def get_collection_dois(collection_id):
     """
     res = requests.get(collection_url + collection_id)
     res.raise_for_status()
-    dois = [pub['rel_doi'] for pub in res.json()['rels']]
-    return dois
+    return res.json()['rels']
+
+#<meta name="citation_pdf_url" content="(.+)full.pdf" />
 
 
 def get_content(doi, bio_or_med='bio', format='xml'):
@@ -47,8 +40,68 @@ def get_content(doi, bio_or_med='bio', format='xml'):
     return res.text
 
 
+def get_pdf_xml_url_base(content):
+    import ipdb; ipdb.set_trace()
+    match = re.match('(?:.*)"citation_pdf_url" content="([^"]+).full.pdf"',
+                     content, re.S)
+    if match:
+        return match.groups()[0]
+    return None
+
+
+def get_text_url_base(content):
+    match = re.match('(?:.*)"citation_html_url" content="([^"]+).full"',
+                     content, re.S)
+    if match:
+        return match.groups()[0]
+    return None
+
+
+def get_pub_content(pub, format):
+    # If we're looking for an abstract, that is directly accessible
+    # in the pub JSON so we can just return it
+    if format == 'abstract':
+        return pub.get('rel_abs')
+
+    # The publication JSON does not contain enough information generally
+    # to identify the URL for the various formats. Therefore we have to
+    # load the landing page for the article and parse out various URLs
+    # to reliably get to the desired content.
+    landing_page_res = requests.get(pub['rel_link'])
+
+    # The URL for the full PDF and XML is often different in format than
+    # the rel_site URL so we need to get the link to it from the content
+    # of the landing page. The XML URL doesn't explicitly appear in the
+    # page content therefore we work with the citation_pdf_url and get
+    # URLs for both the PDF and the XML.
+    pdf_xml_url_base = get_pdf_xml_url_base(landing_page_res.text)
+    text_url_base = get_text_url_base(landing_page_res.text)
+    # For PDFs we return the result in bytes that can then be dumped
+    # into a file.
+    if format == 'pdf':
+        if not pdf_xml_url_base:
+            logger.warning('Could not get PDF URL for this content.')
+            return None
+        url = pdf_xml_url_base + '.full.pdf'
+        return requests.get(url).content
+    # For xml and text, we return the result as str
+    elif format == 'xml':
+        if not pdf_xml_url_base:
+            logger.warning('Could not get XML URL for this content.')
+            return None
+        url = pdf_xml_url_base + 'source.xml'
+        return requests.get(url).text
+    elif format == 'txt':
+        url = text_url_base + 'txt'
+        return requests.get(url).text
+    else:
+        logger.warning('Unknown format: %s' % format)
+        return None
+
+
 if __name__ == '__main__':
-    covid19_dois = get_collection_dois(covid19_collection_id)
-    get_content(covid19_dois[0])
+    covid19_pubs = get_collection_pubs(covid19_collection_id)
+    abs = get_pub_content(covid19_pubs[0], 'abstract')
+    pdf = get_pub_content(covid19_pubs[0], 'pdf')
 
 

--- a/indra/literature/biorxiv_client.py
+++ b/indra/literature/biorxiv_client.py
@@ -1,0 +1,37 @@
+import json
+import logging
+import requests
+
+
+logger = logging.getLogger('biorxiv_client')
+
+
+covid_json_url = 'https://connect.biorxiv.org/relate/' \
+                  'collection_json.php?grp=181'
+
+
+def get_covid_dois():
+    """Get current list of Covid-19 relevant DOIs from biorxiv and medrxiv.
+
+    Browser link at https://connect.biorxiv.org/relate/content/181
+    """
+    res = requests.get(covid_json_url)
+    if res.status_code != 200:
+        logger.error('Error querying biorxiv Covid-19 collection: '
+                     f'status code {res.status_code}')
+        return None
+    res_json = res.json()
+    dois = []
+    for pub in res_json['rels']:
+        dois.append(pub['rel_doi'])
+    return dois
+
+
+def get_pdf_from_doi(doi):
+    pdf_url = 'https://www.biorxiv.org/content/{doi}.full.pdf'
+    res = request.get(pdf_url)
+
+
+if __name__ == '__main__':
+    res = get_covid_dois()
+


### PR DESCRIPTION
This PR adds a simple client for bioRxiv that can:
- get publication metadata for a given collection of preprints
- get a list of DOIs for a given collection of preprints
- retrieve a set of formats and direct URLs available for a given preprint (PDF, XML, full text, etc.)
- extract clean text from the full text XML and the markdown-like full text formats