### PR TITLE
Reorganize preassembly to support multiple pre-filters

### DIFF
--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -313,8 +313,24 @@ class Preassembler(object):
         # Here we apply any additional filters to cut down the number of
         # potential comparisons before actually making comparisons
         if filters:
+            # We apply filter functions sequentially
             for filter_fun in filters:
-                stmts_to_compare = filter_fun(stmts_to_compare, stmts_by_hash)
+                # We call the filter function to get a filter-specific set
+                # of statements to compare
+                filtered_stmts_to_compare = filter_fun(stmts_by_hash)
+                # We then take the intersection of the existing stmts_to_compare
+                # and the ones found by the filter.
+                stmts_to_compare = {
+                    # We do a set intersection between the sets of potentially
+                    # refined statements
+                    filtered_stmt_hash: (filtered_potential_refs &
+                                         stmts_to_compare[filtered_stmt_hash])
+                    for filtered_stmt_hash, filtered_potential_refs in
+                    filtered_stmts_to_compare.items()
+                    # And here we also apply an intersection over the keys
+                    # of the existing and the filtered dicts
+                    if filtered_stmt_hash in stmts_to_compare
+                }
 
         logger.debug('Identified potential refinements in %.2fs' % (te-ts))
 

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -918,8 +918,8 @@ def ontology_refinement_filter(stmts_by_hash, stmts_to_compare, ontology):
     stmts_by_type = dict(stmts_by_type)
 
     for stmt_type, stmt_hashes in stmts_by_type.items():
