### PR TITLE
Fix name standardization with custom namespace order

### DIFF
--- a/indra/ontology/standardize.py
+++ b/indra/ontology/standardize.py
@@ -105,7 +105,7 @@ def standardize_name_db_refs(db_refs, ontology=None, ns_order=None):
     """
     db_refs = standardize_db_refs(db_refs, ontology=ontology,
                                   ns_order=ns_order)
-    name = get_standard_name(db_refs)
+    name = get_standard_name(db_refs, ns_order=ns_order)
     return name, db_refs
 
 

--- a/indra/ontology/standardize.py
+++ b/indra/ontology/standardize.py
@@ -105,7 +105,7 @@ def standardize_name_db_refs(db_refs, ontology=None, ns_order=None):
     """
     db_refs = standardize_db_refs(db_refs, ontology=ontology,
                                   ns_order=ns_order)
-    name = get_standard_name(db_refs, ns_order=ns_order)
+    name = get_standard_name(db_refs, ontology=ontology, ns_order=ns_order)
     return name, db_refs
 
 

--- a/indra/tests/test_ontology.py
+++ b/indra/tests/test_ontology.py
@@ -295,6 +295,11 @@ def test_drugbank_mappings():
     assert db_refs.get('CHEBI') == 'CHEBI:142437', db_refs
     assert db_refs.get('CHEMBL') == 'CHEMBL1201666', db_refs
     assert name == 'lepirudin'
+    # Here we test for alternative prioritization of name spaces
+    name, db_refs = standardize_name_db_refs({'DRUGBANK': 'DB00001'},
+                                             ns_order=['DRUGBANK', 'CHEBI'])
+    # We expect to get the Drugbank standard name
+    assert name == 'Lepirudin'
 
 
 def test_standardize_up_isoform():


### PR DESCRIPTION
This PR fixes a small bug in which the custom namespace order was not propagated to name standardization in one of the standardization functions and thus the default order was always used.