### PR TITLE
HtmlAssembler developments

### DIFF
--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -7,8 +7,8 @@ import re
 import uuid
 import logging
 import itertools
+from collections import OrderedDict
 from os.path import abspath, dirname, join
-from collections import OrderedDict, Counter
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -94,12 +94,16 @@ class HtmlAssembler(object):
         evidence totals. The keys should be informative human-readable strings.
     ev_counts : Optional[dict]
         A dictionary of the total evidence available for each
-        statement indexed by hash.
+        statement indexed by hash. If not provided, the statements that are
+        passed to the constructor are used to determine these, with whatever
+        evidences these statements carry.
     ev_totals : Optional[dict]
         DEPRECATED. Same as ev_counts which should be used instead.
     source_counts : Optional[dict]
         A dictionary of the itemized evidence counts, by source, available for
-        each statement, indexed by hash. Default: None.
+        each statement, indexed by hash. If not provided, the statements
+        that are passed to the constructor are used to determine these, with
+        whatever evidences these statements carry.
     title : str
         The title to be printed at the top of the page.
     db_rest_url : Optional[str]

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -663,10 +663,21 @@ def get_available_ev_counts(stmts):
 
 
 def get_available_source_counts(stmts):
-    return {stmt.get_hash(): get_available_ev_source_counts(stmt.evidence)
+    return {stmt.get_hash(): _get_available_ev_source_counts(stmt.evidence)
             for stmt in stmts}
 
 
-def get_available_ev_source_counts(evidences):
-    return dict(**Counter([ev.source_api for ev in evidences]))
+def _get_available_ev_source_counts(evidences):
+    counts = _get_initial_source_counts()
+    for ev in evidences:
+        sa = internal_source_mappings.get(ev.source_api, ev.source_api)
+        try:
+            counts[sa] += 1
+        except KeyError:
+            continue
+    return counts
+
+
+def _get_initial_source_counts():
+    return {s: 0 for s in all_sources}
 

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -32,7 +32,8 @@ color_schemes = {
     'dark': ['#b2df8a', '#000099', '#6a3d9a', '#1f78b4', '#fdbf6f', '#ff7f00',
              '#cab2d6', '#fb9a99', '#a6cee3', '#33a02c', '#b15928', '#e31a1c'],
     'light': ['#bc80bd', '#fccde5', '#b3de69', '#80b1d3', '#fb8072', '#bebada',
-              '#fdb462', '#8dd3c7', '#ffffb3', '#d9d9d9', '#ccebc5', '#ffed6f']
+              '#fdb462', '#8dd3c7', '#d9d9d9', '#ffed6f', '#ccebc5', '#e0e03d',
+              '#ffe8f4', '#acfcfc']
 }
 
 
@@ -43,10 +44,11 @@ def color_gen(scheme):
 
 
 db_sources = ['phosphosite', 'cbn', 'pc11', 'biopax', 'bel_lc',
-              'signor', 'biogrid', 'tas', 'lincs_drug', 'hprd', 'trrust']
+              'signor', 'biogrid', 'tas', 'lincs_drug', 'hprd', 'trrust',
+              'ctd', 'virhostnet', 'phosphoelm']
 
 reader_sources = ['geneways', 'tees', 'isi', 'trips', 'rlimsp', 'medscan',
-                  'sparser', 'reach']
+                  'sparser', 'eidos', 'reach']
 
 all_sources = db_sources + reader_sources
 

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -539,10 +539,11 @@ def tag_agents(english, agents):
             continue
         url = id_url(ag)
         if url is None:
-            continue
-        # Build up a set of indices
-        tag_start = "<a href='%s' target='_blank'>" % url
-        tag_close = "</a>"
+            tag_start = '<b>'
+            tag_close = '</b>'
+        else:
+            tag_start = "<a href='%s' target='_blank'>" % url
+            tag_close = "</a>"
         # If coordinates are passed, use them. Otherwise, try to find agent
         # names in english text
         if isinstance(ag, AgentWithCoordinates):

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -32,8 +32,8 @@ color_schemes = {
     'dark': ['#b2df8a', '#000099', '#6a3d9a', '#1f78b4', '#fdbf6f', '#ff7f00',
              '#cab2d6', '#fb9a99', '#a6cee3', '#33a02c', '#b15928', '#e31a1c'],
     'light': ['#bc80bd', '#fccde5', '#b3de69', '#80b1d3', '#fb8072', '#bebada',
-              '#fdb462', '#8dd3c7', '#d9d9d9', '#ffed6f', '#ccebc5', '#e0e03d',
-              '#ffe8f4', '#acfcfc']
+              '#fdb462', '#d9d9d9', '#8dd3c7', '#ffed6f', '#ccebc5', '#e0e03d',
+              '#ffe8f4', '#acfcfc', '#dd99ff']
 }
 
 
