### PR TITLE
Path constraints

### DIFF
--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -440,6 +440,10 @@ class ModelChecker(object):
 
         def node_filter_func(n):
             ag = self.nodes_to_agents.get(n[0])
+            if ag is None:
+                logger.warning('Could not get agent for node %s' % n[0])
+                # Do not filter the node if we can't map it to agent
+                return True
             return agent_filter_func(ag)
 
         return node_filter_func

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -332,8 +332,8 @@ class ModelChecker(object):
             Whether the target is a dummy node.
         filter_func : function or None
             A function to constrain the search. A function should take a node
-            as a parameter and return True if the node should be filtered and
-            False otherwise. If None, then no filtering is done.
+            as a parameter and return True if the node is allowed to be in a
+            path and False otherwise. If None, then no filtering is done.
 
         Returns
         -------

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -446,6 +446,8 @@ class ModelChecker(object):
             return None
 
         def node_filter_func(n):
+            # We're using n[0] here because n is a signed node while
+            # nodes_to_agents contains unsigned nodes (equivalent of n[0])
             ag = self.nodes_to_agents.get(n[0])
             if ag is None:
                 logger.warning('Could not get agent for node %s' % n[0])

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -453,6 +453,8 @@ class ModelChecker(object):
                 return True
             return agent_filter_func(ag)
 
+        logger.info('Converted %s to node filter function'
+                    % agent_filter_func.__name__)
         return node_filter_func
 
     def get_nodes_to_agents(self, *args, **kwargs):

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -198,17 +198,19 @@ class ModelChecker(object):
             a PathResult object describing the results of model checking.
         """
         results = []
+        # Convert agent filter function to node filter function once here
+        node_filter_func = self.update_filter_func(agent_filter_func)
         for idx, stmt in enumerate(self.statements):
             logger.info('---')
             logger.info('Checking statement (%d/%d): %s' %
                         (idx + 1, len(self.statements), stmt))
             result = self.check_statement(stmt, max_paths, max_path_length,
-                                          agent_filter_func)
+                                          node_filter_func=node_filter_func)
             results.append((stmt, result))
         return results
 
     def check_statement(self, stmt, max_paths=1, max_path_length=5,
-                        agent_filter_func=None):
+                        agent_filter_func=None, node_filter_func=None):
         """Check a single Statement against the model.
 
         Parameters
@@ -224,6 +226,10 @@ class ModelChecker(object):
             A function to constrain the intermediate nodes in the path. A
             function should take an agent as a parameter and return True if the
             agent is allowed to be in a path and False otherwise.
+        node_filter_func : Optional[function]
+            Similar to agent_filter_func but it takes a node as a parameter
+            instead of agent. If not provided, node_filter_func will be
+            generated from agent_filter_func.
 
         Returns
         -------
@@ -241,7 +247,8 @@ class ModelChecker(object):
             loop = True
 
         # Convert agent filter function to node filter function
-        node_filter_func = self.update_filter_func(agent_filter_func)
+        if agent_filter_func and not node_filter_func:
+            node_filter_func = self.update_filter_func(agent_filter_func)
         # If we have several objects in obj_list or we have a loop, we add a
         # dummy target node as a child to all nodes in obj_list
         if len(obj_list) > 1 or loop:

--- a/indra/explanation/model_checker/pysb.py
+++ b/indra/explanation/model_checker/pysb.py
@@ -230,13 +230,13 @@ class PysbModelChecker(ModelChecker):
         if self.graph:
             return self.graph
         im = self.get_im(force_update=True)
-        self.get_nodes_to_agents(self.model_stmts, add_namespaces)
         if prune_im:
             self.prune_influence_map()
         if prune_im_degrade:
             self.prune_influence_map_degrade_bind_positive(self.model_stmts)
         if prune_im_subj_obj:
             self.prune_influence_map_subj_obj()
+        self.get_nodes_to_agents(self.model_stmts, add_namespaces)
         self.graph = signed_edges_to_signed_nodes(
             im, prune_nodes=False, edge_signs={'pos': 1, 'neg': -1})
         return self.graph

--- a/indra/explanation/model_checker/signed_graph.py
+++ b/indra/explanation/model_checker/signed_graph.py
@@ -89,4 +89,6 @@ class SignedGraphModelChecker(ModelChecker):
         # externally.
         graph = self.get_graph()
         for node, data in graph.nodes(data=True):
