### PR TITLE
Add Full Text search links for PMC in HTML Assembler

### DIFF
--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -325,7 +325,7 @@ class HtmlAssembler(object):
         add_full_text_search_link : bool
             If True, link with Text fragment search in PMC journal will be added
             for the statements
-
+            
         All other keyword arguments are passed along to the template. If you
         are using a custom template with args that are not passed below, this
         is how you pass them.
@@ -343,13 +343,15 @@ class HtmlAssembler(object):
                 for stmt_formatted in statement["stmts_formatted"]:
                     for stmt_info in stmt_formatted["stmt_info_list"]:
                         for evidence in stmt_info["evidence"]:
-                            if not set(['PMCID', 'pmcid']) \
-                                    .issubset(evidence["text_refs"].keys()):
+                            if 'PMCID' not in evidence.get('text_refs', {}):
                                 ev_pmcid = id_lookup(
                                     evidence['pmid'], 'pmid') \
                                     .get('pmcid', None)
                                 if ev_pmcid:
                                     evidence['pmcid'] = ev_pmcid
+                            else:
+                                evidence['pmcid'] = \
+                                    evidence['text_refs']['PMCID']
 
         metadata = {k.replace('_', ' ').title(): v
                     for k, v in self.metadata.items()

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -323,9 +323,9 @@ class HtmlAssembler(object):
             False, all headings will be collapsed into one on every level, with
             all statements placed under a single heading.
         add_full_text_search_link : bool
-            If True, link with Text fragment search in PMC journal will be added
-            for the statements
-            
+            If True, link with Text fragment search in PMC journal will be
+            added for the statements.
+
         All other keyword arguments are passed along to the template. If you
         are using a custom template with args that are not passed below, this
         is how you pass them.

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -344,11 +344,12 @@ class HtmlAssembler(object):
                     for stmt_info in stmt_formatted["stmt_info_list"]:
                         for evidence in stmt_info["evidence"]:
                             if 'PMCID' not in evidence.get('text_refs', {}):
-                                ev_pmcid = id_lookup(
-                                    evidence['pmid'], 'pmid') \
-                                    .get('pmcid', None)
-                                if ev_pmcid:
-                                    evidence['pmcid'] = ev_pmcid
+                                if evidence.get('pmid'):
+                                    ev_pmcid = id_lookup(
+                                        evidence['pmid'], 'pmid') \
+                                        .get('pmcid', None)
+                                    if ev_pmcid:
+                                        evidence['pmcid'] = ev_pmcid
                             else:
                                 evidence['pmcid'] = \
                                     evidence['text_refs']['PMCID']
@@ -477,9 +478,10 @@ def _format_evidence_text(stmt, curation_dict=None, correct_tags=None):
         num_correct = len(
             [cur for cur in curations if cur['error_type'] in correct_tags])
         num_incorrect = num_curations - num_correct
+        text_refs = {k.upper(): v for k, v in ev.text_refs.items()}
         ev_list.append({'source_api': source_api,
                         'pmid': ev.pmid,
-                        'text_refs': ev.text_refs,
+                        'text_refs': text_refs,
                         'text': format_text,
                         'source_hash': str(ev.source_hash),
                         'num_curations': num_curations,

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -415,25 +415,13 @@
                                href='https://www.ncbi.nlm.nih.gov/pubmed/{{ ev["pmid"] }}'
                                target="_blank">
                               {{ ev['pmid'] }}</a>
-                          {% elif 'pmid' in ev['text_refs'] and ev['text_refs']['pmid'] %}
+                          {% elif 'PMID' in ev['text_refs'] and ev['text_refs']['PMID'] %}
                             <a class="pmid_link"
                                title="Hover again to see info"
                                onmouseover="setPMIDlinkTitle(this.textContent, this); this.onmouseover=null;"
                                href='https://www.ncbi.nlm.nih.gov/pubmed/{{ ev["text_refs"]["pmid"] }}'
                                target="_blank">
-                              {{ ev['text_refs']['pmid'] }}</a>
-                          {% endif %}
-
-                          {% if 'pmcid' in ev['text_refs'] and ev['text_refs']['pmcid'] %}
-                            | <a class="pmcid_link"
-                               href='https://www.ncbi.nlm.nih.gov/pmc/articles/{{ ev["text_refs"]["pmcid"] }}'
-                               target="_blank">PMC</a>
-                          {% endif %}
-
-                          {% if 'doi' in ev['text_refs'] and ev['text_refs']['doi'] %}
-                            | <a class="doi_link"
-                               href='https://dx.doi.org/{{ ev["text_refs"]["doi"] }}'
-                               target="_blank">DOI</a>
+                              {{ ev['text_refs']['PMID'] }}</a>
                           {% endif %}
                                                     
                           {% if add_full_text_search_link and 'pmcid' in ev and ev['pmcid'] %}
@@ -441,7 +429,20 @@
                               data-sentence= '{{ev["text"]|urlencode}}'
                               href="https://www.ncbi.nlm.nih.gov/pmc/articles/{{ ev["pmcid"] }}" target=_blank rel=noopener >Full-Text Search: {{ev['pmcid']}}</a>
                             <span style="cursor:default" title="This link will search for and highlight the sentence in the full-text article. Works with Chrome 80+">  &#9432;</span>
+                          {% else %}
+                            {% if 'PMCID' in ev['text_refs'] and ev['text_refs']['PMCID'] %}
+                              | <a class="pmcid_link"
+                                href='https://www.ncbi.nlm.nih.gov/pmc/articles/{{ ev["text_refs"]["pmcid"] }}'
+                                target="_blank">PMC</a>
+                            {% endif %}
                           {% endif %}
+
+                          {% if 'DOI' in ev['text_refs'] and ev['text_refs']['DOI'] %}
+                            | <a class="doi_link"
+                               href='https://dx.doi.org/{{ ev["text_refs"]["DOI"] }}'
+                               target="_blank">DOI</a>
+                          {% endif %}
+
                         </div>
                       </div>
                     {% endfor %}

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -116,6 +116,41 @@
         tag.style.cssText = setCss
       }
     }
+
+    {% if add_full_text_search_link %}
+    window.onload = function() {
+      // Populate text fragment in Full Text search for PMC journal
+      var elements = document.querySelectorAll('.full_text_search');
+      for (elem_idx = 0 ;elem_idx < elements.length ;elem_idx++ ) {
+        var element = elements[elem_idx];
+        var span = document.createElement('span');  
+        span.innerHTML = decodeURIComponent(element.dataset.sentence);
+        var text = span.innerText;
+        var searchText = "";
+        var words = [];
+        var temp_words= text.split(" ");
+        for(var idx = 0; idx < temp_words.length ; idx++){
+          if(!temp_words[idx].includes("XREF"))
+            words.push(temp_words[idx]);
+        }
+        if(words.length<7)
+          searchText = encodeURIComponent(text);        
+        else{
+          for(var idx = 0; idx < 6 && idx < words.length ; idx++){
+            searchText += " " + encodeURIComponent(words[idx]);
+          }        
+          var secondLastWord = "";
+          if(words.length>7)
+            secondLastWord = words[words.length - 2] + " ";
+          var lastWord = words[words.length - 1];
+          if(lastWord.endsWith("."))
+            lastWord = lastWord.substring(0,lastWord.length-1)
+          searchText += "," + encodeURIComponent(secondLastWord + lastWord);
+        }
+        element.href += "#:~:text="+ searchText.trim()        
+      }
+    };
+    {% endif %}
   </script>
   <style>
     {% for category, data in source_colors %}
@@ -208,6 +243,11 @@
     .curation_toggle {
         cursor: pointer;
     }
+
+    .pmid_link, .pmcid_link, .doi_link {
+      display: block;
+    }
+    
   </style>
 {% endblock %}
 
@@ -350,14 +390,24 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-10">
+                        {% if add_full_text_search_link %}
+                          <div class="col-9">
+                        {% else %}
+                          <div class="col-10">
+                        {% endif %}
+
                           {% if ev['text'] %}
                             "{{ ev['text'] }}"
                           {% else %}
                             <i>No evidence text available</i>
                           {% endif %}
                         </div>
-                        <div class="col-1 text-right">
+                        
+                        {% if add_full_text_search_link %}
+                          <div class="col-2 text-right">
+                        {% else %}
+                          <div class="col-1 text-right">
+                        {% endif %}
                           {% if ev['pmid'] %}
                             <a class="pmid_link"
                                title="Hover again to see info"
@@ -385,6 +435,13 @@
                                href='https://dx.doi.org/{{ ev["text_refs"]["doi"] }}'
                                target="_blank">DOI</a>
                           {% endif %}
+                                                    
+                          {% if add_full_text_search_link and 'pmcid' in ev and ev['pmcid'] %}
+                            <a class="full_text_search"
+                              data-sentence= '{{ev["text"]|urlencode}}'
+                              href="https://www.ncbi.nlm.nih.gov/pmc/articles/{{ ev["pmcid"] }}" target=_blank rel=noopener >Full-Text Search: {{ev['pmcid']}}</a>
+                            <span style="cursor:default" title="This link will search for and highlight the sentence in the full-text article. Works with Chrome 80+">  &#9432;</span>
+                          {% endif %}
                         </div>
                       </div>
                     {% endfor %}
@@ -398,4 +455,3 @@
      </div> <!-- type groups -->
   {% endfor %}
 {% endblock %}
-

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree as ET
 import requests
 import logging
 from functools import lru_cache
+from time import sleep
 from indra.databases import hgnc_client, mesh_client
 from indra.util import UnicodeXMLTreeBuilder as UTB
 
@@ -29,6 +30,9 @@ def send_request(url, data):
         logger.error('url: %s, data: %s' % (url, data))
         logger.error(e)
         return None
+    if res.status_code == 429:
+        sleep(0.5)
+        res = requests.get(url, params=data)
     if not res.status_code == 200:
         logger.error('Got return code %d from pubmed client.'
                      % res.status_code)


### PR DESCRIPTION
Adds [Scroll To Text Fragment](https://chromestatus.com/feature/4733392803332096) feature for links to PMC journals, when 
-  `add_full_text_search_link` is `True` in `make_model()`
-  *PMCID* is available for the sentence

The links will automatically search for the sentence, scroll to it, and highlight, without using any plugin.
![Highlighted Sentence](https://user-images.githubusercontent.com/34039705/85835606-f58de400-b7b2-11ea-80df-04c8381c62af.png)

#### Sample Output
HTML Assembler [output](https://gistcdn.githack.com/PritiShaw/840ad0a586d5f43da5b83f59080e6313/raw/83e9189d67a233f62ceff0da952ba6f45d689a8c/output.html), [source](https://gist.github.com/PritiShaw/840ad0a586d5f43da5b83f59080e6313#file-output-html)
[Script used to generate above output](https://gist.github.com/PritiShaw/840ad0a586d5f43da5b83f59080e6313#file-script-py)
![Sample Output from HTML Assembler](https://user-images.githubusercontent.com/34039705/85834237-a8107780-b7b0-11ea-876a-0b143f5c9c8c.png)

#### Supported Browsers
- Chrome v80+for both desktop and android
- Chromium-based Edge, Opera
