### PR TITLE
Not add common target for single object node

### DIFF
--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -253,7 +253,7 @@ class ModelChecker(object):
             loop = True
 
         # If we have several objects in obj_list or we have a loop, we add a
-        # dummy target node ∂as a child to all nodes in obj_list
+        # dummy target node as a child to all nodes in obj_list
         if len(obj_list) > 1 or loop:
             common_target = ('common_target', 0)
             self.graph.add_node(common_target)

--- a/indra/explanation/pathfinding/pathfinding.py
+++ b/indra/explanation/pathfinding/pathfinding.py
@@ -358,7 +358,7 @@ def bfs_search(g, source_node, g_nodes=None, g_edges=None, reverse=False,
             break
 
 
-def get_path_iter(graph, source, target, path_length, loop):
+def get_path_iter(graph, source, target, path_length, loop, dummy_target):
     """Return a generator of paths with path_length cutoff from source to
     target."""
     path_iter = nx.all_simple_paths(graph, source, target, path_length)
@@ -366,7 +366,8 @@ def get_path_iter(graph, source, target, path_length, loop):
         for p in path_iter:
             path = deepcopy(p)
             # Remove common target from a path.
-            path.remove(target)
+            if dummy_target:
+                path.remove(target)
             if loop:
                 path.append(path[0])
             # A path should contain at least one edge


### PR DESCRIPTION
This PR updates the modelchecker code to only add a dummy node as a common target if there's more than one potential target. Dummy node doesn't add any benefit when added to only one node, but significantly slows down the pathfinding in large models.