### PR TITLE
Improvements in reader processors

### DIFF
--- a/indra/sources/indra_db_rest/processor.py
+++ b/indra/sources/indra_db_rest/processor.py
@@ -391,7 +391,7 @@ class IndraDBRestSearchProcessor(IndraDBRestProcessor):
                            "statement load to complete." % dt.total_seconds())
             ret = False
         else:
-            logger.info("Waited %0.3f seconds for statements to finish"
+            logger.info("Waited %0.3f seconds for statements to finish "
                         "loading." % dt.total_seconds())
             ret = True
         return ret

--- a/indra/sources/reach/__init__.py
+++ b/indra/sources/reach/__init__.py
@@ -15,7 +15,7 @@ Setup and usage: Follow standard instructions to install
 
     git clone https://github.com/clulab/reach.git
     cd reach
-    sbt 'run-main org.clulab.reach.export.server.ApiServer'
+    sbt 'runMain org.clulab.reach.export.server.ApiServer'
 
 Then read text by specifying the url parameter when using
 `indra.sources.reach.process_text`.

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -523,7 +523,12 @@ class ReachProcessor(object):
         for mod in mods:
             mod_res, mod_pos = mod
             mod_type_str = mod_term['type'].lower()
+            if mod_type_str == 'unknown':
+                continue
             mod_state = agent_mod_map.get(mod_type_str)
+            # We skip unknown modifications since they are very often
+            # unrelated to PTMs, representing things like "expression"
+            # These are real PTM states
             if mod_state is not None:
                 mc = ModCondition(mod_state[0], residue=mod_res,
                                   position=mod_pos, is_modified=mod_state[1])
@@ -844,7 +849,6 @@ agent_mod_map = {
     'deribosylation': ('ribosylation', False),
     'methylation': ('methylation', True),
     'demethylation': ('methylation', False),
-    'unknown': ('modification', True),
 }
 
 

--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -959,18 +959,22 @@ class TripsProcessor(object):
             if agent is None:
                 continue
             # Get from location
-            from_loc_tag = event.find("from-location")
-            if from_loc_tag is None:
+            froms = [event.find(from_tag)
+                     for from_tag in ('from', 'from_location')]
+            froms = [f for f in froms if f is not None]
+            if not froms:
                 from_location = None
             else:
-                from_loc_id = from_loc_tag.attrib.get('id')
+                from_loc_id = froms[0].attrib.get('id')
                 from_location = self._get_cell_loc_by_id(from_loc_id)
             # Get to location
-            to_loc_tag = event.find("to-location")
-            if to_loc_tag is None:
+            tos = [event.find(from_tag)
+                   for from_tag in ('to', 'to_location')]
+            tos = [t for t in tos if t is not None]
+            if not tos:
                 to_location = None
             else:
-                to_loc_id = to_loc_tag.attrib.get('id')
+                to_loc_id = tos[0].attrib.get('id')
                 to_location = self._get_cell_loc_by_id(to_loc_id)
             if from_location is None and to_location is None:
                 continue

--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -1675,6 +1675,12 @@ class TripsProcessor(object):
         all_events = self.tree.findall('EVENT')
         active_event_args = set()
         for event in all_events:
+            ev_type = event.find('type').text
+            # This is a special case of an uninteresting event type
+            # that we don't want to consider as a connection for a TERM
+            # of interes.
+            if ev_type == 'ONT::HAVE-PROPERTY':
+                continue
             if event.attrib.get('id') in self._static_events:
                 continue
             args = event.findall('arg') + \

--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -960,7 +960,7 @@ class TripsProcessor(object):
                 continue
             # Get from location
             froms = [event.find(from_tag)
-                     for from_tag in ('from', 'from_location')]
+                     for from_tag in ('from', 'from-location')]
             froms = [f for f in froms if f is not None]
             if not froms:
                 from_location = None
@@ -969,7 +969,7 @@ class TripsProcessor(object):
                 from_location = self._get_cell_loc_by_id(from_loc_id)
             # Get to location
             tos = [event.find(from_tag)
-                   for from_tag in ('to', 'to_location')]
+                   for from_tag in ('to', 'to-location')]
             tos = [t for t in tos if t is not None]
             if not tos:
                 to_location = None

