### PR TITLE
Add Entrez mappings to ontology graph

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,8 +36,8 @@ jobs:
         pip install pydot jsonschema coverage nose-timer doctest-ignore-unicode awscli pycodestyle
         mkdir -p $HOME/.pybel/data
         aws s3 cp s3://bigmech/travis/pybel_cache.db $HOME/.pybel/data/ --no-sign-request  --source-region us-east-1
-        mkdir -p $HOME/.indra/bio_ontology/1.4
-        aws s3 cp s3://bigmech/travis/bio_ontology/1.4/mock_ontology.pkl $HOME/.indra/bio_ontology/1.4/bio_ontology.pkl --no-sign-request  --source-region us-east-1
+        mkdir -p $HOME/.indra/bio_ontology/1.5
+        aws s3 cp s3://bigmech/travis/bio_ontology/1.5/mock_ontology.pkl $HOME/.indra/bio_ontology/1.5/bio_ontology.pkl --no-sign-request  --source-region us-east-1
         # PySB and dependencies
         wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" -O bionetgen.tar.gz -nv
         tar xzf bionetgen.tar.gz

--- a/indra/databases/hgnc_client.py
+++ b/indra/databases/hgnc_client.py
@@ -358,8 +358,9 @@ def _read_hgnc_maps():
             uniprot_ids[hgnc_id] = uniprot_id
         # Entrez
         entrez_id = row[5]
-        entrez_ids[hgnc_id] = entrez_id
-        entrez_ids_reverse[entrez_id] = hgnc_id
+        if entrez_id:
+            entrez_ids[hgnc_id] = entrez_id
+            entrez_ids_reverse[entrez_id] = hgnc_id
         # Mouse
         mgi_id = row[7]
         if mgi_id:

--- a/indra/ontology/bio/ontology.py
+++ b/indra/ontology/bio/ontology.py
@@ -19,7 +19,7 @@ class BioOntology(IndraOntology):
     # should be incremented to "force" rebuilding the ontology to be consistent
     # with the underlying resource files.
     name = 'bio'
-    version = '1.4'
+    version = '1.5'
 
     def __init__(self):
         super().__init__()
@@ -65,6 +65,7 @@ class BioOntology(IndraOntology):
         # Add xrefs
         logger.info('Adding xrefs...')
         self.add_hgnc_uniprot_xrefs()
+        self.add_hgnc_entrez_xrefs()
         self.add_famplex_xrefs()
         self.add_chemical_xrefs()
         self.add_ncit_xrefs()
@@ -124,6 +125,16 @@ class BioOntology(IndraOntology):
         edges = [(self.label('UP', uid), self.label('HGNC', hid),
                   {'type': 'xref', 'source': 'hgnc'})
                  for uid, hid in uniprot_client.um.uniprot_hgnc.items()]
+        self.add_edges_from(edges)
+
+    def add_hgnc_entrez_xrefs(self):
+        from indra.databases import hgnc_client
+        edges = []
+        for hid, eid in hgnc_client.entrez_ids.items():
+            edges.append((self.label('HGNC', hid), self.label('EGID', eid),
+                          {'type': 'xref', 'source': 'hgnc'}))
+            edges.append((self.label('EGID', eid), self.label('HGNC', hid),
+                          {'type': 'xref', 'source': 'hgnc'}))
         self.add_edges_from(edges)
 
     def add_famplex_nodes(self):

--- a/indra/sources/biogrid.py
+++ b/indra/sources/biogrid.py
@@ -7,8 +7,7 @@ from io import BytesIO, StringIO
 from zipfile import ZipFile
 from collections import namedtuple
 from indra.util import read_unicode_csv
-from indra.statements import *
-import indra.databases.hgnc_client as hgnc_client
+from indra.statements import Agent, Complex, Evidence
 from indra.ontology.standardize import standardize_name_db_refs
 
 logger = logging.getLogger(__name__)
