### PR TITLE
Bump Biogrid version to 4.2.192 (Nov 25 2020)

### DIFF
--- a/indra/sources/biogrid.py
+++ b/indra/sources/biogrid.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 biogrid_file_url = 'https://downloads.thebiogrid.org/Download/BioGRID/' + \
-        'Release-Archive/BIOGRID-3.4.158/BIOGRID-ALL-3.4.158.tab2.zip'
+        'Release-Archive/BIOGRID-4.2.192/BIOGRID-ALL-4.2.192.tab2.zip'
 
 
 # The explanation for each column of the tsv file is here:


### PR DESCRIPTION
Bumps the Biogrid version to the latest release, which increases the number of INDRA statements we get from ~679k in the previous version we were using to over 1M. A better approach in the longer term would be to find a way to follow their mapping from `https://downloads.thebiogrid.org/Download/BioGRID/Current-Release`.