### PR TITLE
Fix data schema of annotations in PyBEL assembler

### DIFF
--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -635,8 +635,10 @@ def _get_evidence(evidence):
     for key, value in evidence.epistemics.items():
         if key == 'direct' or value is None:
             continue
-        annotations[key] = {v: True for v in value}
-
+        if isinstance(value, (list, set, tuple)):
+            annotations[key] = {v: True for v in value}
+        else:
+            annotations[key] = {value: True}
     return citation, text, annotations
 
 

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -626,16 +626,16 @@ def _get_evidence(evidence):
         )
 
     annotations = {
-        'source_hash': evidence.get_source_hash(),
+        'source_hash': {evidence.get_source_hash(): True},
     }
     if evidence.source_api:
-        annotations['source_api'] = evidence.source_api
+        annotations['source_api'] = {evidence.source_api: True}
     if evidence.source_id:
-        annotations['source_id'] = evidence.source_id
+        annotations['source_id'] = {evidence.source_id: True}
     for key, value in evidence.epistemics.items():
         if key == 'direct':
             continue
-        annotations[key] = value
+        annotations[key] = {value: True}
 
     return citation, text, annotations
 

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -400,7 +400,7 @@ def belgraph_to_signed_graph(
         rel = edge_data.get('relation')
         pos_edge = \
             (u, v, ('sign', 0)) + \
-            tuple((k, (tuple(v) if isinstance(v, list) else v))
+            tuple((k, tuple(v))
                   for k, v in edge_data.get('annotations', {}).items()) \
             if propagate_annotations else (u, v, ('sign', 0))
         # Unpack tuple pairs at indices >1 or they'll be in nested tuples

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -633,9 +633,9 @@ def _get_evidence(evidence):
     if evidence.source_id:
         annotations['source_id'] = {evidence.source_id: True}
     for key, value in evidence.epistemics.items():
-        if key == 'direct':
+        if key == 'direct' or value is None:
             continue
-        annotations[key] = {value: True}
+        annotations[key] = {v: True for v in value}
 
     return citation, text, annotations
 

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -457,9 +457,9 @@ def _update_edge_data_from_evidence(evidence, edge_data):
 
 def _get_annotations_from_stmt(stmt):
     return {
-        'stmt_hash': stmt.get_hash(refresh=True),
-        'uuid': stmt.uuid,
-        'belief': stmt.belief
+        'stmt_hash': {stmt.get_hash(refresh=True): True},
+        'uuid': {stmt.uuid: True},
+        'belief': {stmt.belief: True},
     }
 
 

--- a/indra/explanation/reporting.py
+++ b/indra/explanation/reporting.py
@@ -173,7 +173,7 @@ def stmts_from_pybel_path(path, model, from_db=True, stmts=None):
         hashes = set()
         for j in range(len(edges)):
             try:
-                hashes.add(edges[j]['annotations']['stmt_hash'])
+                hashes.add(list(edges[j]['annotations']['stmt_hash'])[0])
             # partOf and hasVariant edges don't have hashes
             except KeyError:
                 continue

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -104,6 +104,7 @@ def test_modification_with_evidences():
     mek = Agent('MAP2K1', db_refs={'HGNC': '6840', 'UP': 'Q02750'})
     evidence = Evidence(source_api='test', text='evidence text', pmid='1234', epistemics={
         'dummy': ['a', 'b'],
+        'scalar': 'yes',
         'missing': None,
     })
     stmt = Phosphorylation(braf_kin, mek, 'S', '218', evidence=evidence)
@@ -129,6 +130,8 @@ def test_modification_with_evidences():
     assert 'dummy' in edge_data[pc.ANNOTATIONS]
     assert 'a' in edge_data[pc.ANNOTATIONS]['dummy']
     assert 'b' in edge_data[pc.ANNOTATIONS]['dummy']
+    assert 'scalar' in edge_data[pc.ANNOTATIONS]
+    assert 'yes' in edge_data[pc.ANNOTATIONS]['scalar']
     assert 'missing' not in edge_data[pc.ANNOTATIONS]
 
 

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -102,7 +102,10 @@ def test_modification_with_evidences():
     braf_kin = Agent('BRAF', activity=ActivityCondition('kinase', True),
                      db_refs={'HGNC': '1097', 'UP': 'P15056'})
     mek = Agent('MAP2K1', db_refs={'HGNC': '6840', 'UP': 'Q02750'})
-    evidence = Evidence(source_api='test', text='evidence text', pmid='1234')
+    evidence = Evidence(source_api='test', text='evidence text', pmid='1234', epistemics={
+        'dummy': ['a', 'b'],
+        'missing': None,
+    })
     stmt = Phosphorylation(braf_kin, mek, 'S', '218', evidence=evidence)
     pba = pa.PybelAssembler([stmt])
     belgraph = pba.make_model()
@@ -123,6 +126,10 @@ def test_modification_with_evidences():
     assert 'test' in edge_data[pc.ANNOTATIONS]['source_api']
     assert 'source_id' not in edge_data[pc.ANNOTATIONS]
     assert 'source_hash' in edge_data[pc.ANNOTATIONS]
+    assert 'dummy' in edge_data[pc.ANNOTATIONS]
+    assert 'a' in edge_data[pc.ANNOTATIONS]['dummy']
+    assert 'b' in edge_data[pc.ANNOTATIONS]['dummy']
+    assert 'missing' not in edge_data[pc.ANNOTATIONS]
 
 
 def test_modification_with_mutation():

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -120,7 +120,7 @@ def test_modification_with_evidences():
         pc.CITATION_IDENTIFIER: '1234',
     }
     assert 'source_api' in edge_data[pc.ANNOTATIONS]
-    assert edge_data[pc.ANNOTATIONS]['source_api'] == 'test'
+    assert 'test' in edge_data[pc.ANNOTATIONS]['source_api']
     assert 'source_id' not in edge_data[pc.ANNOTATIONS]
     assert 'source_hash' in edge_data[pc.ANNOTATIONS]
 
@@ -151,9 +151,9 @@ def test_activation():
         pc.RELATION: pc.INCREASES,
         pc.OBJECT: {pc.MODIFIER: pc.ACTIVITY},
         pc.ANNOTATIONS: {
-            'stmt_hash': hash1,
-            'uuid': stmt1.uuid,
-            'belief': stmt1.belief,
+            'stmt_hash': {hash1: True},
+            'uuid': {stmt1.uuid: True},
+            'belief': {stmt1.belief: True},
         },
     }
     edge2 = {
@@ -161,9 +161,9 @@ def test_activation():
         pc.SUBJECT: activity('kin'),
         pc.OBJECT: activity('kin'),
         pc.ANNOTATIONS: {
-            'stmt_hash': hash2,
-            'uuid': stmt2.uuid,
-            'belief': stmt2.belief,
+            'stmt_hash': {hash2: True},
+            'uuid': {stmt2.uuid: True},
+            'belief': {stmt2.belief: True},
         },
     }
     for stmt, edge in ((stmt1, edge1), (stmt2, edge2)):
