### PR TITLE
Extract activation of modified form as modification statement from Reach

### DIFF
--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -291,12 +291,25 @@ class ReachProcessor(object):
                 continue
             annotations['agents']['coords'] = [controller_coords,
                                                controlled_coords]
-            if r['subtype'] == 'positive-activation':
-                st = Activation(controller_agent, controlled_agent,
-                                evidence=ev)
-            else:
-                st = Inhibition(controller_agent, controlled_agent,
-                                evidence=ev)
+            positive = (r['subtype'] == 'positive-activation')
+            # By default, we choose Activation/Inhibition based on polarity
+            stmt_cls = Activation if positive else Inhibition
+            stmt_kwargs = {}
+            # Here we handle a special case where we have the activation of
+            # a phosphorylated form, which we transform into a Phosphorylation
+            # or a Dephosphorylation
+            if controlled_agent.mods:
+                # NOTE: can there be more than one mods here?
+                mod = controlled_agent.mods[0]
+                if mod.mod_type in modtype_to_modclass:
+                    stmt_cls = modtype_to_modclass[mod.mod_type]
+                    if mod.residue:
+                        stmt_kwargs['residue'] = mod.residue
+                    if mod.position:
+                        stmt_kwargs['position'] = mod.position
+                controlled_agent.mods = []
+            st = stmt_cls(controller_agent, controlled_agent, **stmt_kwargs,
+                          evidence=ev)
             self.statements.append(st)
 
     def get_translocation(self):

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -296,13 +296,16 @@ class ReachProcessor(object):
             stmt_cls = Activation if positive else Inhibition
             stmt_kwargs = {}
             # Here we handle a special case where we have the activation of
-            # a phosphorylated form, which we transform into a Phosphorylation
-            # or a Dephosphorylation
+            # a modified form, which we transform into a modification
+            # statement, e.g., Phosphorylation
             if controlled_agent.mods:
                 # NOTE: can there be more than one mods here?
                 mod = controlled_agent.mods[0]
+                # We check all modification classes here
                 if mod.mod_type in modtype_to_modclass:
                     stmt_cls = modtype_to_modclass[mod.mod_type]
+                    # We take the residue/position information from
+                    # the modificatio, if available
                     if mod.residue:
                         stmt_kwargs['residue'] = mod.residue
                     if mod.position:

