### PR TITLE
Generalize BioPAX processor to Reactome-sourced content

### DIFF
--- a/doc/modules/sources/biopax/index.rst
+++ b/doc/modules/sources/biopax/index.rst
@@ -1,13 +1,16 @@
-Biopax (:py:mod:`indra.sources.biopax`)
+BioPAX (:py:mod:`indra.sources.biopax`)
 =======================================
 
-Biopax API (:py:mod:`indra.sources.biopax.api`)
+.. automodule:: indra.sources.biopax
+    :members:
+
+BioPAX API (:py:mod:`indra.sources.biopax.api`)
 -----------------------------------------------
 
 .. automodule:: indra.sources.biopax.api
     :members:
 
-Biopax Processor (:py:mod:`indra.sources.biopax.processor`)
+BioPAX Processor (:py:mod:`indra.sources.biopax.processor`)
 -----------------------------------------------------------
 
 .. automodule:: indra.sources.biopax.processor

--- a/indra/sources/biopax/__init__.py
+++ b/indra/sources/biopax/__init__.py
@@ -1,1 +1,10 @@
+"""This module allows processing BioPAX content into INDRA Statements. It uses
+the pybiopax package to process OWL files or strings, or to obtain
+BioPAX content by querying the PathwayCommons web service. The module has
+been tested with BioPAX content from PathwayCommons
+https://www.pathwaycommons.org/archives/PC2/v12/. BioPAX from other sources
+may not adhere to the same conventions and could result in processing issues,
+though these can typically be addressed with minor changes in the processor's
+logic.
+"""
 from .api import *

--- a/indra/sources/biopax/__init__.py
+++ b/indra/sources/biopax/__init__.py
@@ -1,9 +1,9 @@
 """This module allows processing BioPAX content into INDRA Statements. It uses
-the pybiopax package to process OWL files or strings, or to obtain
-BioPAX content by querying the PathwayCommons web service. The module has
-been tested with BioPAX content from PathwayCommons
-https://www.pathwaycommons.org/archives/PC2/v12/. BioPAX from other sources
-may not adhere to the same conventions and could result in processing issues,
+the pybiopax package (https://github.com/indralab/pybiopax) to process OWL
+files or strings, or to obtain BioPAX content by querying the PathwayCommons
+web service. The module has been tested with BioPAX content from PathwayCommons
+https://www.pathwaycommons.org/archives/PC2/v12/. BioPAX from other sources may
+not adhere to the same conventions and could result in processing issues,
 though these can typically be addressed with minor changes in the processor's
 logic.
 """

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -830,10 +830,13 @@ def expand_complex(pe: bp.PhysicalEntity):
 
 
 def expand_family(pe: bp.PhysicalEntity):
+    members = []
     if pe.member_physical_entity:
-        return pe.member_physical_entity
+        for member in pe.member_physical_entity:
+            members += expand_family(member)
     else:
-        return [pe]
+        members = [pe]
+    return members
 
 
 def infer_pe_type(pe: bp.PhysicalEntity):

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -13,6 +13,7 @@ from indra.util import flatten
 from indra.ontology.standardize import standardize_name_db_refs
 from indra.databases import hgnc_client, uniprot_client, chebi_client, \
     parse_identifiers_url
+from indra.statements.validate import assert_valid_agent
 
 logger = logging.getLogger(__name__)
 
@@ -497,6 +498,15 @@ class BiopaxProcessor(object):
             if standard_name:
                 name = standard_name
             agents.append(Agent(name, db_refs=db_refs, mods=mcs))
+        # Since there are so many cases above, we fix UP / UPISO issues
+        # in a single loop here
+        for agent in agents:
+            up_id = agent.db_refs.get('UP')
+            if up_id is not None and '-' in up_id:
+                base_id = up_id.split('-')[0]
+                agent.db_refs['UP'] = base_id
+                agent.db_refs['UPISO'] = up_id
+
         # There is a potential here that an Agent name was set to None
         # if both the display name and the standard name are missing.
         # We filter these out

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -10,10 +10,10 @@ from pybiopax import model_to_owl_file
 
 from indra.statements import *
 from indra.util import flatten
+from indra.statements.validate import print_validation_report
 from indra.ontology.standardize import standardize_name_db_refs
 from indra.databases import hgnc_client, uniprot_client, chebi_client, \
     parse_identifiers_url
-from indra.statements.validate import assert_valid_agent
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +65,8 @@ class BiopaxProcessor(object):
         self.get_conversions()
         self.get_gap_gef()
         self.eliminate_exact_duplicates()
+        print_validation_report(self.statements)
+
 
     def save_model(self, file_name):
         """Save the BioPAX model object in an OWL file.


### PR DESCRIPTION
This PR makes some minor changes to the BioPAX processor to allow processing content directly from Reactome. Fixes #1184.