### PR TITLE
Implement counts based on obtained statements in DB REST client

### DIFF
--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -16,7 +16,9 @@ from indra.statements import *
 from indra.assemblers.english import EnglishAssembler, AgentWithCoordinates
 from indra.databases import get_identifiers_url
 from indra.util.statement_presentation import group_and_sort_statements, \
-    make_top_level_label_from_names_key, make_stmt_from_sort_key
+    make_top_level_label_from_names_key, make_stmt_from_sort_key, \
+    reader_sources, db_sources, all_sources, get_available_source_counts, \
+    get_available_ev_counts, standardize_counts
 from indra.literature import id_lookup
 
 logger = logging.getLogger(__name__)
@@ -41,23 +43,6 @@ def color_gen(scheme):
     while True:
         for color in color_schemes[scheme]:
             yield color
-
-
-db_sources = ['phosphosite', 'cbn', 'pc11', 'biopax', 'bel_lc',
-              'signor', 'biogrid', 'lincs_drug', 'tas', 'hprd', 'trrust',
-              'ctd', 'virhostnet', 'phosphoelm', 'drugbank', 'omnipath']
-
-reader_sources = ['geneways', 'tees', 'isi', 'trips', 'rlimsp', 'medscan',
-                  'sparser', 'eidos', 'reach']
-
-all_sources = db_sources + reader_sources
-
-# These are mappings where the actual INDRA source, as it appears
-# in the evidence source_api is inconsistent with the colors here and
-# with what comes out of the INDRA DB
-internal_source_mappings = {
-    'bel': 'bel_lc'
-}
 
 
 SOURCE_COLORS = [
@@ -678,40 +663,3 @@ def tag_text(text, tag_info_list):
     # Add the last section of text
     format_text += text[start_pos:]
     return format_text
-
-
-def standardize_counts(counts):
-    """Standardize hash-based counts dicts to be int-keyed."""
-    standardized_counts = {}
-    for k, v in counts.items():
-        try:
-            int_k = int(k)
-            standardized_counts[int_k] = v
-        except ValueError:
-            logger.warning('Could not convert statement hash %s to int' % k)
-    return standardized_counts
-
-
-def get_available_ev_counts(stmts):
-    return {stmt.get_hash(): len(stmt.evidence) for stmt in stmts}
-
-
-def get_available_source_counts(stmts):
-    return {stmt.get_hash(): _get_available_ev_source_counts(stmt.evidence)
-            for stmt in stmts}
-
-
-def _get_available_ev_source_counts(evidences):
-    counts = _get_initial_source_counts()
-    for ev in evidences:
-        sa = internal_source_mappings.get(ev.source_api, ev.source_api)
-        try:
-            counts[sa] += 1
-        except KeyError:
-            continue
-    return counts
-
-
-def _get_initial_source_counts():
-    return {s: 0 for s in all_sources}
-

--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -12,6 +12,8 @@ from indra.statements import stmts_from_json, get_statement_by_name, \
 from indra.sources.indra_db_rest.util import submit_query_request, \
     submit_statement_request
 from indra.sources.indra_db_rest.exceptions import IndraDBRestResponseError
+from indra.util.statement_presentation import get_available_source_counts, \
+    get_available_ev_counts, standardize_counts
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +65,8 @@ class IndraDBRestProcessor(object):
         self.__statement_jsons = {}
         self.__evidence_counts = {}
         self.__source_counts = {}
+
+        self.use_obtained_counts = kwargs.pop('use_obtained_counts', False)
 
         # Define the basic generic defaults.
         default_api_params = dict(timeout=None, ev_limit=10, best_first=True,
@@ -147,6 +151,9 @@ class IndraDBRestProcessor(object):
     def _compile_statements(self):
         """Generate statements from the jsons."""
         self.statements = stmts_from_json(self.__statement_jsons.values())
+        if self.use_obtained_counts:
+            self.__source_counts = get_available_source_counts(self.statements)
+            self.__evidence_counts = get_available_ev_counts(self.statements)
 
     def _unload_and_merge_resp(self, resp):
         resp_dict = resp.json(object_pairs_hook=OrderedDict)

--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -51,6 +51,10 @@ class IndraDBRestProcessor(object):
         Select the maximum number of statements to return. When set less than
         1000 the effect is much the same as setting persist to false, and will
         guarantee a faster response. Default is None.
+    use_obtained_counts : Optional[bool]
+        If set to True, the statement evidence counts and source counts are
+        calculated based on the actual obtained statements and evidences
+        rather than the counts provided by the DB API. Default: False.
 
     Attributes
     ----------
@@ -84,7 +88,6 @@ class IndraDBRestProcessor(object):
         # specified by the user.
         kwargs.update((k, kwargs.get(k, default_api_params[k]))
                       for k in default_api_params.keys())
-
         self._run(*args, **kwargs)
         return
 
@@ -528,16 +531,3 @@ class IndraDBRestSearchProcessor(IndraDBRestProcessor):
                          % timeout)
             self.__th.join(timeout)
         return
-
-
-def standardize_counts(counts):
-    """Standardize hash-based counts dicts to be int-keyed."""
-    standardized_counts = {}
-    for k, v in counts.items():
-        try:
-            int_k = int(k)
-            standardized_counts[int_k] = v
-        except ValueError:
-            logger.warning('Could not convert statement hash %s to int' % k)
-    return standardized_counts
-


### PR DESCRIPTION
This PR adds an option to the INDRA DB REST client to use evidence/source counts based on the actual statements obtained. This is a useful as an option in the special case where we use MeSH filters and make sure to fetch all statements and evidences, resulting in correct counts obtained from the statements themselves. This involved moving shared code I previously implemented into the statement presentation module to make it shared between the processor and the HTML assembler.