### PR TITLE
Bfs update

### DIFF
--- a/indra/explanation/pathfinding/pathfinding.py
+++ b/indra/explanation/pathfinding/pathfinding.py
@@ -1,5 +1,6 @@
 __all__ = ['shortest_simple_paths', 'bfs_search', 'find_sources',
            'get_path_iter']
+import sys
 import logging
 from collections import deque
 from copy import deepcopy
@@ -165,7 +166,7 @@ def shortest_simple_paths(G, source, target, weight=None, ignore_nodes=None,
 def bfs_search(g, source_node, g_nodes=None, g_edges=None, reverse=False,
                depth_limit=2, path_limit=None, max_per_node=5,
                node_filter=None, node_blacklist=None, terminal_ns=None,
-               sign=None, **kwargs):
+               sign=None, max_memory=1073741824, **kwargs):
     """Do breadth first search from a given node and yield paths
 
     Parameters
@@ -203,7 +204,10 @@ def bfs_search(g, source_node, g_nodes=None, g_edges=None, reverse=False,
         are encountered and only yield paths that terminate at these
         namepsaces
     sign : int
-        If set, defines the search to be a signed search. Default: None.
+        If set, defines the search to be a signed search. Default: None.\
+    max_memory : int
+        The maximum memory usage in bytes allowed for the variables queue
+        and visited. Default: 1073741824 bytes (== 1 GiB).
 
     Yields
     ------
@@ -335,6 +339,10 @@ def bfs_search(g, source_node, g_nodes=None, g_edges=None, reverse=False,
 
             # Append yielded path
             queue.append(new_path)
+
+            # Check for memory
+            if sys.getsizeof(queue) + sys.getsizeof(visited) > max_memory:
+                raise StopIteration('Reached maxmimum allowed memory usage')
 
             # Check if we've visited enough neighbors
             # Todo: add all neighbors to 'visited' and add all skipped

--- a/indra/explanation/pathfinding/pathfinding.py
+++ b/indra/explanation/pathfinding/pathfinding.py
@@ -166,7 +166,7 @@ def shortest_simple_paths(G, source, target, weight=None, ignore_nodes=None,
 def bfs_search(g, source_node, g_nodes=None, g_edges=None, reverse=False,
                depth_limit=2, path_limit=None, max_per_node=5,
                node_filter=None, node_blacklist=None, terminal_ns=None,
-               sign=None, max_memory=1073741824, **kwargs):
+               sign=None, max_memory=int(2**29), **kwargs):
     """Do breadth first search from a given node and yield paths
 
     Parameters
@@ -342,6 +342,8 @@ def bfs_search(g, source_node, g_nodes=None, g_edges=None, reverse=False,
 
             # Check for memory
             if sys.getsizeof(queue) + sys.getsizeof(visited) > max_memory:
+                logger.warning('Memory overflow reached: %d' %
+                               (sys.getsizeof(queue) + sys.getsizeof(visited)))
                 raise StopIteration('Reached maxmimum allowed memory usage')
 
             # Check if we've visited enough neighbors

--- a/indra/tests/test_pathfinding.py
+++ b/indra/tests/test_pathfinding.py
@@ -133,19 +133,17 @@ def test_bfs():
 
     # Test terminal NS
     # Terminate on 'b'
-    expected_paths = {('D1', 'C1'), ('D1', 'C1', 'B1'), ('D1', 'C1', 'B2'),
+    expected_paths = {('D1', 'C1', 'B1'), ('D1', 'C1', 'B2'),
                       ('D1', 'C1', 'B3')}
     paths = [p for p in bfs_search(dg, 'D1', depth_limit=5,
                                    reverse=True, terminal_ns=['b'],
                                    node_filter=all_ns)]
-    assert len(paths) == 4, len(paths)
+    assert len(paths) == len(expected_paths), len(paths)
     assert set(paths) == expected_paths, 'sets of paths not equal'
 
     # Terminate on 'a'
-    expected_paths = {('D1', 'C1'), ('D1', 'C1', 'B1'), ('D1', 'C1', 'B2'),
-                      ('D1', 'C1', 'B3'), ('D1', 'C1', 'B1', 'A1'),
-                      ('D1', 'C1', 'B1', 'A2'), ('D1', 'C1', 'B2', 'A3'),
-                      ('D1', 'C1', 'B2', 'A4')}
+    expected_paths = {('D1', 'C1', 'B1', 'A1'), ('D1', 'C1', 'B1', 'A2'),
+                      ('D1', 'C1', 'B2', 'A3'), ('D1', 'C1', 'B2', 'A4')}
     paths = [p for p in bfs_search(dg, 'D1', depth_limit=5,
                                    reverse=True, terminal_ns=['a'],
                                    node_filter=all_ns)]

--- a/indra/tests/test_pathfinding.py
+++ b/indra/tests/test_pathfinding.py
@@ -150,6 +150,16 @@ def test_bfs():
     assert len(paths) == len(expected_paths), len(paths)
     assert set(paths) == expected_paths, 'sets of paths not equal'
 
+    # Test memory limit; a very low number should yield one path
+    error = False
+    gen = bfs_search(dg, 'D1', depth_limit=5, reverse=True, max_memory=16)
+    _ = next(gen)
+    try:
+        _ = next(gen)
+    except (RuntimeError, StopIteration):
+        error = True
+    assert error
+
 
 def test_signed_bfs():
     dg, _ = _setup_unsigned_graph()


### PR DESCRIPTION
This PR changes the default behavior of `bfs_search()` when the `terminal_ns` argument is provided. Now, the generator _only_ yield paths that terminate on nodes from the provided namespaces. 

Previously any path would be yielded.

Another change in the PR is to add a memory limit for the sum of the memory allocated for two variables in the function as a safeguard.

Tests have been updated and added.