-            ag = Agent(node, db_refs={data.get('ns'): data.get('id')})
+            ag = Agent(node[0], db_refs={data.get('ns'): data.get('id')})
+            self.nodes_to_agents[node[0]] = ag
+        return self.nodes_to_agents

--- a/indra/explanation/model_checker/signed_graph.py
+++ b/indra/explanation/model_checker/signed_graph.py
@@ -89,4 +89,4 @@ class SignedGraphModelChecker(ModelChecker):
         # externally.
         graph = self.get_graph()
         for node, data in graph.nodes(data=True):
-            ag = Agent(node, db_refs={data.get('ns'): data.get('id')])
+            ag = Agent(node, db_refs={data.get('ns'): data.get('id')})

--- a/indra/explanation/model_checker/signed_graph.py
+++ b/indra/explanation/model_checker/signed_graph.py
@@ -21,8 +21,10 @@ class SignedGraphModelChecker(ModelChecker):
     seed : int
         Random seed for sampling (optional, default is None).
     """
-    def __init__(self, model, statements=None, do_sampling=False, seed=None):
+    def __init__(self, model, statements=None, do_sampling=False, seed=None,
+                 model_agents=None):
         super().__init__(model, statements, do_sampling, seed)
+        self.model_agents = model_agents if model_agents else []
 
     def get_graph(self):
         if self.graph:

--- a/indra/explanation/model_checker/unsigned_graph.py
+++ b/indra/explanation/model_checker/unsigned_graph.py
@@ -22,8 +22,10 @@ class UnsignedGraphModelChecker(ModelChecker):
     seed : int
         Random seed for sampling (optional, default is None).
     """
-    def __init__(self, model, statements=None, do_sampling=False, seed=None):
+    def __init__(self, model, statements=None, do_sampling=False, seed=None,
+                 model_agents=None):
         super().__init__(model, statements, do_sampling, seed)
+        self.model_agents = model_agents if model_agents else []
 
     def get_graph(self):
         if self.graph:

--- a/indra/explanation/model_checker/unsigned_graph.py
+++ b/indra/explanation/model_checker/unsigned_graph.py
@@ -21,11 +21,18 @@ class UnsignedGraphModelChecker(ModelChecker):
         generate paths. Default is False (breadth-first search).
     seed : int
         Random seed for sampling (optional, default is None).