@@ -132,13 +131,8 @@ class BiogridProcessor(object):
         elif trembl_id:
             if '|' not in trembl_id:
                 db_refs['UP'] = trembl_id
-
         if entrez_id:
             db_refs['EGID'] = entrez_id
-            if 'UP' not in db_refs:
-                hgnc_id = hgnc_client.get_hgnc_from_entrez(entrez_id)
-                if hgnc_id:
-                    db_refs['HGNC'] = hgnc_id
         standard_name, db_refs = standardize_name_db_refs(db_refs)
         if standard_name:
             name = standard_name

--- a/indra/tests/make_mock_ontology.py
+++ b/indra/tests/make_mock_ontology.py
@@ -2,6 +2,7 @@
 which can be put in the appropriate cache location in place of the
 real bio ontology for testing purposes"""
 import os
+import boto3
 import pickle
 from indra.ontology.bio.ontology import BioOntology, CACHE_DIR
 
@@ -39,7 +40,7 @@ always_include = {
     'HGNC:31476', 'DRUGBANK:DB00001', 'MESH:D013812', 'CHEBI:CHEBI:26523',
     'UP:Q99490', 'MESH:D008099', 'MESH:D057189',
     'UP:P15056', 'UP:O60674', 'UP:P0DP23', 'UP:Q13507', 'UP:P36507',
-    'DRUGBANK:DB00305', 'HGNC:23077', 'HGNC:17347'
+    'DRUGBANK:DB00305', 'HGNC:23077', 'HGNC:17347', 'EGID:27113'
 }
 
 always_include_ns = {'FPLX', 'INDRA_ACTIVITIES', 'INDRA_MODS'}
@@ -76,3 +77,10 @@ if __name__ == '__main__':
     fname = os.path.join(CACHE_DIR, 'mock_ontology.pkl')
     with open(fname, 'wb') as fh:
         pickle.dump(bio_ontology, fh, protocol=pickle.HIGHEST_PROTOCOL)
+    # Uploading to S3
+    s3 = boto3.client('s3')
+    s3.put_object(Body=pickle.dumps(bio_ontology), Bucket='bigmech',
+                  Key=(f'travis/bio_ontology/{bio_ontology.version}/'
+                       f'mock_ontology.pkl'),
+                  ACL='public-read')
+

--- a/indra/tests/make_mock_ontology.py
+++ b/indra/tests/make_mock_ontology.py
@@ -76,11 +76,10 @@ if __name__ == '__main__':
     bio_ontology._build_transitive_closure()
     fname = os.path.join(CACHE_DIR, 'mock_ontology.pkl')
     with open(fname, 'wb') as fh:
-        pickle.dump(bio_ontology, fh, protocol=pickle.HIGHEST_PROTOCOL)
+        pickle.dump(bio_ontology, fh, protocol=4)
     # Uploading to S3
     s3 = boto3.client('s3')
     s3.put_object(Body=pickle.dumps(bio_ontology), Bucket='bigmech',
                   Key=(f'travis/bio_ontology/{bio_ontology.version}/'
                        f'mock_ontology.pkl'),
                   ACL='public-read')
-

--- a/indra/tests/test_groundingmapper.py
+++ b/indra/tests/test_groundingmapper.py
@@ -311,7 +311,8 @@ def test_map_entry_hgnc_and_up():
     ms = mapped_stmts[0]
     assert ms.sub.db_refs == \
            {'TEXT': 'NF-kappaB p65', 'UP': 'Q04206',
-            'HGNC': '9955', 'MESH': 'D051996'}, ms.sub.db_refs
+            'HGNC': '9955', 'MESH': 'D051996',
+            'EGID': '5970'}, ms.sub.db_refs
 
 
 def test_map_agent():


### PR DESCRIPTION
This PR adds mappings between Entrez and HGNC to the ontology graph so that these can be handled by the standardization process instead of having to be looked up and applied manually via the hgnc_client.