### PR TITLE
Add notify and health endpoints to LiveCuration service

### DIFF
--- a/indra/tools/live_curation/live_curation.py
+++ b/indra/tools/live_curation/live_curation.py
@@ -185,7 +185,7 @@ def notify():
                     'error_message': 'Bad Request: missing or invalid body'})
 
 
-@app.route('/health')
+@app.route('/health', methods=['GET', 'POST'])
 def health():
     return jsonify({'state': 'healthy', 'version': '1.0.0'})
 

--- a/indra/tools/live_curation/live_curation.py
+++ b/indra/tools/live_curation/live_curation.py
@@ -166,6 +166,25 @@ def save_curations():
     return jsonify({})
 
 
+@app.route('/notify')
+def notify():
+    if request.json is None:
+        abort(Response('Missing application/json header.', 415))
+
+    # Check validity of JSON
+    # {
+    #   identity: string,  # Name of the tool, e.g. "MyTool"
+    #   version: string,  # Version of the tool e.g. "3.1.4"
+    #   document_id: string,  # ID of the document, e.g. "qwerty1234"
+    #   storage_key: string,  # Storage key e.g. "uuid.ext"
+    # }
+    req_args = {'identity', 'version', 'document_id', 'storage_key'}
+    if all(k in req_args for k in request.json.keys()):
+        return Response('OK', 200)
+    return jsonify({'status': 400,
+                    'error_message': 'Bad Request: missing or invalid body'})
+
+
 if __name__ == '__main__':
     # Process arguments
     parser = argparse.ArgumentParser(

--- a/indra/tools/live_curation/live_curation.py
+++ b/indra/tools/live_curation/live_curation.py
@@ -185,6 +185,11 @@ def notify():
                     'error_message': 'Bad Request: missing or invalid body'})
 
 
+@app.route('/health')
+def health():
+    return jsonify({'state': 'healthy', 'version': '1.0.0'})
+
+
 if __name__ == '__main__':
     # Process arguments
     parser = argparse.ArgumentParser(

--- a/indra/tools/live_curation/live_curation.py
+++ b/indra/tools/live_curation/live_curation.py
@@ -166,7 +166,7 @@ def save_curations():
     return jsonify({})
 
 
-@app.route('/notify')
+@app.route('/notify', methods=['POST'])
 def notify():
     if request.json is None:
         abort(Response('Missing application/json header.', 415))


### PR DESCRIPTION
This PR adds two endpoints for future development of a notification API, `/health` and `/notify`.

- `/health` simply responds with a 200 status and a short message for GET and POST.
- For now, `/notify` checks that a) there is a JSON present in the POST request and b) that the JSON contains the correct entries for the endpoint