@@ -199,10 +199,10 @@ def test_direct_activation():
             pc.CITATION_IDENTIFIER: '1234',
         },
         pc.ANNOTATIONS: {
-            'stmt_hash': hash1,
-            'source_hash': stmt1_ev.get_source_hash(),
-            'uuid': stmt1.uuid,
-            'belief': stmt1.belief,
+            'stmt_hash': {hash1: True},
+            'source_hash': {stmt1_ev.get_source_hash(): True},
+            'uuid': {stmt1.uuid: True},
+            'belief': {stmt1.belief: True},
         },
     }
     edge2 = {
@@ -215,10 +215,10 @@ def test_direct_activation():
             pc.CITATION_IDENTIFIER: '1234',
         },
         pc.ANNOTATIONS: {
-            'stmt_hash': hash2,
-            'source_hash': stmt1_ev.get_source_hash(),
-            'uuid': stmt2.uuid,
-            'belief': stmt2.belief,
+            'stmt_hash': {hash2: True},
+            'source_hash': {stmt1_ev.get_source_hash(): True},
+            'uuid': {stmt2.uuid: True},
+            'belief': {stmt2.belief: True},
         },
     }
     for stmt, expected_edge in ((stmt1, edge1), (stmt2, edge2)):
@@ -243,9 +243,9 @@ def test_inhibition():
         pc.SUBJECT: activity('kin'),
         pc.OBJECT: activity('kin'),
         pc.ANNOTATIONS: {
-            'stmt_hash': stmt_hash,
-            'uuid': stmt.uuid,
-            'belief': stmt.belief,
+            'stmt_hash': {stmt_hash: True},
+            'uuid': {stmt.uuid: True},
+            'belief': {stmt.belief: True},
         },
     }
     pba = pa.PybelAssembler([stmt])
