### PR TITLE
Implement local stashing of DART reader output

### DIFF
--- a/indra/literature/dart_client.py
+++ b/indra/literature/dart_client.py
@@ -1,5 +1,5 @@
 """A client for accessing reader output from the DART system."""
-
+import os
 import json
 import logging
 import requests
@@ -43,7 +43,7 @@ def get_content_by_storage_key(storage_key):
 
 
 def get_reader_outputs(readers=None, versions=None, document_ids=None,
-                       timestamp=None):
+                       timestamp=None, local_storage=None):
     """Return reader outputs by querying the DART API.
 
     Parameters
@@ -57,6 +57,10 @@ def get_reader_outputs(readers=None, versions=None, document_ids=None,
     timestamp : dict("on"|"before"|"after",str)
         The timestamp string must of format "yyyy-mm-dd" or "yyyy-mm-dd
         hh:mm:ss" (only for "before" and "after").
+    local_storage : Optional[str]
+        The path to a local folder in which the downloaded reader
+        outputs should be stored. If not given, the outputs are
+        just returned, not stored.
 
     Returns
     -------
@@ -69,16 +73,21 @@ def get_reader_outputs(readers=None, versions=None, document_ids=None,
                                         timestamp=timestamp)
     logger.info('Got %d document storage keys. Fetching output...' %
                 len(records))
-    return download_records(records)
+    reader_outputs = download_records(records, local_storage)
+    return reader_outputs
 
 
-def download_records(records):
+def download_records(records, local_storage=None):
     """Return reader outputs corresponding to a list of records.
 
     Parameters
     ----------
     records : list of dict
         A list of records returned from the reader output query.
+    local_storage : Optional[str]
+        The path to a local folder in which the downloaded reader
+        outputs should be stored. If not given, the outputs are
+        just returned, not stored.
 
     Returns
     -------
@@ -89,15 +98,26 @@ def download_records(records):
     # Loop document keys and get documents
     reader_outputs = defaultdict(dict)
     for record in records:
-        reader = record['identity']
-        doc_id = record['document_id']
         storage_key = record['storage_key']
         try:
-            reader_outputs[reader][doc_id] = \
-                get_content_by_storage_key(storage_key)
+            output = get_content_by_storage_key(storage_key)
+            reader_outputs[record['identity']][record['document_id']] = output
+            if local_storage:
+                store_reader_output(local_storage, record, output)
         except Exception as e:
             logger.warning('Error downloading %s' % storage_key)
-    return dict(reader_outputs)
+    reader_outputs = dict(reader_outputs)
+    return reader_outputs
+
+
+def store_reader_output(path, record, output):
+    """Save a reader output in a standardized form locally."""
+    folder = os.path.join(path, record['identity'], record['version'])
+    if not os.path.exists(folder):
+        os.makedirs(folder)
+    fname = os.path.join(folder, record['document_id'])
+    with open(fname, 'w') as fh:
+        fh.write(output)
 
 
 def prioritize_records(records, priorities=None):
@@ -186,6 +206,12 @@ def get_reader_output_records(readers=None, versions=None, document_ids=None,
     if not rj or 'records' not in rj:
         return []
     return rj['records']
+
+
+def get_reader_versions(reader):
+    """Return the available versions for a given reader."""
+    records = get_reader_output_records([reader])
+    return {record['version'] for record in records}
 
 
 def _check_lists(lst):

--- a/indra/literature/dart_client.py
+++ b/indra/literature/dart_client.py
@@ -1,5 +1,6 @@
 """A client for accessing reader output from the DART system."""
 import os
+import tqdm
 import json
 import logging
 import requests
@@ -97,7 +98,7 @@ def download_records(records, local_storage=None):
     """
     # Loop document keys and get documents
     reader_outputs = defaultdict(dict)
-    for record in records:
+    for record in tqdm.tqdm(records):
         storage_key = record['storage_key']
         try:
             output = get_content_by_storage_key(storage_key)


### PR DESCRIPTION
This PR adds a way to cache some reader outputs locally from DART.