--- a/indra/tests/test_trips_ekbs.py
+++ b/indra/tests/test_trips_ekbs.py
@@ -833,6 +833,17 @@ def test_60():
     assert mod.is_modified is False
 
 
+def test_61():
+    sentence = 'ELK1 translocates to the nucleus.'
+    tp = process_sentence_xml(sentence)
+    assert len(tp.statements) == 1
+    stmt = tp.statements[0]
+    assert isinstance(stmt, Translocation)
+    assert stmt.agent.name == 'ELK1'
+    assert stmt.from_location is None
+    assert stmt.to_location == 'nucleus'
+
+
 def test_assoc_with():
     fname = os.path.join(path_this, 'trips_ekbs', 'ekb_assoc.ekb')
     tp = trips.process_xml(open(fname, 'r').read())

--- a/indra/tests/test_trips_ekbs.py
+++ b/indra/tests/test_trips_ekbs.py
@@ -819,6 +819,20 @@ def test_59():
     assert {st.subj.name for st in tp.statements} == {'HRAS', 'KRAS'}
 
 
+def test_60():
+    sentence = 'RB1 not phosphorylated at S807 is active.'
+    tp = process_sentence_xml(sentence)
+    assert len(tp.statements) == 1
+    stmt = tp.statements[0]
+    assert isinstance(stmt, ActiveForm)
+    assert stmt.agent.name == 'RB1'
+    mod = stmt.agent.mods[0]
+    assert mod.mod_type == 'phosphorylation'
+    assert mod.residue == 'S'
+    assert mod.position == '807'
+    assert mod.is_modified is False
+
+
 def test_assoc_with():
     fname = os.path.join(path_this, 'trips_ekbs', 'ekb_assoc.ekb')
     tp = trips.process_xml(open(fname, 'r').read())

