### PR TITLE
Update to PyBEL 15

### DIFF
--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -2,12 +2,14 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import uuid
 import logging
+from typing import Mapping
+
 import networkx as nx
 from copy import deepcopy, copy
 import pybel
 import pybel.constants as pc
 from pybel.dsl import *
-from pybel.language import pmod_namespace, activity_mapping
+from pybel.language import pmod_mappings, pmod_namespace, activity_mapping
 try:  # this works after pybel pull request #453
     from pybel.language import citation_dict
 except ImportError: # this works before pybel pull request #453
@@ -18,7 +20,8 @@ from indra.databases import hgnc_client
 logger = logging.getLogger(__name__)
 
 
-_indra_pybel_act_map = {
+_indra_pybel_act_map: Mapping[str, Entity] = {
+    'activity': activity_mapping['act'],
     'kinase': activity_mapping['kin'],
     'phosphatase': activity_mapping['phos'],
     'catalytic': activity_mapping['cat'],
@@ -28,7 +31,10 @@ _indra_pybel_act_map = {
     'gap': activity_mapping['gap'],
 }
 
-_pybel_indra_act_map = {v: k for k, v in _indra_pybel_act_map.items()}
+_pybel_indra_act_map: Mapping[Entity, str] = {
+    pybel_activity: indra_key
+    for indra_key, pybel_activity in _indra_pybel_act_map.items()
+}
 
 
 class PybelAssembler(object):
@@ -608,8 +614,7 @@ def _get_agent_activity(agent):
     if ac.activity_type == 'activity':
         return activity()
 
-    pybel_activity = _indra_pybel_act_map[ac.activity_type]
-    return activity(pybel_activity)
+    return activity(**_indra_pybel_act_map[ac.activity_type])
 
 
 def _get_evidence(evidence):

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -612,8 +612,8 @@ def _get_evidence(evidence):
     # If there is a PMID, use it as the citation
     if evidence.pmid:
         citation = citation_dict(
-            db=pc.CITATION_TYPE_PUBMED,
-            db_id=evidence.pmid,
+            namespace=pc.CITATION_TYPE_PUBMED,
+            identifier=evidence.pmid,
         )
     # If no PMID, include the interface and source_api for now--
     # in general this should probably be in the annotations for all evidence
@@ -622,8 +622,8 @@ def _get_evidence(evidence):
         cit_id = evidence.source_id or 'Unknown'
         cit_ref_str = '%s:%s' % (cit_source, cit_id)
         citation = citation_dict(
-            db=pc.CITATION_TYPE_OTHER,
-            db_id=cit_ref_str,
+            namespace=pc.CITATION_TYPE_OTHER,
+            identifier=cit_ref_str,
         )
 
     annotations = {

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -507,7 +507,13 @@ def _get_agent_node_no_bcs(agent):
             logger.info('Skipping modification of type %s on agent %s',
                         mod.mod_type, agent)
             continue
-        var = pmod(namespace=pc.BEL_DEFAULT_NAMESPACE, name=pybel_mod)
+        pmod_entity = pmod_mappings[pybel_mod]['xrefs'][0]
+
+        var = ProteinModification(
+            namespace=pmod_entity.namespace,
+            name=pmod_entity.name,
+            identifier=pmod_entity.identifier,
+        )
         if mod.residue is not None:
             res = amino_acids[mod.residue]['short_name'].capitalize()
             var[pc.PMOD_CODE] = res

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -73,7 +73,7 @@ class PybelAssembler(object):
     >>> pba = PybelAssembler([stmt])
     >>> belgraph = pba.make_model()
     >>> sorted(node.as_bel() for node in belgraph) # doctest:+IGNORE_UNICODE
-    ['p(HGNC:6840 ! MAP2K1)', 'p(HGNC:6871 ! MAPK1)', 'p(HGNC:6871 ! MAPK1, pmod(Ph, Thr, 185))']
+    ['p(HGNC:6840 ! MAP2K1)', 'p(HGNC:6871 ! MAPK1)', 'p(HGNC:6871 ! MAPK1, pmod(go:0006468 ! "protein phosphorylation", Thr, 185))']
     >>> len(belgraph)
     3
     >>> belgraph.number_of_edges()

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -7,7 +7,7 @@ from copy import deepcopy, copy
 import pybel
 import pybel.constants as pc
 from pybel.dsl import *
-from pybel.language import pmod_namespace
+from pybel.language import pmod_namespace, activity_mapping
 try:  # this works after pybel pull request #453
     from pybel.language import citation_dict
 except ImportError: # this works before pybel pull request #453
@@ -19,13 +19,13 @@ logger = logging.getLogger(__name__)
 
 
 _indra_pybel_act_map = {
-    'kinase': 'kin',
-    'phosphatase': 'phos',
-    'catalytic': 'cat',
-    'gtpbound': 'gtp',
-    'transcription': 'tscript',
-    'gef': 'gef',
-    'gap': 'gap'
+    'kinase': activity_mapping['kin'],
+    'phosphatase': activity_mapping['phos'],
+    'catalytic': activity_mapping['cat'],
+    'gtpbound': activity_mapping['gtp'],
+    'transcription': activity_mapping['tscript'],
+    'gef': activity_mapping['gef'],
+    'gap': activity_mapping['gap'],
 }
 
 _pybel_indra_act_map = {v: k for k, v in _indra_pybel_act_map.items()}

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -99,9 +99,9 @@ class PybelProcessor(object):
             for node_ix, node in enumerate((u_data, v_data)):
                 if isinstance(node, dsl.ComplexAbundance):
                     self._get_enum_complex(u_data, v_data, k, d, node_ix)
-            subj_activity = _get_activity_condition(d.get(pc.SOURCE))
-            obj_activity = _get_activity_condition(d.get(pc.TARGET))
-            obj_to_loc = _get_translocation_target(d.get(pc.TARGET))
+            subj_activity = _get_activity_condition(d.get(pc.SOURCE_MODIFIER))
+            obj_activity = _get_activity_condition(d.get(pc.TARGET_MODIFIER))
+            obj_to_loc = _get_translocation_target(d.get(pc.TARGET_MODIFIER))
             # If the object is a translocation, this represents a controlled
             # translocation, which we currently do not represent
             if obj_to_loc:
@@ -200,12 +200,12 @@ class PybelProcessor(object):
         self.statements.append(stmt)
 
     def _get_regulate_amount(self, u_data, v_data, k, edge_data):
-        subj_agent = get_agent(u_data, edge_data.get(pc.SOURCE))
-        obj_agent = get_agent(v_data, edge_data.get(pc.TARGET))
+        subj_agent = get_agent(u_data, edge_data.get(pc.SOURCE_MODIFIER))
+        obj_agent = get_agent(v_data, edge_data.get(pc.TARGET_MODIFIER))
         if subj_agent is None or obj_agent is None:
             self.unhandled.append((u_data, v_data, edge_data))
             return
-        obj_mod = edge_data.get(pc.TARGET)
+        obj_mod = edge_data.get(pc.TARGET_MODIFIER)
         has_deg = (obj_mod and obj_mod.get(pc.MODIFIER) == pc.DEGRADATION)
         rel = edge_data[pc.RELATION]
         if rel == pc.REGULATES:
@@ -224,10 +224,10 @@ class PybelProcessor(object):
         self.statements.append(stmt)
 
     def _get_modification(self, u_data, v_data, k, edge_data):
-        subj_agent = get_agent(u_data, edge_data.get(pc.SOURCE))
+        subj_agent = get_agent(u_data, edge_data.get(pc.SOURCE_MODIFIER))
         mods, muts = _get_mods_and_muts(v_data)
         v_data_no_mods = v_data.get_parent()
-        obj_agent = get_agent(v_data_no_mods, edge_data.get(pc.TARGET))
+        obj_agent = get_agent(v_data_no_mods, edge_data.get(pc.TARGET_MODIFIER))
         if subj_agent is None or obj_agent is None:
             self.unhandled.append((u_data, v_data, k, edge_data))
             return
@@ -240,8 +240,8 @@ class PybelProcessor(object):
 
     def _get_regulate_activity(self, u_data, v_data, k, edge_data):
         # Subject info
-        subj_agent = get_agent(u_data, edge_data.get(pc.SOURCE))
-        subj_activity = _get_activity_condition(edge_data.get(pc.SOURCE))
+        subj_agent = get_agent(u_data, edge_data.get(pc.SOURCE_MODIFIER))
+        subj_activity = _get_activity_condition(edge_data.get(pc.SOURCE_MODIFIER))
         # Object info
         # Note: Don't pass the object modifier data because we don't want to
         # put an activity on the agent
@@ -251,7 +251,7 @@ class PybelProcessor(object):
             activity_type = 'activity'
         else:
             obj_activity_condition = \
-                            _get_activity_condition(edge_data.get(pc.TARGET))
+                            _get_activity_condition(edge_data.get(pc.TARGET_MODIFIER))
             activity_type = obj_activity_condition.activity_type
             assert obj_activity_condition.is_active is True
         # Check for valid subject/object
@@ -278,7 +278,7 @@ class PybelProcessor(object):
         self.statements.append(stmt)
 
     def _get_active_form(self, u_data, v_data, k, edge_data):
-        subj_agent = get_agent(u_data, edge_data.get(pc.SOURCE))
+        subj_agent = get_agent(u_data, edge_data.get(pc.SOURCE_MODIFIER))
         # Don't pass the object modifier info because we don't want an activity
         # condition applied to the agent
         obj_agent = get_agent(v_data)
@@ -286,7 +286,7 @@ class PybelProcessor(object):
             self.unhandled.append((u_data, v_data, edge_data))
             return
         obj_activity_condition = \
-                        _get_activity_condition(edge_data.get(pc.TARGET))
+                        _get_activity_condition(edge_data.get(pc.TARGET_MODIFIER))
         activity_type = obj_activity_condition.activity_type
         # If the relation is DECREASES, this means that this agent state
         # is inactivating
@@ -296,7 +296,7 @@ class PybelProcessor(object):
         self.statements.append(stmt)
 
     def _get_gef_gap(self, u_data, v_data, k, edge_data):
-        subj_agent = get_agent(u_data, edge_data.get(pc.SOURCE))
+        subj_agent = get_agent(u_data, edge_data.get(pc.SOURCE_MODIFIER))
         obj_agent = get_agent(v_data)
         if subj_agent is None or obj_agent is None:
             self.unhandled.append((u_data, v_data, k, edge_data))
@@ -310,7 +310,7 @@ class PybelProcessor(object):
         self.statements.append(stmt)
 
     def _get_conversion(self, u_data, v_data, k, edge_data):
-        subj_agent = get_agent(u_data, edge_data.get(pc.SOURCE))
+        subj_agent = get_agent(u_data, edge_data.get(pc.SOURCE_MODIFIER))
         # Get the nodes for the reactants and products
         reactant_agents = [get_agent(r) for r in v_data[pc.REACTANTS]]
         product_agents = [get_agent(p) for p in v_data[pc.PRODUCTS]]
@@ -866,8 +866,8 @@ def _get_translocation_target(node_modifier_data):
     to_loc_info = transloc_data.get(pc.TO_LOC)
     if not to_loc_info:
         return None
-    to_loc_ns = to_loc_info.get('namespace')
-    to_loc_name = to_loc_info.get('name')
+    to_loc_ns = to_loc_info.get(pc.NAMESPACE)
+    to_loc_name = to_loc_info.get(pc.NAME)
     # Only use GO Cellular Component location names
     if to_loc_ns not in ('GO', 'GOCC', 'GOCCID') or not to_loc_name:
         return None

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -353,13 +353,7 @@ class PybelProcessor(object):
 
         text_location = annotations.pop('TextLocation', None)
         if text_location:
-            # Handle dictionary text_location like {'Abstract': True}
-            if isinstance(text_location, dict):
-                # FIXME: INDRA's section_type entry is meant to contain
-                # a single section string like "abstract" but in principle
-                # pybel could have a list of entries in the TextLocation dict.
-                # Here we just take the first one.
-                text_location = list(text_location.keys())[0]
+            text_location = text_location[0].name
             epistemics['section_type'] = \
                 _pybel_text_location_map.get(text_location)
 
@@ -691,14 +685,13 @@ def extract_context(annotations, annot_manager):
     """
     def get_annot(annotations, key):
         """Return a specific annotation given a key."""
-        val = annotations.pop(key, None)
-        if val:
-            val_list = [v for v, tf in val.items() if tf]
+        val_list = annotations.pop(key, None)
+        if val_list:
             if len(val_list) > 1:
                 logger.warning('More than one "%s" in annotations' % key)
             elif not val_list:
                 return None
-            return val_list[0]
+            return val_list[0].name
         return None
 
     bc = BioContext()

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -337,7 +337,7 @@ class PybelProcessor(object):
         if ev_citation:
             cit_type = ev_citation[pc.NAMESPACE]
             cit_ref = ev_citation[pc.IDENTIFIER]
-            if cit_type == pc.CITATION_TYPES[pc.CITATION_TYPE_PUBMED]:
+            if cit_type == pc.CITATION_TYPE_PUBMED:
                 ev_pmid = cit_ref
                 ev_ref = None
             else:

--- a/indra/tests/test_pybel_api.py
+++ b/indra/tests/test_pybel_api.py
@@ -468,7 +468,7 @@ def test_regulate_amount4_subj_act():
     mek = Protein(name='MAP2K1', namespace='HGNC')
     erk = Protein(name='MAPK1', namespace='HGNC')
     g = BELGraph()
-    g.add_increases(mek, erk, subject_modifier=activity(name='tscript'),
+    g.add_increases(mek, erk, source_modifier=activity(name='tscript'),
                     evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements
@@ -483,7 +483,7 @@ def test_regulate_amount4_subj_act():
     assert len(pbp.statements[0].evidence) == 1
 
     g = BELGraph()
-    g.add_increases(mek, erk, subject_modifier=activity(),
+    g.add_increases(mek, erk, source_modifier=activity(),
                     evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements
@@ -501,8 +501,8 @@ def test_regulate_activity():
     mek = Protein(name='MAP2K1', namespace='HGNC')
     erk = Protein(name='MAPK1', namespace='HGNC')
     g = BELGraph()
-    g.add_increases(mek, erk, subject_modifier=activity(name='kin'),
-                    object_modifier=activity(name='kin'),
+    g.add_increases(mek, erk, source_modifier=activity(name='kin'),
+                    target_modifier=activity(name='kin'),
                     evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements
@@ -526,7 +526,7 @@ def test_active_form():
     p53_obj = Protein(name='TP53', namespace='HGNC')
     g = BELGraph()
     g.add_increases(p53_pmod, p53_obj,
-                    object_modifier=activity(name='tscript'),
+                    target_modifier=activity(name='tscript'),
                     evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements
@@ -550,8 +550,8 @@ def test_gef():
     kras = Protein(name='KRAS', namespace='HGNC')
     g = BELGraph()
     g.add_directly_increases(sos, kras,
-                             subject_modifier=activity(),
-                             object_modifier=activity(name='gtp'),
+                             source_modifier=activity(),
+                             target_modifier=activity(name='gtp'),
                              evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements
@@ -570,8 +570,8 @@ def test_indirect_gef_is_activation():
     sos = Protein(name='SOS1', namespace='HGNC')
     kras = Protein(name='KRAS', namespace='HGNC')
     g = BELGraph()
-    g.add_increases(sos, kras, subject_modifier=activity(),
-                    object_modifier=activity(name='gtp'),
+    g.add_increases(sos, kras, source_modifier=activity(),
+                    target_modifier=activity(name='gtp'),
                     evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements
@@ -592,8 +592,8 @@ def test_gap():
     kras = Protein(name='KRAS', namespace='HGNC')
     g = BELGraph()
     g.add_directly_decreases(sos, kras,
-                             subject_modifier=activity(),
-                             object_modifier=activity(name='gtp'),
+                             source_modifier=activity(),
+                             target_modifier=activity(name='gtp'),
                              evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements
@@ -630,8 +630,8 @@ def test_gtpactivation():
     braf = Protein(name='BRAF', namespace='HGNC')
     g = BELGraph()
     g.add_directly_increases(kras, braf,
-                             subject_modifier=activity(name='gtp'),
-                             object_modifier=activity(name='kin'),
+                             source_modifier=activity(name='gtp'),
+                             target_modifier=activity(name='kin'),
                              evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements
@@ -660,7 +660,7 @@ def test_conversion():
     )
     g = BELGraph()
     g.add_directly_increases(enz, rxn,
-                             subject_modifier=activity(),
+                             source_modifier=activity(),
                              evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements
@@ -694,7 +694,7 @@ def test_controlled_transloc_loc_cond():
         from_loc=Entity(namespace='GOCC', name='intracellular'),
         to_loc=Entity(namespace='GOCC', name='extracellular space'),
     )
-    g.add_increases(subj, obj, object_modifier=transloc,
+    g.add_increases(subj, obj, target_modifier=transloc,
                     evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert not pbp.statements, pbp.statements
@@ -710,7 +710,7 @@ def test_subject_transloc_loc_cond():
         to_loc=Entity(namespace='GOCC', name='extracellular space'),
     )
     g = BELGraph()
-    g.add_increases(subj, obj, subject_modifier=transloc,
+    g.add_increases(subj, obj, source_modifier=transloc,
                     evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements
@@ -733,8 +733,8 @@ def test_subject_transloc_active_form():
         to_loc=Entity(namespace='GOCC', name='extracellular space'),
     )
     g = BELGraph()
-    g.add_increases(subj, obj, subject_modifier=transloc,
-                    object_modifier=activity(name='kin'),
+    g.add_increases(subj, obj, source_modifier=transloc,
+                    target_modifier=activity(name='kin'),
                     evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements
@@ -755,7 +755,7 @@ def test_complex_stmt_with_activation():
     cplx = complex_abundance([raf, mek])
     g = BELGraph()
     g.add_directly_increases(cplx, erk,
-                             object_modifier=activity(name='kin'),
+                             target_modifier=activity(name='kin'),
                              evidence="Some evidence.", citation='123456')
     pbp = bel.process_pybel_graph(g)
     assert pbp.statements

--- a/indra/tests/test_pybel_api.py
+++ b/indra/tests/test_pybel_api.py
@@ -67,7 +67,8 @@ def test_process_pybel():
 def test_process_jgif():
     test_file_url = 'https://s3.amazonaws.com/bigmech/travis/Hox-2.0-Hs.jgf'
     test_file = 'Hox-2.0-Hs.jgf'
-    request.urlretrieve(url=test_file_url, filename=test_file)
+    if not os.path.exists(test_file):
+        request.urlretrieve(url=test_file_url, filename=test_file)
     pbp = process_cbn_jgif_file(test_file)
 
     # Clean up
@@ -82,7 +83,8 @@ def test_nodelink_json():
     test_file_url = \
         'https://s3.amazonaws.com/bigmech/travis/Hox-2.0-Hs_nljson.json'
     test_file = 'Hox-2.0-Hs_nljson.json'
-    request.urlretrieve(url=test_file_url, filename=test_file)
+    if not os.path.exists(test_file):
+        request.urlretrieve(url=test_file_url, filename=test_file)
     pbp = process_pybel_graph(from_nodelink_file(test_file))
 
     # Clean up

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -159,7 +159,7 @@ def test_activation():
     hash2 = stmt2.get_hash(refresh=True)
     edge1 = {
         pc.RELATION: pc.INCREASES,
-        pc.OBJECT: {pc.MODIFIER: pc.ACTIVITY},
+        pc.OBJECT: activity(),
         pc.ANNOTATIONS: {
             'stmt_hash': {hash1: True},
             'uuid': {stmt1.uuid: True},
@@ -202,7 +202,7 @@ def test_direct_activation():
     hash2 = stmt2.get_hash(refresh=True)
     edge1 = {
         pc.RELATION: pc.DIRECTLY_INCREASES,
-        pc.OBJECT: {pc.MODIFIER: pc.ACTIVITY},
+        pc.OBJECT: activity(),
         pc.EVIDENCE: 'No evidence text.',
         pc.CITATION: {
             pc.CITATION_DB: pc.CITATION_TYPE_PUBMED,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def main():
                       'hypothesis': ['gilda'],
                       'geneways': ['stemming', 'nltk'],
                       'sofia': ['openpyxl'],
-                      'bel': ['pybel>=0.14.2,<0.15.0'],
+                      'bel': ['pybel>=0.15.0,<0.16.0'],
                       'sbml': ['python-libsbml'],
                       # Tools and analysis
                       'machine': ['pytz', 'tzlocal', 'tweepy', 'pyyaml>=5.1.0',


### PR DESCRIPTION
PyBEL 15 has been released, and this PR updates the assembler, processor, and model checker to work with the new interface.

What's changed:
- some constants changed names
- activities get automatically converted to Gene Ontology entries now (e.g., Ph -> go:0006468 ! "protein phosphorylation")
- the default activity now also uses the top level Gene Ontology term for "molecular function" @bgyori let me know if this is problematic with the way that INDRA's "refinement" system and statement linker works.
- annotation data structure is now a dictionary of strings (keys) and list of `pybel.language.Entity` instances (values) where the key is the "category" of annotation. Sometimes this is the same as a prefix, and sometimes it isn't. This might change again in the future if there's a good way to unify the PyOBO data structure which is quite similar (a prefix, identifier, name triple)
- citations now use a data structure inheriting from dict to become more standardized the same as the `pybel.language.Entity`. Shouldn't affect much, except now you can use the getattr() for `citation.namespace` and `citation.identifier`