--- a/indra/tests/reach_reg_phos.json
+++ b/indra/tests/reach_reg_phos.json
@@ -1,0 +1,424 @@
+{
+  "events" : {
+    "frames" : [ {
+      "frame-id" : "evem-api9-UAZ-r1-Reach-0-4",
+      "text" : "Akt induced by IGF-I",
+      "arguments" : [ {
+        "text" : "Akt",
+        "argument-type" : "entity",
+        "type" : "controlled",
+        "object-type" : "argument",
+        "index" : 0,
+        "arg" : "ment-api9-UAZ-r1-Reach-0-4"
+      }, {
+        "text" : "IGF-I",
+        "argument-type" : "entity",
+        "type" : "controller",
+        "object-type" : "argument",
+        "index" : 0,
+        "arg" : "ment-api9-UAZ-r1-Reach-0-5"
+      } ],
+      "type" : "activation",
+      "frame-type" : "event-mention",
+      "subtype" : "positive-activation",
+      "is-direct" : false,
+      "end-pos" : {
+        "reference" : "pass-api9-UAZ-r1-Reach",
+        "offset" : 48,
+        "object-type" : "relative-pos"
+      },
+      "trigger" : "induced",
+      "object-type" : "frame",
+      "start-pos" : {
+        "reference" : "pass-api9-UAZ-r1-Reach",
+        "offset" : 28,
+        "object-type" : "relative-pos"
+      },
+      "sentence" : "sent-api9-UAZ-r1-Reach-0",
+      "found-by" : "Positive_activation_syntax_2_verb",
+      "verbose-text" : "the level of phosphorylated Akt induced by IGF-I"
+    } ],
+    "object-type" : "frame-collection",
+    "object-meta" : {
+      "processing-end" : "2020-11-01T22:35:29Z",
+      "doc-id" : "api9",
+      "component-type" : "machine",
+      "component" : "Reach",
+      "processing-start" : "2020-11-01T22:35:29Z",
+      "object-type" : "meta-info",
+      "organization" : "UAZ"
+    }
+  },
+  "entities" : {
+    "frames" : [ {
+      "text" : "IGF-I",
+      "frame-id" : "ment-api9-UAZ-r1-Reach-0-5",
+      "type" : "protein",
+      "frame-type" : "entity-mention",
+      "end-pos" : {
+        "reference" : "pass-api9-UAZ-r1-Reach",
+        "offset" : 48,
+        "object-type" : "relative-pos"
+      },
+      "xrefs" : [ {
+        "namespace" : "uniprot",
+        "species" : "homo sapiens",
+        "object-type" : "db-reference",
+        "id" : "P05019"
+      } ],
+      "object-type" : "frame",
+      "start-pos" : {
+        "reference" : "pass-api9-UAZ-r1-Reach",
+        "offset" : 43,
+        "object-type" : "relative-pos"
+      },
+      "sentence" : "sent-api9-UAZ-r1-Reach-0",
+      "alt-xrefs" : [ {
+        "namespace" : "uniprot",
+        "species" : "homo sapiens",
+        "object-type" : "db-reference",
+        "id" : "P05019"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "human",
+        "object-type" : "db-reference",
+        "id" : "P05019"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "african clawed frog",
+        "object-type" : "db-reference",
+        "id" : "P16501"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "african clawed frog",
+        "object-type" : "db-reference",
+        "id" : "P84775"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "ailuropoda melanoleuca",
+        "object-type" : "db-reference",
+        "id" : "Q6JLX1"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "ailurus fulgens",
+        "object-type" : "db-reference",
+        "id" : "Q6IVA5"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "asian house shrew",
+        "object-type" : "db-reference",
+        "id" : "Q28933"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bos taurus",
+        "object-type" : "db-reference",
+        "id" : "P07455"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bovine",
+        "object-type" : "db-reference",
+        "id" : "P07455"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "canis familiaris",
+        "object-type" : "db-reference",
+        "id" : "P33712"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "canis lupus familiaris",
+        "object-type" : "db-reference",
+        "id" : "P33712"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "capra hircus",
+        "object-type" : "db-reference",
+        "id" : "P51457"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "cavia porcellus",
+        "object-type" : "db-reference",
+        "id" : "P17647"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "chicken",
+        "object-type" : "db-reference",
+        "id" : "P18254"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "coho salmon",
+        "object-type" : "db-reference",
+        "id" : "P17085"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "coturnix coturnix japonica",
+        "object-type" : "db-reference",
+        "id" : "P51462"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "coturnix japonica",
+        "object-type" : "db-reference",
+        "id" : "P51462"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "dog",
+        "object-type" : "db-reference",
+        "id" : "P33712"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "equus caballus",
+        "object-type" : "db-reference",
+        "id" : "P51458"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "gallus gallus",
+        "object-type" : "db-reference",
+        "id" : "P18254"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "giant panda",
+        "object-type" : "db-reference",
+        "id" : "Q6JLX1"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "goat",
+        "object-type" : "db-reference",
+        "id" : "P51457"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "golden snub-nosed monkey",
+        "object-type" : "db-reference",
+        "id" : "Q68LC0"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "guinea pig",
+        "object-type" : "db-reference",
+        "id" : "P17647"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "horse",
+        "object-type" : "db-reference",
+        "id" : "P51458"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "japanese quail",
+        "object-type" : "db-reference",
+        "id" : "P51462"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "lesser panda",
+        "object-type" : "db-reference",
+        "id" : "Q6IVA5"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "mouse",
+        "object-type" : "db-reference",
+        "id" : "P05017"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "mus musculus",
+        "object-type" : "db-reference",
+        "id" : "P05017"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "musk shrew",
+        "object-type" : "db-reference",
+        "id" : "Q28933"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "oncorhynchus kisutch",
+        "object-type" : "db-reference",
+        "id" : "P17085"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "oncorhynchus mykiss",
+        "object-type" : "db-reference",
+        "id" : "Q02815"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "oryctolagus cuniculus",
+        "object-type" : "db-reference",
+        "id" : "Q95222"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "ovis aries",
+        "object-type" : "db-reference",
+        "id" : "P10763"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "panthera tigris altaica",
+        "object-type" : "db-reference",
+        "id" : "Q6GUL6"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "pig",
+        "object-type" : "db-reference",
+        "id" : "P16545"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "pygathrix roxellana",
+        "object-type" : "db-reference",
+        "id" : "Q68LC0"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "rabbit",
+        "object-type" : "db-reference",
+        "id" : "Q95222"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "rainbow trout",
+        "object-type" : "db-reference",
+        "id" : "Q02815"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "rat",
+        "object-type" : "db-reference",
+        "id" : "P08025"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "rattus norvegicus",
+        "object-type" : "db-reference",
+        "id" : "P08025"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "red panda",
+        "object-type" : "db-reference",
+        "id" : "Q6IVA5"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "rhinopithecus roxellana",
+        "object-type" : "db-reference",
+        "id" : "Q68LC0"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "salmo gairdneri",
+        "object-type" : "db-reference",
+        "id" : "Q02815"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "salmo kisutch",
+        "object-type" : "db-reference",
+        "id" : "P17085"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "sheep",
+        "object-type" : "db-reference",
+        "id" : "P10763"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "siberian tiger",
+        "object-type" : "db-reference",
+        "id" : "Q6GUL6"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "suncus murinus",
+        "object-type" : "db-reference",
+        "id" : "Q28933"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "sus scrofa",
+        "object-type" : "db-reference",
+        "id" : "P16545"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "xenopus laevis",
+        "object-type" : "db-reference",
+        "id" : "P16501"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "xenopus laevis",
+        "object-type" : "db-reference",
+        "id" : "P84775"
+      } ]
+    }, {
+      "text" : "Akt",
+      "frame-id" : "ment-api9-UAZ-r1-Reach-0-4",
+      "modifications" : [ {
+        "type" : "Phosphorylation",
+        "object-type" : "modification",
+        "negated" : false
+      } ],
+      "type" : "family",
+      "frame-type" : "entity-mention",
+      "end-pos" : {
+        "reference" : "pass-api9-UAZ-r1-Reach",
+        "offset" : 31,
+        "object-type" : "relative-pos"
+      },
+      "xrefs" : [ {
+        "namespace" : "fplx",
+        "species" : "human",
+        "object-type" : "db-reference",
+        "id" : "AKT"
+      } ],
+      "object-type" : "frame",
+      "start-pos" : {
+        "reference" : "pass-api9-UAZ-r1-Reach",
+        "offset" : 28,
+        "object-type" : "relative-pos"
+      },
+      "sentence" : "sent-api9-UAZ-r1-Reach-0",
+      "alt-xrefs" : [ {
+        "namespace" : "fplx",
+        "species" : "human",
+        "object-type" : "db-reference",
+        "id" : "AKT"
+      } ]
+    } ],
+    "object-type" : "frame-collection",
+    "object-meta" : {
+      "processing-end" : "2020-11-01T22:35:29Z",
+      "doc-id" : "api9",
+      "component-type" : "machine",
+      "component" : "Reach",
+      "processing-start" : "2020-11-01T22:35:29Z",
+      "object-type" : "meta-info",
+      "organization" : "UAZ"
+    }
+  },
+  "sentences" : {
+    "frames" : [ {
+      "text" : "the level of phosphorylated Akt induced by IGF-I",
+      "frame-id" : "pass-api9-UAZ-r1-Reach",
+      "section-id" : "NoSection",
+      "frame-type" : "passage",
+      "is-title" : false,
+      "section-name" : "NoSection",
+      "object-type" : "frame",
+      "index" : "Reach",
+      "object-meta" : {
+        "component" : "nxml2fries",
+        "object-type" : "meta-info"
+      }
+    }, {
+      "text" : "the level of phosphorylated Akt induced by IGF-I",
+      "frame-id" : "sent-api9-UAZ-r1-Reach-0",
+      "passage" : "pass-api9-UAZ-r1-Reach",
+      "frame-type" : "sentence",
+      "end-pos" : {
+        "reference" : "pass-api9-UAZ-r1-Reach",
+        "offset" : 48,
+        "object-type" : "relative-pos"
+      },
+      "object-type" : "frame",
+      "start-pos" : {
+        "reference" : "pass-api9-UAZ-r1-Reach",
+        "offset" : 0,
+        "object-type" : "relative-pos"
+      },
+      "object-meta" : {
+        "component" : "BioNLPProcessor",
+        "object-type" : "meta-info"
+      }
+    } ],
+    "object-type" : "frame-collection",
+    "object-meta" : {
+      "processing-end" : "2020-11-01T22:35:29Z",
+      "doc-id" : "api9",
+      "component-type" : "machine",
+      "component" : "Reach",
+      "processing-start" : "2020-11-01T22:35:29Z",
+      "object-type" : "meta-info",
+      "organization" : "UAZ"
+    }
+  }
+}

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -469,3 +469,14 @@ def test_amount_embedded_in_activation():
     assert isinstance(rp.statements[0], IncreaseAmount)
     assert rp.statements[0].subj is not None
     assert rp.statements[0].obj is not None
