### PR TITLE
Fix ActiveForm assembly with grouping

### DIFF
--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -253,7 +253,10 @@ class HtmlAssembler(object):
                         del ag.db_refs[dbn]
 
             # Update the top level grouping.
-            tl_names = key[1]
+            if isinstance(stmt, ActiveForm):
+                tl_names = [key[1][0]]
+            else:
+                tl_names = key[1]
             if with_grouping:
                 tl_key = '-'.join([str(name) for name in tl_names])
                 tl_agents = {name: Agent(name) for name in tl_names

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -117,3 +117,10 @@ def test_influence():
     stmt2 = Influence(Event(c1), Event(c3))
     ha = HtmlAssembler([stmt, stmt2])
     ha.make_model()
+
+
+def test_active_form():
+    stmt = ActiveForm(Agent('MAPK1', mods=[ModCondition('phosphorylation')]),
+                      'kinase', True)
+    ha = HtmlAssembler([stmt])
+    ha.make_model()


### PR DESCRIPTION
This PR fixes a pre-existing bug in how ActiveForm keys are generated and then used in the HtmlAssembler, exposed by https://github.com/sorgerlab/indra/commit/d1f227ebc16b3786f96fd1b11bfad7bb21ee405b.