### PR TITLE
Fix documentation of HTML Assembler

### DIFF
--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -324,11 +324,11 @@ class HtmlAssembler(object):
             all statements placed under a single heading.
         add_full_text_search_link : bool
             If True, link with Text fragment search in PMC journal will be
-            added for the statements.
+            added for the statements.  
 
-        All other keyword arguments are passed along to the template. If you
-        are using a custom template with args that are not passed below, this
-        is how you pass them.
+            All other keyword arguments are passed along to the template. If you
+            are using a custom template with args that are not passed below, this
+            is how you pass them.
 
         Returns
         -------


### PR DESCRIPTION
This PR fixes docstring which was not properly indented in the code for `html.assembler.make_model`

| [Now ](https://indra.readthedocs.io/en/latest/modules/assemblers/html_assembler.html#indra.assemblers.html.assembler.HtmlAssembler.make_model)|[After PR](https://indrap.readthedocs.io/en/latest/modules/assemblers/html_assembler.html#indra.assemblers.html.assembler.HtmlAssembler.make_model) |
|-----|----------|
| ![image](https://user-images.githubusercontent.com/34039705/87627314-18753d80-c74c-11ea-84f2-e6be8657ae9a.png)  <hr> |  ![image](https://user-images.githubusercontent.com/34039705/87627235-e4018180-c74b-11ea-9e62-285e6309769a.png) <hr> *Difference is highlighted in yellow*|

[Old Documentation](https://indra.readthedocs.io/en/latest/modules/assemblers/html_assembler.html#indra.assemblers.html.assembler.HtmlAssembler.make_model)  
[New Documentation](https://indrap.readthedocs.io/en/latest/modules/assemblers/html_assembler.html#indra.assemblers.html.assembler.HtmlAssembler.make_model)