@@ -314,9 +314,9 @@ def test_gef():
         pc.SUBJECT: activity('gef'),
         pc.OBJECT: activity('gtp'),
         pc.ANNOTATIONS: {
-            'stmt_hash': stmt_hash,
-            'uuid': stmt.uuid,
-            'belief': stmt.belief,
+            'stmt_hash': {stmt_hash: True},
+            'uuid': {stmt.uuid: True},
+            'belief': {stmt.belief: True},
         },
     }
     assert edge_data == edge, edge_data
@@ -496,9 +496,9 @@ def test_bound_condition():
              pc.RELATION: pc.DIRECTLY_INCREASES,
              pc.OBJECT: activity('gtp'),
              pc.ANNOTATIONS: {
-                 'stmt_hash': stmt_hash,
-                 'uuid': stmt.uuid,
-                 'belief': stmt.belief,
+                 'stmt_hash': {stmt_hash: True},
+                 'uuid': {stmt.uuid: True},
+                 'belief': {stmt.belief: True},
              },
         },
     )
@@ -523,9 +523,9 @@ def test_transphosphorylation():
     assert edge_data == {
         pc.RELATION: pc.DIRECTLY_INCREASES,
         pc.ANNOTATIONS: {
-            'stmt_hash': stmt_hash,
-            'uuid': stmt.uuid,
-            'belief': stmt.belief,
+            'stmt_hash': {stmt_hash: True},
+            'uuid': {stmt.uuid: True},
+            'belief': {stmt.belief: True},
         },
     }, edge_data
 

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -347,9 +347,9 @@ def test_gap():
         pc.SUBJECT: activity('gap'),
         pc.OBJECT: activity('gtp'),
         pc.ANNOTATIONS: {
-            'stmt_hash': stmt_hash,
-            'uuid': stmt.uuid,
-            'belief': stmt.belief,
+            'stmt_hash': {stmt_hash: True},
+            'uuid': {stmt.uuid: True},
+            'belief': {stmt.belief: True},
         },
     }
     assert edge_data == edge, edge_data
@@ -451,10 +451,11 @@ def test_autophosphorylation():
     edge_dicts = list(belgraph.get_edge_data(egfr_dsl,
                                              egfr_phos_node).values())
     assert {pc.RELATION: pc.DIRECTLY_INCREASES,
-            pc.ANNOTATIONS: {'stmt_hash': stmt_hash,
-                             'uuid': stmt.uuid,
-                             'belief': stmt.belief}} \
-        in edge_dicts
+            pc.ANNOTATIONS: {
+                'stmt_hash': {stmt_hash: True},
+                'uuid': {stmt.uuid: True},
+                'belief': {stmt.belief: True},
+            }} in edge_dicts
 
     # Test an autophosphorylation with a bound condition
     tab1 = Agent('TAB1', db_refs={'HGNC': id('TAB1')})
@@ -632,6 +633,15 @@ def test_belgraph_to_signed_graph():
 
     edge_dict = pb_seg.edges.get(edge)
     assert edge_dict
-    assert edge_dict.get('stmt_hash') == hsh
-    assert edge_dict.get('uuid') == stmt.uuid
-    assert edge_dict.get('belief') == stmt.belief
+
+    assert 'stmt_hash' in edge_dict
+    assert 1 == len(edge_dict['stmt_hash'])
+    assert hsh == list(edge_dict['stmt_hash'])[0]
+
+    assert 'uuid' in edge_dict
+    assert 1 == len(edge_dict['uuid'])
+    assert stmt.uuid == list(edge_dict['uuid'])[0]
+
+    assert 'belief' in edge_dict
+    assert 1 == len(edge_dict['belief'])
+    assert stmt.belief == list(edge_dict['belief'])[0]


### PR DESCRIPTION
In PyBEL v14, the annotations data structure should be a `Mapping[str, Mapping[str, bool]]` where the first key is the name of the annotation, the nested key is the value of the annotation, and the bool is always just True (unless you have some negative annotations, then set it to false!). Even for annotations that only have a singleton value and the positive/negative dichotomy is irrelevant, it should still be done this way. Typically, even developers won't be accessing the networkx Graph class's `add_edge()` function and the PyBEL wrappers on it should handle of a variety of data structures, such as this one, but since we're accessing it directly in the PyBEL assembler, this is a problem.

Addresses https://github.com/sorgerlab/indra/issues/1184#issuecomment-718036895