### PR TITLE
Implement extracting grounded Agents from Eidos output

### DIFF
--- a/indra/sources/eidos/__init__.py
+++ b/indra/sources/eidos/__init__.py
@@ -147,4 +147,4 @@ in INDRA to process the JSON-LD output files.
 
 from .api import process_text, process_json_str, process_json_file, \
     process_json, reground_texts, initialize_reader, process_json_bio, \
-    process_text_bio
+    process_text_bio, process_text_bio_entities, process_json_bio_entities

--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -308,6 +308,30 @@ class EidosProcessor(object):
             return rc
         return None
 
+    def get_all_events(self):
+        """Return a list of all standalone events from a list
+        of statements."""
+        events = []
+        for stmt in self.statements:
+            stmt = copy.deepcopy(stmt)
+            if isinstance(stmt, Influence):
+                for member in [stmt.subj, stmt.obj]:
+                    member.evidence = stmt.evidence[:]
+                    # Remove the context since it may be for the other member
+                    for ev in member.evidence:
+                        ev.context = None
+                    events.append(member)
+            elif isinstance(stmt, Association):
+                for member in stmt.members:
+                    member.evidence = stmt.evidence[:]
+                    # Remove the context since it may be for the other member
+                    for ev in member.evidence:
+                        ev.context = None
+                    events.append(member)
+            elif isinstance(stmt, Event):
+                events.append(stmt)
+        return events
+
 
 class EidosDocument(object):
     def __init__(self, json_dict):

