### PR TITLE
Handle curation JSON in assemble_corpus.

### DIFF
--- a/indra/tests/test_assemble_corpus.py
+++ b/indra/tests/test_assemble_corpus.py
@@ -730,15 +730,19 @@ def test_filter_by_curation():
     stmts_in = [new_st1, st2, st3]
     assert len(new_st1.evidence) == 2
     assert all(st.belief != 1 for st in stmts_in)
-    Curation = namedtuple('Curation', ['pa_hash', 'source_hash', 'tag'])
-    cur1 = Curation(new_st1.get_hash(), new_st1.evidence[0].get_source_hash(),
-                    'grounding')
-    cur2 = Curation(new_st1.get_hash(), new_st1.evidence[1].get_source_hash(),
-                    'wrong_relation')
-    cur3 = Curation(new_st1.get_hash(), new_st1.evidence[0].get_source_hash(),
-                    'correct')
-    cur4 = Curation(st2.get_hash(), st2.evidence[0].get_source_hash(),
-                    'correct')
+
+    cur1 = {'pa_hash': new_st1.get_hash(),
+            'source_hash': new_st1.evidence[0].get_source_hash(),
+            'tag': 'grounding'}
+    cur2 = {'pa_hash': new_st1.get_hash(),
+            'source_hash': new_st1.evidence[1].get_source_hash(),
+            'tag': 'wrong_relation'}
+    cur3 = {'pa_hash': new_st1.get_hash(),
+            'source_hash': new_st1.evidence[0].get_source_hash(),
+            'tag': 'correct'}
+    cur4 = {'pa_hash': st2.get_hash(),
+            'source_hash': st2.evidence[0].get_source_hash(),
+            'tag': 'correct'}
     # With 'any' policy it is enough to have one incorrect curation
     any_incorrect_one_cur = ac.filter_by_curation(stmts_in, [cur1], 'any')
     assert len(any_incorrect_one_cur) == 2

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -1739,7 +1739,7 @@ def filter_by_curation(stmts_in, curations, incorrect_policy='any',
     ----------
     stmts_in : list[indra.statements.Statement]
         A list of statements to filter.
-    curations : list[Curation]
+    curations : list[dict]
         A list of curations for evidences. Curation object should have
         (at least) the following attributes:
         pa_hash (preassembled statement hash), source_hash (evidence hash) and
@@ -1764,18 +1764,19 @@ def filter_by_curation(stmts_in, curations, incorrect_policy='any',
     # curations). Incorrect is a set of hashes of statements that only have
     # incorrect curations (for all or some of the evidences). These sets do
     # not intersect.
-    correct = {c.pa_hash for c in curations if c.tag in correct_tags}
-    incorrect = {c.pa_hash for c in curations if c.pa_hash not in correct}
+    correct = {c['pa_hash'] for c in curations if c['tag'] in correct_tags}
+    incorrect = {c['pa_hash'] for c in curations if c['pa_hash'] not in correct}
     # Store evidence level curations for overall correct statements
     correct_stmt_evid = {}
     for c in curations:
-        if c.pa_hash in correct:
-            if c.pa_hash not in correct_stmt_evid:
-                correct_stmt_evid[c.pa_hash] = defaultdict(set)
-            if c.tag in correct_tags:
-                correct_stmt_evid[c.pa_hash]['correct'].add(c.source_hash)
+        pa_hash = c['pa_hash']
+        if pa_hash in correct:
+            if pa_hash not in correct_stmt_evid:
+                correct_stmt_evid[pa_hash] = defaultdict(set)
+            if c['tag'] in correct_tags:
+                correct_stmt_evid[pa_hash]['correct'].add(c['source_hash'])
             else:
-                correct_stmt_evid[c.pa_hash]['incorrect'].add(c.source_hash)
+                correct_stmt_evid[pa_hash]['incorrect'].add(c['source_hash'])
     stmts_out = []
     logger.info('Filtering %d statements with %s incorrect curations...' %
                 (len(stmts_in), incorrect_policy))
@@ -1816,8 +1817,8 @@ def filter_by_curation(stmts_in, curations, incorrect_policy='any',
         # First, map curated statements to curated evidences.
         incorrect_stmt_evid = defaultdict(set)
         for c in curations:
-            if c.pa_hash in incorrect:
-                incorrect_stmt_evid[c.pa_hash].add(c.source_hash)
+            if c['pa_hash'] in incorrect:
+                incorrect_stmt_evid[c['pa_hash']].add(c['source_hash'])
         for stmt in stmts_in:
             # Compare set of evidence hashes of given statements to set of
             # hashes of curated evidences.


### PR DESCRIPTION
This PR goes hand-in-hand with https://github.com/indralab/indra_db/pull/143 in `indra_db`, in which the results from `get_curations` are returned as JSON rather then objects which leak database connections.