+    nodes_to_agents : dict
+        A dictionary mapping nodes of intermediate signed edges graph to INDRA
+        agents.
+
+    Attributes
+    ----------
+    graph : nx.Digraph
+        A DiGraph with signed nodes to find paths in.
     """
     def __init__(self, model, statements=None, do_sampling=False, seed=None,
-                 model_agents=None):
-        super().__init__(model, statements, do_sampling, seed)
-        self.model_agents = model_agents if model_agents else []
+                 nodes_to_agents=None):
+        super().__init__(model, statements, do_sampling, seed, nodes_to_agents)
 
     def get_graph(self):
         if self.graph:
@@ -37,6 +44,7 @@ class UnsignedGraphModelChecker(ModelChecker):
         self.graph.add_nodes_from(nodes)
         for (u, v, data) in self.model.edges(data=True):
             self.graph.add_edge((u, 0), (v, 0), belief=data['belief'])
+        self.get_nodes_to_agents()
         return self.graph
 
     def process_statement(self, stmt):
@@ -74,3 +82,15 @@ class UnsignedGraphModelChecker(ModelChecker):
         if node not in graph.nodes:
             return None
         return [node]
+
+    def get_nodes_to_agents(self):
+        """Return a dictionary mapping IndraNet nodes to INDRA agents."""
+        if self.nodes_to_agents:
+            return self.nodes_to_agents
+
+        # NOTE: this way of retrieving agents might miss some important
+        # agent properties. The recommended way is to provide this mapping
+        # externally.
+        graph = self.get_graph()
+        for node, data in graph.nodes(data=True):
+            ag = Agent(node, db_refs={data.get('ns'): data.get('id')])

--- a/indra/explanation/model_checker/unsigned_graph.py
+++ b/indra/explanation/model_checker/unsigned_graph.py
@@ -93,4 +93,4 @@ class UnsignedGraphModelChecker(ModelChecker):
         # externally.
         graph = self.get_graph()
         for node, data in graph.nodes(data=True):
-            ag = Agent(node, db_refs={data.get('ns'): data.get('id')])
+            ag = Agent(node, db_refs={data.get('ns'): data.get('id')})

--- a/indra/explanation/model_checker/unsigned_graph.py
+++ b/indra/explanation/model_checker/unsigned_graph.py
@@ -93,4 +93,6 @@ class UnsignedGraphModelChecker(ModelChecker):
         # externally.
         graph = self.get_graph()
         for node, data in graph.nodes(data=True):
-            ag = Agent(node, db_refs={data.get('ns'): data.get('id')})
+            ag = Agent(node[0], db_refs={data.get('ns'): data.get('id')})
+            self.nodes_to_agents[node[0]] = ag
+        return self.nodes_to_agents

--- a/indra/explanation/pathfinding/pathfinding.py
+++ b/indra/explanation/pathfinding/pathfinding.py
@@ -490,7 +490,7 @@ def get_path_iter(graph, source, target, path_length, loop, dummy_target,
         pass
 
 
-def find_sources(graph, target, sources, filter_func=None, allow_source=True):
+def find_sources(graph, target, sources, filter_func=None):
     """Get the set of source nodes with paths to the target.
 
     Given a common target and  a list of sources (or None if test statement
@@ -509,6 +509,10 @@ def find_sources(graph, target, sources, filter_func=None, allow_source=True):
     sources : list[node]
         Signed nodes corresponding to the subject or upstream influence
         being checked.
+    filter_func : Optional[function]
+        A function to constrain the intermediate nodes in the path. A
+        function should take a node as a parameter and return True if the node
+        is allowed to be a path of a path and False otherwise.
 
     Returns
     -------
@@ -516,7 +520,8 @@ def find_sources(graph, target, sources, filter_func=None, allow_source=True):
         Yields tuples of source node and path length (int). If there are no
         paths to any of the given source nodes, the generator is empty.
     """
-    if allow_source and sources:
+    # Update filter function to not filter the sources
+    if sources is not None:
         filter_func = filter_except(filter_func, sources)
     # First, create a list of visited nodes
     # Adapted from
@@ -849,7 +854,7 @@ def open_dijkstra_search(g, start, reverse=False, path_limit=None,
 
 # This code is adapted from nx.algorithms.simple_paths._all_simple_paths_graph
 def simple_paths_with_constraints(G, source, target, cutoff=None,
-                                  filter_func=None, allow_target=True):
+                                  filter_func=None):
     """Find all simple paths between source and target with given constraints.
 
     Parameters
@@ -863,9 +868,9 @@ def simple_paths_with_constraints(G, source, target, cutoff=None,
     cutoff : Optional[int]
         Maximum depth of the paths.
     filter_func : Optional[function]
-        A function to constrain the search. A function should take a node as
-        a parameter and return True if the node should be filtered and False
-        otherwise.
+        A function to constrain the intermediate nodes in the path. A
+        function should take a node as a parameter and return True if the node
+        is allowed to be a path of a path and False otherwise.
 
     Returns
     -------
@@ -874,8 +879,8 @@ def simple_paths_with_constraints(G, source, target, cutoff=None,
     """
     if cutoff is None:
         cutoff = len(G) - 1
-    if allow_target:
-        filter_func = filter_except(filter_func, {target})
+    # Update filter function to not filter target
+    filter_func = filter_except(filter_func, {target})
     visited = OrderedDict.fromkeys([source])
     new_nodes = iter(G[source])
     if filter_func:
@@ -904,6 +909,7 @@ def simple_paths_with_constraints(G, source, target, cutoff=None,
 
 
 def filter_except(filter_func, nodes_to_keep):
+    """Update the filter function to keep some nodes."""
     if filter_func is None:
         return None
 

--- a/indra/explanation/pathfinding/pathfinding.py
+++ b/indra/explanation/pathfinding/pathfinding.py
@@ -473,7 +473,7 @@ def get_path_iter(graph, source, target, path_length, loop, dummy_target,
         A generator of the paths between source and target.
     """
     path_iter = simple_paths_with_constraints(
-        graph, source, target, path_length, filter_func, True)
+        graph, source, target, path_length, filter_func)
     try:
         for p in path_iter:
             path = deepcopy(p)

--- a/indra/explanation/pathfinding/pathfinding.py
+++ b/indra/explanation/pathfinding/pathfinding.py
@@ -909,7 +909,23 @@ def simple_paths_with_constraints(G, source, target, cutoff=None,
 
 
 def filter_except(filter_func, nodes_to_keep):
-    """Update the filter function to keep some nodes."""
+    """Update the filter function to keep some nodes.
+
+    Parameters
+    ----------
+    filter_func : function
+        A function to constrain the intermediate nodes in the path. A
+        function should take a node as a parameter and return True if the node
+        is allowed to be a path of a path and False otherwise.
+    nodes_to_keep : iterable
+        A collection of nodes to keep regardless of filter function.
+
+    Returns
+    -------
+    new_filter : function
+        Updated filter function that filters out everything according to
+        original filter_func except nodes_to_keep.
+    """
     if filter_func is None:
         return None
 

--- a/indra/explanation/pathfinding/pathfinding.py
+++ b/indra/explanation/pathfinding/pathfinding.py
@@ -443,11 +443,37 @@ def bfs_search_multiple_nodes(g, source_nodes, path_limit=None, **kwargs):
             break
 
 
-def get_path_iter(graph, source, target, path_length, loop, dummy_target):
+def get_path_iter(graph, source, target, path_length, loop, dummy_target,
+                  filter_func):
     """Return a generator of paths with path_length cutoff from source to
-    target."""
+    target.
+
+    Parameters
+    ----------
+    graph : nx.Digraph
+        An nx.DiGraph to search in.
+    source : node
+        Starting node for path.
+    target : node
+        Ending node for path.
+    path_length : int
+        Maximum depth of the paths.
+    loop : bool
+        Whether the path should be a loop. If True, source is appended to path.
+    dummy_target : bool
+        Whether provided target is a dummy node and should be removed from path
+    filter_func : function or None
+        A function to constrain the search. A function should take a node as
+        a parameter and return True if the node should be filtered and False
+        otherwise. If None, then no filtering is done.
+
+    Returns
+    -------
+    path_generator: generator
+        A generator of the paths between source and target.
+    """
     path_iter = simple_paths_with_constraints(
-        graph, source, target, path_length)
+        graph, source, target, path_length, filter_func)
     try:
         for p in path_iter:
             path = deepcopy(p)

--- a/indra/explanation/pathfinding/pathfinding.py
+++ b/indra/explanation/pathfinding/pathfinding.py
@@ -512,7 +512,7 @@ def find_sources(graph, target, sources, filter_func=None):
     filter_func : Optional[function]
         A function to constrain the intermediate nodes in the path. A
         function should take a node as a parameter and return True if the node
-        is allowed to be a path of a path and False otherwise.
+        is allowed to be in a path and False otherwise.
 
     Returns
     -------
@@ -870,7 +870,7 @@ def simple_paths_with_constraints(G, source, target, cutoff=None,
     filter_func : Optional[function]
         A function to constrain the intermediate nodes in the path. A
         function should take a node as a parameter and return True if the node
-        is allowed to be a path of a path and False otherwise.
+        is allowed to be in a path and False otherwise.
 
     Returns
     -------

--- a/indra/explanation/pathfinding/pathfinding.py
+++ b/indra/explanation/pathfinding/pathfinding.py
@@ -464,8 +464,8 @@ def get_path_iter(graph, source, target, path_length, loop, dummy_target,
         Whether provided target is a dummy node and should be removed from path
     filter_func : function or None
         A function to constrain the search. A function should take a node as
-        a parameter and return True if the node should be filtered and False
-        otherwise. If None, then no filtering is done.
+        a parameter and return True if the node is allowed to be in a path and
+        False otherwise. If None, then no filtering is done.
 
     Returns
     -------
@@ -916,7 +916,7 @@ def filter_except(filter_func, nodes_to_keep):
     filter_func : function
         A function to constrain the intermediate nodes in the path. A
         function should take a node as a parameter and return True if the node
-        is allowed to be a path of a path and False otherwise.
+        is allowed to be in a path and False otherwise.
     nodes_to_keep : iterable
         A collection of nodes to keep regardless of filter function.
 

--- a/indra/tests/test_pathfinding.py
+++ b/indra/tests/test_pathfinding.py
@@ -515,22 +515,22 @@ def test_simple_paths_with_constraints():
     dg.add_edge('B2', 'B1')
     dg.add_edge('B1', 'D1')
 
-    # # Run without cutoff and constraints
-    # paths = tuple(
-    #     [tuple(p) for p in simple_paths_with_constraints(dg, 'A3', 'D1')])
-    # assert len(paths) == 3
-    # expected_paths = {('A3', 'B2', 'B1', 'D1'),
-    #                   ('A3', 'B2', 'C1', 'D1'),
-    #                   ('A3', 'B2', 'B1', 'C1', 'D1')}
-    # assert expected_paths == set(paths), set(paths)
+    # Run without cutoff and constraints
+    paths = tuple(
+        [tuple(p) for p in simple_paths_with_constraints(dg, 'A3', 'D1')])
+    assert len(paths) == 3
+    expected_paths = {('A3', 'B2', 'B1', 'D1'),
+                      ('A3', 'B2', 'C1', 'D1'),
+                      ('A3', 'B2', 'B1', 'C1', 'D1')}
+    assert expected_paths == set(paths), set(paths)
 
-    # # Test cutoff
-    # paths = tuple([tuple(p) for p in simple_paths_with_constraints(
-    #     dg, 'A3', 'D1', cutoff=3)])
-    # assert len(paths) == 2
-    # expected_paths = {('A3', 'B2', 'B1', 'D1'),
-    #                   ('A3', 'B2', 'C1', 'D1')}
-    # assert expected_paths == set(paths), set(paths)
+    # Test cutoff
+    paths = tuple([tuple(p) for p in simple_paths_with_constraints(
+        dg, 'A3', 'D1', cutoff=3)])
+    assert len(paths) == 2
+    expected_paths = {('A3', 'B2', 'B1', 'D1'),
+                      ('A3', 'B2', 'C1', 'D1')}
+    assert expected_paths == set(paths), set(paths)
 
     # Test constraints
     def _isC(n):

--- a/indra/tests/test_pathfinding.py
+++ b/indra/tests/test_pathfinding.py
@@ -515,35 +515,35 @@ def test_simple_paths_with_constraints():
     dg.add_edge('B2', 'B1')
     dg.add_edge('B1', 'D1')
 
-    # Run without cutoff and constraints
-    paths = tuple(
-        [tuple(p) for p in simple_paths_with_constraints(dg, 'A3', 'D1')])
-    assert len(paths) == 3
-    expected_paths = {('A3', 'B2', 'B1', 'D1'),
-                      ('A3', 'B2', 'C1', 'D1'),
-                      ('A3', 'B2', 'B1', 'C1', 'D1')}
-    assert expected_paths == set(paths), set(paths)
+    # # Run without cutoff and constraints
+    # paths = tuple(
+    #     [tuple(p) for p in simple_paths_with_constraints(dg, 'A3', 'D1')])
+    # assert len(paths) == 3
+    # expected_paths = {('A3', 'B2', 'B1', 'D1'),
+    #                   ('A3', 'B2', 'C1', 'D1'),
+    #                   ('A3', 'B2', 'B1', 'C1', 'D1')}
+    # assert expected_paths == set(paths), set(paths)
 
-    # Test cutoff
-    paths = tuple([tuple(p) for p in simple_paths_with_constraints(
-        dg, 'A3', 'D1', cutoff=3)])
-    assert len(paths) == 2
-    expected_paths = {('A3', 'B2', 'B1', 'D1'),
-                      ('A3', 'B2', 'C1', 'D1')}
-    assert expected_paths == set(paths), set(paths)
+    # # Test cutoff
+    # paths = tuple([tuple(p) for p in simple_paths_with_constraints(
+    #     dg, 'A3', 'D1', cutoff=3)])
+    # assert len(paths) == 2
+    # expected_paths = {('A3', 'B2', 'B1', 'D1'),
+    #                   ('A3', 'B2', 'C1', 'D1')}
+    # assert expected_paths == set(paths), set(paths)
 
     # Test constraints
     def _isC(n):
         # Filter out nodes starting with C
         if n.startswith('C'):
-            return True
-        return False
+            return False
+        return True
 
     def _isB(n):
         # Filter out nodes starting with B
         if n.startswith('B'):
-            return True
-        return False
+            return False
+        return True
 
     paths = tuple([tuple(p) for p in simple_paths_with_constraints(
         dg, 'A3', 'D1', filter_func=_isC)])


### PR DESCRIPTION
This PR enables setting constraints on intermediate nodes in path search. To trigger this, one has to provide a function that takes an INDRA agent as a parameter and outputs True if the agent can be a part of a path and False otherwise. All conversions between agents and nodes of specific types are handled by corresponding model checkers.