### PR TITLE
Handle location change of citation_dict

### DIFF
--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -8,7 +8,10 @@ import pybel
 import pybel.constants as pc
 from pybel.dsl import *
 from pybel.language import pmod_namespace
-from pybel.utils import citation_dict
+try:  # this works after pybel pull request #453
+    from pybel.language import citation_dict
+except ImportError: # this works before pybel pull request #453
+    from pybel.utils import citation_dict
 from indra.statements import *
 from indra.databases import hgnc_client
 


### PR DESCRIPTION
According to https://github.com/pybel/pybel/pull/453
@cthoyt  moved `citation_dict` from `pybel.utils` to `pybel.language`
This code tries to import  `citation_dict` from the new `pybel.language` location and if it results in an `ImportError` it tries to import from the old `pybel.utils` location.