@@ -44,8 +44,8 @@ def color_gen(scheme):
 
 
 db_sources = ['phosphosite', 'cbn', 'pc11', 'biopax', 'bel_lc',
-              'signor', 'biogrid', 'tas', 'lincs_drug', 'hprd', 'trrust',
-              'ctd', 'virhostnet', 'phosphoelm']
+              'signor', 'biogrid', 'lincs_drug', 'tas', 'hprd', 'trrust',
+              'ctd', 'virhostnet', 'phosphoelm', 'drugbank']
 
 reader_sources = ['geneways', 'tees', 'isi', 'trips', 'rlimsp', 'medscan',
                   'sparser', 'eidos', 'reach']

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -408,41 +408,43 @@
                         {% else %}
                           <div class="col-1 text-right">
                         {% endif %}
-                          {% if ev['pmid'] %}
-                            <a class="pmid_link"
-                               title="Hover again to see info"
-                               onmouseover="setPMIDlinkTitle(this.textContent, this); this.onmouseover=null;"
-                               href='https://www.ncbi.nlm.nih.gov/pubmed/{{ ev["pmid"] }}'
-                               target="_blank">
-                              {{ ev['pmid'] }}</a>
-                          {% elif 'PMID' in ev['text_refs'] and ev['text_refs']['PMID'] %}
-                            <a class="pmid_link"
-                               title="Hover again to see info"
-                               onmouseover="setPMIDlinkTitle(this.textContent, this); this.onmouseover=null;"
-                               href='https://www.ncbi.nlm.nih.gov/pubmed/{{ ev["text_refs"]["pmid"] }}'
-                               target="_blank">
-                              {{ ev['text_refs']['PMID'] }}</a>
-                          {% endif %}
-                                                    
+                        {% if ev['pmid'] %}
+                          <a class="pmid_link"
+                              title="Hover again to see info"
+                              onmouseover="setPMIDlinkTitle(this.textContent, this); this.onmouseover=null;"
+                              href='https://www.ncbi.nlm.nih.gov/pubmed/{{ ev["pmid"] }}'
+                              target="_blank">
+                            {{ ev['pmid'] }}</a>
+                        {% elif 'PMID' in ev['text_refs'] and ev['text_refs']['PMID'] %}
+                          <a class="pmid_link"
+                              title="Hover again to see info"
+                              onmouseover="setPMIDlinkTitle(this.textContent, this); this.onmouseover=null;"
+                              href='https://www.ncbi.nlm.nih.gov/pubmed/{{ ev["text_refs"]["pmid"] }}'
+                              target="_blank">
+                            {{ ev['text_refs']['PMID'] }}</a>
+                        {% elif 'PMCID' in ev['text_refs'] and ev['text_refs']['PMCID'] %}
                           {% if add_full_text_search_link and 'pmcid' in ev and ev['pmcid'] %}
                             <a class="full_text_search"
                               data-sentence= '{{ev["text"]|urlencode}}'
                               href="https://www.ncbi.nlm.nih.gov/pmc/articles/{{ ev["pmcid"] }}" target=_blank rel=noopener >Full-Text Search: {{ev['pmcid']}}</a>
                             <span style="cursor:default" title="This link will search for and highlight the sentence in the full-text article. Works with Chrome 80+">  &#9432;</span>
                           {% else %}
-                            {% if 'PMCID' in ev['text_refs'] and ev['text_refs']['PMCID'] %}
-                              | <a class="pmcid_link"
-                                href='https://www.ncbi.nlm.nih.gov/pmc/articles/{{ ev["text_refs"]["pmcid"] }}'
-                                target="_blank">PMC</a>
-                            {% endif %}
+                            | <a class="pmcid_link"
+                              href='https://www.ncbi.nlm.nih.gov/pmc/articles/{{ ev["text_refs"]["pmcid"] }}'
+                              target="_blank">PMC</a>
                           {% endif %}
+                        {% elif 'DOI' in ev['text_refs'] and ev['text_refs']['DOI'] %}
+                          | <a class="doi_link"
+                              href='https://dx.doi.org/{{ ev["text_refs"]["DOI"] }}'
+                              target="_blank">DOI</a>
+                        {% endif %}
 
-                          {% if 'DOI' in ev['text_refs'] and ev['text_refs']['DOI'] %}
-                            | <a class="doi_link"
-                               href='https://dx.doi.org/{{ ev["text_refs"]["DOI"] }}'
-                               target="_blank">DOI</a>
+                          {% if add_full_text_search_link and 'pmcid' in ev and ev['pmcid'] %}
+                            <a class="full_text_search"
+                              data-sentence= '{{ev["text"]|urlencode}}'
+                              href="https://www.ncbi.nlm.nih.gov/pmc/articles/{{ ev["pmcid"] }}" target=_blank rel=noopener >Full-Text Search: {{ev['pmcid']}}</a>
+                            <span style="cursor:default" title="This link will search for and highlight the sentence in the full-text article. Works with Chrome 80+">  &#9432;</span>
                           {% endif %}
-
                         </div>
                       </div>
                     {% endfor %}


### PR DESCRIPTION
This PR bundles a few updates to the HtmlAssembler, in particular:
- If `ev_counts` and `source_counts` are not provided, the assembler can now use the statements' available evidences to construct these. This allows better integration with INDRA Statements in general, independent of the DB REST API.
- Sources and colors extended to multiple new sources, and the definition of sources is separated out from the definition of colors.
- Due to UI space constraints, PMC and DOI links are only added if the PMID link is not available (but the full text search link option still appears if chosen). 