### PR TITLE
Fixes to ontology and HTML assembler

### DIFF
--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -576,7 +576,8 @@ def id_url(ag):
     # Return identifier URLs in a prioritized order
     for db_name in ('FPLX', 'HGNC', 'UP',
                     'GO', 'MESH',
-                    'CHEBI', 'PUBCHEM', 'HMDB',
+                    'CHEBI', 'PUBCHEM', 'HMDB', 'DRUGBANK',
+                    'HMS-LINCS', 'CAS',
                     'IP', 'PF', 'NXPFA',
                     'MIRBASEM', 'MIRBASE',
                     'NCIT',

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -576,7 +576,7 @@ def id_url(ag):
     # Return identifier URLs in a prioritized order
     for db_name in ('FPLX', 'HGNC', 'UP',
                     'GO', 'MESH',
-                    'CHEBI', 'PUBCHEM', 'HMDB', 'DRUGBANK',
+                    'CHEBI', 'PUBCHEM', 'HMDB', 'DRUGBANK', 'CHEMBL',
                     'HMS-LINCS', 'CAS',
                     'IP', 'PF', 'NXPFA',
                     'MIRBASEM', 'MIRBASE',

--- a/indra/ontology/bio/ontology.py
+++ b/indra/ontology/bio/ontology.py
@@ -356,8 +356,10 @@ class BioOntology(IndraOntology):
 
         nodes = []
         for hmsl_id, data in lc._sm_data.items():
-            hmsl_base_id, suffix = hmsl_id.split('-') if '-' in hmsl_id else \
-                hmsl_id, None
+            if '-' in hmsl_id:
+                hmsl_base_id, suffix = hmsl_id.split('-')
+            else:
+                hmsl_base_id, suffix = hmsl_id, None
             if suffix == '999':
                 continue
             nodes.append((self.label('HMS-LINCS', hmsl_base_id),
@@ -370,8 +372,10 @@ class BioOntology(IndraOntology):
 
         edges = []
         for hmsl_id, data in lc._sm_data.items():
-            hmsl_base_id, suffix = hmsl_id.split('-') if '-' in hmsl_id else \
-                hmsl_id, None
+            if '-' in hmsl_id:
+                hmsl_base_id, suffix = hmsl_id.split('-')
+            else:
+                hmsl_base_id, suffix = hmsl_id, None
             if suffix == '999':
                 continue
             refs = lc.get_small_molecule_refs(hmsl_id)


### PR DESCRIPTION
This PR fixes HMS-LINCS entries in the ontology, and adds more name spaces (relevant for recently added sources) to the HTML assembler for linking out.