### PR TITLE
Propagate statement information to BEL signed edge graph

### DIFF
--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -387,7 +387,8 @@ def belgraph_to_signed_graph(
             tuple((k, v)
                   for k, v in edge_data.get('annotations', {}).items()) \
             if propagate_annotations else (u, v, ('sign', 0))
-        rev_pos_edge = (pos_edge[1], pos_edge[0], pos_edge[2:])
+        # Unpack tuple pairs at indices >1 or they'll be in nested tuples
+        rev_pos_edge = (pos_edge[1], pos_edge[0], *pos_edge[2:])
         if rel in pc.CAUSAL_INCREASE_RELATIONS:
             edge_set.add(pos_edge)
         elif rel in pc.HAS_VARIANT and include_variants:
@@ -399,7 +400,9 @@ def belgraph_to_signed_graph(
             if symmetric_component_links:
                 edge_set.add(rev_pos_edge)
         elif rel in pc.CAUSAL_DECREASE_RELATIONS:
-            edge_set.add((pos_edge[0], pos_edge[1], ('sign', 1), pos_edge[3:]))
+            # Unpack tuples
+            edge_set.add((pos_edge[0], pos_edge[1],
+                          ('sign', 1), *pos_edge[3:]))
         else:
             continue
 

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -436,7 +436,8 @@ def _update_edge_data_from_evidence(evidence, edge_data):
 def _get_annotations_from_stmt(stmt):
     return {
         'stmt_hash': stmt.get_hash(refresh=True),
-        'uuid': stmt.uuid
+        'uuid': stmt.uuid,
+        'belief': stmt.belief
     }
 
 

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -153,6 +153,7 @@ def test_activation():
         pc.ANNOTATIONS: {
             'stmt_hash': hash1,
             'uuid': stmt1.uuid,
+            'belief': stmt1.belief,
         },
     }
     edge2 = {
@@ -162,6 +163,7 @@ def test_activation():
         pc.ANNOTATIONS: {
             'stmt_hash': hash2,
             'uuid': stmt2.uuid,
+            'belief': stmt2.belief,
         },
     }
     for stmt, edge in ((stmt1, edge1), (stmt2, edge2)):
@@ -200,6 +202,7 @@ def test_direct_activation():
             'stmt_hash': hash1,
             'source_hash': stmt1_ev.get_source_hash(),
             'uuid': stmt1.uuid,
+            'belief': stmt1.belief,
         },
     }
     edge2 = {
@@ -215,6 +218,7 @@ def test_direct_activation():
             'stmt_hash': hash2,
             'source_hash': stmt1_ev.get_source_hash(),
             'uuid': stmt2.uuid,
+            'belief': stmt2.belief,
         },
     }
     for stmt, expected_edge in ((stmt1, edge1), (stmt2, edge2)):
@@ -241,6 +245,7 @@ def test_inhibition():
         pc.ANNOTATIONS: {
             'stmt_hash': stmt_hash,
             'uuid': stmt.uuid,
+            'belief': stmt.belief,
         },
     }
     pba = pa.PybelAssembler([stmt])
@@ -311,6 +316,7 @@ def test_gef():
         pc.ANNOTATIONS: {
             'stmt_hash': stmt_hash,
             'uuid': stmt.uuid,
+            'belief': stmt.belief,
         },
     }
     assert edge_data == edge, edge_data
@@ -343,6 +349,7 @@ def test_gap():
         pc.ANNOTATIONS: {
             'stmt_hash': stmt_hash,
             'uuid': stmt.uuid,
+            'belief': stmt.belief,
         },
     }
     assert edge_data == edge, edge_data
@@ -445,7 +452,8 @@ def test_autophosphorylation():
                                              egfr_phos_node).values())
     assert {pc.RELATION: pc.DIRECTLY_INCREASES,
             pc.ANNOTATIONS: {'stmt_hash': stmt_hash,
-                             'uuid': stmt.uuid}} \
+                             'uuid': stmt.uuid,
+                             'belief': stmt.belief}} \
         in edge_dicts
 
     # Test an autophosphorylation with a bound condition
@@ -490,6 +498,7 @@ def test_bound_condition():
              pc.ANNOTATIONS: {
                  'stmt_hash': stmt_hash,
                  'uuid': stmt.uuid,
+                 'belief': stmt.belief,
              },
         },
     )
@@ -516,6 +525,7 @@ def test_transphosphorylation():
         pc.ANNOTATIONS: {
             'stmt_hash': stmt_hash,
             'uuid': stmt.uuid,
+            'belief': stmt.belief,
         },
     }, edge_data
 


### PR DESCRIPTION
This PR allows annotations in a belgraph to be propagated to the corresponding signed edge graph. Statement belief was also added as one of the annotation to add from statements.

A test is also added to `test_pybel_assembler.py`.