### PR TITLE
Adeft pos labels

### DIFF
--- a/indra/preassembler/grounding_mapper/disambiguate.py
+++ b/indra/preassembler/grounding_mapper/disambiguate.py
@@ -106,26 +106,34 @@ class DisambManager(object):
             # If grounding with highest score is not a positive label we
             # explicitly remove grounding and reset the (potentially incorrectly
             # standardized) name to the original text value.
+            # Ungrounded labels will lack a ':', an ungrounded label should
+            # never be a pos_label but we still check both if the label is
+            # positive and if it contains ':' for the sake of caution since
+            # pos_labels are determined by manual review.
             # Otherwise if the Adeft model's precision for that particular
             # grounding is greater than or equal to 0.5 or if there is a
             # defining pattern for the ambiguous shortform in the text we
             # update the db_refs with what we got from Adeft and set the
-            # standard name
-            # ungrounded labels will lack a ':', an ungrounded label should
-            # never be a pos_label but we still check both is the label is
-            # positive and if it contains ':' for the sake of caution since
-            # pos_labels are determined by manual review.
+            # standard name.
             if ':' in ns_and_id and ns_and_id in da.pos_labels:
+                # Determine the precision associated with the given grounding
                 stats = da.classifier.stats
                 if stats and ns_and_id in stats:
                     precision = stats[ns_and_id]['pr']['mean']
+                # If there is no precision info, we fall back to a value that
+                # is < 0.5.
                 else:
                     precision = .499
+                # With high enough precision or a defining pattern, we accept
+                # the grounding and set it.
                 if precision >= 0.5 or disamb_scores[ns_and_id] == 1:
                     apply_grounding(agent, agent_txt, ns_and_id)
                     annots['agents']['adeft'][idx] = disamb_scores
+                # Otherwise we remove any prior grounding.
                 else:
                     remove_grounding(agent, agent_txt)
+            # In this case the entity is either ungrounded or not a positive
+            # label so we remove any prior grounding.
             else:
                 remove_grounding(agent, agent_txt)
             success = True

--- a/indra/tests/test_groundingmapper.py
+++ b/indra/tests/test_groundingmapper.py
@@ -355,15 +355,29 @@ def test_adeft_mapping():
 
 
 def test_adeft_mapping_non_pos():
-    pcs = Agent('PCS', db_refs={'TEXT': 'PCS'})
-    # This is an exact definition of a non-positive label entry so we
-    # expect that it will be applied as a grounding
-    ev = Evidence(text='post concussive symptoms (PCS)')
+    er = Agent('ER', db_refs={'TEXT': 'ER'})
+    # This is an exact definition of a pos_label entry so we
+    # expect that it will be applied as a grounding even though the
+    # Adeft model has low precision for this label.
+    ev = Evidence(text='estradiol (ER)')
+    stmt = Phosphorylation(None, er, evidence=[ev])
+    mapped_stmt = gm.map_stmts([stmt])[0]
+    assert 'CHEBI' in mapped_stmt.sub.db_refs, mapped_stmt.evidence
+    # This one is not an exact definition so we expect the grounding to
+    # be stripped out.
+    ev = Evidence(text='Estradiol is one of the three estrogen hormones'
+                  'naturally produced in the body.')
+    stmt = Phosphorylation(None, er, evidence=[ev])
+    mapped_stmt = gm.map_stmts([stmt])[0]
+    assert 'CHEBI' not in mapped_stmt.sub.db_refs, mapped_stmt.evidence
+    # This is a non-positive label, and we expect it to be stripped out
+    # whether it's an exact definition or not.
+    pcs = Agent('PCS', db_refs={'TEXT': 'PCS', 'MESH': 'xxx'})
+    ev = Evidence(text='physical component summary (PCS)')
     stmt = Phosphorylation(None, pcs, evidence=[ev])
     mapped_stmt = gm.map_stmts([stmt])[0]
-    assert 'MESH' in mapped_stmt.sub.db_refs, mapped_stmt.evidence
-
-    pcs = Agent('PCS', db_refs={'TEXT': 'PCS', 'MESH': 'xxx'})
+    assert 'MESH' not in mapped_stmt.sub.db_refs, \
+        (mapped_stmt.sub.db_refs, mapped_stmt.evidence)
     ev = Evidence(text='physical component summary')
     stmt = Phosphorylation(None, pcs, evidence=[ev])
     mapped_stmt = gm.map_stmts([stmt])[0]


### PR DESCRIPTION
This PR updates the logic that decides whether to apply a grounding produced with adeft when performing disambiguation in the grounding mapper. The previous behavior was to keep groundings that have been marked as positive labels in adeft or those determined with a defining pattern. This behavior was not ideal since it was based on a conflation involved in what should be a positive label. Previously labels were declared non-positive either if they were determined to not be of interest in INDRA statements or if the classifier was not sufficiently accurate for that particular grounding. The decision to incorporate groundings for non-positive labels determined with a defining pattern was made after noticing some groundings were being removed that should not be, but this also meant that some things that make no sense within mechanistic INDRA statements were slipping through.

The new behavior is based on the decision that a grounding should be considered a positive label if and only if it makes sense in the context of an INDRA statement. Groundings that cannot be successfully determined with one of Adeft's logistic regression model are still considered positive labels but INDRA will now not keep Adeft groundings if the precision for that particular label in the model statistics is less than 0.5, unless there is a defining pattern. To make this possible, every Adeft model without statistics available at the granularity of individual labels had to be retrained.