### PR TITLE
Fix bugs and simplify preassembly

### DIFF
--- a/indra/assemblers/pysb/sites.py
+++ b/indra/assemblers/pysb/sites.py
@@ -72,7 +72,6 @@ def get_binding_site_name(agent):
     # cases here such as CHEBI (e.g., GTP) which requires thousands
     # of lookups to resolve
     if grounding != (None, None) and grounding[0] in {'HGNC', 'FPLX'}:
-        print('Getting parents for %s' % str(grounding))
         top_parents = bio_ontology.get_top_level_parents(*grounding)
         if top_parents:
             parent_name = bio_ontology.get_name(*top_parents[0])

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -374,10 +374,6 @@ class Preassembler(object):
 
         te = time.time()
         logger.info('Applied all refinement pre-filters in %.2fs' % (te-ts))
-        import json
-        with open('stmts_to_compare.json', 'w') as fh:
-            json.dump({k: list(v) for k, v in stmts_to_compare.items()},
-                      fh, indent=1)
         logger.info('Total comparisons: %d' % total_comparisons)
 
         # Here we handle split_idx to allow finding refinements between

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -352,12 +352,15 @@ class Preassembler(object):
         """
         ts = time.time()
         # Make a list of Statement types
-        logger.info('Number of unique statements: %d' % len(unique_stmts))
         stmt_to_idx = {stmt.get_hash(matches_fun=self.matches_fun): idx
                        for idx, stmt in enumerate(unique_stmts)}
-        logger.info('Number of unique statements with unique hashes: %d'
-                    % len(stmt_to_idx))
-
+        if len(unique_stmts) != len(stmt_to_idx):
+            raise ValueError('The unique statements used as an input for '
+                             'finding refinements do not all have distinct '
+                             'matches key hashes. This could be due to cached '
+                             'hashes being outdated or hashes not having been '
+                             'calculated according to a custom matches key '
+                             'function used for refinement finding.')
         # Statements keyed by their hashes
         stmts_by_hash = {stmt.get_hash(matches_fun=self.matches_fun):
                          stmt for stmt in unique_stmts}

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -346,8 +346,12 @@ class Preassembler(object):
         """
         ts = time.time()
         # Make a list of Statement types