-        logger.info('Finding refinements for %d %s statements' %
-                    (len(stmts_by_hash), stmt_type.__name__))
+        logger.info('Finding ontology-based refinements for %d %s statements'
+                    % (len(stmts_by_hash), stmt_type.__name__))
         stmts_by_hash_this_type = {
             stmt_hash: stmts_by_hash[stmt_hash]
             for stmt_hash in stmt_hashes
@@ -998,7 +998,8 @@ def ontology_refinement_filter_by_stmt_type(stmts_by_hash, stmts_to_compare,
     # Step 3. Identify all the pairs of statements which can be in a
     # refinement relationship
     first_filter = True if stmts_to_compare is None else False
-    stmts_to_compare = {}
+    if first_filter:
+        stmts_to_compare = {}
     # We iterate over each statement and find all other statements that it
     # can potentially refine
     ts = time.time()

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -315,22 +315,9 @@ class Preassembler(object):
         if filters:
             # We apply filter functions sequentially
             for filter_fun in filters:
-                # We call the filter function to get a filter-specific set
-                # of statements to compare
-                filtered_stmts_to_compare = filter_fun(stmts_by_hash)
-                # We then take the intersection of the existing stmts_to_compare
-                # and the ones found by the filter.
-                stmts_to_compare = {
-                    # We do a set intersection between the sets of potentially
-                    # refined statements
-                    filtered_stmt_hash: (filtered_potential_refs &
-                                         stmts_to_compare[filtered_stmt_hash])
-                    for filtered_stmt_hash, filtered_potential_refs in
-                    filtered_stmts_to_compare.items()
-                    # And here we also apply an intersection over the keys
-                    # of the existing and the filtered dicts
-                    if filtered_stmt_hash in stmts_to_compare
-                }
+                stmts_to_compare = \
+                    apply_refinement_filter(stmts_by_hash, stmts_to_compare,
+                                            filter_fun)
 
         logger.debug('Identified potential refinements in %.2fs' % (te-ts))
 
@@ -922,3 +909,23 @@ def get_relevant_keys(agent_key, all_keys_for_role, ontology):
         relevant_keys |= set(ontology.get_parents(*agent_key))
     relevant_keys &= all_keys_for_role
     return relevant_keys
+
+
+def apply_refinement_filter(stmts_by_hash, stmts_to_compare, filter_fun):
+    # We call the filter function to get a filter-specific set
+    # of statements to compare
+    filtered_stmts_to_compare = filter_fun(stmts_by_hash)
+    # We then take the intersection of the existing stmts_to_compare
+    # and the ones found by the filter.
+    stmts_to_compare = {
+        # We do a set intersection between the sets of potentially
+        # refined statements
+        filtered_stmt_hash: (filtered_potential_refs &
+                             stmts_to_compare[filtered_stmt_hash])
+        for filtered_stmt_hash, filtered_potential_refs in
+        filtered_stmts_to_compare.items()
+        # And here we also apply an intersection over the keys
+        # of the existing and the filtered dicts
+        if filtered_stmt_hash in stmts_to_compare
+    }
+    return stmts_to_compare

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -1035,7 +1035,8 @@ def ontology_refinement_filter_by_stmt_type(stmts_by_hash, stmts_to_compare,
         if first_filter:
             stmts_to_compare[sh] = relevants
         else:
-            stmts_to_compare[sh] &= relevants
+            stmts_to_compare[sh] = \
+                stmts_to_compare.get(sh, set()) & relevants
     return stmts_to_compare
 
 

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -900,16 +900,19 @@ def ontology_refinement_filter(stmts_by_hash, stmts_to_compare, ontology):
     stmts_by_hash : dict
         A dict whose keys are statement hashes that point to the
         (deduplicated) statement with that hash as a value.
+    stmts_to_compare : dict or None
+        A dict of existing statements to compare that will be further
+        filtered down in this function and then returned.
     ontology : indra.ontology.IndraOntology
         An IndraOntology instance iwth respect to which this
         filter is applied.
 
     Returns
     -------
-    list of tuple
-        A list of tuples where the first element of each tuple is the
-        hash of a statement which refines that statement whose hash
-        is the second element of the tuple.
+    dict
+        A dict whose keys are statement hashes and values are sets
+        of statement hashes that can potentially be refined by the
+        statement identified by the key.
     """
     ts = time.time()
     stmts_by_type = collections.defaultdict(set)
@@ -931,6 +934,9 @@ def ontology_refinement_filter(stmts_by_hash, stmts_to_compare, ontology):
     te = time.time()
     logger.debug('Identified ontology-based possible refinements in %.2fs'
                  % (te-ts))
+    # Make an empty dict to make sure we don't return a None
+    if stmts_to_compare is None:
+        stmts_to_compare = {}
     return stmts_to_compare
 
 

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -314,9 +314,14 @@ class Preassembler(object):
 
         total_comparisons = sum(len(v) for v in stmts_to_compare.values())
         logger.info('Total comparisons: %d' % total_comparisons)
-
         # Step 4. We can now do the actual comparisons and save pairs of
         # confirmed refinements in a list.
+        maps = self.compare_stmts_by_hash(stmts_by_hash, stmts_to_compare,
+                                          split_groups=split_groups)
+        return maps
+
+    def compare_stmts_by_hash(self, stmts_by_hash, stmts_to_compare,
+                              split_groups=None):
         maps = []
         # We again iterate over statements
         ts = time.time()
@@ -331,14 +336,15 @@ class Preassembler(object):
                     # And then do the actual comparison. Here we use
                     # entities_refined=True which means that we assert that
                     # the entities, in each role, are already confirmed to
-                    # be "compatible" for refinement, and therefore, we don't need
-                    # to again confirm this (i.e., call "isa") in the refinement_of
-                    # function.
+                    # be "compatible" for refinement, and therefore, we
+                    # don't need to again confirm this (i.e., call "isa") in
+                    # the refinement_of function.
                     self._comparison_counter += 1
-                    ref = self.refinement_fun(stmts_by_hash[stmt_hash],
-                                              stmts_by_hash[possible_refined_hash],
-                                              ontology=self.ontology,
-                                              entities_refined=True)
+                    ref = self.refinement_fun(
+                        stmts_by_hash[stmt_hash],
+                        stmts_by_hash[possible_refined_hash],
+                        ontology=self.ontology,
+                        entities_refined=True)
                     if ref:
                         maps.append((stmt_hash, possible_refined_hash))
         te = time.time()

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -863,10 +863,13 @@ def ontology_refinement_filter(stmts_by_hash, ontology):
     for stmt_type, stmt_hashes in stmts_by_type.items():
         logger.info('Finding refinements for %d %s statements' %
                     (len(stmts_by_hash), stmt_type.__name__))
-        stmts_by_hash = {stmt_hash: stmts_by_hash[stmt_hash]
-                         for stmt_hash in stmt_hashes}
+        stmts_by_hash_this_type = {
+            stmt_hash: stmts_by_hash[stmt_hash]
+            for stmt_hash in stmt_hashes
+        }
         stmts_to_compare_by_type = \
-            ontology_refinement_filter_by_stmt_type(stmts_by_hash, ontology)
+            ontology_refinement_filter_by_stmt_type(stmts_by_hash_this_type,
+                                                    ontology)
         stmts_to_compare.update(stmts_to_compare_by_type)
     return stmts_to_compare
 

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -248,10 +248,10 @@ class Preassembler(object):
         filters : Optional[list[function]]
             A list of function handles that define filter functions on
             possible statement refinements. Each function takes
-            a stmts_by_hash dict as its input and returns a dict
-            of possible refinements where the keys are statement hashes
-            and the values are sets of statement hashes that the
-            key statement possibly refines.
+            a stmts_by_hash dict and a stmts_to_compare dict as its input and
+            returns a dict of possible refinements where the keys are
+            statement hashes and the values are sets of statement hashes that
+            the key statement possibly refines.
 
         Returns
         -------
@@ -1046,10 +1046,10 @@ def apply_refinement_filter(stmts_by_hash, stmts_to_compare, filter_fun):
         possibly refine.
     filter_fun : function
         A function handle that defines a filter on possible statement
-        refinements. The function takes a stmts_by_hash dict as its input and
-        returns a dict of possible refinements where the keys are statement
-        hashes and the values are sets of statement hashes that the key
-        statement possibly refines.
+        refinements. The function takes a stmts_by_hash dict and a
+        stmts_to_compare dict as its input and returns a dict of possible
+        refinements where the keys are statement hashes and the values are
+        sets of statement hashes that the key statement possibly refines.
 
     Returns
     -------
@@ -1061,7 +1061,7 @@ def apply_refinement_filter(stmts_by_hash, stmts_to_compare, filter_fun):
     # We call the filter function to get a filter-specific set
     # of statements to compare
     logger.debug('Applying filter function')
-    filtered_stmts_to_compare = filter_fun(stmts_by_hash)
+    filtered_stmts_to_compare = filter_fun(stmts_by_hash, stmts_to_compare)
     logger.debug('Getting updated stmts to compare')
     # We then take the intersection of the existing stmts_to_compare
     # and the ones found by the filter.

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -1050,3 +1050,8 @@ def test_refinement_filters():
     pa = Preassembler(bio_ontology, stmts=[st1, st2, st3])
     pa.combine_related(filters=[filter_all])
     assert pa._comparison_counter == 2
+
+    # Just to make sure lists of more than one filter are correctly handled
+    pa = Preassembler(bio_ontology, stmts=[st1, st2, st3])
+    pa.combine_related(filters=[filter_all, filter_empty])
+    assert pa._comparison_counter == 0

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -1046,7 +1046,13 @@ def test_refinement_filters():
     # This is a superset of all comparisons constrained by the ontology
     # so will not change what the preassembler does internally
     def filter_all(stmts_by_hash, stmts_to_compare, *args):
-        return {k: set(stmts_by_hash.keys()) - {k} for k in stmts_by_hash}
+        filter_set = {k: (set(stmts_by_hash) - {k}) for k in stmts_by_hash}
+        if stmts_to_compare is None:
+            return filter_set
+        else:
+            for k in filter_set:
+                filter_set[k] &= stmts_to_compare.get(k, set())
+            return filter_set
     # The same number of comparisons here as without the filter
     pa = Preassembler(bio_ontology, stmts=[st1, st2, st3])
     pa.combine_related(filters=[bio_ontology_refinement_filter,

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -625,28 +625,6 @@ def test_return_toplevel():
     assert len(stmts[ix].supports[0].supported_by) == 1
 
 
-def test_multiprocessing():
-    braf = Agent('BRAF', db_refs={'HGNC': '1097'})
-    mek1 = Agent('MAP2K1', db_refs={'HGNC': '6840'})
-    mek = Agent('MEK', db_refs={'FPLX':'MEK'})
-    # Statements
-    p0 = Phosphorylation(braf, mek)
-    p1 = Phosphorylation(braf, mek1)
-    p2 = Phosphorylation(braf, mek1, position='218')
-    p3 = Phosphorylation(braf, mek1, position='222')
-    p4 = Phosphorylation(braf, mek1, 'serine')
-    p5 = Phosphorylation(braf, mek1, 'serine', '218')
-    p6 = Phosphorylation(braf, mek1, 'serine', '222')
-    p7 = Dephosphorylation(braf, mek1)
-    stmts = [p0, p1, p2, p3, p4, p5, p6, p7]
-    pa = Preassembler(bio_ontology, stmts=stmts)
-    # Size cutoff set to a low number so that one group will run remotely
-    # and one locally
-    toplevel = pa.combine_related(return_toplevel=True, poolsize=1,
-                                  size_cutoff=2)
-    assert len(toplevel) == 3, 'Got %d toplevel statements.' % len(toplevel)
-
-
 def test_conversion_refinement():
     ras = Agent('RAS', db_refs={'FPLX': 'RAS'})
     hras = Agent('HRAS', db_refs={'HGNC': '5173'})

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -1035,7 +1035,7 @@ def test_refinement_filters():
     st3 = Phosphorylation(Agent('x'), hras)
 
     # This filters everything out so no comparisons will be done
-    def filter_empty(stmts_by_hash):
+    def filter_empty(stmts_by_hash, *args):
         return {k: set() for k in stmts_by_hash}
     # No comparisons here
     pa = Preassembler(bio_ontology, stmts=[st1, st2, st3])
@@ -1044,7 +1044,7 @@ def test_refinement_filters():
 
     # This is a superset of all comparisons constrained by the ontology
     # so will not change what the preassembler does internally
-    def filter_all(stmts_by_hash):
+    def filter_all(stmts_by_hash, *args):
         return {k: set(stmts_by_hash.keys()) - {k} for k in stmts_by_hash}
     # The same number of comparisons here as without the filter
     pa = Preassembler(bio_ontology, stmts=[st1, st2, st3])

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -1055,6 +1055,6 @@ def test_refinement_filters():
 
     # Just to make sure lists of more than one filter are correctly handled
     pa = Preassembler(bio_ontology, stmts=[st1, st2, st3])
-    pa.combine_related(filters=[bio_ontology_refinement_filter,
-                                filter_all, filter_empty])
+    pa.combine_related(filters=[filter_all, filter_empty,
+                                bio_ontology_refinement_filter])
     assert pa._comparison_counter == 0, pa._comparison_counter


### PR DESCRIPTION
This PR reorganizes the Preassembler to support a sequence of user-supplied pre-filters to quickly determine possible statement refinements before actually computing whether each refinement is valid. The new implementation of finding possible refinements in #1177 constitutes one such pre-filter (one that is applied by default), and is now refactored to fit a standard API that user-supplied additional filters also follow. Given that this built-in default filter just considers Agents and their positions in an ontology, user-supplied filters can provide further optimizations by considering other aspects of Statements that can play a role in refinements (for instance modification sites, cellular locations, etc.). The PR also does a lot of renaming and cleaning up of function interfaces for clarity. The PR doesn't change any of the user-facing API of the Preassembler or its general behavior.