### PR TITLE
Handle multiple text fields in grounding mapping and disambiguation

### DIFF
--- a/indra/preassembler/grounding_mapper/adeft.py
+++ b/indra/preassembler/grounding_mapper/adeft.py
@@ -17,7 +17,7 @@ except Exception:
     adeft_disambiguators = {}
 
 
-def run_adeft_disambiguation(stmt, agent, idx):
+def run_adeft_disambiguation(stmt, agent, idx, agent_txt):
     """Run Adeft disambiguation on an Agent in a given Statement.
 
     This function looks at the evidence of the given Statement and attempts
@@ -58,7 +58,6 @@ def run_adeft_disambiguation(stmt, agent, idx):
     # Initialize annotations if needed so Adeft predicted
     # probabilities can be added to Agent annotations
     annots = stmt.evidence[0].annotations
-    agent_txt = agent.db_refs['TEXT']
     if 'agents' in annots:
         if 'adeft' not in annots['agents']:
             annots['agents']['adeft'] = \

--- a/indra/preassembler/grounding_mapper/gilda.py
+++ b/indra/preassembler/grounding_mapper/gilda.py
@@ -170,7 +170,7 @@ def ground_statements(stmts, mode='web', sources=None, ungrounded_only=False):
     return stmts
 
 
-def run_gilda_disambiguation(stmt, agent, idx, mode='web'):
+def run_gilda_disambiguation(stmt, agent, idx, agent_txt, mode='web'):
     """Run Gilda disambiguation on an Agent in a given Statement.
 
     This function looks at the evidence of the given Statement and attempts
@@ -215,7 +215,6 @@ def run_gilda_disambiguation(stmt, agent, idx, mode='web'):
     # Initialize annotations if needed so predicted
     # probabilities can be added to Agent annotations
     annots = stmt.evidence[0].annotations
-    agent_txt = agent.db_refs['TEXT']
     if 'agents' in annots:
         if 'gilda' not in annots['agents']:
             annots['agents']['gilda'] = \

--- a/indra/preassembler/grounding_mapper/mapper.py
+++ b/indra/preassembler/grounding_mapper/mapper.py
@@ -149,16 +149,17 @@ class GroundingMapper(object):
             # then filter out the Statement
             agent_txts = {agent.db_refs[t] for t in {'TEXT', 'TEXT_NORM'}
                           if t in agent.db_refs}
-            if agent_txts and agent_txts & self.ignores:
+            if agent_txts and agent_txts & set(self.ignores):
                 return None
 
             # Check if an adeft model exists for agent text
             adeft_success = False
             if self.use_adeft and agent_txts and agent_txts & \
-                    adeft_disambiguators:
+                    set(adeft_disambiguators):
                 try:
                     # Us the longest match for disambiguation
-                    txt_for_adeft = sorted(agent_txts & adeft_disambiguators,
+                    txt_for_adeft = sorted(agent_txts &
+                                           set(adeft_disambiguators),
                                            key=lambda x: len(x))[-1]
                     adeft_success = run_adeft_disambiguation(mapped_stmt,
                                                              agent, idx,

--- a/indra/tests/test_groundingmapper.py
+++ b/indra/tests/test_groundingmapper.py
@@ -516,3 +516,13 @@ def test_text_and_norm_text():
                            evidence=Evidence(text='Arachidonic acid (AA)'))
     res = gm.map_stmts([stmt])
     assert res[0].sub.name == 'arachidonic acid', res[0]
+
+    ag = Agent('x', db_refs={'TEXT': 'XXX', 'TEXT_NORM': 'ERK'})
+    stmt = Phosphorylation(None, ag)
+    res = gm.map_stmts([stmt])
+    assert res[0].sub.name == 'ERK', res[0]
+
+    ag = Agent('x', db_refs={'TEXT': 'ERK', 'TEXT_NORM': 'XXX'})
+    stmt = Phosphorylation(None, ag)
+    res = gm.map_stmts([stmt])
+    assert res[0].sub.name == 'ERK', res[0]

--- a/indra/tests/test_groundingmapper.py
+++ b/indra/tests/test_groundingmapper.py
@@ -490,3 +490,29 @@ def test_gilda_disambiguation_local():
         annotations
     # This is to make sure the to_json of the ScoredMatches works
     assert annotations['agents']['gilda'][1][0]['term']['db'] == 'HGNC'
+
+
+def test_text_and_norm_text():
+    gm.gilda_mode = 'local'
+
+    # We should filter out ignores in both TEXT and TEXT_NORM
+    ag = Agent('x', db_refs={'TEXT': 'XREF_BIBR', 'TEXT_NORM': 'ERK'})
+    stmt = Phosphorylation(None, ag)
+    res = gm.map_stmts([stmt])
+    assert not res
+    ag = Agent('x', db_refs={'TEXT': 'ERK', 'TEXT_NORM': 'XREF_BIBR'})
+    stmt = Phosphorylation(None, ag)
+    res = gm.map_stmts([stmt])
+    assert not res
+
+    # We should disambiguate based on both TEXT and TEXT_NORM
+    ag = Agent('x', db_refs={'TEXT': 'AA', 'TEXT_NORM': 'XXX'},)
+    stmt = Phosphorylation(None, ag,
+                           evidence=Evidence(text='Arachidonic acid (AA)'))
+    res = gm.map_stmts([stmt])
+    assert res[0].sub.name == 'arachidonic acid', res[0]
+    ag = Agent('x', db_refs={'TEXT': 'XXX', 'TEXT_NORM': 'AA'})
+    stmt = Phosphorylation(None, ag,
+                           evidence=Evidence(text='Arachidonic acid (AA)'))
+    res = gm.map_stmts([stmt])
+    assert res[0].sub.name == 'arachidonic acid', res[0]


### PR DESCRIPTION
This PR implements handling for multiple text fields during grounding mapping and disambiguation to assure that TEXT and TEXT_NORM are both taken into account when checking for disambiguation models, ignores, misgroundings, etc.