--- a/indra/tests/trips_ekbs/ELK1_translocates_to_the_nucleus.ekb
+++ b/indra/tests/trips_ekbs/ELK1_translocates_to_the_nucleus.ekb
@@ -1,0 +1,94 @@
+<?xml version="1.0" ?>
+<ekb>
+	<input type="">
+		<paragraphs>
+			<paragraph file="/Users/wbeaumont/drum-dev/etc/Data/WP/TEXT00006_IO-49306" id="paragraph5">ELK1 translocates to the nucleus.</paragraph>
+		</paragraphs>
+		<sentences>
+			<sentence id="6" pid="paragraph5">ELK1 translocates to the nucleus.</sentence>
+		</sentences>
+	</input>
+	<EVENT end="32" id="V49336" lisp="(ONT::EVENT ONT::V49336 ONT::TRANSLOCATE :AGENT ONT::V49330 :TO ONT::V49392 :FORCE ONT::TRUE :TENSE W::PRES)" paragraph="paragraph5" rule="-RULE10_4_AGENT_AFFECTED-CELL_LOC3-GD-TO-AGENT,-ADD-SPEC" start="0" uttnum="6">
+		<type>ONT::TRANSLOCATE</type>
+		<text normalization="">ELK1 translocates to the nucleus</text>
+		<force>ONT::TRUE</force>
+		<tense>PRES</tense>
+		<predicate end="32" start="0">
+			<type>ONT::TRANSLOCATE</type>
+			<text normalization="TRANSLOCATE">ELK1 translocates to the nucleus</text>
+		</predicate>
+		<arg1 end="5" id="V49330" role=":AGENT" start="0">
+			<type>ONT::GENE-PROTEIN</type>
+			<text normalization="">ELK1</text>
+		</arg1>
+		<to id="V49392"/>
+	</EVENT>
+	<TERM dbid="UP:P19419|HGNC:3321|XFAM:PF00520|NCIT:C52540|XFAM:PF00027|HGNC:6253|XFAM:PF13426|NCIT:C18288|UP:Q9UQ05|HGNC:18864|UP:Q96L42" end="5" id="V49330" lisp="(ONT::TERM ONT::V49330 ONT::GENE-PROTEIN :NAME W::ELK-1 :DRUM ((:DRUM (TERM :ID NCIT::C52540 :NAME &quot;ELK1&quot; :SCORE 0.85542 :MATCHES ((MATCH :SCORE 0.85542 :INPUT &quot;ELK1&quot; :MATCHED &quot;ELK1&quot; :STATUS &quot;name&quot; :EXACT 1) (MATCH :SCORE 0.85368 :INPUT &quot;ELK1&quot; :MATCHED &quot;ELK1&quot; :VIA &quot;elk1&quot; :STATUS &quot;name&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.35435992 :NO-CAPS-ALL-CAPS 1) (MATCH :SCORE 0.71082 :INPUT &quot;ELK1&quot; :MATCHED &quot;ELK-1&quot; :STATUS &quot;synonym&quot; :NO-DASH-DASH 1 :EXACT 1) (MATCH :SCORE 0.70908 :INPUT &quot;ELK1&quot; :MATCHED &quot;ELK-1&quot; :VIA &quot;elk1&quot; :STATUS &quot;synonym&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.35435992 :NO-DASH-DASH 1 :NO-CAPS-ALL-CAPS 1)) :ONT-TYPES (ONT::GENE)) (TERM :ID HGNC::|3321| :NAME &quot;ETS transcription factor ELK1&quot; :SCORE 0.85542 :MATCHES ((MATCH :SCORE 0.85542 :INPUT &quot;ELK1&quot; :MATCHED &quot;ELK1&quot; :STATUS &quot;Approved Symbol&quot; :EXACT 1) (MATCH :SCORE 0.85368 :INPUT &quot;ELK1&quot; :MATCHED &quot;ELK1&quot; :VIA &quot;elk1&quot; :STATUS &quot;Approved Symbol&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.35435992 :NO-CAPS-ALL-CAPS 1)) :DBXREFS (UP::P19419) :ONT-TYPES (ONT::GENE)) (TERM :ID NCIT::C18288 :NAME &quot;ETS domain-containing protein elk-1&quot; :SCORE 0.71084 :MATCHES ((MATCH :SCORE 0.71084 :INPUT &quot;ELK1&quot; :MATCHED &quot;ELK1&quot; :STATUS &quot;synonym&quot; :EXACT 1) (MATCH :SCORE 0.7091 :INPUT &quot;ELK1&quot; :MATCHED &quot;ELK1&quot; :VIA &quot;elk1&quot; :STATUS &quot;synonym&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.35435992 :NO-CAPS-ALL-CAPS 1)) :ONT-TYPES (ONT::PROTEIN)) (TERM :ID UP::Q9UQ05 :NAME &quot;Potassium voltage-gated channel subfamily H member 4&quot; :SCORE 0.56627 :MATCHES ((MATCH :SCORE 0.56627 :INPUT &quot;ELK1&quot; :MATCHED &quot;ELK1&quot; :STATUS &quot;AltName: Short&quot; :EXACT 1) (MATCH :SCORE 0.56452 :INPUT &quot;ELK1&quot; :MATCHED &quot;ELK1&quot; :VIA &quot;elk1&quot; :STATUS &quot;AltName: Short&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.35435992 :NO-CAPS-ALL-CAPS 1)) :SPECIES &quot;Homo sapiens (Human)&quot; :DBXREFS (HGNC::|6253| XFAM::PF00520 XFAM::PF13426) :ONT-TYPES (ONT::PROTEIN)) (TERM :ID UP::Q96L42 :NAME &quot;Potassium voltage-gated channel subfamily H member 8&quot; :SCORE 0.56627 :MATCHES ((MATCH :SCORE 0.56627 :INPUT &quot;ELK1&quot; :MATCHED &quot;ELK1&quot; :STATUS &quot;AltName: Full&quot; :EXACT 1) (MATCH :SCORE 0.56452 :INPUT &quot;ELK1&quot; :MATCHED &quot;ELK1&quot; :VIA &quot;elk1&quot; :STATUS &quot;AltName: Full&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.35435992 :NO-CAPS-ALL-CAPS 1)) :SPECIES &quot;Homo sapiens (Human)&quot; :DBXREFS (HGNC::|18864| XFAM::PF00027 XFAM::PF00520 XFAM::PF13426) :ONT-TYPES (ONT::PROTEIN)) (TERM :ID HGNC::|6253| :NAME &quot;potassium voltage-gated channel subfamily H member 4&quot; :SCORE 0.56627 :MATCHES ((MATCH :SCORE 0.56627 :INPUT &quot;ELK1&quot; :MATCHED &quot;elk1&quot; :VIA &quot;elk1&quot; :STATUS &quot;Synonym&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.35435992 :EXACT 1) (MATCH :SCORE 0.56452 :INPUT &quot;ELK1&quot; :MATCHED &quot;elk1&quot; :STATUS &quot;Synonym&quot; :ALL-CAPS-NO-CAPS 1)) :DBXREFS (UP::Q9UQ05) :ONT-TYPES (ONT::GENE)))))" paragraph="paragraph5" rule="-SIMPLE-REF,-ADD-SPEC" start="0" uttnum="6">
+		<type>ONT::GENE-PROTEIN</type>
+		<text normalization="">ELK1</text>
+		<name>ELK-1</name>
+		<drum-terms>
+			<drum-term dbid="NCIT:C52540" match-score="0.85542" matched-name="ELK1" name="ELK1" text-input="ELK1">
+				<types>
+					<type>ONT::GENE</type>
+				</types>
+			</drum-term>
+			<drum-term dbid="HGNC:3321" match-score="0.85542" matched-name="ELK1" name="ETS transcription factor ELK1" text-input="ELK1">
+				<types>
+					<type>ONT::GENE</type>
+				</types>
+				<xrefs>
+					<xref dbid="UP:P19419"/>
+				</xrefs>
+			</drum-term>
+			<drum-term dbid="NCIT:C18288" match-score="0.71084" matched-name="ELK1" name="ETS domain-containing protein elk-1" text-input="ELK1">
+				<types>
+					<type>ONT::PROTEIN</type>
+				</types>
+			</drum-term>
+			<drum-term dbid="UP:Q9UQ05" match-score="0.56627" matched-name="ELK1" name="Potassium voltage-gated channel subfamily H member 4" text-input="ELK1">
+				<types>
+					<type>ONT::PROTEIN</type>
+				</types>
+				<xrefs>
+					<xref dbid="HGNC:6253"/>
+					<xref dbid="XFAM:PF00520"/>
+					<xref dbid="XFAM:PF13426"/>
+				</xrefs>
+				<species>Homo sapiens (Human)</species>
+			</drum-term>
+			<drum-term dbid="UP:Q96L42" match-score="0.56627" matched-name="ELK1" name="Potassium voltage-gated channel subfamily H member 8" text-input="ELK1">
+				<types>
+					<type>ONT::PROTEIN</type>
+				</types>
+				<xrefs>
+					<xref dbid="HGNC:18864"/>
+					<xref dbid="XFAM:PF00027"/>
+					<xref dbid="XFAM:PF00520"/>
+					<xref dbid="XFAM:PF13426"/>
+				</xrefs>
+				<species>Homo sapiens (Human)</species>
+			</drum-term>
+			<drum-term dbid="HGNC:6253" match-score="0.56627" matched-name="elk1" name="potassium voltage-gated channel subfamily H member 4" text-input="ELK1">
+				<types>
+					<type>ONT::GENE</type>
+				</types>
+				<xrefs>
+					<xref dbid="UP:Q9UQ05"/>
+				</xrefs>
+			</drum-term>
+		</drum-terms>
+	</TERM>
+	<TERM dbid="UP:SL-0191" end="32" id="V49392" lisp="(ONT::TERM ONT::V49392 ONT::CELL-PART :NAME W::NUCLEUS :DRUM ((:DRUM (TERM :ID UP::SL-0191 :NAME &quot;Nucleus&quot; :SCORE 0.85542 :MATCHES ((MATCH :SCORE 0.85542 :INPUT &quot;nucleus&quot; :MATCHED &quot;nucleus&quot; :STATUS &quot;I*&quot; :EXACT 1)) :ONT-TYPES (ONT::CELL-PART)) (SPECIALIST :EUI E0222333 :CITATION-FORM &quot;nucleus&quot; :MATCHES ((MATCH :SCORE 1.0 :INPUT &quot;nucleus&quot; :MATCHED &quot;nucleus&quot; :EXACT 1)) :COMPLEMENTS (&quot;compl=pphr(of,np(thalamus))&quot; &quot;compl=pphr(of,np(vagus nerve))&quot; &quot;compl=pphr(of,np(pretectal area))&quot; &quot;compl=pphr(of,np(lateral geniculate body))&quot; &quot;compl=pphr(of,np(medial geniculate body))&quot; &quot;compl=pphr(of,np(lens))&quot; &quot;compl=pphr(of,np(solitary tract))&quot; &quot;compl=pphr(of,np(abducens nerve))&quot; &quot;compl=pphr(of,np(ansa lenticularis))&quot; &quot;compl=pphr(of,np(facial nerve))&quot; &quot;compl=pphr(of,np(hypoglossal nerve))&quot; &quot;compl=pphr(of,np(Luys))&quot; &quot;compl=pphr(of,np(oculomotor nerve))&quot; &quot;compl=pphr(of,np(trochlear nerve))&quot; &quot;compl=pphr(of,np(Darkschewitsch))&quot; &quot;compl=pphr(of,np(origin),pphr(of,np))&quot; &quot;compl=pphr(of,np(accessory nerve))&quot; &quot;compl=pphr(of,np)&quot; &quot;compl=pphr(of,np(optic tract))&quot; &quot;compl=pphr(of,np(lateral lemniscus))&quot;)))))" paragraph="paragraph5" rule="-SIMPLE-REF,-ADD-SPEC" start="21" uttnum="6">
+		<type>ONT::CELL-PART</type>
+		<text normalization="">the nucleus</text>
+		<name>NUCLEUS</name>
+		<drum-terms>
+			<drum-term dbid="UP:SL-0191" match-score="0.85542" matched-name="nucleus" name="Nucleus" text-input="nucleus">
+				<types>
+					<type>ONT::CELL-PART</type>
+				</types>
+			</drum-term>
+		</drum-terms>
+	</TERM>
+</ekb>

