### PR TITLE
Work around Travis memory issues in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,11 +88,15 @@ script:
         --exclude='.*isi.*'
         --ignore-files='.*test_reach.py'
         --ignore-files='.*test_pysb_assembler.py'
+        --ignore-files='.*test_rest_api.py'
         --with-coverage --cover-inclusive --cover-package=indra
         --with-doctest --with-doctest-ignore-unicode --with-timer --timer-top-n 10
         --processes=0
   # PySB assembler tests (separated due to memory issues)
   - python -m nose_notify indra/tests/test_pysb_assembler.py --slack_hook $SLACK_NOTIFY_HOOK
+    --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR --process-restartworker;
+  # REST API tests (separated due to memory issues)
+  - python -m nose_notify indra/tests/test_rest_api.py --slack_hook $SLACK_NOTIFY_HOOK
     --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR --process-restartworker;
   # TEES tests
   - python -m nose_notify indra/tests/test_tees.py --slack_hook $SLACK_NOTIFY_HOOK

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,6 @@ install:
   - pip install cython
   # Now install INDRA with all its extras
   - pip install .[all]
-  - aws s3 cp s3://bigmech/travis/reach-82631d-biores-e9ee36.jar . --no-sign-request  --source-region us-east-1
-  - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
-  - aws s3 cp s3://bigmech/travis/eidos.jar . --no-sign-request --source-region us-east-1
-  - export EIDOSPATH=$TRAVIS_BUILD_DIR/eidos.jar
   - aws s3 cp s3://bigmech/travis/Phosphorylation_site_dataset.tsv indra/resources/ --no-sign-request  --source-region us-east-1
   # Run slow tests only if we're in the cron setting
   - |
@@ -101,12 +97,16 @@ script:
   # TEES tests
   - python -m nose_notify indra/tests/test_tees.py --slack_hook $SLACK_NOTIFY_HOOK
     --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR --process-restartworker;
-  # Eidos tests
-  - python -m nose_notify indra/tests/test_eidos.py --slack_hook $SLACK_NOTIFY_HOOK
-    --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR;
   # Reach tests
+  - aws s3 cp s3://bigmech/travis/reach-82631d-biores-e9ee36.jar . --no-sign-request  --source-region us-east-1
+  - export REACHPATH=$TRAVIS_BUILD_DIR/reach-82631d-biores-e9ee36.jar
   - python -m nose_notify indra/tests/test_reach.py
     --slack_hook $SLACK_NOTIFY_HOOK
+    --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR;
+  # Eidos tests
+  - aws s3 cp s3://bigmech/travis/eidos.jar . --no-sign-request --source-region us-east-1
+  - export EIDOSPATH=$TRAVIS_BUILD_DIR/eidos.jar
+  - python -m nose_notify indra/tests/test_eidos.py --slack_hook $SLACK_NOTIFY_HOOK
     --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR;
   # Run NL model examples only when the environmental variable
   # RUN_NL_MODELS is set to true in the Travis build

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,19 +79,28 @@ script:
       export NOSEATTR="!cron,$NOSEATTR";
     fi
   - echo $NOSEATTR
-  # Now run all INDRA tests
   - cd $TRAVIS_BUILD_DIR
+  # Now run all INDRA tests
   - python -u -m nose_notify --slack_hook $SLACK_NOTIFY_HOOK --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH"
-    indra -v -a $NOSEATTR --exclude='.*tees.*' --exclude='.*eidos.*' --exclude='.*isi.*'
+    indra -v -a $NOSEATTR
+        --exclude='.*tees.*'
+        --exclude='.*eidos.*'
+        --exclude='.*isi.*'
         --ignore-files='.*test_reach.py'
+        --ignore-files='.*test_pysb_assembler.py'
         --with-coverage --cover-inclusive --cover-package=indra
         --with-doctest --with-doctest-ignore-unicode --with-timer --timer-top-n 10
         --processes=0
-  # First run TEES and Eidos tests separately for technical reasons
+  # PySB assembler tests (separated due to memory issues)
+  - python -m nose_notify indra/tests/test_pysb_assembler.py --slack_hook $SLACK_NOTIFY_HOOK
+    --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR --process-restartworker;
+  # TEES tests
   - python -m nose_notify indra/tests/test_tees.py --slack_hook $SLACK_NOTIFY_HOOK
     --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR --process-restartworker;
+  # Eidos tests
   - python -m nose_notify indra/tests/test_eidos.py --slack_hook $SLACK_NOTIFY_HOOK
     --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR;
+  # Reach tests
   - python -m nose_notify indra/tests/test_reach.py
     --slack_hook $SLACK_NOTIFY_HOOK
     --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR;


### PR DESCRIPTION
This PR separates out two more sets of tests which helps avoid memory issues related to running subprocesses on Travis. It also optimizes the execution of tests a little bit to move large downloads to right before the specific tests that need them.

Fixes #907 and #952.