### PR TITLE
Enable specification of BioPAX OWL file encoding

### DIFF
--- a/indra/sources/biopax/api.py
+++ b/indra/sources/biopax/api.py
@@ -157,20 +157,22 @@ def process_pc_pathsfromto(source_genes, target_genes, neighbor_limit=1,
         return process_model(model)
 
 
-def process_owl(owl_filename):
+def process_owl(owl_filename, encoding=None):
     """Returns a BiopaxProcessor for a BioPAX OWL file.
 
     Parameters
     ----------
     owl_filename : str
         The name of the OWL file to process.
+    encoding : Optional[str]
+        The encoding type to be passed to :func:`pybiopax.model_from_owl_file`.
 
     Returns
     -------
     bp : BiopaxProcessor
         A BiopaxProcessor containing the obtained BioPAX model in bp.model.
     """
-    model = model_from_owl_file(owl_filename)
+    model = model_from_owl_file(owl_filename, encoding=encoding)
     return process_model(model)
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def main():
                     'requests>=2.11', 'lxml', 'ipython', 'future',
                     'networkx>=2', 'pandas', 'ndex2==2.0.1', 'jinja2',
                     'protmapper>=0.0.16', 'obonet', 'sympy==1.3',
-                    'tqdm', 'pybiopax>=0.0.4']
+                    'tqdm', 'pybiopax>=0.0.5']
 
     extras_require = {
                       # Inputs and outputs


### PR DESCRIPTION
As a follow-up to https://github.com/indralab/pybiopax/pull/7, this uses the new PyBioPAX v0.0.5 functionality to specify the file encoding when opening an OWL file. This is useful for Windows users, whose default encoding is wack (cp1252 instead of utf-8).