-        stmt_to_idx = {stmt.get_hash(matches_fun=self.matches_fun): idx
+        logger.info('Number of unique statements: %d' % len(unique_stmts))
+        stmt_to_idx = {stmt.get_hash(matches_fun=self.matches_fun,
+                                     refresh=True): idx
                        for idx, stmt in enumerate(unique_stmts)}
+        logger.info('Number of unique statements with unique hashes: %d'
+                    % len(stmt_to_idx))
 
         # Statements keyed by their hashes
         stmts_by_hash = {stmt.get_hash(matches_fun=self.matches_fun):

--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -189,6 +189,12 @@ class Preassembler(object):
             # This should never be None or anything else
             assert isinstance(new_stmt, Statement)
             unique_stmts.append(new_stmt)
+        # At this point, we should do a hash refresh so that the statements
+        # returned don't have stale hashes.
+        for stmt in unique_stmts:
+            for shallow in (True, False):
+                stmt.get_hash(shallow=shallow, refresh=True,
+                              matches_fun=self.matches_fun)
         return unique_stmts
 
     # Note that the kwargs here are just there for backwards compatibility
@@ -347,8 +353,7 @@ class Preassembler(object):
         ts = time.time()
         # Make a list of Statement types
         logger.info('Number of unique statements: %d' % len(unique_stmts))
-        stmt_to_idx = {stmt.get_hash(matches_fun=self.matches_fun,
-                                     refresh=True): idx
+        stmt_to_idx = {stmt.get_hash(matches_fun=self.matches_fun): idx
                        for idx, stmt in enumerate(unique_stmts)}
         logger.info('Number of unique statements with unique hashes: %d'
                     % len(stmt_to_idx))

--- a/indra/preassembler/grounding_mapper/gilda.py
+++ b/indra/preassembler/grounding_mapper/gilda.py
@@ -2,6 +2,7 @@
 and contains functions to help apply it during the course of INDRA assembly."""
 import logging
 import requests
+from copy import deepcopy
 from urllib.parse import urljoin
 from indra.ontology.standardize \
     import standardize_agent_name
@@ -163,8 +164,9 @@ def ground_statements(stmts, mode='web', sources=None, ungrounded_only=False):
         The list of Statements that were changed in place by reference.
     """
     source_filter = set(sources) if sources else set()
-    for stmt in stmts:
+    grounded_stmts = deepcopy(stmts)
+    for stmt in grounded_stmts:
         if not source_filter or (stmt.evidence and stmt.evidence[0].source_api
                                  in source_filter):
             ground_statement(stmt, mode=mode, ungrounded_only=ungrounded_only)
-    return stmts
+    return grounded_stmts

--- a/indra/tests/test_groundingmapper.py
+++ b/indra/tests/test_groundingmapper.py
@@ -386,7 +386,8 @@ def test_ground_gilda():
         mek = Agent('Mek', db_refs={'TEXT': 'MEK'})
         erk = Agent('Erk1', db_refs={'TEXT': 'Erk1'})
         stmt = Phosphorylation(mek, erk)
-        ground_statements([stmt], mode=mode)
+        grounded_stmts = ground_statements([stmt], mode=mode)
+        stmt = grounded_stmts[0]
         assert stmt.enz.name == 'MEK', stmt.enz
         assert stmt.enz.db_refs['FPLX'] == 'MEK'
         assert stmt.sub.name == 'MAPK3'
@@ -401,12 +402,13 @@ def test_ground_gilda_source():
     stmts = [Phosphorylation(None, Agent('x', db_refs={'TEXT': 'kras'}),
                              evidence=ev)
              for ev in (ev1, ev2, ev3)]
-    ground_statements(stmts, sources=['trips'])
-    assert stmts[0].sub.name == 'x', stmts[0]
-    assert stmts[1].sub.name == 'x'
-    assert stmts[2].sub.name == 'KRAS'
-    ground_statements(stmts, sources=['reach', 'sparser'])
-    assert all(stmt.sub.name == 'KRAS' for stmt in stmts)
+    grounded_stmts = ground_statements(stmts, sources=['trips'])
+    assert grounded_stmts[0].sub.name == 'x', stmts[0]
+    assert grounded_stmts[1].sub.name == 'x'
+    assert grounded_stmts[2].sub.name == 'KRAS'
+    grounded_stmts = ground_statements(stmts, sources=['reach', 'sparser'])
+    assert all(stmt.sub.name == 'KRAS'
+               for stmt in grounded_stmts[:2])
 
 
 def test_gilda_ground_ungrounded():
@@ -420,8 +422,8 @@ def test_gilda_ground_ungrounded():
     assert ag1.name == 'RAS', ag1
     ground_statement(stmts[1], ungrounded_only=True)
     assert ag2.name == 'RAS'
-    ground_statements([stmts[2]], ungrounded_only=True)
-    assert ag3.name == 'RAS'
+    grounded_stmts = ground_statements([stmts[2]], ungrounded_only=True)
+    assert grounded_stmts[0].sub.name == 'RAS'
 
 
 def test_get_gilda_models():

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -1064,3 +1064,20 @@ def test_refinement_filters():
     pa.combine_related(filters=[filter_all, filter_empty,
                                 bio_ontology_refinement_filter])
     assert pa._comparison_counter == 0, pa._comparison_counter
+
+    # Now try adding more statement types
+    st4 = Activation(Agent('x'), ras)
+    st5 = Activation(Agent('x'), kras)
+    st6 = Activation(Agent('x'), hras)
+
+    # The same number of comparisons here as without the filter
+    pa = Preassembler(bio_ontology, stmts=[st1, st2, st3, st4, st5, st6])
+    pa.combine_related(filters=[bio_ontology_refinement_filter,
+                                filter_all])
+    assert pa._comparison_counter == 4, pa._comparison_counter
+
+    # Just to make sure lists of more than one filter are correctly handled
+    pa = Preassembler(bio_ontology, stmts=[st1, st2, st3, st4, st5, st6])
+    pa.combine_related(filters=[filter_all, filter_empty,
+                                bio_ontology_refinement_filter])
+    assert pa._comparison_counter == 0, pa._comparison_counter

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -1076,6 +1076,11 @@ def test_refinement_filters():
                                 filter_all])
     assert pa._comparison_counter == 4, pa._comparison_counter
 
+    pa = Preassembler(bio_ontology, stmts=[st1, st2, st3, st4, st5, st6])
+    pa.combine_related(filters=[filter_all,
+                                bio_ontology_refinement_filter])
+    assert pa._comparison_counter == 4, pa._comparison_counter
+
     # Just to make sure lists of more than one filter are correctly handled
     pa = Preassembler(bio_ontology, stmts=[st1, st2, st3, st4, st5, st6])
     pa.combine_related(filters=[filter_all, filter_empty,


### PR DESCRIPTION
This PR fixes a bug introduced in #1194 that wasn't covered by existing tests. It also cleans up and simplifies some of the code related to statement-type-specific ontology-based refinement filters.

It also fixes the following issues:
- Statement hashes are refreshed at the end of duplicate finding since hashes, can be outdated at this point with statements having gone through multiple stages of assembly.
- The `ground_statements` function now deep-copies statements so that it doesn't change inputs in place