### PR TITLE
Mesh supc

### DIFF
--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -196,6 +196,11 @@ def get_ids_for_mesh(mesh_id, major_topic=False, **kwargs):
     suffix = 'majr' if major_topic else 'mh'
     search_term = '%s [%s]' % (mesh_name, suffix)
     ids = get_ids(search_term, use_text_word=False, **kwargs)
+    if mesh_id.startswith('C') and not major_topic:
+        # Get pmids for supplementary concepts as well
+        search_term = '%s [nm]' % mesh_name
+        ids2 = get_ids(search_term, use_text_word=False, **kwargs)
+        ids = list(set(ids) | set(ids2))
     return ids
 
 

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -6,7 +6,6 @@ import requests
 import logging
 from functools import lru_cache
 from time import sleep
-from indra.databases import hgnc_client, mesh_client
 from indra.util import UnicodeXMLTreeBuilder as UTB
 
 logger = logging.getLogger(__name__)
@@ -145,7 +144,7 @@ def get_ids_for_gene(hgnc_name, **kwargs):
         (using the hgnc_client module) and in turn used to obtain the Entrez
         ID associated with the gene. Entrez is then queried for that ID.
     """
-
+    from indra.databases import hgnc_client
     # Get the HGNC ID for the HGNC name
     hgnc_id = hgnc_client.get_hgnc_id(hgnc_name)
     if hgnc_id is None:
@@ -189,6 +188,7 @@ def get_ids_for_mesh(mesh_id, major_topic=False, **kwargs):
         Any further PudMed search arguments that are passed to
         get_ids.
     """
+    from indra.databases import mesh_client
     mesh_name = mesh_client.get_mesh_name(mesh_id)
     if not mesh_name:
         logger.error('Could not get MeSH name for ID %s' % mesh_id)

--- a/indra/resources/grounding/ignore.csv
+++ b/indra/resources/grounding/ignore.csv
@@ -116,3 +116,6 @@ molecule
 set
 app
 kit
+star
+end
+aim

--- a/indra/resources/grounding/misgrounding_map.csv
+++ b/indra/resources/grounding/misgrounding_map.csv
@@ -94,7 +94,6 @@ ir-NGF,HGNC,6091
 aiK,HGNC,11393
 kdp,HGNC,14540
 pKD,HGNC,9407
-star,HGNC,4688
 type I receptor,HGNC,11772
 cytokines and growth factor receptors,HGNC,8031
 LY294002 and SP600125,HGNC,12401

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -44,6 +44,13 @@ def test_get_id_mesh():
 
 
 @attr('webservice')
+def test_get_id_mesh_supc():
+    time.sleep(0.5)
+    ids = pubmed_client.get_ids_for_mesh('C000657245')
+    assert len(ids) > 15000
+
+
+@attr('webservice')
 def test_get_pmc_ids():
     time.sleep(0.5)
     ids = pubmed_client.get_ids('braf', retmax=10, db='pmc')

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -4,7 +4,7 @@ from nose.plugins.attrib import attr
 
 
 @attr('webservice')
-def test_get_ids():
+def test_get_ids1():
     time.sleep(0.5)
     ids = pubmed_client.get_ids('braf', retmax=10, db='pubmed')
     assert len(ids) == 10
@@ -18,7 +18,7 @@ def test_get_no_ids():
 
 
 @attr('webservice')
-def test_get_ids():
+def test_get_ids2():
     time.sleep(0.5)
     ids1 = pubmed_client.get_ids('JUN', use_text_word=False)
     ids2 = pubmed_client.get_ids('JUN', use_text_word=True)


### PR DESCRIPTION
This PR updates the function `get_ids_for_mesh` in `indra.literature.pubmed_client` to allow for querying pmids annotated with MeSH supplementary concepts. The new behavior is that if major_topic is set to False and the input MeSH id is a supplementary concept starting with `'C'`, then in addition to the query being made for regular MeSH terms, a query is also made based on supplementary concepts. The returned set of pmids is then the union of the pmids returned for the query based on regular MeSH terms and that based on supplementary concepts.