### PR TITLE
Fix pbseg edges

### DIFF
--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -400,8 +400,8 @@ def belgraph_to_signed_graph(
         rel = edge_data.get('relation')
         pos_edge = \
             (u, v, ('sign', 0)) + \
-            tuple((k, *tuple(v))
-                  for k, v in edge_data.get('annotations', {}).items()) \
+            tuple((key, *tuple(entry))
+                  for key, entry in edge_data.get('annotations', {}).items()) \
             if propagate_annotations else (u, v, ('sign', 0))
         # Unpack tuple pairs at indices >1 or they'll be in nested tuples
         rev_pos_edge = (pos_edge[1], pos_edge[0], *pos_edge[2:])

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -400,8 +400,9 @@ def belgraph_to_signed_graph(
         rel = edge_data.get('relation')
         pos_edge = \
             (u, v, ('sign', 0)) + \
-            tuple((key, *tuple(entry))
-                  for key, entry in edge_data.get('annotations', {}).items()) \
+            tuple((key, tuple(entry)) if len(entry) > 1 else tuple(
+                (key, *tuple(entry)))
+                for key, entry in edge_data.get('annotations', {}).items()) \
             if propagate_annotations else (u, v, ('sign', 0))
         # Unpack tuple pairs at indices >1 or they'll be in nested tuples
         rev_pos_edge = (pos_edge[1], pos_edge[0], *pos_edge[2:])

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -400,7 +400,7 @@ def belgraph_to_signed_graph(
         rel = edge_data.get('relation')
         pos_edge = \
             (u, v, ('sign', 0)) + \
-            tuple((k, tuple(v))
+            tuple((k, *tuple(v))
                   for k, v in edge_data.get('annotations', {}).items()) \
             if propagate_annotations else (u, v, ('sign', 0))
         # Unpack tuple pairs at indices >1 or they'll be in nested tuples

--- a/indra/tests/test_pybel_assembler.py
+++ b/indra/tests/test_pybel_assembler.py
@@ -645,13 +645,13 @@ def test_belgraph_to_signed_graph():
     assert edge_dict
 
     assert 'stmt_hash' in edge_dict
-    assert 1 == len(edge_dict['stmt_hash'])
-    assert hsh == list(edge_dict['stmt_hash'])[0]
+    assert isinstance(edge_dict['stmt_hash'], int)
+    assert hsh == edge_dict['stmt_hash']
 
     assert 'uuid' in edge_dict
-    assert 1 == len(edge_dict['uuid'])
-    assert stmt.uuid == list(edge_dict['uuid'])[0]
+    assert isinstance(edge_dict['uuid'], str)
+    assert stmt.uuid == edge_dict['uuid']
 
     assert 'belief' in edge_dict
-    assert 1 == len(edge_dict['belief'])
-    assert stmt.belief == list(edge_dict['belief'])[0]
+    assert isinstance(edge_dict['belief'], (float, int))
+    assert stmt.belief == edge_dict['belief']


### PR DESCRIPTION
This PR fixes a bug were edge data in signed graphs assembled from Bel graphs were represented as 1-tuples instead of their values.