--- a/indra/tests/eidos_bio_abstract.json
+++ b/indra/tests/eidos_bio_abstract.json
@@ -1,0 +1,7069 @@
+{
+  "@context": {
+    "Argument": "https://w3id.org/wm/cag/argument",
+    "Grounding": "https://w3id.org/wm/cag/grounding",
+    "Interval": "https://w3id.org/wm/cag/interval",
+    "Modifier": "https://w3id.org/wm/cag/modifier",
+    "Extraction": "https://w3id.org/wm/cag/extraction",
+    "Provenance": "https://w3id.org/wm/cag/provenance",
+    "Groundings": "https://w3id.org/wm/cag/groundings",
+    "State": "https://w3id.org/wm/cag/state",
+    "Dependency": "https://w3id.org/wm/cag/dependency",
+    "Corpus": "https://w3id.org/wm/cag/corpus",
+    "Trigger": "https://w3id.org/wm/cag/trigger",
+    "Sentence": "https://w3id.org/wm/cag/sentence",
+    "Word": "https://w3id.org/wm/cag/word",
+    "Document": "https://w3id.org/wm/cag/document"
+  },
+  "@type": "Corpus",
+  "documents": [
+    {
+      "@type": "Document",
+      "@id": "_:Document_1",
+      "text": "Since December 2019, there has been an outbreak of a novel coronavirus (COVID-19) infection in Wuhan, China. Meanwhile, the outbreak also drew attention and concern from the World Health Organization (WHO). COVID-19 is another human infectious disease caused by coronavirus. The transmission of COVID-19 is potent and the infection rate is fast. Since there is no specific drug for COVID-19, the treatment is mainly symptomatic supportive therapy. In addition, it should be pointed out that patients with severe illness need more aggressive treatment and meticulous care. Recently, accurate RNA detection has been decisive for the diagnosis of COVID-19. The development of highly sensitive RT-PCR has facilitated epidemiological studies that provide insight into the prevalence, seasonality, clinical manifestations and course of COVID-19 infection. In this review, we summarize the epidemiology and characteristics of COVID-19.",
+      "sentences": [
+        {
+          "text": "Since December 2019 , there has been an outbreak of a novel coronavirus ( COVID-19 ) infection in Wuhan , China .",
+          "words": [
+            {
+              "endOffset": 5,
+              "chunk": "B-PP",
+              "lemma": "since",
+              "tag": "IN",
+              "text": "Since",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 0,
+              "@type": "Word",
+              "@id": "_:Word_1"
+            },
+            {
+              "endOffset": 14,
+              "chunk": "B-NP",
+              "lemma": "December",
+              "tag": "NNP",
+              "text": "December",
+              "norm": "2019-12",
+              "entity": "DATE",
+              "startOffset": 6,
+              "@type": "Word",
+              "@id": "_:Word_2"
+            },
+            {
+              "endOffset": 19,
+              "chunk": "I-NP",
+              "lemma": "2019",
+              "tag": "CD",
+              "text": "2019",
+              "norm": "2019-12",
+              "entity": "DATE",
+              "startOffset": 15,
+              "@type": "Word",
+              "@id": "_:Word_3"
+            },
+            {
+              "endOffset": 20,
+              "chunk": "O",
+              "lemma": ",",
+              "tag": ",",
+              "text": ",",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 19,
+              "@type": "Word",
+              "@id": "_:Word_4"
+            },
+            {
+              "endOffset": 26,
+              "chunk": "B-NP",
+              "lemma": "there",
+              "tag": "EX",
+              "text": "there",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 21,
+              "@type": "Word",
+              "@id": "_:Word_5"
+            },
+            {
+              "endOffset": 30,
+              "chunk": "B-VP",
+              "lemma": "have",
+              "tag": "VBZ",
+              "text": "has",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 27,
+              "@type": "Word",
+              "@id": "_:Word_6"
+            },
+            {
+              "endOffset": 35,
+              "chunk": "I-VP",
+              "lemma": "be",
+              "tag": "VBN",
+              "text": "been",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 31,
+              "@type": "Word",
+              "@id": "_:Word_7"
+            },
+            {
+              "endOffset": 38,
+              "chunk": "B-NP",
+              "lemma": "a",
+              "tag": "DT",
+              "text": "an",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 36,
+              "@type": "Word",
+              "@id": "_:Word_8"
+            },
+            {
+              "endOffset": 47,
+              "chunk": "I-NP",
+              "lemma": "outbreak",
+              "tag": "NN",
+              "text": "outbreak",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 39,
+              "@type": "Word",
+              "@id": "_:Word_9"
+            },
+            {
+              "endOffset": 50,
+              "chunk": "B-PP",
+              "lemma": "of",
+              "tag": "IN",
+              "text": "of",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 48,
+              "@type": "Word",
+              "@id": "_:Word_10"
+            },
+            {
+              "endOffset": 52,
+              "chunk": "B-NP",
+              "lemma": "a",
+              "tag": "DT",
+              "text": "a",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 51,
+              "@type": "Word",
+              "@id": "_:Word_11"
+            },
+            {
+              "endOffset": 58,
+              "chunk": "I-NP",
+              "lemma": "novel",
+              "tag": "JJ",
+              "text": "novel",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 53,
+              "@type": "Word",
+              "@id": "_:Word_12"
+            },
+            {
+              "endOffset": 70,
+              "chunk": "I-NP",
+              "lemma": "coronavirus",
+              "tag": "NN",
+              "text": "coronavirus",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 59,
+              "@type": "Word",
+              "@id": "_:Word_13"
+            },
+            {
+              "endOffset": 72,
+              "chunk": "I-NP",
+              "lemma": "(",
+              "tag": "-LRB-",
+              "text": "(",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 71,
+              "@type": "Word",
+              "@id": "_:Word_14"
+            },
+            {
+              "endOffset": 80,
+              "chunk": "I-NP",
+              "lemma": "covid-19",
+              "tag": "NN",
+              "text": "COVID-19",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 72,
+              "@type": "Word",
+              "@id": "_:Word_15"
+            },
+            {
+              "endOffset": 81,
+              "chunk": "I-NP",
+              "lemma": ")",
+              "tag": "-RRB-",
+              "text": ")",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 80,
+              "@type": "Word",
+              "@id": "_:Word_16"
+            },
+            {
+              "endOffset": 91,
+              "chunk": "I-NP",
+              "lemma": "infection",
+              "tag": "NN",
+              "text": "infection",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 82,
+              "@type": "Word",
+              "@id": "_:Word_17"
+            },
+            {
+              "endOffset": 94,
+              "chunk": "B-PP",
+              "lemma": "in",
+              "tag": "IN",
+              "text": "in",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 92,
+              "@type": "Word",
+              "@id": "_:Word_18"
+            },
+            {
+              "endOffset": 100,
+              "chunk": "B-NP",
+              "lemma": "Wuhan",
+              "tag": "NNP",
+              "text": "Wuhan",
+              "norm": "O",
+              "entity": "LOCATION",
+              "startOffset": 95,
+              "@type": "Word",
+              "@id": "_:Word_19"
+            },
+            {
+              "endOffset": 101,
+              "chunk": "O",
+              "lemma": ",",
+              "tag": ",",
+              "text": ",",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 100,
+              "@type": "Word",
+              "@id": "_:Word_20"
+            },
+            {
+              "endOffset": 107,
+              "chunk": "B-NP",
+              "lemma": "China",
+              "tag": "NNP",
+              "text": "China",
+              "norm": "O",
+              "entity": "LOCATION",
+              "startOffset": 102,
+              "@type": "Word",
+              "@id": "_:Word_21"
+            },
+            {
+              "endOffset": 108,
+              "chunk": "O",
+              "lemma": ".",
+              "tag": ".",
+              "text": ".",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 107,
+              "@type": "Word",
+              "@id": "_:Word_22"
+            }
+          ],
+          "@type": "Sentence",
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_2"
+              },
+              "destination": {
+                "@id": "_:Word_1"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_2"
+              },
+              "destination": {
+                "@id": "_:Word_3"
+              },
+              "relation": "nummod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_9"
+              },
+              "destination": {
+                "@id": "_:Word_2"
+              },
+              "relation": "nmod_since"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_9"
+              },
+              "destination": {
+                "@id": "_:Word_4"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_9"
+              },
+              "destination": {
+                "@id": "_:Word_5"
+              },
+              "relation": "expl"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_9"
+              },
+              "destination": {
+                "@id": "_:Word_6"
+              },
+              "relation": "aux"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_9"
+              },
+              "destination": {
+                "@id": "_:Word_22"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_9"
+              },
+              "destination": {
+                "@id": "_:Word_7"
+              },
+              "relation": "cop"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_9"
+              },
+              "destination": {
+                "@id": "_:Word_8"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_9"
+              },
+              "destination": {
+                "@id": "_:Word_13"
+              },
+              "relation": "nmod_of"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_13"
+              },
+              "destination": {
+                "@id": "_:Word_17"
+              },
+              "relation": "dep"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_13"
+              },
+              "destination": {
+                "@id": "_:Word_10"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_13"
+              },
+              "destination": {
+                "@id": "_:Word_11"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_13"
+              },
+              "destination": {
+                "@id": "_:Word_12"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_13"
+              },
+              "destination": {
+                "@id": "_:Word_15"
+              },
+              "relation": "appos"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_15"
+              },
+              "destination": {
+                "@id": "_:Word_16"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_15"
+              },
+              "destination": {
+                "@id": "_:Word_14"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_17"
+              },
+              "destination": {
+                "@id": "_:Word_19"
+              },
+              "relation": "nmod_in"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_19"
+              },
+              "destination": {
+                "@id": "_:Word_18"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_19"
+              },
+              "destination": {
+                "@id": "_:Word_20"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_19"
+              },
+              "destination": {
+                "@id": "_:Word_21"
+              },
+              "relation": "appos"
+            }
+          ],
+          "@id": "_:Sentence_1"
+        },
+        {
+          "text": "Meanwhile , the outbreak also drew attention and concern from the World Health Organization ( WHO ) .",
+          "words": [
+            {
+              "endOffset": 118,
+              "chunk": "B-ADVP",
+              "lemma": "meanwhile",
+              "tag": "RB",
+              "text": "Meanwhile",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 109,
+              "@type": "Word",
+              "@id": "_:Word_23"
+            },
+            {
+              "endOffset": 119,
+              "chunk": "O",
+              "lemma": ",",
+              "tag": ",",
+              "text": ",",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 118,
+              "@type": "Word",
+              "@id": "_:Word_24"
+            },
+            {
+              "endOffset": 123,
+              "chunk": "B-NP",
+              "lemma": "the",
+              "tag": "DT",
+              "text": "the",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 120,
+              "@type": "Word",
+              "@id": "_:Word_25"
+            },
+            {
+              "endOffset": 132,
+              "chunk": "I-NP",
+              "lemma": "outbreak",
+              "tag": "NN",
+              "text": "outbreak",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 124,
+              "@type": "Word",
+              "@id": "_:Word_26"
+            },
+            {
+              "endOffset": 137,
+              "chunk": "B-ADVP",
+              "lemma": "also",
+              "tag": "RB",
+              "text": "also",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 133,
+              "@type": "Word",
+              "@id": "_:Word_27"
+            },
+            {
+              "endOffset": 142,
+              "chunk": "B-VP",
+              "lemma": "draw",
+              "tag": "VBD",
+              "text": "drew",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 138,
+              "@type": "Word",
+              "@id": "_:Word_28"
+            },
+            {
+              "endOffset": 152,
+              "chunk": "B-NP",
+              "lemma": "attention",
+              "tag": "NN",
+              "text": "attention",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 143,
+              "@type": "Word",
+              "@id": "_:Word_29"
+            },
+            {
+              "endOffset": 156,
+              "chunk": "I-NP",
+              "lemma": "and",
+              "tag": "CC",
+              "text": "and",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 153,
+              "@type": "Word",
+              "@id": "_:Word_30"
+            },
+            {
+              "endOffset": 164,
+              "chunk": "I-NP",
+              "lemma": "concern",
+              "tag": "NN",
+              "text": "concern",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 157,
+              "@type": "Word",
+              "@id": "_:Word_31"
+            },
+            {
+              "endOffset": 169,
+              "chunk": "B-PP",
+              "lemma": "from",
+              "tag": "IN",
+              "text": "from",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 165,
+              "@type": "Word",
+              "@id": "_:Word_32"
+            },
+            {
+              "endOffset": 173,
+              "chunk": "B-NP",
+              "lemma": "the",
+              "tag": "DT",
+              "text": "the",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 170,
+              "@type": "Word",
+              "@id": "_:Word_33"
+            },
+            {
+              "endOffset": 179,
+              "chunk": "I-NP",
+              "lemma": "World",
+              "tag": "NNP",
+              "text": "World",
+              "norm": "O",
+              "entity": "ORGANIZATION",
+              "startOffset": 174,
+              "@type": "Word",
+              "@id": "_:Word_34"
+            },
+            {
+              "endOffset": 186,
+              "chunk": "I-NP",
+              "lemma": "Health",
+              "tag": "NNP",
+              "text": "Health",
+              "norm": "O",
+              "entity": "ORGANIZATION",
+              "startOffset": 180,
+              "@type": "Word",
+              "@id": "_:Word_35"
+            },
+            {
+              "endOffset": 199,
+              "chunk": "I-NP",
+              "lemma": "Organization",
+              "tag": "NNP",
+              "text": "Organization",
+              "norm": "O",
+              "entity": "ORGANIZATION",
+              "startOffset": 187,
+              "@type": "Word",
+              "@id": "_:Word_36"
+            },
+            {
+              "endOffset": 201,
+              "chunk": "B-VP",
+              "lemma": "(",
+              "tag": "-LRB-",
+              "text": "(",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 200,
+              "@type": "Word",
+              "@id": "_:Word_37"
+            },
+            {
+              "endOffset": 204,
+              "chunk": "B-NP",
+              "lemma": "who",
+              "tag": "WP",
+              "text": "WHO",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 201,
+              "@type": "Word",
+              "@id": "_:Word_38"
+            },
+            {
+              "endOffset": 205,
+              "chunk": "I-NP",
+              "lemma": ")",
+              "tag": "-RRB-",
+              "text": ")",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 204,
+              "@type": "Word",
+              "@id": "_:Word_39"
+            },
+            {
+              "endOffset": 206,
+              "chunk": "O",
+              "lemma": ".",
+              "tag": ".",
+              "text": ".",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 205,
+              "@type": "Word",
+              "@id": "_:Word_40"
+            }
+          ],
+          "@type": "Sentence",
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_26"
+              },
+              "destination": {
+                "@id": "_:Word_25"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_28"
+              },
+              "destination": {
+                "@id": "_:Word_26"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_28"
+              },
+              "destination": {
+                "@id": "_:Word_27"
+              },
+              "relation": "advmod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_28"
+              },
+              "destination": {
+                "@id": "_:Word_29"
+              },
+              "relation": "dobj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_28"
+              },
+              "destination": {
+                "@id": "_:Word_31"
+              },
+              "relation": "dobj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_28"
+              },
+              "destination": {
+                "@id": "_:Word_36"
+              },
+              "relation": "nmod_from"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_28"
+              },
+              "destination": {
+                "@id": "_:Word_23"
+              },
+              "relation": "advmod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_28"
+              },
+              "destination": {
+                "@id": "_:Word_24"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_28"
+              },
+              "destination": {
+                "@id": "_:Word_40"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_29"
+              },
+              "destination": {
+                "@id": "_:Word_30"
+              },
+              "relation": "cc"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_29"
+              },
+              "destination": {
+                "@id": "_:Word_31"
+              },
+              "relation": "conj_and"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_36"
+              },
+              "destination": {
+                "@id": "_:Word_32"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_36"
+              },
+              "destination": {
+                "@id": "_:Word_33"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_36"
+              },
+              "destination": {
+                "@id": "_:Word_34"
+              },
+              "relation": "compound"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_36"
+              },
+              "destination": {
+                "@id": "_:Word_35"
+              },
+              "relation": "compound"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_36"
+              },
+              "destination": {
+                "@id": "_:Word_38"
+              },
+              "relation": "appos"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_38"
+              },
+              "destination": {
+                "@id": "_:Word_37"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_38"
+              },
+              "destination": {
+                "@id": "_:Word_39"
+              },
+              "relation": "punct"
+            }
+          ],
+          "@id": "_:Sentence_2"
+        },
+        {
+          "text": "COVID-19 is another human infectious disease caused by coronavirus .",
+          "words": [
+            {
+              "endOffset": 215,
+              "chunk": "B-NP",
+              "lemma": "covid-19",
+              "tag": "NN",
+              "text": "COVID-19",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 207,
+              "@type": "Word",
+              "@id": "_:Word_41"
+            },
+            {
+              "endOffset": 218,
+              "chunk": "B-VP",
+              "lemma": "be",
+              "tag": "VBZ",
+              "text": "is",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 216,
+              "@type": "Word",
+              "@id": "_:Word_42"
+            },
+            {
+              "endOffset": 226,
+              "chunk": "B-NP",
+              "lemma": "another",
+              "tag": "DT",
+              "text": "another",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 219,
+              "@type": "Word",
+              "@id": "_:Word_43"
+            },
+            {
+              "endOffset": 232,
+              "chunk": "I-NP",
+              "lemma": "human",
+              "tag": "JJ",
+              "text": "human",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 227,
+              "@type": "Word",
+              "@id": "_:Word_44"
+            },
+            {
+              "endOffset": 243,
+              "chunk": "I-NP",
+              "lemma": "infectious",
+              "tag": "JJ",
+              "text": "infectious",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 233,
+              "@type": "Word",
+              "@id": "_:Word_45"
+            },
+            {
+              "endOffset": 251,
+              "chunk": "I-NP",
+              "lemma": "disease",
+              "tag": "NN",
+              "text": "disease",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 244,
+              "@type": "Word",
+              "@id": "_:Word_46"
+            },
+            {
+              "endOffset": 258,
+              "chunk": "B-VP",
+              "lemma": "cause",
+              "tag": "VBN",
+              "text": "caused",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 252,
+              "@type": "Word",
+              "@id": "_:Word_47"
+            },
+            {
+              "endOffset": 261,
+              "chunk": "B-PP",
+              "lemma": "by",
+              "tag": "IN",
+              "text": "by",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 259,
+              "@type": "Word",
+              "@id": "_:Word_48"
+            },
+            {
+              "endOffset": 273,
+              "chunk": "B-NP",
+              "lemma": "coronavirus",
+              "tag": "NN",
+              "text": "coronavirus",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 262,
+              "@type": "Word",
+              "@id": "_:Word_49"
+            },
+            {
+              "endOffset": 274,
+              "chunk": "O",
+              "lemma": ".",
+              "tag": ".",
+              "text": ".",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 273,
+              "@type": "Word",
+              "@id": "_:Word_50"
+            }
+          ],
+          "@type": "Sentence",
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_46"
+              },
+              "destination": {
+                "@id": "_:Word_47"
+              },
+              "relation": "acl"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_46"
+              },
+              "destination": {
+                "@id": "_:Word_50"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_46"
+              },
+              "destination": {
+                "@id": "_:Word_41"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_46"
+              },
+              "destination": {
+                "@id": "_:Word_42"
+              },
+              "relation": "cop"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_46"
+              },
+              "destination": {
+                "@id": "_:Word_43"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_46"
+              },
+              "destination": {
+                "@id": "_:Word_44"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_46"
+              },
+              "destination": {
+                "@id": "_:Word_45"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_47"
+              },
+              "destination": {
+                "@id": "_:Word_49"
+              },
+              "relation": "nmod_by"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_49"
+              },
+              "destination": {
+                "@id": "_:Word_48"
+              },
+              "relation": "case"
+            }
+          ],
+          "@id": "_:Sentence_3"
+        },
+        {
+          "text": "The transmission of COVID-19 is potent and the infection rate is fast .",
+          "words": [
+            {
+              "endOffset": 278,
+              "chunk": "B-NP",
+              "lemma": "the",
+              "tag": "DT",
+              "text": "The",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 275,
+              "@type": "Word",
+              "@id": "_:Word_51"
+            },
+            {
+              "endOffset": 291,
+              "chunk": "I-NP",
+              "lemma": "transmission",
+              "tag": "NN",
+              "text": "transmission",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 279,
+              "@type": "Word",
+              "@id": "_:Word_52"
+            },
+            {
+              "endOffset": 294,
+              "chunk": "B-PP",
+              "lemma": "of",
+              "tag": "IN",
+              "text": "of",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 292,
+              "@type": "Word",
+              "@id": "_:Word_53"
+            },
+            {
+              "endOffset": 303,
+              "chunk": "B-NP",
+              "lemma": "covid-19",
+              "tag": "NN",
+              "text": "COVID-19",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 295,
+              "@type": "Word",
+              "@id": "_:Word_54"
+            },
+            {
+              "endOffset": 306,
+              "chunk": "B-VP",
+              "lemma": "be",
+              "tag": "VBZ",
+              "text": "is",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 304,
+              "@type": "Word",
+              "@id": "_:Word_55"
+            },
+            {
+              "endOffset": 313,
+              "chunk": "B-ADJP",
+              "lemma": "potent",
+              "tag": "JJ",
+              "text": "potent",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 307,
+              "@type": "Word",
+              "@id": "_:Word_56"
+            },
+            {
+              "endOffset": 317,
+              "chunk": "O",
+              "lemma": "and",
+              "tag": "CC",
+              "text": "and",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 314,
+              "@type": "Word",
+              "@id": "_:Word_57"
+            },
+            {
+              "endOffset": 321,
+              "chunk": "B-NP",
+              "lemma": "the",
+              "tag": "DT",
+              "text": "the",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 318,
+              "@type": "Word",
+              "@id": "_:Word_58"
+            },
+            {
+              "endOffset": 331,
+              "chunk": "I-NP",
+              "lemma": "infection",
+              "tag": "NN",
+              "text": "infection",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 322,
+              "@type": "Word",
+              "@id": "_:Word_59"
+            },
+            {
+              "endOffset": 336,
+              "chunk": "I-NP",
+              "lemma": "rate",
+              "tag": "NN",
+              "text": "rate",
+              "norm": "O",
+              "entity": "B-Property",
+              "startOffset": 332,
+              "@type": "Word",
+              "@id": "_:Word_60"
+            },
+            {
+              "endOffset": 339,
+              "chunk": "B-VP",
+              "lemma": "be",
+              "tag": "VBZ",
+              "text": "is",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 337,
+              "@type": "Word",
+              "@id": "_:Word_61"
+            },
+            {
+              "endOffset": 344,
+              "chunk": "B-ADVP",
+              "lemma": "fast",
+              "tag": "RB",
+              "text": "fast",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 340,
+              "@type": "Word",
+              "@id": "_:Word_62"
+            },
+            {
+              "endOffset": 345,
+              "chunk": "O",
+              "lemma": ".",
+              "tag": ".",
+              "text": ".",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 344,
+              "@type": "Word",
+              "@id": "_:Word_63"
+            }
+          ],
+          "@type": "Sentence",
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_60"
+              },
+              "destination": {
+                "@id": "_:Word_59"
+              },
+              "relation": "compound"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_60"
+              },
+              "destination": {
+                "@id": "_:Word_58"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_62"
+              },
+              "destination": {
+                "@id": "_:Word_60"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_62"
+              },
+              "destination": {
+                "@id": "_:Word_61"
+              },
+              "relation": "cop"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_52"
+              },
+              "destination": {
+                "@id": "_:Word_51"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_52"
+              },
+              "destination": {
+                "@id": "_:Word_54"
+              },
+              "relation": "nmod_of"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_54"
+              },
+              "destination": {
+                "@id": "_:Word_53"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_56"
+              },
+              "destination": {
+                "@id": "_:Word_62"
+              },
+              "relation": "conj_and"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_56"
+              },
+              "destination": {
+                "@id": "_:Word_63"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_56"
+              },
+              "destination": {
+                "@id": "_:Word_52"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_56"
+              },
+              "destination": {
+                "@id": "_:Word_55"
+              },
+              "relation": "cop"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_56"
+              },
+              "destination": {
+                "@id": "_:Word_57"
+              },
+              "relation": "cc"
+            }
+          ],
+          "@id": "_:Sentence_4"
+        },
+        {
+          "text": "Since there is no specific drug for COVID-19 , the treatment is mainly symptomatic supportive therapy .",
+          "words": [
+            {
+              "endOffset": 351,
+              "chunk": "B-SBAR",
+              "lemma": "since",
+              "tag": "IN",
+              "text": "Since",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 346,
+              "@type": "Word",
+              "@id": "_:Word_64"
+            },
+            {
+              "endOffset": 357,
+              "chunk": "B-NP",
+              "lemma": "there",
+              "tag": "EX",
+              "text": "there",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 352,
+              "@type": "Word",
+              "@id": "_:Word_65"
+            },
+            {
+              "endOffset": 360,
+              "chunk": "B-VP",
+              "lemma": "be",
+              "tag": "VBZ",
+              "text": "is",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 358,
+              "@type": "Word",
+              "@id": "_:Word_66"
+            },
+            {
+              "endOffset": 363,
+              "chunk": "B-NP",
+              "lemma": "no",
+              "tag": "DT",
+              "text": "no",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 361,
+              "@type": "Word",
+              "@id": "_:Word_67"
+            },
+            {
+              "endOffset": 372,
+              "chunk": "I-NP",
+              "lemma": "specific",
+              "tag": "JJ",
+              "text": "specific",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 364,
+              "@type": "Word",
+              "@id": "_:Word_68"
+            },
+            {
+              "endOffset": 377,
+              "chunk": "I-NP",
+              "lemma": "drug",
+              "tag": "NN",
+              "text": "drug",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 373,
+              "@type": "Word",
+              "@id": "_:Word_69"
+            },
+            {
+              "endOffset": 381,
+              "chunk": "B-PP",
+              "lemma": "for",
+              "tag": "IN",
+              "text": "for",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 378,
+              "@type": "Word",
+              "@id": "_:Word_70"
+            },
+            {
+              "endOffset": 390,
+              "chunk": "B-NP",
+              "lemma": "covid-19",
+              "tag": "NN",
+              "text": "COVID-19",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 382,
+              "@type": "Word",
+              "@id": "_:Word_71"
+            },
+            {
+              "endOffset": 391,
+              "chunk": "O",
+              "lemma": ",",
+              "tag": ",",
+              "text": ",",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 390,
+              "@type": "Word",
+              "@id": "_:Word_72"
+            },
+            {
+              "endOffset": 395,
+              "chunk": "B-NP",
+              "lemma": "the",
+              "tag": "DT",
+              "text": "the",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 392,
+              "@type": "Word",
+              "@id": "_:Word_73"
+            },
+            {
+              "endOffset": 405,
+              "chunk": "I-NP",
+              "lemma": "treatment",
+              "tag": "NN",
+              "text": "treatment",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 396,
+              "@type": "Word",
+              "@id": "_:Word_74"
+            },
+            {
+              "endOffset": 408,
+              "chunk": "B-VP",
+              "lemma": "be",
+              "tag": "VBZ",
+              "text": "is",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 406,
+              "@type": "Word",
+              "@id": "_:Word_75"
+            },
+            {
+              "endOffset": 415,
+              "chunk": "B-NP",
+              "lemma": "mainly",
+              "tag": "RB",
+              "text": "mainly",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 409,
+              "@type": "Word",
+              "@id": "_:Word_76"
+            },
+            {
+              "endOffset": 427,
+              "chunk": "I-NP",
+              "lemma": "symptomatic",
+              "tag": "JJ",
+              "text": "symptomatic",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 416,
+              "@type": "Word",
+              "@id": "_:Word_77"
+            },
+            {
+              "endOffset": 438,
+              "chunk": "I-NP",
+              "lemma": "supportive",
+              "tag": "JJ",
+              "text": "supportive",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 428,
+              "@type": "Word",
+              "@id": "_:Word_78"
+            },
+            {
+              "endOffset": 446,
+              "chunk": "I-NP",
+              "lemma": "therapy",
+              "tag": "NN",
+              "text": "therapy",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 439,
+              "@type": "Word",
+              "@id": "_:Word_79"
+            },
+            {
+              "endOffset": 447,
+              "chunk": "O",
+              "lemma": ".",
+              "tag": ".",
+              "text": ".",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 446,
+              "@type": "Word",
+              "@id": "_:Word_80"
+            }
+          ],
+          "@type": "Sentence",
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_77"
+              },
+              "destination": {
+                "@id": "_:Word_76"
+              },
+              "relation": "advmod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_79"
+              },
+              "destination": {
+                "@id": "_:Word_75"
+              },
+              "relation": "cop"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_79"
+              },
+              "destination": {
+                "@id": "_:Word_77"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_79"
+              },
+              "destination": {
+                "@id": "_:Word_78"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_79"
+              },
+              "destination": {
+                "@id": "_:Word_80"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_79"
+              },
+              "destination": {
+                "@id": "_:Word_66"
+              },
+              "relation": "advcl_since"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_79"
+              },
+              "destination": {
+                "@id": "_:Word_72"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_79"
+              },
+              "destination": {
+                "@id": "_:Word_74"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_66"
+              },
+              "destination": {
+                "@id": "_:Word_64"
+              },
+              "relation": "mark"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_66"
+              },
+              "destination": {
+                "@id": "_:Word_65"
+              },
+              "relation": "expl"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_66"
+              },
+              "destination": {
+                "@id": "_:Word_69"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_69"
+              },
+              "destination": {
+                "@id": "_:Word_67"
+              },
+              "relation": "neg"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_69"
+              },
+              "destination": {
+                "@id": "_:Word_68"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_69"
+              },
+              "destination": {
+                "@id": "_:Word_71"
+              },
+              "relation": "nmod_for"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_71"
+              },
+              "destination": {
+                "@id": "_:Word_70"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_74"
+              },
+              "destination": {
+                "@id": "_:Word_73"
+              },
+              "relation": "det"
+            }
+          ],
+          "@id": "_:Sentence_5"
+        },
+        {
+          "text": "In addition , it should be pointed out that patients with severe illness need more aggressive treatment and meticulous care .",
+          "words": [
+            {
+              "endOffset": 450,
+              "chunk": "B-PP",
+              "lemma": "in",
+              "tag": "IN",
+              "text": "In",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 448,
+              "@type": "Word",
+              "@id": "_:Word_81"
+            },
+            {
+              "endOffset": 459,
+              "chunk": "B-NP",
+              "lemma": "addition",
+              "tag": "NN",
+              "text": "addition",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 451,
+              "@type": "Word",
+              "@id": "_:Word_82"
+            },
+            {
+              "endOffset": 460,
+              "chunk": "O",
+              "lemma": ",",
+              "tag": ",",
+              "text": ",",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 459,
+              "@type": "Word",
+              "@id": "_:Word_83"
+            },
+            {
+              "endOffset": 463,
+              "chunk": "B-NP",
+              "lemma": "it",
+              "tag": "PRP",
+              "text": "it",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 461,
+              "@type": "Word",
+              "@id": "_:Word_84"
+            },
+            {
+              "endOffset": 470,
+              "chunk": "B-VP",
+              "lemma": "should",
+              "tag": "MD",
+              "text": "should",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 464,
+              "@type": "Word",
+              "@id": "_:Word_85"
+            },
+            {
+              "endOffset": 473,
+              "chunk": "I-VP",
+              "lemma": "be",
+              "tag": "VB",
+              "text": "be",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 471,
+              "@type": "Word",
+              "@id": "_:Word_86"
+            },
+            {
+              "endOffset": 481,
+              "chunk": "I-VP",
+              "lemma": "point",
+              "tag": "VBN",
+              "text": "pointed",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 474,
+              "@type": "Word",
+              "@id": "_:Word_87"
+            },
+            {
+              "endOffset": 485,
+              "chunk": "B-PRT",
+              "lemma": "out",
+              "tag": "RP",
+              "text": "out",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 482,
+              "@type": "Word",
+              "@id": "_:Word_88"
+            },
+            {
+              "endOffset": 490,
+              "chunk": "B-SBAR",
+              "lemma": "that",
+              "tag": "IN",
+              "text": "that",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 486,
+              "@type": "Word",
+              "@id": "_:Word_89"
+            },
+            {
+              "endOffset": 499,
+              "chunk": "B-NP",
+              "lemma": "patient",
+              "tag": "NNS",
+              "text": "patients",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 491,
+              "@type": "Word",
+              "@id": "_:Word_90"
+            },
+            {
+              "endOffset": 504,
+              "chunk": "B-PP",
+              "lemma": "with",
+              "tag": "IN",
+              "text": "with",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 500,
+              "@type": "Word",
+              "@id": "_:Word_91"
+            },
+            {
+              "endOffset": 511,
+              "chunk": "B-NP",
+              "lemma": "severe",
+              "tag": "JJ",
+              "text": "severe",
+              "norm": "O",
+              "entity": "B-Quantifier",
+              "startOffset": 505,
+              "@type": "Word",
+              "@id": "_:Word_92"
+            },
+            {
+              "endOffset": 519,
+              "chunk": "I-NP",
+              "lemma": "illness",
+              "tag": "NN",
+              "text": "illness",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 512,
+              "@type": "Word",
+              "@id": "_:Word_93"
+            },
+            {
+              "endOffset": 524,
+              "chunk": "B-VP",
+              "lemma": "need",
+              "tag": "VBP",
+              "text": "need",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 520,
+              "@type": "Word",
+              "@id": "_:Word_94"
+            },
+            {
+              "endOffset": 529,
+              "chunk": "B-NP",
+              "lemma": "more",
+              "tag": "RBR",
+              "text": "more",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 525,
+              "@type": "Word",
+              "@id": "_:Word_95"
+            },
+            {
+              "endOffset": 540,
+              "chunk": "I-NP",
+              "lemma": "aggressive",
+              "tag": "JJ",
+              "text": "aggressive",
+              "norm": "O",
+              "entity": "B-Quantifier",
+              "startOffset": 530,
+              "@type": "Word",
+              "@id": "_:Word_96"
+            },
+            {
+              "endOffset": 550,
+              "chunk": "I-NP",
+              "lemma": "treatment",
+              "tag": "NN",
+              "text": "treatment",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 541,
+              "@type": "Word",
+              "@id": "_:Word_97"
+            },
+            {
+              "endOffset": 554,
+              "chunk": "O",
+              "lemma": "and",
+              "tag": "CC",
+              "text": "and",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 551,
+              "@type": "Word",
+              "@id": "_:Word_98"
+            },
+            {
+              "endOffset": 565,
+              "chunk": "B-NP",
+              "lemma": "meticulous",
+              "tag": "JJ",
+              "text": "meticulous",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 555,
+              "@type": "Word",
+              "@id": "_:Word_99"
+            },
+            {
+              "endOffset": 570,
+              "chunk": "I-NP",
+              "lemma": "care",
+              "tag": "NN",
+              "text": "care",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 566,
+              "@type": "Word",
+              "@id": "_:Word_100"
+            },
+            {
+              "endOffset": 571,
+              "chunk": "O",
+              "lemma": ".",
+              "tag": ".",
+              "text": ".",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 570,
+              "@type": "Word",
+              "@id": "_:Word_101"
+            }
+          ],
+          "@type": "Sentence",
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_96"
+              },
+              "destination": {
+                "@id": "_:Word_95"
+              },
+              "relation": "advmod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_97"
+              },
+              "destination": {
+                "@id": "_:Word_96"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_97"
+              },
+              "destination": {
+                "@id": "_:Word_98"
+              },
+              "relation": "cc"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_97"
+              },
+              "destination": {
+                "@id": "_:Word_100"
+              },
+              "relation": "conj_and"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_100"
+              },
+              "destination": {
+                "@id": "_:Word_99"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_82"
+              },
+              "destination": {
+                "@id": "_:Word_81"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_87"
+              },
+              "destination": {
+                "@id": "_:Word_82"
+              },
+              "relation": "nmod_in"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_87"
+              },
+              "destination": {
+                "@id": "_:Word_83"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_87"
+              },
+              "destination": {
+                "@id": "_:Word_84"
+              },
+              "relation": "nsubjpass"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_87"
+              },
+              "destination": {
+                "@id": "_:Word_85"
+              },
+              "relation": "aux"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_87"
+              },
+              "destination": {
+                "@id": "_:Word_101"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_87"
+              },
+              "destination": {
+                "@id": "_:Word_86"
+              },
+              "relation": "auxpass"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_87"
+              },
+              "destination": {
+                "@id": "_:Word_88"
+              },
+              "relation": "compound:prt"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_87"
+              },
+              "destination": {
+                "@id": "_:Word_94"
+              },
+              "relation": "ccomp"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_90"
+              },
+              "destination": {
+                "@id": "_:Word_93"
+              },
+              "relation": "nmod_with"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_93"
+              },
+              "destination": {
+                "@id": "_:Word_91"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_93"
+              },
+              "destination": {
+                "@id": "_:Word_92"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_94"
+              },
+              "destination": {
+                "@id": "_:Word_97"
+              },
+              "relation": "dobj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_94"
+              },
+              "destination": {
+                "@id": "_:Word_100"
+              },
+              "relation": "dobj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_94"
+              },
+              "destination": {
+                "@id": "_:Word_89"
+              },
+              "relation": "mark"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_94"
+              },
+              "destination": {
+                "@id": "_:Word_90"
+              },
+              "relation": "nsubj"
+            }
+          ],
+          "@id": "_:Sentence_6"
+        },
+        {
+          "text": "Recently , accurate RNA detection has been decisive for the diagnosis of COVID-19 .",
+          "words": [
+            {
+              "endOffset": 580,
+              "chunk": "B-ADVP",
+              "lemma": "recently",
+              "tag": "RB",
+              "text": "Recently",
+              "norm": "PAST_REF",
+              "entity": "DATE",
+              "startOffset": 572,
+              "@type": "Word",
+              "@id": "_:Word_102"
+            },
+            {
+              "endOffset": 581,
+              "chunk": "O",
+              "lemma": ",",
+              "tag": ",",
+              "text": ",",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 580,
+              "@type": "Word",
+              "@id": "_:Word_103"
+            },
+            {
+              "endOffset": 590,
+              "chunk": "B-NP",
+              "lemma": "accurate",
+              "tag": "JJ",
+              "text": "accurate",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 582,
+              "@type": "Word",
+              "@id": "_:Word_104"
+            },
+            {
+              "endOffset": 594,
+              "chunk": "I-NP",
+              "lemma": "rna",
+              "tag": "NN",
+              "text": "RNA",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 591,
+              "@type": "Word",
+              "@id": "_:Word_105"
+            },
+            {
+              "endOffset": 604,
+              "chunk": "I-NP",
+              "lemma": "detection",
+              "tag": "NN",
+              "text": "detection",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 595,
+              "@type": "Word",
+              "@id": "_:Word_106"
+            },
+            {
+              "endOffset": 608,
+              "chunk": "B-VP",
+              "lemma": "have",
+              "tag": "VBZ",
+              "text": "has",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 605,
+              "@type": "Word",
+              "@id": "_:Word_107"
+            },
+            {
+              "endOffset": 613,
+              "chunk": "I-VP",
+              "lemma": "be",
+              "tag": "VBN",
+              "text": "been",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 609,
+              "@type": "Word",
+              "@id": "_:Word_108"
+            },
+            {
+              "endOffset": 622,
+              "chunk": "B-ADJP",
+              "lemma": "decisive",
+              "tag": "JJ",
+              "text": "decisive",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 614,
+              "@type": "Word",
+              "@id": "_:Word_109"
+            },
+            {
+              "endOffset": 626,
+              "chunk": "B-PP",
+              "lemma": "for",
+              "tag": "IN",
+              "text": "for",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 623,
+              "@type": "Word",
+              "@id": "_:Word_110"
+            },
+            {
+              "endOffset": 630,
+              "chunk": "B-NP",
+              "lemma": "the",
+              "tag": "DT",
+              "text": "the",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 627,
+              "@type": "Word",
+              "@id": "_:Word_111"
+            },
+            {
+              "endOffset": 640,
+              "chunk": "I-NP",
+              "lemma": "diagnosis",
+              "tag": "NN",
+              "text": "diagnosis",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 631,
+              "@type": "Word",
+              "@id": "_:Word_112"
+            },
+            {
+              "endOffset": 643,
+              "chunk": "B-PP",
+              "lemma": "of",
+              "tag": "IN",
+              "text": "of",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 641,
+              "@type": "Word",
+              "@id": "_:Word_113"
+            },
+            {
+              "endOffset": 652,
+              "chunk": "B-NP",
+              "lemma": "covid-19",
+              "tag": "NN",
+              "text": "COVID-19",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 644,
+              "@type": "Word",
+              "@id": "_:Word_114"
+            },
+            {
+              "endOffset": 653,
+              "chunk": "O",
+              "lemma": ".",
+              "tag": ".",
+              "text": ".",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 652,
+              "@type": "Word",
+              "@id": "_:Word_115"
+            }
+          ],
+          "@type": "Sentence",
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_106"
+              },
+              "destination": {
+                "@id": "_:Word_104"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_106"
+              },
+              "destination": {
+                "@id": "_:Word_105"
+              },
+              "relation": "compound"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_109"
+              },
+              "destination": {
+                "@id": "_:Word_103"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_109"
+              },
+              "destination": {
+                "@id": "_:Word_106"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_109"
+              },
+              "destination": {
+                "@id": "_:Word_107"
+              },
+              "relation": "aux"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_109"
+              },
+              "destination": {
+                "@id": "_:Word_108"
+              },
+              "relation": "cop"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_109"
+              },
+              "destination": {
+                "@id": "_:Word_112"
+              },
+              "relation": "nmod_for"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_109"
+              },
+              "destination": {
+                "@id": "_:Word_115"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_109"
+              },
+              "destination": {
+                "@id": "_:Word_102"
+              },
+              "relation": "advmod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_112"
+              },
+              "destination": {
+                "@id": "_:Word_110"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_112"
+              },
+              "destination": {
+                "@id": "_:Word_111"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_112"
+              },
+              "destination": {
+                "@id": "_:Word_114"
+              },
+              "relation": "nmod_of"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_114"
+              },
+              "destination": {
+                "@id": "_:Word_113"
+              },
+              "relation": "case"
+            }
+          ],
+          "@id": "_:Sentence_7"
+        },
+        {
+          "text": "The development of highly sensitive RT-PCR has facilitated epidemiological studies that provide insight into the prevalence , seasonality , clinical manifestations and course of COVID-19 infection .",
+          "words": [
+            {
+              "endOffset": 657,
+              "chunk": "B-NP",
+              "lemma": "the",
+              "tag": "DT",
+              "text": "The",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 654,
+              "@type": "Word",
+              "@id": "_:Word_116"
+            },
+            {
+              "endOffset": 669,
+              "chunk": "I-NP",
+              "lemma": "development",
+              "tag": "NN",
+              "text": "development",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 658,
+              "@type": "Word",
+              "@id": "_:Word_117"
+            },
+            {
+              "endOffset": 672,
+              "chunk": "B-PP",
+              "lemma": "of",
+              "tag": "IN",
+              "text": "of",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 670,
+              "@type": "Word",
+              "@id": "_:Word_118"
+            },
+            {
+              "endOffset": 679,
+              "chunk": "B-NP",
+              "lemma": "highly",
+              "tag": "RB",
+              "text": "highly",
+              "norm": "O",
+              "entity": "B-Quantifier",
+              "startOffset": 673,
+              "@type": "Word",
+              "@id": "_:Word_119"
+            },
+            {
+              "endOffset": 689,
+              "chunk": "I-NP",
+              "lemma": "sensitive",
+              "tag": "JJ",
+              "text": "sensitive",
+              "norm": "O",
+              "entity": "B-Quantifier",
+              "startOffset": 680,
+              "@type": "Word",
+              "@id": "_:Word_120"
+            },
+            {
+              "endOffset": 696,
+              "chunk": "I-NP",
+              "lemma": "rt-pcr",
+              "tag": "NN",
+              "text": "RT-PCR",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 690,
+              "@type": "Word",
+              "@id": "_:Word_121"
+            },
+            {
+              "endOffset": 700,
+              "chunk": "B-VP",
+              "lemma": "have",
+              "tag": "VBZ",
+              "text": "has",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 697,
+              "@type": "Word",
+              "@id": "_:Word_122"
+            },
+            {
+              "endOffset": 712,
+              "chunk": "I-VP",
+              "lemma": "facilitate",
+              "tag": "VBN",
+              "text": "facilitated",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 701,
+              "@type": "Word",
+              "@id": "_:Word_123"
+            },
+            {
+              "endOffset": 728,
+              "chunk": "B-NP",
+              "lemma": "epidemiological",
+              "tag": "JJ",
+              "text": "epidemiological",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 713,
+              "@type": "Word",
+              "@id": "_:Word_124"
+            },
+            {
+              "endOffset": 736,
+              "chunk": "I-NP",
+              "lemma": "study",
+              "tag": "NNS",
+              "text": "studies",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 729,
+              "@type": "Word",
+              "@id": "_:Word_125"
+            },
+            {
+              "endOffset": 741,
+              "chunk": "B-NP",
+              "lemma": "that",
+              "tag": "WDT",
+              "text": "that",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 737,
+              "@type": "Word",
+              "@id": "_:Word_126"
+            },
+            {
+              "endOffset": 749,
+              "chunk": "B-VP",
+              "lemma": "provide",
+              "tag": "VBP",
+              "text": "provide",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 742,
+              "@type": "Word",
+              "@id": "_:Word_127"
+            },
+            {
+              "endOffset": 757,
+              "chunk": "B-NP",
+              "lemma": "insight",
+              "tag": "NN",
+              "text": "insight",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 750,
+              "@type": "Word",
+              "@id": "_:Word_128"
+            },
+            {
+              "endOffset": 762,
+              "chunk": "B-PP",
+              "lemma": "into",
+              "tag": "IN",
+              "text": "into",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 758,
+              "@type": "Word",
+              "@id": "_:Word_129"
+            },
+            {
+              "endOffset": 766,
+              "chunk": "B-NP",
+              "lemma": "the",
+              "tag": "DT",
+              "text": "the",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 763,
+              "@type": "Word",
+              "@id": "_:Word_130"
+            },
+            {
+              "endOffset": 777,
+              "chunk": "I-NP",
+              "lemma": "prevalence",
+              "tag": "NN",
+              "text": "prevalence",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 767,
+              "@type": "Word",
+              "@id": "_:Word_131"
+            },
+            {
+              "endOffset": 778,
+              "chunk": "O",
+              "lemma": ",",
+              "tag": ",",
+              "text": ",",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 777,
+              "@type": "Word",
+              "@id": "_:Word_132"
+            },
+            {
+              "endOffset": 790,
+              "chunk": "B-NP",
+              "lemma": "seasonality",
+              "tag": "NN",
+              "text": "seasonality",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 779,
+              "@type": "Word",
+              "@id": "_:Word_133"
+            },
+            {
+              "endOffset": 791,
+              "chunk": "O",
+              "lemma": ",",
+              "tag": ",",
+              "text": ",",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 790,
+              "@type": "Word",
+              "@id": "_:Word_134"
+            },
+            {
+              "endOffset": 800,
+              "chunk": "B-NP",
+              "lemma": "clinical",
+              "tag": "JJ",
+              "text": "clinical",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 792,
+              "@type": "Word",
+              "@id": "_:Word_135"
+            },
+            {
+              "endOffset": 815,
+              "chunk": "I-NP",
+              "lemma": "manifestation",
+              "tag": "NNS",
+              "text": "manifestations",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 801,
+              "@type": "Word",
+              "@id": "_:Word_136"
+            },
+            {
+              "endOffset": 819,
+              "chunk": "O",
+              "lemma": "and",
+              "tag": "CC",
+              "text": "and",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 816,
+              "@type": "Word",
+              "@id": "_:Word_137"
+            },
+            {
+              "endOffset": 826,
+              "chunk": "B-NP",
+              "lemma": "course",
+              "tag": "NN",
+              "text": "course",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 820,
+              "@type": "Word",
+              "@id": "_:Word_138"
+            },
+            {
+              "endOffset": 829,
+              "chunk": "B-PP",
+              "lemma": "of",
+              "tag": "IN",
+              "text": "of",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 827,
+              "@type": "Word",
+              "@id": "_:Word_139"
+            },
+            {
+              "endOffset": 838,
+              "chunk": "B-NP",
+              "lemma": "covid-19",
+              "tag": "NN",
+              "text": "COVID-19",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 830,
+              "@type": "Word",
+              "@id": "_:Word_140"
+            },
+            {
+              "endOffset": 848,
+              "chunk": "I-NP",
+              "lemma": "infection",
+              "tag": "NN",
+              "text": "infection",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 839,
+              "@type": "Word",
+              "@id": "_:Word_141"
+            },
+            {
+              "endOffset": 849,
+              "chunk": "O",
+              "lemma": ".",
+              "tag": ".",
+              "text": ".",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 848,
+              "@type": "Word",
+              "@id": "_:Word_142"
+            }
+          ],
+          "@type": "Sentence",
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_117"
+              },
+              "destination": {
+                "@id": "_:Word_121"
+              },
+              "relation": "nmod_of"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_117"
+              },
+              "destination": {
+                "@id": "_:Word_116"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_120"
+              },
+              "destination": {
+                "@id": "_:Word_119"
+              },
+              "relation": "advmod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_121"
+              },
+              "destination": {
+                "@id": "_:Word_120"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_121"
+              },
+              "destination": {
+                "@id": "_:Word_118"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_123"
+              },
+              "destination": {
+                "@id": "_:Word_122"
+              },
+              "relation": "aux"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_123"
+              },
+              "destination": {
+                "@id": "_:Word_125"
+              },
+              "relation": "dobj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_123"
+              },
+              "destination": {
+                "@id": "_:Word_142"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_123"
+              },
+              "destination": {
+                "@id": "_:Word_117"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_125"
+              },
+              "destination": {
+                "@id": "_:Word_124"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_125"
+              },
+              "destination": {
+                "@id": "_:Word_126"
+              },
+              "relation": "ref"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_125"
+              },
+              "destination": {
+                "@id": "_:Word_127"
+              },
+              "relation": "acl:relcl"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_127"
+              },
+              "destination": {
+                "@id": "_:Word_125"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_127"
+              },
+              "destination": {
+                "@id": "_:Word_128"
+              },
+              "relation": "dobj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_128"
+              },
+              "destination": {
+                "@id": "_:Word_136"
+              },
+              "relation": "nmod_into"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_128"
+              },
+              "destination": {
+                "@id": "_:Word_138"
+              },
+              "relation": "nmod_into"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_128"
+              },
+              "destination": {
+                "@id": "_:Word_131"
+              },
+              "relation": "nmod_into"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_131"
+              },
+              "destination": {
+                "@id": "_:Word_136"
+              },
+              "relation": "conj_and"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_131"
+              },
+              "destination": {
+                "@id": "_:Word_137"
+              },
+              "relation": "cc"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_131"
+              },
+              "destination": {
+                "@id": "_:Word_138"
+              },
+              "relation": "conj_and"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_131"
+              },
+              "destination": {
+                "@id": "_:Word_141"
+              },
+              "relation": "nmod_of"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_131"
+              },
+              "destination": {
+                "@id": "_:Word_129"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_131"
+              },
+              "destination": {
+                "@id": "_:Word_130"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_131"
+              },
+              "destination": {
+                "@id": "_:Word_132"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_131"
+              },
+              "destination": {
+                "@id": "_:Word_133"
+              },
+              "relation": "appos"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_131"
+              },
+              "destination": {
+                "@id": "_:Word_134"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_136"
+              },
+              "destination": {
+                "@id": "_:Word_135"
+              },
+              "relation": "amod"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_141"
+              },
+              "destination": {
+                "@id": "_:Word_139"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_141"
+              },
+              "destination": {
+                "@id": "_:Word_140"
+              },
+              "relation": "compound"
+            }
+          ],
+          "@id": "_:Sentence_8"
+        },
+        {
+          "text": "In this review , we summarize the epidemiology and characteristics of COVID-19 .",
+          "words": [
+            {
+              "endOffset": 852,
+              "chunk": "B-PP",
+              "lemma": "in",
+              "tag": "IN",
+              "text": "In",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 850,
+              "@type": "Word",
+              "@id": "_:Word_143"
+            },
+            {
+              "endOffset": 857,
+              "chunk": "B-NP",
+              "lemma": "this",
+              "tag": "DT",
+              "text": "this",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 853,
+              "@type": "Word",
+              "@id": "_:Word_144"
+            },
+            {
+              "endOffset": 864,
+              "chunk": "I-NP",
+              "lemma": "review",
+              "tag": "NN",
+              "text": "review",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 858,
+              "@type": "Word",
+              "@id": "_:Word_145"
+            },
+            {
+              "endOffset": 865,
+              "chunk": "O",
+              "lemma": ",",
+              "tag": ",",
+              "text": ",",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 864,
+              "@type": "Word",
+              "@id": "_:Word_146"
+            },
+            {
+              "endOffset": 868,
+              "chunk": "B-NP",
+              "lemma": "we",
+              "tag": "PRP",
+              "text": "we",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 866,
+              "@type": "Word",
+              "@id": "_:Word_147"
+            },
+            {
+              "endOffset": 878,
+              "chunk": "B-VP",
+              "lemma": "summarize",
+              "tag": "VBP",
+              "text": "summarize",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 869,
+              "@type": "Word",
+              "@id": "_:Word_148"
+            },
+            {
+              "endOffset": 882,
+              "chunk": "B-NP",
+              "lemma": "the",
+              "tag": "DT",
+              "text": "the",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 879,
+              "@type": "Word",
+              "@id": "_:Word_149"
+            },
+            {
+              "endOffset": 895,
+              "chunk": "I-NP",
+              "lemma": "epidemiology",
+              "tag": "NN",
+              "text": "epidemiology",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 883,
+              "@type": "Word",
+              "@id": "_:Word_150"
+            },
+            {
+              "endOffset": 899,
+              "chunk": "I-NP",
+              "lemma": "and",
+              "tag": "CC",
+              "text": "and",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 896,
+              "@type": "Word",
+              "@id": "_:Word_151"
+            },
+            {
+              "endOffset": 915,
+              "chunk": "I-NP",
+              "lemma": "characteristic",
+              "tag": "NNS",
+              "text": "characteristics",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 900,
+              "@type": "Word",
+              "@id": "_:Word_152"
+            },
+            {
+              "endOffset": 918,
+              "chunk": "B-PP",
+              "lemma": "of",
+              "tag": "IN",
+              "text": "of",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 916,
+              "@type": "Word",
+              "@id": "_:Word_153"
+            },
+            {
+              "endOffset": 927,
+              "chunk": "B-NP",
+              "lemma": "covid-19",
+              "tag": "NN",
+              "text": "COVID-19",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 919,
+              "@type": "Word",
+              "@id": "_:Word_154"
+            },
+            {
+              "endOffset": 928,
+              "chunk": "O",
+              "lemma": ".",
+              "tag": ".",
+              "text": ".",
+              "norm": "O",
+              "entity": "O",
+              "startOffset": 927,
+              "@type": "Word",
+              "@id": "_:Word_155"
+            }
+          ],
+          "@type": "Sentence",
+          "dependencies": [
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_145"
+              },
+              "destination": {
+                "@id": "_:Word_143"
+              },
+              "relation": "case"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_145"
+              },
+              "destination": {
+                "@id": "_:Word_144"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_148"
+              },
+              "destination": {
+                "@id": "_:Word_150"
+              },
+              "relation": "dobj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_148"
+              },
+              "destination": {
+                "@id": "_:Word_152"
+              },
+              "relation": "dobj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_148"
+              },
+              "destination": {
+                "@id": "_:Word_155"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_148"
+              },
+              "destination": {
+                "@id": "_:Word_145"
+              },
+              "relation": "nmod_in"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_148"
+              },
+              "destination": {
+                "@id": "_:Word_146"
+              },
+              "relation": "punct"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_148"
+              },
+              "destination": {
+                "@id": "_:Word_147"
+              },
+              "relation": "nsubj"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_150"
+              },
+              "destination": {
+                "@id": "_:Word_151"
+              },
+              "relation": "cc"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_150"
+              },
+              "destination": {
+                "@id": "_:Word_152"
+              },
+              "relation": "conj_and"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_150"
+              },
+              "destination": {
+                "@id": "_:Word_154"
+              },
+              "relation": "nmod_of"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_150"
+              },
+              "destination": {
+                "@id": "_:Word_149"
+              },
+              "relation": "det"
+            },
+            {
+              "@type": "Dependency",
+              "source": {
+                "@id": "_:Word_154"
+              },
+              "destination": {
+                "@id": "_:Word_153"
+              },
+              "relation": "case"
+            }
+          ],
+          "@id": "_:Sentence_9"
+        }
+      ]
+    }
+  ],
+  "extractions": [
+    {
+      "subtype": "entity",
+      "rule": "simple-np",
+      "text": "COVID-19 is another human infectious disease",
+      "canonicalName": "covid-19 be human infectious disease",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 207,
+              "end": 250
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 6
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_3"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "interventions",
+          "version": "359829afbe9bb5ba9af990121c1bd936a52e7a2e",
+          "versionDate": "2019-02-24T01:21:07Z"
+        },
+        {
+          "name": "mitre12",
+          "versionDate": "2019-01-16T20:38:37Z",
+          "version": "c60184fd04a89ebdea7ccf633b83e6bc6623a207",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Other diseases that are treated",
+              "value": 0.7771876454353333
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Contagious Bovine Pleuropneumonia (CBPP) that are vaccinated",
+              "value": 0.7320500016212463
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Cause of death, by communicable diseases and maternal, prenatal and nutrition conditions",
+              "value": 0.7299333214759827
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Contagious Bovine Pleuropneumonia (CBPP) that are reported",
+              "value": 0.7271103858947754
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Lumpy Skin Disease (LSD) that are treated",
+              "value": 0.7104572653770447
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Lumpy Skin Disease (LSD) that are vaccinated",
+              "value": 0.7033374309539795
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Contagious Caprine Pleuropneumonia (CCPP) that are reported",
+              "value": 0.6780744791030884
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Lumpy Skin Disease (LSD) that are reported",
+              "value": 0.6753506660461426
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Other diseases that are reported",
+              "value": 0.6725918054580688
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Cause of death, by non-communicable diseases",
+              "value": 0.6578769087791443
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props",
+          "version": "104fb23a0ab1ef178c133a95a0b25f42c4ea94ca",
+          "versionDate": "2018-08-07T23:00:18Z"
+        },
+        {
+          "name": "un",
+          "versionDate": "2019-01-05T06:06:38Z",
+          "version": "dd7a44ceac00dc514d0c5926b25235018deb5670",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/disease",
+              "value": 0.7259082794189453
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/health_intervention",
+              "value": 0.5801927447319031
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/pest",
+              "value": 0.5043924450874329
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/death",
+              "value": 0.45086681842803955
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/biology/fauna",
+              "value": 0.44772976636886597
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/livestock",
+              "value": 0.44512268900871277
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_insecurity",
+              "value": 0.4180295467376709
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/nature_impact/pollution/land_pollution",
+              "value": 0.3874787986278534
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/famine",
+              "value": 0.3809967339038849
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/nutrient",
+              "value": 0.3707854151725769
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "who",
+          "versionDate": "2018-11-21T22:10:05Z",
+          "version": "94f46343f7428aac6160e24788850a8fe6e8c5e7",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/New cases of IHR-notifiable diseases and other notifiable diseases",
+              "value": 0.7664413452148438
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/New cases of vaccine-preventable diseases",
+              "value": 0.7651791572570801
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Mortality between 30 and 70 years of age from cardiovascular diseases, cancer, diabetes or chronic respiratory diseases",
+              "value": 0.7147617340087891
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV/People living with HIV who have been diagnosed",
+              "value": 0.6774632334709167
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/Malaria incidence rate",
+              "value": 0.6461554765701294
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Neglected tropical diseases/Coverage of preventive chemotherapy for selected neglected tropical diseases",
+              "value": 0.6288770437240601
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Malaria/Treatment of confirmed malaria cases",
+              "value": 0.6276588439941406
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/HIV incidence rate",
+              "value": 0.6235688328742981
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Tuberculosis/TB patients with results for drug susceptibility testing",
+              "value": 0.6174383163452148
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Malaria mortality rate",
+              "value": 0.6164438724517822
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "wm_flattened",
+          "versionDate": "2019-12-12T17:02:39Z",
+          "version": "87c0acf615936fa8ee078bfc81e1f5b39a3d35e2",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/disease/human_disease",
+              "value": 0.771277666091919
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/communicable_disease_outbreak_control",
+              "value": 0.7312753200531006
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/agriculture/livestock_disease",
+              "value": 0.6617177128791809
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/therapeutic_feeding",
+              "value": 0.6189769506454468
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/treatment/health_treatment",
+              "value": 0.5952654480934143
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/crisis_and_disaster/environmental_disasters/insect_infestation",
+              "value": 0.5344899892807007
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/nutrition/malnutrition",
+              "value": 0.5240693688392639
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/provision_of_insecticide_treated_bednets",
+              "value": 0.5178910493850708
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/agriculture/plant_disease/pest_infestation",
+              "value": 0.5073145627975464
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/crisis_and_disaster/famine",
+              "value": 0.5037875175476074
+            }
+          ],
+          "@type": "Groundings"
+        }
+      ],
+      "@id": "_:Extraction_1"
+    },
+    {
+      "subtype": "causation",
+      "rule": "ported_syntax_1c_verb-Causal",
+      "text": "COVID-19 is another human infectious disease caused by coronavirus",
+      "canonicalName": "covid-19 be human infectious disease cause coronavirus",
+      "labels": [
+        "Causal",
+        "DirectedRelation",
+        "EntityLinker",
+        "Event"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 207,
+              "end": 272
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 9
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_3"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "relation",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "interventions",
+          "version": "359829afbe9bb5ba9af990121c1bd936a52e7a2e",
+          "versionDate": "2019-02-24T01:21:07Z"
+        },
+        {
+          "@type": "Groundings",
+          "name": "mitre12",
+          "version": "c60184fd04a89ebdea7ccf633b83e6bc6623a207",
+          "versionDate": "2019-01-16T20:38:37Z"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props",
+          "version": "104fb23a0ab1ef178c133a95a0b25f42c4ea94ca",
+          "versionDate": "2018-08-07T23:00:18Z"
+        },
+        {
+          "@type": "Groundings",
+          "name": "un",
+          "version": "dd7a44ceac00dc514d0c5926b25235018deb5670",
+          "versionDate": "2019-01-05T06:06:38Z"
+        },
+        {
+          "@type": "Groundings",
+          "name": "who",
+          "version": "94f46343f7428aac6160e24788850a8fe6e8c5e7",
+          "versionDate": "2018-11-21T22:10:05Z"
+        },
+        {
+          "@type": "Groundings",
+          "name": "wm_flattened",
+          "version": "87c0acf615936fa8ee078bfc81e1f5b39a3d35e2",
+          "versionDate": "2019-12-12T17:02:39Z"
+        }
+      ],
+      "arguments": [
+        {
+          "@type": "Argument",
+          "type": "source",
+          "value": {
+            "@id": "_:Extraction_3"
+          }
+        },
+        {
+          "@type": "Argument",
+          "type": "destination",
+          "value": {
+            "@id": "_:Extraction_1"
+          }
+        }
+      ],
+      "@id": "_:Extraction_2",
+      "trigger": {
+        "@type": "Trigger",
+        "text": "caused",
+        "provenance": [
+          {
+            "documentCharPositions": [
+              {
+                "@type": "Interval",
+                "start": 252,
+                "end": 257
+              }
+            ],
+            "document": {
+              "@id": "_:Document_1"
+            },
+            "sentenceWordPositions": [
+              {
+                "@type": "Interval",
+                "start": 7,
+                "end": 7
+              }
+            ],
+            "@type": "Provenance",
+            "sentence": {
+              "@id": "_:Sentence_3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "subtype": "entity",
+      "rule": "simple-np",
+      "text": "coronavirus",
+      "canonicalName": "coronavirus",
+      "labels": [
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 262,
+              "end": 272
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 9,
+              "end": 9
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_3"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "interventions",
+          "version": "359829afbe9bb5ba9af990121c1bd936a52e7a2e",
+          "versionDate": "2019-02-24T01:21:07Z"
+        },
+        {
+          "name": "mitre12",
+          "versionDate": "2019-01-16T20:38:37Z",
+          "version": "c60184fd04a89ebdea7ccf633b83e6bc6623a207",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of HIV",
+              "value": 0.6234621405601501
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of tuberculosis",
+              "value": 0.5979281067848206
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of malaria",
+              "value": 0.5962808728218079
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Contagious Bovine Pleuropneumonia (CBPP) that are vaccinated",
+              "value": 0.5841183066368103
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Cause of death, by non-communicable diseases",
+              "value": 0.5835002660751343
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Contagious Bovine Pleuropneumonia (CBPP) that are reported",
+              "value": 0.5715135931968689
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Emissions (CO2eq) (Enteric), All Animals",
+              "value": 0.5598170757293701
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Emissions (CH4) (Enteric), All Animals",
+              "value": 0.5598170757293701
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Cause of death, by communicable diseases and maternal, prenatal and nutrition conditions",
+              "value": 0.5590007305145264
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Contagious Caprine Pleuropneumonia (CCPP) that are reported",
+              "value": 0.5552124977111816
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props",
+          "version": "104fb23a0ab1ef178c133a95a0b25f42c4ea94ca",
+          "versionDate": "2018-08-07T23:00:18Z"
+        },
+        {
+          "name": "un",
+          "versionDate": "2019-01-05T06:06:38Z",
+          "version": "dd7a44ceac00dc514d0c5926b25235018deb5670",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/disease",
+              "value": 0.7289406061172485
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/health_intervention",
+              "value": 0.5783351063728333
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/pest",
+              "value": 0.4672566056251526
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/biology/fauna",
+              "value": 0.3889879882335663
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/livestock",
+              "value": 0.3677811920642853
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/nature_impact/pollution/land_pollution",
+              "value": 0.34496912360191345
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/death",
+              "value": 0.32718318700790405
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/pesticide",
+              "value": 0.319604754447937
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/nutrient",
+              "value": 0.2755662202835083
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/chemical",
+              "value": 0.237339049577713
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "who",
+          "versionDate": "2018-11-21T22:10:05Z",
+          "version": "94f46343f7428aac6160e24788850a8fe6e8c5e7",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/New cases of IHR-notifiable diseases and other notifiable diseases",
+              "value": 0.7273988723754883
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/New cases of vaccine-preventable diseases",
+              "value": 0.7065185308456421
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/HIV incidence rate",
+              "value": 0.6234621405601501
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/HIV prevalence rate",
+              "value": 0.6169477105140686
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/Malaria incidence rate",
+              "value": 0.5962808728218079
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/Sexually transmitted infections (STIs) incidence rate",
+              "value": 0.5959169864654541
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Care-seeking for symptoms of pneumonia",
+              "value": 0.5919041633605957
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Mortality between 30 and 70 years of age from cardiovascular diseases, cancer, diabetes or chronic respiratory diseases",
+              "value": 0.5839962959289551
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV/HIV viral load suppression",
+              "value": 0.5735390782356262
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/Cancer incidence, by type of cancer",
+              "value": 0.5304582715034485
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "wm_flattened",
+          "versionDate": "2019-12-12T17:02:39Z",
+          "version": "87c0acf615936fa8ee078bfc81e1f5b39a3d35e2",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/disease/human_disease",
+              "value": 0.7371057868003845
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/agriculture/livestock_disease",
+              "value": 0.5994155406951904
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/communicable_disease_outbreak_control",
+              "value": 0.5786002278327942
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/agriculture/plant_disease/pest_infestation",
+              "value": 0.4661996066570282
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/crisis_and_disaster/environmental_disasters/insect_infestation",
+              "value": 0.4569494426250458
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/therapeutic_feeding",
+              "value": 0.4341307580471039
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/treatment/health_treatment",
+              "value": 0.40784189105033875
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/nutrition/malnutrition",
+              "value": 0.4069540500640869
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/death",
+              "value": 0.39632490277290344
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/agriculture/livestock_production",
+              "value": 0.3318766951560974
+            }
+          ],
+          "@type": "Groundings"
+        }
+      ],
+      "@id": "_:Extraction_3"
+    },
+    {
+      "subtype": "entity",
+      "rule": "simple-np++Decrease_explicit_neg_dep",
+      "text": "no specific drug for COVID-19",
+      "canonicalName": "specific drug covid-19",
+      "labels": [
+        "Concept-Expanded",
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 361,
+              "end": 389
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 4,
+              "end": 8
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_5"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "interventions",
+          "version": "359829afbe9bb5ba9af990121c1bd936a52e7a2e",
+          "versionDate": "2019-02-24T01:21:07Z"
+        },
+        {
+          "name": "mitre12",
+          "versionDate": "2019-01-16T20:38:37Z",
+          "version": "c60184fd04a89ebdea7ccf633b83e6bc6623a207",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Children with fever receiving antimalarial drugs",
+              "value": 0.6263973116874695
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Antiretroviral therapy coverage for PMTCT",
+              "value": 0.5027800798416138
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Antiretroviral therapy coverage",
+              "value": 0.5027800798416138
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Direct emissions (CO2eq) (Manure applied), All Animals",
+              "value": 0.45640674233436584
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Direct emissions (N2O) (Manure applied), All Animals",
+              "value": 0.45640674233436584
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Direct emissions (N2O) (Manure applied), Asses",
+              "value": 0.4458337426185608
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Direct emissions (CO2eq) (Manure applied), Mules and Asses",
+              "value": 0.4458337426185608
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Direct emissions (CO2eq) (Manure applied), Cattle, non-dairy",
+              "value": 0.4458337426185608
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Direct emissions (CO2eq) (Manure applied), Goats",
+              "value": 0.4458337426185608
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Direct emissions (N2O) (Manure applied), Poultry Birds",
+              "value": 0.4458337426185608
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props",
+          "version": "104fb23a0ab1ef178c133a95a0b25f42c4ea94ca",
+          "versionDate": "2018-08-07T23:00:18Z"
+        },
+        {
+          "name": "un",
+          "versionDate": "2019-01-05T06:06:38Z",
+          "version": "dd7a44ceac00dc514d0c5926b25235018deb5670",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_security",
+              "value": 0.4183288514614105
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/government/government_actions/regulation",
+              "value": 0.4095083177089691
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/nutrient",
+              "value": 0.3843506872653961
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/disease",
+              "value": 0.37004539370536804
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/government/government_actions/duty",
+              "value": 0.3649544417858124
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/pesticide",
+              "value": 0.35314682126045227
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/health_intervention",
+              "value": 0.3460547626018524
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/food_availability",
+              "value": 0.3200252652168274
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/product",
+              "value": 0.31855931878089905
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/humanitarian assistance",
+              "value": 0.30535104870796204
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "who",
+          "versionDate": "2018-11-21T22:10:05Z",
+          "version": "94f46343f7428aac6160e24788850a8fe6e8c5e7",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Tuberculosis/TB patients with results for drug susceptibility testing",
+              "value": 0.6029143333435059
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Contraceptive prevalence rate",
+              "value": 0.5047789216041565
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Malaria/Intermittent preventive therapy for malaria during pregnancy (IPTp)",
+              "value": 0.4762782156467438
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV/Antiretroviral therapy (ART) coverage",
+              "value": 0.4640315771102905
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Malaria/Treatment of confirmed malaria cases",
+              "value": 0.4638948142528534
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Neglected tropical diseases/Coverage of preventive chemotherapy for selected neglected tropical diseases",
+              "value": 0.45241421461105347
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV\\/TB/TB preventive therapy for HIV-positive people newly enrolled in HIV care",
+              "value": 0.4363936483860016
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV\\/TB/HIV test results for registered new and relapse TB patients",
+              "value": 0.43391847610473633
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Noncommunicable diseases/Raised blood glucose\\/diabetes among adults",
+              "value": 0.43322813510894775
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Children with diarrhoea receiving oral rehydration solution (ORS)",
+              "value": 0.4135478138923645
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "wm_flattened",
+          "versionDate": "2019-12-12T17:02:39Z",
+          "version": "87c0acf615936fa8ee078bfc81e1f5b39a3d35e2",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/disease/alcohol_drug_and_substance_abuse",
+              "value": 0.6761161088943481
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/anti_retroviral_treatment",
+              "value": 0.5544342994689941
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/provision_of_insecticide_treated_bednets",
+              "value": 0.5217075943946838
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/clinical_management_of_sexual_violence",
+              "value": 0.5070027709007263
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/treatment/health_treatment",
+              "value": 0.48746973276138306
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/micro_nutrient_supplementation",
+              "value": 0.46581998467445374
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/malnutrition_screening",
+              "value": 0.4505588114261627
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/nutrition/food_diversity",
+              "value": 0.4480610191822052
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/therapeutic_feeding",
+              "value": 0.4452876150608063
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/provision_of_non_formal_education",
+              "value": 0.4253058135509491
+            }
+          ],
+          "@type": "Groundings"
+        }
+      ],
+      "states": [
+        {
+          "@type": "State",
+          "type": "DEC",
+          "text": "no",
+          "provenance": [
+            {
+              "documentCharPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 361,
+                  "end": 362
+                }
+              ],
+              "document": {
+                "@id": "_:Document_1"
+              },
+              "sentenceWordPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 4,
+                  "end": 4
+                }
+              ],
+              "@type": "Provenance",
+              "sentence": {
+                "@id": "_:Sentence_5"
+              }
+            }
+          ]
+        }
+      ],
+      "@id": "_:Extraction_4"
+    },
+    {
+      "subtype": "entity",
+      "rule": "simple-np++quantification2",
+      "text": "severe illness",
+      "canonicalName": "illness",
+      "labels": [
+        "Concept-Expanded",
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 505,
+              "end": 518
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 12,
+              "end": 13
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_6"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "interventions",
+          "version": "359829afbe9bb5ba9af990121c1bd936a52e7a2e",
+          "versionDate": "2019-02-24T01:21:07Z"
+        },
+        {
+          "name": "mitre12",
+          "versionDate": "2019-01-16T20:38:37Z",
+          "version": "c60184fd04a89ebdea7ccf633b83e6bc6623a207",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Cause of death, by non-communicable diseases",
+              "value": 0.7110844254493713
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Cause of death, by communicable diseases and maternal, prenatal and nutrition conditions",
+              "value": 0.6477725505828857
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Number of children aged 6 to 59 months with severe acute malnutrition admitted for treatment",
+              "value": 0.6414816379547119
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of tuberculosis",
+              "value": 0.6355893015861511
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Cause of death, by injury",
+              "value": 0.5968014597892761
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Tuberculosis treatment success rate",
+              "value": 0.5892245173454285
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of malaria",
+              "value": 0.5872447490692139
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of HIV",
+              "value": 0.5773097276687622
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Tuberculosis case detection rate",
+              "value": 0.5286874771118164
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Prevalence of anemia among children",
+              "value": 0.5250416994094849
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props",
+          "version": "104fb23a0ab1ef178c133a95a0b25f42c4ea94ca",
+          "versionDate": "2018-08-07T23:00:18Z"
+        },
+        {
+          "name": "un",
+          "versionDate": "2019-01-05T06:06:38Z",
+          "version": "dd7a44ceac00dc514d0c5926b25235018deb5670",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/disease",
+              "value": 0.6723352074623108
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/death",
+              "value": 0.4851799011230469
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/health_intervention",
+              "value": 0.4736287593841553
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/famine",
+              "value": 0.43058428168296814
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_insecurity",
+              "value": 0.3676756024360657
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/crisis",
+              "value": 0.32276269793510437
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/natural_disaster/drought",
+              "value": 0.3062300384044647
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/physical_insecurity",
+              "value": 0.30361583828926086
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/pest",
+              "value": 0.2796691358089447
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/nutrient",
+              "value": 0.26538538932800293
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "who",
+          "versionDate": "2018-11-21T22:10:05Z",
+          "version": "94f46343f7428aac6160e24788850a8fe6e8c5e7",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Care-seeking for symptoms of pneumonia",
+              "value": 0.7628383636474609
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/New cases of vaccine-preventable diseases",
+              "value": 0.7363280653953552
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Mortality between 30 and 70 years of age from cardiovascular diseases, cancer, diabetes or chronic respiratory diseases",
+              "value": 0.7231131792068481
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/New cases of IHR-notifiable diseases and other notifiable diseases",
+              "value": 0.7005384564399719
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Mental Health/Coverage of services for severe mental health disorders",
+              "value": 0.6329517364501953
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/Malaria incidence rate",
+              "value": 0.5872447490692139
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Tuberculosis/Second-line treatment coverage among multidrug-resistant tuberculosis (MDR-TB) cases",
+              "value": 0.5835109949111938
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/Cancer incidence, by type of cancer",
+              "value": 0.5830661058425903
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/HIV incidence rate",
+              "value": 0.5773097276687622
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV\\/TB/HIV-positive new and relapse TB patients on ART during TB treatment",
+              "value": 0.5770328044891357
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "wm_flattened",
+          "versionDate": "2019-12-12T17:02:39Z",
+          "version": "87c0acf615936fa8ee078bfc81e1f5b39a3d35e2",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/disease/human_disease",
+              "value": 0.7727895975112915
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/treatment/health_treatment",
+              "value": 0.5962254405021667
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/communicable_disease_outbreak_control",
+              "value": 0.5810407996177673
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/agriculture/livestock_disease",
+              "value": 0.5664222836494446
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/therapeutic_feeding",
+              "value": 0.5571349859237671
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/death",
+              "value": 0.5321665406227112
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/crisis_and_disaster/famine",
+              "value": 0.5118430852890015
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/nutrition/malnutrition",
+              "value": 0.49638795852661133
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/birth",
+              "value": 0.44527724385261536
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/trauma_injury_and_post_operative_rehabilitation",
+              "value": 0.43176528811454773
+            }
+          ],
+          "@type": "Groundings"
+        }
+      ],
+      "states": [
+        {
+          "@type": "State",
+          "type": "QUANT",
+          "text": "severe",
+          "provenance": [
+            {
+              "documentCharPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 505,
+                  "end": 510
+                }
+              ],
+              "document": {
+                "@id": "_:Document_1"
+              },
+              "sentenceWordPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 12,
+                  "end": 12
+                }
+              ],
+              "@type": "Provenance",
+              "sentence": {
+                "@id": "_:Sentence_6"
+              }
+            }
+          ]
+        }
+      ],
+      "@id": "_:Extraction_5"
+    },
+    {
+      "subtype": "entity",
+      "rule": "simple-np++quantification2",
+      "text": "more aggressive treatment",
+      "canonicalName": "treatment",
+      "labels": [
+        "Concept-Expanded",
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 525,
+              "end": 549
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 15,
+              "end": 17
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_6"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "interventions",
+          "version": "359829afbe9bb5ba9af990121c1bd936a52e7a2e",
+          "versionDate": "2019-02-24T01:21:07Z"
+        },
+        {
+          "name": "mitre12",
+          "versionDate": "2019-01-16T20:38:37Z",
+          "version": "c60184fd04a89ebdea7ccf633b83e6bc6623a207",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Tuberculosis treatment success rate",
+              "value": 0.7732090353965759
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Antiretroviral therapy coverage for PMTCT",
+              "value": 0.7035070061683655
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Antiretroviral therapy coverage",
+              "value": 0.7035070061683655
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Number of children aged 6 to 59 months with severe acute malnutrition admitted for treatment",
+              "value": 0.6348246932029724
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Children with fever receiving antimalarial drugs",
+              "value": 0.6100537776947021
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Pregnant women receiving prenatal care",
+              "value": 0.5559564232826233
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Cause of death, by communicable diseases and maternal, prenatal and nutrition conditions",
+              "value": 0.5548078417778015
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Prevalence of anemia among children",
+              "value": 0.5368232727050781
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Number of surgical procedures",
+              "value": 0.5307372212409973
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Tuberculosis case detection rate",
+              "value": 0.5100619196891785
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props",
+          "version": "104fb23a0ab1ef178c133a95a0b25f42c4ea94ca",
+          "versionDate": "2018-08-07T23:00:18Z"
+        },
+        {
+          "name": "un",
+          "versionDate": "2019-01-05T06:06:38Z",
+          "version": "dd7a44ceac00dc514d0c5926b25235018deb5670",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/disease",
+              "value": 0.522254467010498
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/health_intervention",
+              "value": 0.43740716576576233
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/nutrient",
+              "value": 0.40418657660484314
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/infrastructure/water_management",
+              "value": 0.39604443311691284
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_security",
+              "value": 0.37326616048812866
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/interventions/humanitarian assistance",
+              "value": 0.3602747619152069
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/death",
+              "value": 0.35330793261528015
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_insecurity",
+              "value": 0.3514510691165924
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/agriculture/farming",
+              "value": 0.3294319808483124
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/pesticide",
+              "value": 0.2876146137714386
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "who",
+          "versionDate": "2018-11-21T22:10:05Z",
+          "version": "94f46343f7428aac6160e24788850a8fe6e8c5e7",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Tuberculosis/Second-line treatment coverage among multidrug-resistant tuberculosis (MDR-TB) cases",
+              "value": 0.8320218324661255
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Quality and safety of care/TB treatment success rate",
+              "value": 0.728390097618103
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Malaria/Treatment of confirmed malaria cases",
+              "value": 0.7274212837219238
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV\\/TB/HIV-positive new and relapse TB patients on ART during TB treatment",
+              "value": 0.7025913000106812
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV\\/TB/TB preventive therapy for HIV-positive people newly enrolled in HIV care",
+              "value": 0.6715782284736633
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Tuberculosis/TB patients with results for drug susceptibility testing",
+              "value": 0.6538662910461426
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Malaria/Intermittent preventive therapy for malaria during pregnancy (IPTp)",
+              "value": 0.6523653864860535
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Screening and preventive care/Cervical cancer screening",
+              "value": 0.632262647151947
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Neglected tropical diseases/Coverage of preventive chemotherapy for selected neglected tropical diseases",
+              "value": 0.6274587512016296
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV/Antiretroviral therapy (ART) coverage",
+              "value": 0.6193976998329163
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "wm_flattened",
+          "versionDate": "2019-12-12T17:02:39Z",
+          "version": "87c0acf615936fa8ee078bfc81e1f5b39a3d35e2",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/treatment/health_treatment",
+              "value": 0.9056107401847839
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/therapeutic_feeding",
+              "value": 0.7635128498077393
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/anti_retroviral_treatment",
+              "value": 0.6984786987304688
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/trauma_and_surgical_care",
+              "value": 0.6727717518806458
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/access/infrastructure_access/medical/medical_facility",
+              "value": 0.6384825110435486
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/provision_of_insecticide_treated_bednets",
+              "value": 0.5944048166275024
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/malnutrition_screening",
+              "value": 0.5820592641830444
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/obstetric_and_newborn_care",
+              "value": 0.5784139037132263
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/point_of_use_water_treatment_at_household_level",
+              "value": 0.5708673596382141
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/access/infrastructure_access/waste",
+              "value": 0.557905375957489
+            }
+          ],
+          "@type": "Groundings"
+        }
+      ],
+      "states": [
+        {
+          "@type": "State",
+          "type": "QUANT",
+          "text": "aggressive",
+          "provenance": [
+            {
+              "documentCharPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 530,
+                  "end": 539
+                }
+              ],
+              "document": {
+                "@id": "_:Document_1"
+              },
+              "sentenceWordPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 16,
+                  "end": 16
+                }
+              ],
+              "@type": "Provenance",
+              "sentence": {
+                "@id": "_:Sentence_6"
+              }
+            }
+          ]
+        }
+      ],
+      "@id": "_:Extraction_6"
+    },
+    {
+      "subtype": "entity",
+      "rule": "simple-np++quantification2",
+      "text": "The development of highly sensitive RT-PCR",
+      "canonicalName": "development rt-pcr",
+      "labels": [
+        "Concept-Expanded",
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 654,
+              "end": 695
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 1,
+              "end": 6
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_8"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "interventions",
+          "version": "359829afbe9bb5ba9af990121c1bd936a52e7a2e",
+          "versionDate": "2019-02-24T01:21:07Z"
+        },
+        {
+          "name": "mitre12",
+          "versionDate": "2019-01-16T20:38:37Z",
+          "version": "c60184fd04a89ebdea7ccf633b83e6bc6623a207",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/CPIA policies for social inclusion\\/equity cluster average",
+              "value": 0.571075439453125
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/CO2 emissions from manufacturing industries and construction",
+              "value": 0.5534005165100098
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/CPIA building human resources rating",
+              "value": 0.5412935018539429
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Emissions (CO2eq) (Enteric), All Animals",
+              "value": 0.5331239700317383
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Emissions (CH4) (Enteric), All Animals",
+              "value": 0.5331239700317383
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/CPIA economic management cluster average",
+              "value": 0.5224558711051941
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Direct emissions (N2O) (Manure management), All Animals",
+              "value": 0.5119603872299194
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Direct emissions (CO2eq) (Manure management), All Animals",
+              "value": 0.5119603872299194
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Grants, excluding technical cooperation",
+              "value": 0.5102124214172363
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Tuberculosis case detection rate",
+              "value": 0.5086265802383423
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props",
+          "version": "104fb23a0ab1ef178c133a95a0b25f42c4ea94ca",
+          "versionDate": "2018-08-07T23:00:18Z"
+        },
+        {
+          "name": "un",
+          "versionDate": "2019-01-05T06:06:38Z",
+          "version": "dd7a44ceac00dc514d0c5926b25235018deb5670",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/management",
+              "value": 0.5482045412063599
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/nature_impact/forestry",
+              "value": 0.5461311340332031
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/government/government_actions/duty",
+              "value": 0.5334855914115906
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/nature_impact/resource_management",
+              "value": 0.4819549322128296
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/government/government_actions/organization",
+              "value": 0.47406160831451416
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/government/government_entity",
+              "value": 0.47127634286880493
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/natural_resources/abiotic_resources/resource",
+              "value": 0.46180838346481323
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/agriculture/farming",
+              "value": 0.45877495408058167
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/health_intervention",
+              "value": 0.4538103938102722
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/pest",
+              "value": 0.43904462456703186
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "who",
+          "versionDate": "2018-11-21T22:10:05Z",
+          "version": "94f46343f7428aac6160e24788850a8fe6e8c5e7",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Tuberculosis/TB patients with results for drug susceptibility testing",
+              "value": 0.4898858368396759
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health workforce/Health worker density and distribution",
+              "value": 0.4713222086429596
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Tuberculosis/TB case detection rate",
+              "value": 0.4633951485157013
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Demand for family planning satis ed with modern methods",
+              "value": 0.4596167504787445
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health information/Completeness of reporting by facilities",
+              "value": 0.4519166946411133
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Neglected tropical diseases/Coverage of preventive chemotherapy for selected neglected tropical diseases",
+              "value": 0.44891801476478577
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Quality and safety of care/TB treatment success rate",
+              "value": 0.4481099843978882
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Immunization/Immunization coverage rate by vaccine for each vaccine in the national schedule",
+              "value": 0.4474603831768036
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV\\/TB/TB preventive therapy for HIV-positive people newly enrolled in HIV care",
+              "value": 0.44364017248153687
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Access/Availability of essential medicines and commodities",
+              "value": 0.44205549359321594
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "wm_flattened",
+          "versionDate": "2019-12-12T17:02:39Z",
+          "version": "87c0acf615936fa8ee078bfc81e1f5b39a3d35e2",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/economic_and_commerce/economic_activity/development",
+              "value": 0.7283195853233337
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/micro_nutrient_supplementation",
+              "value": 0.5841516256332397
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/environmental/forestry",
+              "value": 0.5177346467971802
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/hygiene_promotion_campaigns",
+              "value": 0.5150930285453796
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/vector_control",
+              "value": 0.5099554657936096
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/anti_retroviral_treatment",
+              "value": 0.5084918737411499
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/environmental/resource_management",
+              "value": 0.5007655620574951
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/malnutrition_screening",
+              "value": 0.4940263032913208
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/therapeutic_feeding",
+              "value": 0.4751548767089844
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/institutional_support/support_to_health_facilities",
+              "value": 0.4751419425010681
+            }
+          ],
+          "@type": "Groundings"
+        }
+      ],
+      "states": [
+        {
+          "text": "sensitive",
+          "modifiers": [
+            {
+              "intercept": 0.6496,
+              "text": "highly",
+              "sigma": -0.001123,
+              "provenance": [
+                {
+                  "documentCharPositions": [
+                    {
+                      "@type": "Interval",
+                      "start": 673,
+                      "end": 678
+                    }
+                  ],
+                  "document": {
+                    "@id": "_:Document_1"
+                  },
+                  "sentenceWordPositions": [
+                    {
+                      "@type": "Interval",
+                      "start": 4,
+                      "end": 4
+                    }
+                  ],
+                  "@type": "Provenance",
+                  "sentence": {
+                    "@id": "_:Sentence_8"
+                  }
+                }
+              ],
+              "@type": "Modifier",
+              "mu": 1.034e-05
+            }
+          ],
+          "provenance": [
+            {
+              "documentCharPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 680,
+                  "end": 688
+                }
+              ],
+              "document": {
+                "@id": "_:Document_1"
+              },
+              "sentenceWordPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 5,
+                  "end": 5
+                }
+              ],
+              "@type": "Provenance",
+              "sentence": {
+                "@id": "_:Sentence_8"
+              }
+            }
+          ],
+          "@type": "State",
+          "type": "QUANT"
+        }
+      ],
+      "@id": "_:Extraction_7"
+    },
+    {
+      "subtype": "entity",
+      "rule": "simple-np++Increase_ported_syntax_1_verb",
+      "text": "insight into the prevalence, seasonality, clinical manifestations and course of COVID-19 infection",
+      "canonicalName": "seasonality clinical manifestation course covid-19 infection",
+      "labels": [
+        "Concept-Expanded",
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 750,
+              "end": 847
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 13,
+              "end": 26
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_8"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "interventions",
+          "version": "359829afbe9bb5ba9af990121c1bd936a52e7a2e",
+          "versionDate": "2019-02-24T01:21:07Z"
+        },
+        {
+          "name": "mitre12",
+          "versionDate": "2019-01-16T20:38:37Z",
+          "version": "c60184fd04a89ebdea7ccf633b83e6bc6623a207",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Tuberculosis treatment success rate",
+              "value": 0.6537290215492249
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of HIV",
+              "value": 0.5988801121711731
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Mortality from CVD, cancer, diabetes or CRD between exact ages 30 and 70",
+              "value": 0.5964562296867371
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Cause of death, by communicable diseases and maternal, prenatal and nutrition conditions",
+              "value": 0.5846115350723267
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of tuberculosis",
+              "value": 0.5798810124397278
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Lumpy Skin Disease (LSD) that are treated",
+              "value": 0.5757822394371033
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of malaria",
+              "value": 0.5719294548034668
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Number of children aged 6 to 59 months with severe acute malnutrition admitted for treatment",
+              "value": 0.5568200349807739
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Lumpy Skin Disease (LSD) that are reported",
+              "value": 0.555085301399231
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Lumpy Skin Disease (LSD) that are vaccinated",
+              "value": 0.5359853506088257
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props",
+          "version": "104fb23a0ab1ef178c133a95a0b25f42c4ea94ca",
+          "versionDate": "2018-08-07T23:00:18Z"
+        },
+        {
+          "name": "un",
+          "versionDate": "2019-01-05T06:06:38Z",
+          "version": "dd7a44ceac00dc514d0c5926b25235018deb5670",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/disease",
+              "value": 0.5716700553894043
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/health_intervention",
+              "value": 0.5187397599220276
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/nutrient",
+              "value": 0.46558746695518494
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/death",
+              "value": 0.45720475912094116
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/pest",
+              "value": 0.398122102022171
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_insecurity",
+              "value": 0.39410990476608276
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/physical_insecurity",
+              "value": 0.36928239464759827
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/agriculture/farming",
+              "value": 0.35950079560279846
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/soil/soil_contents",
+              "value": 0.3220760226249695
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/biology/ecosystem",
+              "value": 0.32100269198417664
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "who",
+          "versionDate": "2018-11-21T22:10:05Z",
+          "version": "94f46343f7428aac6160e24788850a8fe6e8c5e7",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Tuberculosis/TB patients with results for drug susceptibility testing",
+              "value": 0.6756271719932556
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Care-seeking for symptoms of pneumonia",
+              "value": 0.6681642532348633
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Mortality between 30 and 70 years of age from cardiovascular diseases, cancer, diabetes or chronic respiratory diseases",
+              "value": 0.6285590529441833
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Quality and safety of care/TB treatment success rate",
+              "value": 0.6141887903213501
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV\\/TB/HIV test results for registered new and relapse TB patients",
+              "value": 0.6136237978935242
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Malaria/Intermittent preventive therapy for malaria during pregnancy (IPTp)",
+              "value": 0.6100496053695679
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/HIV incidence rate",
+              "value": 0.5988801121711731
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Neglected tropical diseases/Coverage of preventive chemotherapy for selected neglected tropical diseases",
+              "value": 0.5981394648551941
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/Cancer incidence, by type of cancer",
+              "value": 0.5937162041664124
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV\\/TB/HIV-positive new and relapse TB patients on ART during TB treatment",
+              "value": 0.5917468070983887
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "wm_flattened",
+          "versionDate": "2019-12-12T17:02:39Z",
+          "version": "87c0acf615936fa8ee078bfc81e1f5b39a3d35e2",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/treatment/health_treatment",
+              "value": 0.6076217889785767
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/disease/human_disease",
+              "value": 0.5954231023788452
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/therapeutic_feeding",
+              "value": 0.5737672448158264
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/nutrition/malnutrition",
+              "value": 0.5182313919067383
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/communicable_disease_outbreak_control",
+              "value": 0.4779245853424072
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/clinical_management_of_sexual_violence",
+              "value": 0.4775715172290802
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/anti_retroviral_treatment",
+              "value": 0.42565643787384033
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/trauma_and_surgical_care",
+              "value": 0.4252038598060608
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/crisis_and_disaster/famine",
+              "value": 0.4251308739185333
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/point_of_use_water_treatment_at_household_level",
+              "value": 0.4209243357181549
+            }
+          ],
+          "@type": "Groundings"
+        }
+      ],
+      "states": [
+        {
+          "@type": "State",
+          "type": "INC",
+          "text": "provide",
+          "provenance": [
+            {
+              "documentCharPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 742,
+                  "end": 748
+                }
+              ],
+              "document": {
+                "@id": "_:Document_1"
+              },
+              "sentenceWordPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 12,
+                  "end": 12
+                }
+              ],
+              "@type": "Provenance",
+              "sentence": {
+                "@id": "_:Sentence_8"
+              }
+            }
+          ]
+        }
+      ],
+      "@id": "_:Extraction_8"
+    },
+    {
+      "subtype": "entity",
+      "rule": "simple-np++Increase_ported_syntax_1_verb",
+      "text": "the prevalence, seasonality, clinical manifestations and course of COVID-19 infection",
+      "canonicalName": "seasonality clinical manifestation course covid-19 infection",
+      "labels": [
+        "Concept-Expanded",
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 763,
+              "end": 847
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 15,
+              "end": 26
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_8"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "interventions",
+          "version": "359829afbe9bb5ba9af990121c1bd936a52e7a2e",
+          "versionDate": "2019-02-24T01:21:07Z"
+        },
+        {
+          "name": "mitre12",
+          "versionDate": "2019-01-16T20:38:37Z",
+          "version": "c60184fd04a89ebdea7ccf633b83e6bc6623a207",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Tuberculosis treatment success rate",
+              "value": 0.6537290215492249
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of HIV",
+              "value": 0.5988801121711731
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Mortality from CVD, cancer, diabetes or CRD between exact ages 30 and 70",
+              "value": 0.5964562296867371
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Cause of death, by communicable diseases and maternal, prenatal and nutrition conditions",
+              "value": 0.5846115350723267
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of tuberculosis",
+              "value": 0.5798810124397278
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Lumpy Skin Disease (LSD) that are treated",
+              "value": 0.5757822394371033
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of malaria",
+              "value": 0.5719294548034668
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Number of children aged 6 to 59 months with severe acute malnutrition admitted for treatment",
+              "value": 0.5568200349807739
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Lumpy Skin Disease (LSD) that are reported",
+              "value": 0.555085301399231
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Percentage of livestock with Lumpy Skin Disease (LSD) that are vaccinated",
+              "value": 0.5359853506088257
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props",
+          "version": "104fb23a0ab1ef178c133a95a0b25f42c4ea94ca",
+          "versionDate": "2018-08-07T23:00:18Z"
+        },
+        {
+          "name": "un",
+          "versionDate": "2019-01-05T06:06:38Z",
+          "version": "dd7a44ceac00dc514d0c5926b25235018deb5670",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/disease",
+              "value": 0.5716700553894043
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/health_intervention",
+              "value": 0.5187397599220276
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/nutrient",
+              "value": 0.46558746695518494
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/death",
+              "value": 0.45720475912094116
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/pest",
+              "value": 0.398122102022171
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_insecurity",
+              "value": 0.39410990476608276
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/physical_insecurity",
+              "value": 0.36928239464759827
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/agriculture/farming",
+              "value": 0.35950079560279846
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/soil/soil_contents",
+              "value": 0.3220760226249695
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/biology/ecosystem",
+              "value": 0.32100269198417664
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "who",
+          "versionDate": "2018-11-21T22:10:05Z",
+          "version": "94f46343f7428aac6160e24788850a8fe6e8c5e7",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Tuberculosis/TB patients with results for drug susceptibility testing",
+              "value": 0.6756271719932556
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Care-seeking for symptoms of pneumonia",
+              "value": 0.6681642532348633
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Mortality between 30 and 70 years of age from cardiovascular diseases, cancer, diabetes or chronic respiratory diseases",
+              "value": 0.6285590529441833
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Quality and safety of care/TB treatment success rate",
+              "value": 0.6141887903213501
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV\\/TB/HIV test results for registered new and relapse TB patients",
+              "value": 0.6136237978935242
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Malaria/Intermittent preventive therapy for malaria during pregnancy (IPTp)",
+              "value": 0.6100496053695679
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/HIV incidence rate",
+              "value": 0.5988801121711731
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Neglected tropical diseases/Coverage of preventive chemotherapy for selected neglected tropical diseases",
+              "value": 0.5981394648551941
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/Cancer incidence, by type of cancer",
+              "value": 0.5937162041664124
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV\\/TB/HIV-positive new and relapse TB patients on ART during TB treatment",
+              "value": 0.5917468070983887
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "wm_flattened",
+          "versionDate": "2019-12-12T17:02:39Z",
+          "version": "87c0acf615936fa8ee078bfc81e1f5b39a3d35e2",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/treatment/health_treatment",
+              "value": 0.6076217889785767
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/disease/human_disease",
+              "value": 0.5954231023788452
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/therapeutic_feeding",
+              "value": 0.5737672448158264
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/nutrition/malnutrition",
+              "value": 0.5182313919067383
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/communicable_disease_outbreak_control",
+              "value": 0.4779245853424072
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/clinical_management_of_sexual_violence",
+              "value": 0.4775715172290802
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/anti_retroviral_treatment",
+              "value": 0.42565643787384033
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/trauma_and_surgical_care",
+              "value": 0.4252038598060608
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/crisis_and_disaster/famine",
+              "value": 0.4251308739185333
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/point_of_use_water_treatment_at_household_level",
+              "value": 0.4209243357181549
+            }
+          ],
+          "@type": "Groundings"
+        }
+      ],
+      "states": [
+        {
+          "@type": "State",
+          "type": "INC",
+          "text": "provide",
+          "provenance": [
+            {
+              "documentCharPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 742,
+                  "end": 748
+                }
+              ],
+              "document": {
+                "@id": "_:Document_1"
+              },
+              "sentenceWordPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 12,
+                  "end": 12
+                }
+              ],
+              "@type": "Provenance",
+              "sentence": {
+                "@id": "_:Sentence_8"
+              }
+            }
+          ]
+        }
+      ],
+      "@id": "_:Extraction_9"
+    },
+    {
+      "subtype": "entity",
+      "rule": "simple-np++Increase_ported_syntax_1_verb",
+      "text": "seasonality",
+      "canonicalName": "seasonality",
+      "labels": [
+        "Concept-Expanded",
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 779,
+              "end": 789
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 18,
+              "end": 18
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_8"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "interventions",
+          "version": "359829afbe9bb5ba9af990121c1bd936a52e7a2e",
+          "versionDate": "2019-02-24T01:21:07Z"
+        },
+        {
+          "name": "mitre12",
+          "versionDate": "2019-01-16T20:38:37Z",
+          "version": "c60184fd04a89ebdea7ccf633b83e6bc6623a207",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Annual growth, US$, 2010 prices, Gross Domestic Product",
+              "value": 0.473371297121048
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Annual growth, Local Currency, 2010 prices, Gross Fixed Capital Formation",
+              "value": 0.473371297121048
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Annual growth, US$, 2010 prices, Gross Fixed Capital Formation",
+              "value": 0.473371297121048
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Annual growth, Local Currency, 2010 prices, Value Added (Agriculture, Forestry and Fishing)",
+              "value": 0.473371297121048
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Annual growth US$, 2005 prices, Value Added (Agriculture, Forestry and Fishing)",
+              "value": 0.473371297121048
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Annual growth, Local Currency, 2010 prices, Gross Domestic Product",
+              "value": 0.473371297121048
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Annual growth, Local Currency, 2010 prices, Value Added (Total Manufacturing)",
+              "value": 0.473371297121048
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Annual growth, US$, 2010 prices, Value Added (Agriculture, Forestry and Fishing)",
+              "value": 0.473371297121048
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Annual growth, US$, 2010 prices, Value Added (Total Manufacturing)",
+              "value": 0.473371297121048
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Merchandise exports by the reporting economy, residual",
+              "value": 0.47309955954551697
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props",
+          "version": "104fb23a0ab1ef178c133a95a0b25f42c4ea94ca",
+          "versionDate": "2018-08-07T23:00:18Z"
+        },
+        {
+          "name": "un",
+          "versionDate": "2019-01-05T06:06:38Z",
+          "version": "dd7a44ceac00dc514d0c5926b25235018deb5670",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/financial/economic/market",
+              "value": 0.3681323230266571
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/nutrient",
+              "value": 0.36190974712371826
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/financial/economic/inflation",
+              "value": 0.3576104938983917
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_price",
+              "value": 0.35730844736099243
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/crop_storage",
+              "value": 0.3491562604904175
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/crop_technology/product",
+              "value": 0.34442025423049927
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/weather/temperature",
+              "value": 0.3410651981830597
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_insecurity",
+              "value": 0.3285275995731354
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/financial/economic/depreciation",
+              "value": 0.327601820230484
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/agriculture/farming",
+              "value": 0.3212677538394928
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "who",
+          "versionDate": "2018-11-21T22:10:05Z",
+          "version": "94f46343f7428aac6160e24788850a8fe6e8c5e7",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Access/Availability of essential medicines and commodities",
+              "value": 0.3871549367904663
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Noncommunicable diseases/Total alcohol per capita (age 15+ years) consumption",
+              "value": 0.3258444666862488
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health security/International Health Regulations (IHR) core capacity index",
+              "value": 0.3166954517364502
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Environmental risk factors/Population using modern fuels for cooking\\/heating\\/lighting",
+              "value": 0.31071314215660095
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/Hepatitis B surface antigen prevalence",
+              "value": 0.29864999651908875
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Headcount ratio of impoverishing health expenditure",
+              "value": 0.29461947083473206
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Demand for family planning satis ed with modern methods",
+              "value": 0.29277846217155457
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Health financing/Headcount ratio of catastrophic health expenditure",
+              "value": 0.29169750213623047
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Quality and safety of care/Institutional maternal mortality ratio",
+              "value": 0.2865837812423706
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Quality and safety of care/Service-specific availability and readiness",
+              "value": 0.28235748410224915
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "wm_flattened",
+          "versionDate": "2019-12-12T17:02:39Z",
+          "version": "87c0acf615936fa8ee078bfc81e1f5b39a3d35e2",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/trend",
+              "value": 0.46051064133644104
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/economic_and_commerce/economic_activity/market/revenue/farmer_income",
+              "value": 0.4160597622394562
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/environmental/meteorologic/weather",
+              "value": 0.40708810091018677
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/livestock_destocking",
+              "value": 0.403344988822937
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/food_security/food_availability",
+              "value": 0.402446985244751
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/economic_and_commerce/economic_activity/market/demand/food_demand",
+              "value": 0.4024316668510437
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/economic_and_commerce/economic_activity/market/depreciation",
+              "value": 0.39734697341918945
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/food_security/food_utilization",
+              "value": 0.3953809142112732
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/nutrition/food_diversity",
+              "value": 0.38658860325813293
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/economic_and_commerce/economic_activity/market/price_or_cost/crop_price",
+              "value": 0.3766709864139557
+            }
+          ],
+          "@type": "Groundings"
+        }
+      ],
+      "states": [
+        {
+          "@type": "State",
+          "type": "INC",
+          "text": "provide",
+          "provenance": [
+            {
+              "documentCharPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 742,
+                  "end": 748
+                }
+              ],
+              "document": {
+                "@id": "_:Document_1"
+              },
+              "sentenceWordPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 12,
+                  "end": 12
+                }
+              ],
+              "@type": "Provenance",
+              "sentence": {
+                "@id": "_:Sentence_8"
+              }
+            }
+          ]
+        }
+      ],
+      "@id": "_:Extraction_10"
+    },
+    {
+      "subtype": "entity",
+      "rule": "simple-np++Increase_ported_syntax_1_verb",
+      "text": "clinical manifestations",
+      "canonicalName": "clinical manifestation",
+      "labels": [
+        "Concept-Expanded",
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 792,
+              "end": 814
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 20,
+              "end": 21
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_8"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "interventions",
+          "version": "359829afbe9bb5ba9af990121c1bd936a52e7a2e",
+          "versionDate": "2019-02-24T01:21:07Z"
+        },
+        {
+          "name": "mitre12",
+          "versionDate": "2019-01-16T20:38:37Z",
+          "version": "c60184fd04a89ebdea7ccf633b83e6bc6623a207",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Tuberculosis treatment success rate",
+              "value": 0.5646857619285583
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Cause of death, by communicable diseases and maternal, prenatal and nutrition conditions",
+              "value": 0.48808154463768005
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Adolescent fertility rate",
+              "value": 0.4764045774936676
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Antiretroviral therapy coverage for PMTCT",
+              "value": 0.4695751667022705
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Antiretroviral therapy coverage",
+              "value": 0.4695751667022705
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Mortality from CVD, cancer, diabetes or CRD between exact ages 30 and 70",
+              "value": 0.46519848704338074
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of HIV",
+              "value": 0.46342483162879944
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Incidence of tuberculosis",
+              "value": 0.4547213315963745
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Prevalence of anemia among women of reproductive age",
+              "value": 0.45056137442588806
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Value, Prevalence of anemia among women of reproductive age (15-49 years)",
+              "value": 0.45056137442588806
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props",
+          "version": "104fb23a0ab1ef178c133a95a0b25f42c4ea94ca",
+          "versionDate": "2018-08-07T23:00:18Z"
+        },
+        {
+          "name": "un",
+          "versionDate": "2019-01-05T06:06:38Z",
+          "version": "dd7a44ceac00dc514d0c5926b25235018deb5670",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/disease",
+              "value": 0.44835802912712097
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/health_intervention",
+              "value": 0.40528160333633423
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/health/nutrient",
+              "value": 0.3653794527053833
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/death",
+              "value": 0.3335275948047638
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/physical_insecurity",
+              "value": 0.33025532960891724
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/events/human/political/political_instability",
+              "value": 0.2888186573982239
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/education",
+              "value": 0.2764815092086792
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/food/food_insecurity",
+              "value": 0.25604286789894104
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/watershed",
+              "value": 0.25528737902641296
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/natural_resources/abiotic_resources/resource",
+              "value": 0.24723868072032928
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "who",
+          "versionDate": "2018-11-21T22:10:05Z",
+          "version": "94f46343f7428aac6160e24788850a8fe6e8c5e7",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Tuberculosis/TB patients with results for drug susceptibility testing",
+              "value": 0.6083058714866638
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Care-seeking for symptoms of pneumonia",
+              "value": 0.588451623916626
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV\\/TB/HIV test results for registered new and relapse TB patients",
+              "value": 0.5315636992454529
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV\\/TB/TB preventive therapy for HIV-positive people newly enrolled in HIV care",
+              "value": 0.5242973566055298
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Malaria/Intermittent preventive therapy for malaria during pregnancy (IPTp)",
+              "value": 0.5239681005477905
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Quality and safety of care/TB treatment success rate",
+              "value": 0.5231998562812805
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV\\/TB/HIV-positive new and relapse TB patients on ART during TB treatment",
+              "value": 0.5231771469116211
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Morbidity/Cancer incidence, by type of cancer",
+              "value": 0.4943070113658905
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Mortality between 30 and 70 years of age from cardiovascular diseases, cancer, diabetes or chronic respiratory diseases",
+              "value": 0.4923478662967682
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Neglected tropical diseases/Coverage of preventive chemotherapy for selected neglected tropical diseases",
+              "value": 0.4881476163864136
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "wm_flattened",
+          "versionDate": "2019-12-12T17:02:39Z",
+          "version": "87c0acf615936fa8ee078bfc81e1f5b39a3d35e2",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/treatment/health_treatment",
+              "value": 0.5629701018333435
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/clinical_management_of_sexual_violence",
+              "value": 0.5398924946784973
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/therapeutic_feeding",
+              "value": 0.50111985206604
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/anti_retroviral_treatment",
+              "value": 0.48342055082321167
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/trauma_and_surgical_care",
+              "value": 0.4574650526046753
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/disease/human_disease",
+              "value": 0.4569445252418518
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/assessment_and_triage_of_health_facilities",
+              "value": 0.4266275465488434
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/obstetric_and_newborn_care",
+              "value": 0.39053627848625183
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/nutrition/malnutrition",
+              "value": 0.388551265001297
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/newborn_and_childhood_essential_health_care_services",
+              "value": 0.37979429960250854
+            }
+          ],
+          "@type": "Groundings"
+        }
+      ],
+      "states": [
+        {
+          "@type": "State",
+          "type": "INC",
+          "text": "provide",
+          "provenance": [
+            {
+              "documentCharPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 742,
+                  "end": 748
+                }
+              ],
+              "document": {
+                "@id": "_:Document_1"
+              },
+              "sentenceWordPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 12,
+                  "end": 12
+                }
+              ],
+              "@type": "Provenance",
+              "sentence": {
+                "@id": "_:Sentence_8"
+              }
+            }
+          ]
+        }
+      ],
+      "@id": "_:Extraction_11"
+    },
+    {
+      "subtype": "entity",
+      "rule": "simple-np++Increase_ported_syntax_1_verb",
+      "text": "course",
+      "canonicalName": "course",
+      "labels": [
+        "Concept-Expanded",
+        "Concept",
+        "Entity"
+      ],
+      "provenance": [
+        {
+          "documentCharPositions": [
+            {
+              "@type": "Interval",
+              "start": 820,
+              "end": 825
+            }
+          ],
+          "document": {
+            "@id": "_:Document_1"
+          },
+          "sentenceWordPositions": [
+            {
+              "@type": "Interval",
+              "start": 23,
+              "end": 23
+            }
+          ],
+          "@type": "Provenance",
+          "sentence": {
+            "@id": "_:Sentence_8"
+          }
+        }
+      ],
+      "@type": "Extraction",
+      "type": "concept",
+      "groundings": [
+        {
+          "@type": "Groundings",
+          "name": "interventions",
+          "version": "359829afbe9bb5ba9af990121c1bd936a52e7a2e",
+          "versionDate": "2019-02-24T01:21:07Z"
+        },
+        {
+          "name": "mitre12",
+          "versionDate": "2019-01-16T20:38:37Z",
+          "version": "c60184fd04a89ebdea7ccf633b83e6bc6623a207",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Import Value, Fodder & Feeding stuff",
+              "value": 0.4480453133583069
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Duration in months pasture is projected to last",
+              "value": 0.40266746282577515
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Import Value, Margarine, short",
+              "value": 0.3887859582901001
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Time required to start a business, male",
+              "value": 0.3732741177082062
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/People practicing open defecation",
+              "value": 0.3716624677181244
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Duration in months browse is projected to last",
+              "value": 0.36858198046684265
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Time required to start a business",
+              "value": 0.36688703298568726
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Primary school starting age",
+              "value": 0.3660546541213989
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/People practicing open defecation, urban",
+              "value": 0.35148146748542786
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "MITRE12/Time required to start a business, female",
+              "value": 0.3464187681674957
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "@type": "Groundings",
+          "name": "props",
+          "version": "104fb23a0ab1ef178c133a95a0b25f42c4ea94ca",
+          "versionDate": "2018-08-07T23:00:18Z"
+        },
+        {
+          "name": "un",
+          "versionDate": "2019-01-05T06:06:38Z",
+          "version": "dd7a44ceac00dc514d0c5926b25235018deb5670",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/infrastructure/transportation/road",
+              "value": 0.32485222816467285
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/temporal/seasons/season",
+              "value": 0.28867730498313904
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/temporal/seasons/crop_season",
+              "value": 0.2652381360530853
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/soil/soil_contents",
+              "value": 0.2291789948940277
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/education",
+              "value": 0.22080563008785248
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/biology/ecosystem",
+              "value": 0.21871210634708405
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/natural/natural_resources/abiotic_resources/land",
+              "value": 0.2174859195947647
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/population",
+              "value": 0.21673132479190826
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/government/government_actions/duty",
+              "value": 0.21479421854019165
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "UN/entities/human/government/government_actions/regulation",
+              "value": 0.2127600461244583
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "who",
+          "versionDate": "2018-11-21T22:10:05Z",
+          "version": "94f46343f7428aac6160e24788850a8fe6e8c5e7",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Demand for family planning satis ed with modern methods",
+              "value": 0.3441672623157501
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Systems/Quality and safety of care/TB treatment success rate",
+              "value": 0.31051215529441833
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Health Status/Mortality by cause/Mortality rate from road traffic injuries",
+              "value": 0.28721556067466736
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Nutrition/Children under 5 years who are stunted",
+              "value": 0.28209954500198364
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Vitamin A supplementation coverage",
+              "value": 0.2799554467201233
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Immunization/Immunization coverage rate by vaccine for each vaccine in the national schedule",
+              "value": 0.27743831276893616
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Nutrition/Exclusive breastfeeding rate 0-5 months of age",
+              "value": 0.2691543996334076
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/HIV/People living with HIV who have been diagnosed",
+              "value": 0.26686790585517883
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Risk Factors/Noncommunicable diseases/Tobacco use among persons aged 18+ years",
+              "value": 0.2629793882369995
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "WHO/Service Coverage/Reproductive, maternal, newborn, child and adolescent/Postpartum care coverage",
+              "value": 0.26159238815307617
+            }
+          ],
+          "@type": "Groundings"
+        },
+        {
+          "name": "wm_flattened",
+          "versionDate": "2019-12-12T17:02:39Z",
+          "version": "87c0acf615936fa8ee078bfc81e1f5b39a3d35e2",
+          "values": [
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/access/infrastructure_access/road_access",
+              "value": 0.36320799589157104
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/construction_of_infrastructure/building_long_term_roads",
+              "value": 0.3410126566886902
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/time/temporal/season",
+              "value": 0.28867730498313904
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/teaching,_training_and_public_awareness/training_of_farmers_on_weed_control",
+              "value": 0.2878879904747009
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/environmental/meteorologic/weather",
+              "value": 0.2716880142688751
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/health_and_life/nutrition/food_preference",
+              "value": 0.2687845528125763
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/time/temporal/crop_season",
+              "value": 0.2652381360530853
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/interventions/provision_of_goods_and_services/child_friendly_learning_spaces",
+              "value": 0.2575336992740631
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/government/regulation",
+              "value": 0.2498791515827179
+            },
+            {
+              "@type": "Grounding",
+              "ontologyConcept": "wm/concept/causal_factor/social_and_political/educational/education",
+              "value": 0.24816933274269104
+            }
+          ],
+          "@type": "Groundings"
+        }
+      ],
+      "states": [
+        {
+          "@type": "State",
+          "type": "INC",
+          "text": "provide",
+          "provenance": [
+            {
+              "documentCharPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 742,
+                  "end": 748
+                }
+              ],
+              "document": {
+                "@id": "_:Document_1"
+              },
+              "sentenceWordPositions": [
+                {
+                  "@type": "Interval",
+                  "start": 12,
+                  "end": 12
+                }
+              ],
+              "@type": "Provenance",
+              "sentence": {
+                "@id": "_:Sentence_8"
+              }
+            }
+          ]
+        }
+      ],
+      "@id": "_:Extraction_12"
+    }
+  ]
+}

--- a/indra/tests/test_eidos.py
+++ b/indra/tests/test_eidos.py
@@ -245,3 +245,16 @@ def test_geoloc_obj():
     ev = st.evidence[0]
     assert not ev.context, ev.context
     assert st.obj.context
+
+
+def test_bio_entity_extract():
+    jsonld = os.path.join(path_this, 'eidos_bio_abstract.json')
+    with open(jsonld, 'r') as fh:
+        js = json.load(fh)
+    agents = eidos.process_json_bio_entities(js)
+    assert len(agents) == 11
+    from indra.statements import Agent
+    assert all(isinstance(a, Agent) for a in agents)
+    ag = [a for a in agents if a.name == 'Therapeutics'][0]
+    assert ag.db_refs['MESH'] == 'D013812'
+    assert ag.db_refs['EFO'] == '0000727'


### PR DESCRIPTION
This PR implements two new functions that allow getting Agents grounded to biomedical ontologies from Eidos reading. Fixes #1121.