--- a/indra/tests/trips_ekbs/RB1_not_phosphorylated_at_S807_is_active.ekb
+++ b/indra/tests/trips_ekbs/RB1_not_phosphorylated_at_S807_is_active.ekb
@@ -1,0 +1,114 @@
+<?xml version="1.0" ?>
+<ekb>
+	<input type="">
+		<paragraphs>
+			<paragraph file="/Users/wbeaumont/drum-dev/etc/Data/WP/TEXT00005_IO-47351" id="paragraph4">RB1 not phosphorylated at S807 is active.</paragraph>
+		</paragraphs>
+		<sentences>
+			<sentence id="5" pid="paragraph4">RB1 not phosphorylated at S807 is active.</sentence>
+		</sentences>
+	</input>
+	<EVENT end="40" id="V47518" lisp="(ONT::EVENT ONT::V47518 (:* ONT::HAVE-PROPERTY W::BE) :NEUTRAL ONT::V47362 :FORMAL ONT::V47542 :TENSE W::PRES :FORCE ONT::TRUE)" paragraph="paragraph4" rule="-ADD-SPEC" start="0" uttnum="5">
+		<type>ONT::HAVE-PROPERTY</type>
+		<text normalization="BE">RB1 not phosphorylated at S807 is active</text>
+		<force>ONT::TRUE</force>
+		<tense>PRES</tense>
+		<predicate end="40" start="0">
+			<type>ONT::HAVE-PROPERTY</type>
+			<text normalization="BE">RB1 not phosphorylated at S807 is active</text>
+		</predicate>
+		<arg1 end="40" id="V47362" role=":NEUTRAL" start="0">
+			<type>ONT::GENE-PROTEIN</type>
+			<text normalization="">RB1 not phosphorylated at S807 is active</text>
+		</arg1>
+		<arg2 end="40" id="V47542" role=":FORMAL" start="34">
+			<type>ONT::ACTIVE</type>
+			<text normalization="ACTIVE">active</text>
+		</arg2>
+	</EVENT>
+	<TERM dbid="NCIT:C52102|XFAM:PF00076|HGNC:9884|UP:Q9LKX9|NCIT:C17394|XFAM:PF01857|UP:P06400|XFAM:PF11934|UP:Q8IUH3|XFAM:PF01858|UP:Q8BHN5|HGNC:24468" end="40" id="V47362" lisp="(ONT::TERM ONT::V47362 ONT::GENE-PROTEIN :INEVENT ONT::V47404 :ACTIVE ONT::TRUE :NAME W::RB-1 :DRUM ((:DRUM (TERM :ID HGNC::|9884| :NAME &quot;RB transcriptional corepressor 1&quot; :SCORE 0.85542 :MATCHES ((MATCH :SCORE 0.85542 :INPUT &quot;RB1&quot; :MATCHED &quot;RB1&quot; :STATUS &quot;Approved Symbol&quot; :EXACT 1) (MATCH :SCORE 0.85542 :INPUT &quot;RB1&quot; :MATCHED &quot;RB1&quot; :STATUS &quot;Approved Symbol&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 1 :EXACT 1) (MATCH :SCORE 0.85368 :INPUT &quot;RB1&quot; :MATCHED &quot;RB1&quot; :VIA &quot;Rb1&quot; :STATUS &quot;Approved Symbol&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.8831169 :SENTENCE-CAP-ALL-CAPS 1)) :DBXREFS (UP::P06400) :ONT-TYPES (ONT::GENE)) (TERM :ID NCIT::C52102 :NAME &quot;RB1&quot; :SCORE 0.85542 :MATCHES ((MATCH :SCORE 0.85542 :INPUT &quot;RB1&quot; :MATCHED &quot;RB1&quot; :STATUS &quot;name&quot; :EXACT 1) (MATCH :SCORE 0.85542 :INPUT &quot;RB1&quot; :MATCHED &quot;RB1&quot; :STATUS &quot;name&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 1 :EXACT 1) (MATCH :SCORE 0.85368 :INPUT &quot;RB1&quot; :MATCHED &quot;RB1&quot; :VIA &quot;Rb1&quot; :STATUS &quot;name&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.8831169 :SENTENCE-CAP-ALL-CAPS 1)) :ONT-TYPES (ONT::GENE)) (TERM :ID UP::Q9LKX9 :NAME &quot;Retinoblastoma-related protein 1&quot; :SCORE 0.85401 :MATCHES ((MATCH :SCORE 0.85401 :INPUT &quot;RB1&quot; :MATCHED &quot;Rb1&quot; :STATUS &quot;RecName: Short&quot; :ALL-CAPS-INITIAL-CAP 1) (MATCH :SCORE 0.85401 :INPUT &quot;RB1&quot; :MATCHED &quot;Rb1&quot; :STATUS &quot;RecName: Short&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 1 :ALL-CAPS-INITIAL-CAP 1) (MATCH :SCORE 0.85368 :INPUT &quot;RB1&quot; :MATCHED &quot;Rb1&quot; :VIA &quot;Rb1&quot; :STATUS &quot;RecName: Short&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.8831169 :SENTENCE-CAP-INITIAL-CAP 1)) :DBXREFS (XFAM::PF11934 XFAM::PF01858 XFAM::PF01857) :ONT-TYPES (ONT::PROTEIN)) (TERM :ID NCIT::C17394 :NAME &quot;retinoblastoma-associated protein&quot; :SCORE 0.71084 :MATCHES ((MATCH :SCORE 0.71084 :INPUT &quot;RB1&quot; :MATCHED &quot;RB1&quot; :STATUS &quot;synonym&quot; :EXACT 1) (MATCH :SCORE 0.71084 :INPUT &quot;RB1&quot; :MATCHED &quot;RB1&quot; :STATUS &quot;synonym&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 1 :EXACT 1) (MATCH :SCORE 0.7091 :INPUT &quot;RB1&quot; :MATCHED &quot;RB1&quot; :VIA &quot;Rb1&quot; :STATUS &quot;synonym&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.8831169 :SENTENCE-CAP-ALL-CAPS 1)) :ONT-TYPES (ONT::PROTEIN)) (TERM :ID UP::Q8IUH3 :NAME &quot;RNA-binding protein 45&quot; :SCORE 0.56624 :MATCHES ((MATCH :SCORE 0.56624 :INPUT &quot;RB1&quot; :MATCHED &quot;RB-1&quot; :STATUS &quot;AltName: Short&quot; :NO-DASH-DASH 1 :EXACT 1) (MATCH :SCORE 0.56624 :INPUT &quot;RB1&quot; :MATCHED &quot;RB-1&quot; :STATUS &quot;AltName: Short&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 1 :NO-DASH-DASH 1 :EXACT 1) (MATCH :SCORE 0.5645 :INPUT &quot;RB1&quot; :MATCHED &quot;RB-1&quot; :VIA &quot;Rb1&quot; :STATUS &quot;AltName: Short&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.8831169 :NO-DASH-DASH 1 :SENTENCE-CAP-ALL-CAPS 1)) :SPECIES &quot;Homo sapiens (Human)&quot; :DBXREFS (HGNC::|24468| XFAM::PF00076) :ONT-TYPES (ONT::PROTEIN)) (TERM :ID UP::Q8BHN5 :NAME &quot;RNA-binding protein 45&quot; :SCORE 0.56624 :MATCHES ((MATCH :SCORE 0.56624 :INPUT &quot;RB1&quot; :MATCHED &quot;RB-1&quot; :STATUS &quot;AltName: Short&quot; :NO-DASH-DASH 1 :EXACT 1) (MATCH :SCORE 0.56624 :INPUT &quot;RB1&quot; :MATCHED &quot;RB-1&quot; :STATUS &quot;AltName: Short&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 1 :NO-DASH-DASH 1 :EXACT 1) (MATCH :SCORE 0.5645 :INPUT &quot;RB1&quot; :MATCHED &quot;RB-1&quot; :VIA &quot;Rb1&quot; :STATUS &quot;AltName: Short&quot; :MAYBE-DEPLURALIZED 1 :SURELY-DEPLURALIZED 0 :DEPLURALIZATION-SCORE 0.8831169 :NO-DASH-DASH 1 :SENTENCE-CAP-ALL-CAPS 1)) :SPECIES &quot;Mus musculus (Mouse)&quot; :DBXREFS (XFAM::PF00076) :ONT-TYPES (ONT::PROTEIN)))))" paragraph="paragraph4" rule="-INEVENT2B,-ACTIVE3,-SIMPLE-REF,-ADD-SPEC" start="0" uttnum="5">
+		<type>ONT::GENE-PROTEIN</type>
+		<text normalization="">RB1 not phosphorylated at S807 is active</text>
+		<name>RB-1</name>
+		<features>
+			<inevent id="V47404"/>
+			<active>TRUE</active>
+		</features>
+		<drum-terms>
+			<drum-term dbid="HGNC:9884" match-score="0.85542" matched-name="RB1" name="RB transcriptional corepressor 1" text-input="RB1">
+				<types>
+					<type>ONT::GENE</type>
+				</types>
+				<xrefs>
+					<xref dbid="UP:P06400"/>
+				</xrefs>
+			</drum-term>
+			<drum-term dbid="NCIT:C52102" match-score="0.85542" matched-name="RB1" name="RB1" text-input="RB1">
+				<types>
+					<type>ONT::GENE</type>
+				</types>
+			</drum-term>
+			<drum-term dbid="UP:Q9LKX9" match-score="0.85401" matched-name="Rb1" name="Retinoblastoma-related protein 1" text-input="RB1">
+				<types>
+					<type>ONT::PROTEIN</type>
+				</types>
+				<xrefs>
+					<xref dbid="XFAM:PF11934"/>
+					<xref dbid="XFAM:PF01858"/>
+					<xref dbid="XFAM:PF01857"/>
+				</xrefs>
+			</drum-term>
+			<drum-term dbid="NCIT:C17394" match-score="0.71084" matched-name="RB1" name="retinoblastoma-associated protein" text-input="RB1">
+				<types>
+					<type>ONT::PROTEIN</type>
+				</types>
+			</drum-term>
+			<drum-term dbid="UP:Q8IUH3" match-score="0.56624" matched-name="RB-1" name="RNA-binding protein 45" text-input="RB1">
+				<types>
+					<type>ONT::PROTEIN</type>
+				</types>
+				<xrefs>
+					<xref dbid="HGNC:24468"/>
+					<xref dbid="XFAM:PF00076"/>
+				</xrefs>
+				<species>Homo sapiens (Human)</species>
+			</drum-term>
+			<drum-term dbid="UP:Q8BHN5" match-score="0.56624" matched-name="RB-1" name="RNA-binding protein 45" text-input="RB1">
+				<types>
+					<type>ONT::PROTEIN</type>
+				</types>
+				<xrefs>
+					<xref dbid="XFAM:PF00076"/>
+				</xrefs>
+				<species>Mus musculus (Mouse)</species>
+			</drum-term>
+		</drum-terms>
+	</TERM>
+	<EVENT end="40" id="V47404" lisp="(ONT::EVENT ONT::V47404 ONT::PHOSPHORYLATION :AFFECTED ONT::V47362 :SITEMOD (:* ONT::AT-LOC W::AT) :SITE ONT::V47499 :FORCE ONT::FALSE :NEGATION +)" paragraph="paragraph4" rule="-RULE60_4_AGENT_AFFECTED-LOC4-GD-AFFECTED,-ADD-SPEC" start="0" uttnum="5">
+		<type>ONT::PHOSPHORYLATION</type>
+		<text normalization="">RB1 not phosphorylated at S807 is active</text>
+		<negation>+</negation>
+		<force>ONT::FALSE</force>
+		<predicate end="40" start="0">
+			<type>ONT::PHOSPHORYLATION</type>
+			<text normalization="PHOSPHORYLATE">RB1 not phosphorylated at S807 is active</text>
+		</predicate>
+		<arg2 end="40" id="V47362" role=":AFFECTED" start="0">
+			<type>ONT::GENE-PROTEIN</type>
+			<text normalization="">RB1 not phosphorylated at S807 is active</text>
+		</arg2>
+		<site id="V47499"/>
+	</EVENT>
+	<TERM end="31" id="V47499" lisp="(ONT::TERM ONT::V47499 ONT::MOLECULAR-SITE :NAME W::S-807 :DRUM ((:DRUM (AA-SITE :NAME &quot;Serine&quot; :LETTER &quot;S&quot; :INDEX 807))))" paragraph="paragraph4" rule="-SIMPLE-REF,-ADD-SPEC" start="26" uttnum="5">
+		<type>ONT::MOLECULAR-SITE</type>
+		<text normalization="">S807</text>
+		<name>S-807</name>
+		<features>
+			<site>
+				<name>Serine</name>
+				<code>S</code>
+				<pos>807</pos>
+			</site>
+		</features>
+	</TERM>
+</ekb>


### PR DESCRIPTION
This PR makes small improvements to reader processors as follows:
- Handle new EKB tags for locations that changed in the latest version of TRIPS/DRUM
- Handle ActiveForm extraction from the latest version of TRIPS/DRUM, which produces an extra HAVE-PROPERTY event
- Remove `UNKNOWN` agent modification conditions when processing statements from Reach
- Update Reach documentation to update instructions for running the web service on the latest Reach master