+
+
+def test_phosphorylation_regulation():
+    here = os.path.dirname(os.path.abspath(__file__))
+    test_file = os.path.join(here, 'reach_reg_phos.json')
+    rp = reach.process_json_file(test_file)
+    assert rp is not None
+    assert len(rp.statements) == 1
+    stmt = rp.statements[0]
+    assert isinstance(stmt, Phosphorylation), stmt
+    assert not stmt.sub.mods

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -341,24 +341,24 @@ def assert_pmid(stmt):
 
 def test_process_mod_condition1():
     test_cases = [
-        ('MEK1 activates ERK1 that is phosphorylated.',
+        ('phosphorylated MEK1 activates ERK1.',
          'phosphorylation', None, None, True),
-        ('MEK1 activates ERK1 that is phosphorylated on tyrosine.',
-         'phosphorylation', 'Y', None, True),
-        ('MEK1 activates ERK1 that is phosphorylated on Y185.',
-         'phosphorylation', 'Y', '185', True),
+        ('MEK1 that is phosphorylated on serine activates ERK1.',
+         'phosphorylation', 'S', None, True),
+        ('MEK1 that is phosphorylated on S222 activates ERK1.',
+         'phosphorylation', 'S', '222', True),
         ]
     for offline in offline_modes:
         for sentence, mod_type, residue, position, is_modified in test_cases:
             rp = reach.process_text(sentence, offline=offline)
             assert rp is not None
             assert len(rp.statements) == 1
-            mcs = rp.statements[0].obj.mods
-            assert len(mcs) == 1
-            assert mcs[0].mod_type == mod_type
-            assert mcs[0].residue == residue
-            assert mcs[0].position == position
-            assert mcs[0].is_modified == is_modified
+            mcs = rp.statements[0].subj.mods
+            assert len(mcs) == 1, 'No mods for %s' % sentence
+            assert mcs[0].mod_type == mod_type, mcs
+            assert mcs[0].residue == residue, mcs
+            assert mcs[0].position == position, mcs
+            assert mcs[0].is_modified == is_modified, mcs
 
 
 def test_get_db_refs_up_human():


### PR DESCRIPTION
This PR handles a special case produced occasionally by Reach where statements such as "phosphorylated X induced by Y" were extracted as Activation(Y, X(mods: phosphorylation)). This PR changes such cases to be extracted as Phosphorylation(Y, X) instead.