### PR TITLE
Belief sorting, sort by function, generalize sorting algorithm.

### DIFF
--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -20,7 +20,7 @@ from indra.statements.validate import validate_id
 from indra.databases.identifiers import get_identifiers_url, ensure_prefix
 from indra.assemblers.english import EnglishAssembler, AgentWithCoordinates
 from indra.util.statement_presentation import group_and_sort_statements, \
-    make_top_level_label_from_names_key, make_stmt_from_sort_key, \
+    make_top_level_label_from_names_key, make_stmt_from_relation_key, \
     reader_sources, db_sources, all_sources, get_available_source_counts, \
     get_available_ev_counts, standardize_counts, get_available_beliefs, \
     merge_to_metric_dict
@@ -226,7 +226,7 @@ class HtmlAssembler(object):
             # objects in `meta_agents` are references to the Agent's in the
             # Statement object `meta_stmts`.
             meta_agents = []
-            meta_stmt = make_stmt_from_sort_key(inps, verb, meta_agents)
+            meta_stmt = make_stmt_from_relation_key(rel_key, meta_agents)
             meta_agent_dict = {ag.name: ag for ag in meta_agents
                                if ag is not None}
 

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -112,19 +112,22 @@ class HtmlAssembler(object):
         If None, the URLs are constructed as relative links.
         Default: None
     sort_by : str or function or None
-        If str, it indicates which parameter in metric_dict to sort by, or
-        either 'belief' or 'ev_count' which are calculated from the statement
-        objects themselves. The default, 'default', is mostly a sort by ev_count
-        but also favors statements with fewer agents. Alternatively, you may
-        give a function that takes a dict as its single argument, where that
-        dict is an value of the `metric_dict`. If no metric dict is given,
-        the argument to the function will receive a dict with values for
-        `belief` and `ev_count`. The value may also be None, in which case the
-        sort function will return the same value for all elements, and thus
-        the original order of elements will be preserved. This could have
-        strange effects when statements are grouped (i.e. when `grouping_level`
-        is not 'statement'); such functionality is untested and we make no
-        guarantee that it will work.
+        If str, it indicates which parameter to sort by, such as 'belief' or
+        'ev_count', or 'ag_count'. Those are the default options because they
+        can be derived from a list of statements, however if you give a custom
+        stmt_sort_gather, you may use any of the parameters used to build it.
+        The default, 'default', is mostly a sort by ev_count but also favors
+        statements with fewer agents. Alternatively, you may give a function
+        that takes a dict as its single argument, a dictionary of metrics. These
+        metrics are determined by the contents of the `stmt_stat_gather` passed
+        as an argument (see StmtStatGather for details), or else will contain
+        the default metrics that can be derived from the statements themselves,
+        namely `ev_count`, `belief`, and `ag_count`. The value may also
+        be None, in which case the sort function will return the
+        same value for all elements, and thus the original order of elements
+        will be preserved. This could have strange effects when statements are
+        grouped (i.e. when `grouping_level` is not 'statement'); such
+        functionality is untested and we make no guarantee that it will work.
     stmt_stat_gather : Optional[StmtStatGather]
         A custom statement statistics gatherer loaded with data from the corpus
         of statements. If None, a new one will be formed with basic statics

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -23,7 +23,7 @@ from indra.util.statement_presentation import group_and_sort_statements, \
     make_top_level_label_from_names_key, make_stmt_from_relation_key, \
     reader_sources, db_sources, all_sources, get_available_source_counts, \
     get_available_ev_counts, standardize_counts, get_available_beliefs, \
-    StmtStatGather, EvCount, source_count_list, Belief
+    StmtStatGather
 from indra.literature import id_lookup
 
 logger = logging.getLogger(__name__)

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -97,9 +97,6 @@ class HtmlAssembler(object):
         A dictionary of the belief of each statement indexed by hash. If not
         provided, the beliefs of the statements passed to the constructor are
         used.
-    sort_by : str
-        Select which value to sort results by, either 'ev_count' or 'belief'.
-        The default is 'ev_count'.
     source_counts : Optional[dict]
         A dictionary of the itemized evidence counts, by source, available for
         each statement, indexed by hash. If not provided, the statements
@@ -114,6 +111,20 @@ class HtmlAssembler(object):
         the configuration entry indra.config.get_config('INDRA_DB_REST_URL').
         If None, the URLs are constructed as relative links.
         Default: None
+    sort_by : str or function or None
+        If str, it indicates which parameter in metric_dict to sort by, or
+        either 'belief' or 'ev_count' which are calculated from the statement
+        objects themselves. The default, 'default', is mostly a sort by ev_count
+        but also favors statements with fewer agents. Alternatively, you may
+        give a function that takes a dict as its single argument, where that
+        dict is an value of the `metric_dict`. If no metric dict is given,
+        the argument to the function will receive a dict with values for
+        `belief` and `ev_count`. The value may also be None, in which case the
+        sort function will return the same value for all elements, and thus
+        the original order of elements will be preserved. This could have
+        strange effects when statements are grouped (i.e. when `grouping_level`
+        is not 'statement'); such functionality is untested and we make no
+        guarantee that it will work.
 
     Attributes
     ----------

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -91,8 +91,6 @@ class HtmlAssembler(object):
         statement indexed by hash. If not provided, the statements that are
         passed to the constructor are used to determine these, with whatever
         evidences these statements carry.
-    ev_totals : Optional[dict]
-        DEPRECATED. Same as ev_counts which should be used instead.
     beliefs : Optional[dict]
         A dictionary of the belief of each statement indexed by hash. If not
         provided, the beliefs of the statements passed to the constructor are
@@ -150,7 +148,7 @@ class HtmlAssembler(object):
         The URL to a DB REST API.
     """
 
-    def __init__(self, statements=None, summary_metadata=None, ev_totals=None,
+    def __init__(self, statements=None, summary_metadata=None,
                  ev_counts=None, beliefs=None, source_counts=None,
                  curation_dict=None, title='INDRA Results', db_rest_url=None,
                  sort_by='default', custom_stats=None):
@@ -158,9 +156,6 @@ class HtmlAssembler(object):
         self.statements = [] if statements is None else statements
         self.metadata = {} if summary_metadata is None \
             else summary_metadata
-        # If the deprecated parameter is used, we make sure we take it
-        if not ev_counts and ev_totals:
-            ev_counts = ev_totals
         self.ev_counts = get_available_ev_counts(self.statements) \
             if ev_counts is None else standardize_counts(ev_counts)
         self.beliefs = get_available_beliefs(self.statements) \

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -146,7 +146,7 @@ class HtmlAssembler(object):
         self.ev_counts = get_available_ev_counts(self.statements) \
             if ev_counts is None else standardize_counts(ev_counts)
         self.beliefs = get_available_beliefs(self.statements) \
-            if beliefs is None else standardize_counts(beliefs)
+            if not beliefs else standardize_counts(beliefs)
         self.source_counts = get_available_source_counts(self.statements) \
             if source_counts is None else standardize_counts(source_counts)
         self.sort_by = sort_by
@@ -187,9 +187,9 @@ class HtmlAssembler(object):
             various metadata.
         """
         # Get an iterator over the statements, carefully grouped.
-        stmt_stats = [EvCount(self.ev_counts), Belief(self.beliefs),
-                      *source_count_list(self.source_counts)]
-        stmt_data = StmtStatGather.from_stmt_stats(*stmt_stats)
+        stmt_data = StmtStatGather.from_dicts(ev_counts=self.ev_counts,
+                                              beliefs=self.beliefs,
+                                              source_counts=self.source_counts)
         stmt_rows = group_and_sort_statements(self.statements,
                                               stmt_data=stmt_data,
                                               sort_by=self.sort_by)

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -23,7 +23,7 @@ from indra.util.statement_presentation import group_and_sort_statements, \
     make_top_level_label_from_names_key, make_stmt_from_relation_key, \
     reader_sources, db_sources, all_sources, get_available_source_counts, \
     get_available_ev_counts, standardize_counts, get_available_beliefs, \
-    merge_to_metric_dict
+    StmtStat, SumStats, MaxStats, StmtStatGather
 from indra.literature import id_lookup
 
 logger = logging.getLogger(__name__)
@@ -187,11 +187,14 @@ class HtmlAssembler(object):
             various metadata.
         """
         # Get an iterator over the statements, carefully grouped.
-        metric_dict = merge_to_metric_dict(ev_count=self.ev_counts,
-                                           source_count=self.source_counts,
-                                           belief=self.beliefs)
+        stmt_stats = [
+            StmtStat('ev_count', self.ev_counts, int, SumStats),
+            *StmtStat.from_dicts(self.source_counts, int, SumStats),
+            StmtStat('belief', self.beliefs, float, MaxStats)
+        ]
+        stmt_data = StmtStatGather.from_stmt_stats(*stmt_stats)
         stmt_rows = group_and_sort_statements(self.statements,
-                                              metric_dict=metric_dict,
+                                              stmt_data=stmt_data,
                                               sort_by=self.sort_by)
 
         # Set up some data structures to gather results.

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -201,15 +201,14 @@ class HtmlAssembler(object):
         all_previous_stmts = set()
         source_count_keys = set() if not self.source_counts \
             else {k for k in next(iter(self.source_counts.values())).keys()}
-        for row in stmt_rows:
+        for key, inps, verb, stmts_group, agp_m, rel_m in stmt_rows:
             # Distinguish between the cases with source counts and without.
             if self.source_counts:
-                key, verb, stmts_group, tl_counts, metrics = row
-                src_counts = {k: metrics[k] for k in source_count_keys}
+                rel_src_counts = {k: rel_m[k] for k in source_count_keys}
+                agp_src_counts = {k: agp_m[k] for k in source_count_keys}
             else:
-                key, verb, stmts_group = row
-                src_counts = None
-                tl_counts = None
+                rel_src_counts = None
+                agp_src_counts = None
             curr_stmt_set = {s.get_hash() for s in stmts_group}
             if curr_stmt_set == previous_stmt_set:
                 continue
@@ -224,7 +223,7 @@ class HtmlAssembler(object):
             # objects in `meta_agents` are references to the Agent's in the
             # Statement object `meta_stmts`.
             meta_agents = []
-            meta_stmt = make_stmt_from_sort_key(key, verb, meta_agents)
+            meta_stmt = make_stmt_from_sort_key(inps, verb, meta_agents)
             meta_agent_dict = {ag.name: ag for ag in meta_agents
                                if ag is not None}
 
@@ -297,7 +296,7 @@ class HtmlAssembler(object):
             if tl_key not in stmts.keys():
                 agents[tl_key] = tl_agents
                 stmts[tl_key] = {'html_key': str(uuid.uuid4()),
-                                 'source_counts': tl_counts,
+                                 'source_counts': agp_src_counts,
                                  'stmts_formatted': [],
                                  'names': tl_names}
                 if tl_label:
@@ -323,12 +322,12 @@ class HtmlAssembler(object):
                 new_dict = {'short_name': short_name,
                             'short_name_key': short_name_key,
                             'stmt_info_list': stmt_info_list,
-                            'src_counts': src_counts}
+                            'src_counts': rel_src_counts}
                 existing_list.append(new_dict)
             else:
                 existing_list[0]['stmt_info_list'].extend(stmt_info_list)
-                if src_counts:
-                    existing_list[0]['src_counts'].update(src_counts)
+                if rel_src_counts:
+                    existing_list[0]['src_counts'].update(rel_src_counts)
 
         # Add labels for each top level group (tlg).
         if with_grouping:

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -23,7 +23,7 @@ from indra.util.statement_presentation import group_and_sort_statements, \
     make_top_level_label_from_names_key, make_stmt_from_relation_key, \
     reader_sources, db_sources, all_sources, get_available_source_counts, \
     get_available_ev_counts, standardize_counts, get_available_beliefs, \
-    StmtStat, SumStats, MaxStats, StmtStatGather
+    StmtStatGather, EvCount, source_count_list, Belief
 from indra.literature import id_lookup
 
 logger = logging.getLogger(__name__)
@@ -187,11 +187,8 @@ class HtmlAssembler(object):
             various metadata.
         """
         # Get an iterator over the statements, carefully grouped.
-        stmt_stats = [
-            StmtStat('ev_count', self.ev_counts, int, SumStats),
-            *StmtStat.from_dicts(self.source_counts, int, SumStats),
-            StmtStat('belief', self.beliefs, float, MaxStats)
-        ]
+        stmt_stats = [EvCount(self.ev_counts), Belief(self.beliefs),
+                      *source_count_list(self.source_counts)]
         stmt_data = StmtStatGather.from_stmt_stats(*stmt_stats)
         stmt_rows = group_and_sort_statements(self.statements,
                                               stmt_data=stmt_data,

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -115,16 +115,19 @@ class HtmlAssembler(object):
         If str, it indicates which parameter to sort by, such as 'belief' or
         'ev_count', or 'ag_count'. Those are the default options because they
         can be derived from a list of statements, however if you give a custom
-        stmt_sort_gather, you may use any of the parameters used to build it.
-        The default, 'default', is mostly a sort by ev_count but also favors
-        statements with fewer agents. Alternatively, you may give a function
-        that takes a dict as its single argument, a dictionary of metrics. The
-        contents of this dictionary always include "belief", "ev_count", and
-        "ag_count". If source_counts are given, each source will also be
-        available as an entry (e.g. "reach" and "sparser"). You may also add
-        your own custom stats using the `custom_stats` argument. The value may
-        also be None, in which case the sort function will return the
-        same value for all elements, and thus the original order of elements
+        list of stats with the `custom_stats` argument, you may use any of the
+        parameters used to build it. The default, 'default', is mostly a sort
+        by ev_count but also favors statements with fewer agents.
+
+        Alternatively, you may give a function that takes a dict as its single
+        argument, a dictionary of metrics. The contents of this dictionary
+        always include "belief", "ev_count", and "ag_count". If source_counts
+        are given, each source will also be available as an entry (e.g. "reach"
+        and "sparser"). As with string values, you may also add your own custom
+        stats using the `custom_stats` argument.
+
+        The value may also be None, in which case the sort function will return
+        the same value for all elements, and thus the original order of elements
         will be preserved. This could have strange effects when statements are
         grouped (i.e. when `grouping_level` is not 'statement'); such
         functionality is untested.

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -201,15 +201,6 @@ class HtmlAssembler(object):
             A complexly structured JSON dict containing grouped statements and
             various metadata.
         """
-        # Handle deprecated case.
-        if "with_grouping" in kwargs:
-            logger.warning("DEPRECATED: The `with_grouping` option has been "
-                           "replaced with `grouping_level`. See doc string for "
-                           "further details.")
-            if grouping_level == 'agent-pair' \
-                    and not kwargs["with_grouping"]:
-                grouping_level = 'statement'
-
         # Get an iterator over the statements, carefully grouped.
         normal_stats = make_standard_stats(ev_counts=self.ev_counts,
                                            beliefs=self.beliefs,
@@ -461,15 +452,6 @@ class HtmlAssembler(object):
         str
             The assembled HTML as a string.
         """
-        # Handle deprecated case.
-        if "with_grouping" in template_kwargs:
-            logger.warning("DEPRECATED: The `with_grouping` option has been "
-                           "replaced with `grouping_level`. See doc string for "
-                           "further details.")
-            if grouping_level == 'agent-pair' \
-               and not template_kwargs.pop("with_grouping"):
-                grouping_level = 'statement'
-
         # Make the JSON model.
         tl_stmts = self.make_json_model(grouping_level=grouping_level,
                                         no_redundancy=no_redundancy)

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -86,6 +86,8 @@ class HtmlAssembler(object):
         INDRA REST API. Default is None. Each value should be a concise
         summary of O(1), not of order the length of the list, such as the
         evidence totals. The keys should be informative human-readable strings.
+        This information is displayed as a tooltip when hovering over the
+        page title.
     ev_counts : Optional[dict]
         A dictionary of the total evidence available for each
         statement indexed by hash. If not provided, the statements that are
@@ -125,7 +127,7 @@ class HtmlAssembler(object):
         same value for all elements, and thus the original order of elements
         will be preserved. This could have strange effects when statements are
         grouped (i.e. when `grouping_level` is not 'statement'); such
-        functionality is untested and we make no guarantee that it will work.
+        functionality is untested.
     custom_stats : Optional[list]
         A list of StmtStat objects containing custom statement statistics to be
         used in sorting of statements and statement groups.
@@ -219,7 +221,7 @@ class HtmlAssembler(object):
         # Loop through the sorted and grouped statements.
         all_hashes = set()
 
-        def handle_rows(rows, level, **kwargs):
+        def handle_rows(rows, level, agent_key=None, agp_agents=None):
             if level == 'agent-pair':
                 ret = OrderedDict()
             else:
@@ -495,10 +497,10 @@ class HtmlAssembler(object):
             template_kwargs['simple'] = True
 
         self.model = template.render(stmt_data=tl_stmts,
-                                     metadata=metadata, title=self.title,
-                                     db_rest_url=db_rest_url,
-                                     add_full_text_search_link=add_full_text_search_link,  # noqa
-                                     **template_kwargs)
+                  metadata=metadata, title=self.title,
+                  db_rest_url=db_rest_url,
+                  add_full_text_search_link=add_full_text_search_link,  # noqa
+                  **template_kwargs)
         return self.model
 
     def append_warning(self, msg):

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -224,7 +224,7 @@ class HtmlAssembler(object):
         # Loop through the sorted and grouped statements.
         all_hashes = set()
 
-        def handle_rows(rows, level, agent_key=None, agp_agents=None):
+        def handle_rows(rows, level, **kwargs):
             if level == 'agent-pair':
                 ret = OrderedDict()
             else:

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -228,7 +228,6 @@ class HtmlAssembler(object):
         # Loop through the sorted and grouped statements.
         all_hashes = set()
 
-
         # Used by the handle_* functions below to distinguish between cases
         # with source counts and without
         def _get_src_counts(metrics):
@@ -258,9 +257,9 @@ class HtmlAssembler(object):
                 agents[agp_key_str] = agp_agents
 
                 # Determine if we are including this row or not.
-                relations, stmt_hashes = handle_relations(contents,
-                                                     agent_key=agp_key_str,
-                                                     agp_agents=agp_agents)
+                relations, stmt_hashes = \
+                    handle_relations(contents, agent_key=agp_key_str,
+                                     agp_agents=agp_agents)
                 if stmt_hashes <= prev_hashes or not relations:
                     continue
                 prev_hashes = stmt_hashes
@@ -276,7 +275,6 @@ class HtmlAssembler(object):
         # RELATION LEVEL
         def handle_relations(rows, agent_key=None, agp_agents=None):
             ret = []
-            prev_hashes = set()
             all_level_hashes = set()
             for _, key, contents, metrics in rows:
                 src_counts = _get_src_counts(metrics)
@@ -338,7 +336,6 @@ class HtmlAssembler(object):
         # STATEMENT LEVEL
         def handle_statements(rows, meta_ag_dict=None):
             ret = []
-            prev_hashes = set()
             all_level_hashes = set()
             for _, key, contents, metrics in rows:
                 src_counts = _get_src_counts(metrics)
@@ -385,6 +382,8 @@ class HtmlAssembler(object):
             output, _ = handle_relations(stmt_rows)
         elif grouping_level == 'statement':
             output, _ = handle_statements(stmt_rows)
+        else:
+            assert False, f"Grouping level enforcement failed: {grouping_level}"
 
         # Massage the output into the expected format.
         stmts = {}

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -232,7 +232,7 @@ class HtmlAssembler(object):
                     # AGENT PAIR LEVEL
 
                     # Create the agent key.
-                    if isinstance(key[1], tuple):
+                    if len(key) > 1 and isinstance(key[1], tuple):
                         agp_names = [key[0]] + [*key[1]] + [*key[2]]
                     else:
                         agp_names = key[:]

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -271,10 +271,10 @@ class HtmlAssembler(object):
                 elif level == 'relation':
                     # RELATION LEVEL
 
-                    # We will keep track the meta data for this stmt group.
-                    # NOTE: Much of the code relies heavily on the fact that the
-                    # Agent objects in `meta_agents` are references to the
-                    # Agent's in the Statement object `meta_stmts`.
+                    # We will keep track of the meta data for this stmt group.
+                    # NOTE: The code relies on the fact that the Agent objects
+                    # in `meta_agents` are references to the Agents in the
+                    # Statement object `meta_stmts`.
                     meta_agents = []
                     meta_stmt = make_stmt_from_relation_key(key, meta_agents)
                     meta_ag_dict = {ag.name: ag for ag in meta_agents

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -351,8 +351,10 @@
         {% set i_stmt = loop.index0 %}
 
                     <a name="{{ stmt_info['hash'] }}"></a>
-                    <div class="row statement">
-                      <div class="col text-left nvp">
+                    <div class="row statement group_heading"
+                         onclick="toggler( '{{ group_dict['short_name_key'] }}-{{ stmt_info['hash'] }}' )"
+                         id="{{ group_dict['short_name_key'] }}-{{ stmt_info['hash'] }}_heading">
+                      <div class="col-auto text-left nvp">
                         <h5>
                           {{ stmt_info['english'] }}
                           <a href="{% if db_rest_url %}{{ db_rest_url }}/from_hash/{{ stmt_info['hash'] }}?format=html{% else %}#{% endif %}"
@@ -365,7 +367,8 @@
                         {{ badges(stmt_info['source_count']) }}
                       </div>
                     </div>  <!-- end statement heading row -->
-                    <div class="row">
+                    <div class="row group"
+                         id="{{ group_dict['short_name_key'] }}-{{ stmt_info['hash'] }}_group">
                       <div class="col">
                         <div class="container bars" id="stmt-{{ i_pair }}-{{ i_type }}-{{ i_stmt }}"
                              data-stmt_hash="{{ stmt_info['hash'] }}">

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -83,12 +83,23 @@
       }
 
       // Loop all tags
-      if (show)
-        for (let invisible_el of document.getElementsByClassName('group'))
-          invisible_el.classList.replace("group", "group_shown");
-      else
-        for (let visible_el in document.getElementsByClassName('group_shown'))
-          visible_el.classList.replace("group_shown", "group");
+      let old_c, new_c;
+      if (show) {
+        old_c = "group";
+        new_c = "group_shown";
+      } else {
+        old_c = "group_shown";
+        new_c = "group";
+      }
+
+      let elements = document.getElementsByClassName(old_c);
+      let elem_arr = Array();
+      for (let el of elements) {
+        elem_arr.push(el);
+      }
+      elem_arr.forEach(el => {
+        el.classList.replace(old_c, new_c);
+      });
     }
 
     {% if add_full_text_search_link %}

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -242,3 +242,33 @@ def test_migration():
     stmt = Migration(Concept('migration'))
     ha = HtmlAssembler([stmt])
     ha.make_model()
+
+
+def test_sort_default():
+    stmts = [
+        Inhibition(
+            Agent('DUSP4'), Agent('MAPK1'),
+            evidence=[Evidence("DUSP4-|MAPK1"), Evidence("MAPK1|-DUSP4")]
+        ),
+        DecreaseAmount(
+            Agent('DUSP4'), Agent('MAPK1'),
+            evidence=[Evidence("DUSP4->MAPK1")]
+        ),
+        Complex(
+            [Agent('DUSP4'), Agent('MAPK1'), Agent('MAP2K1')],
+            evidence=[Evidence("DUSP4-MAPK1-MAP2K1 complex"),
+                      Evidence("Complex of DUSP4, MAPK1, & MAP2K1")]
+        ),
+        Phosphorylation(
+            Agent('MAP2K1'), Agent('MAPK1'), 'T', '185',
+            evidence=[Evidence("MAP2K1 phosphorylates MAPK1 on T 185"),
+                      Evidence("MAP2K1 phosphorylate MAPK1 on Tyrosine 185")]
+        ),
+        Phosphorylation(
+            Agent('MAP2K1'), Agent('MAPK1'),
+            evidence=[Evidence("MAP2K1 phosphorylates MAPK1")]
+        )
+    ]
+    ha = HtmlAssembler(stmts)
+    json_model = ha.make_json_model()
+    ha.make_model()

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -322,7 +322,7 @@ def test_sort_group_by_relation():
     assert len(relations) == 5, len(relations)
 
     # Make sure the HTML assembles.
-    ha.make_model()
+    ha.make_model(grouping_level='relation')
 
 
 def test_sort_group_by_statement():
@@ -338,5 +338,4 @@ def test_sort_group_by_statement():
     assert [len(s['evidence']) for s in statements] == [4, 3, 2, 2, 1, 1]
 
     # Make sure the html assembly works.
-    ha.make_model()
-
+    ha.make_model(grouping_level='statement')

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -3,7 +3,7 @@ from indra.statements import *
 from indra.assemblers.english import AgentWithCoordinates
 from indra.assemblers.html.assembler import HtmlAssembler, tag_text, loader, \
     _format_evidence_text, tag_agents
-from indra.util.statement_presentation import AveStats, StmtStat, StmtStatGather
+from indra.util.statement_presentation import AveAggregator, StmtStat, StmtGroup
 
 
 def make_stmt():
@@ -363,8 +363,8 @@ def test_sort_group_by_statement_custom_ordering():
     custom_values = [0.1, 0.2, 0.15, 0.6, 0.3, 0.8]
     val_dict = {s.get_hash(): v for v, s in zip(custom_values, stmts)}
 
-    custom_stat = StmtStat('value', val_dict, float, AveStats)
-    stmt_gather = StmtStatGather.from_stmt_stats(custom_stat)
+    custom_stat = StmtStat('value', val_dict, float, AveAggregator)
+    stmt_gather = StmtGroup.from_stmt_stats(custom_stat)
 
     ha = HtmlAssembler(stmts, sort_by='value', stmt_stat_gather=stmt_gather)
     json_model = ha.make_json_model(grouping_level='statement')
@@ -385,8 +385,8 @@ def test_sort_group_by_relation_custom_ordering():
     custom_values = [0.1, 0.2, 0.15, 0.6, 0.3, 0.8]
     val_dict = {s.get_hash(): v for v, s in zip(custom_values, stmts)}
 
-    custom_stat = StmtStat('value', val_dict, float, AveStats)
-    stmt_gather = StmtStatGather.from_stmt_stats(custom_stat)
+    custom_stat = StmtStat('value', val_dict, float, AveAggregator)
+    stmt_gather = StmtGroup.from_stmt_stats(custom_stat)
 
     ha = HtmlAssembler(stmts, sort_by='value', stmt_stat_gather=stmt_gather)
     json_model = ha.make_json_model(grouping_level='relation')
@@ -413,8 +413,8 @@ def test_sort_group_by_agent_custom_ordering():
     custom_values = [0.1, 0.2, 0.15, 0.6, 0.3, 0.8]
     val_dict = {s.get_hash(): v for v, s in zip(custom_values, stmts)}
 
-    custom_stat = StmtStat('value', val_dict, float, AveStats)
-    stmt_gather = StmtStatGather.from_stmt_stats(custom_stat)
+    custom_stat = StmtStat('value', val_dict, float, AveAggregator)
+    stmt_gather = StmtGroup.from_stmt_stats(custom_stat)
 
     ha = HtmlAssembler(stmts, sort_by='value', stmt_stat_gather=stmt_gather)
     json_model = ha.make_json_model(grouping_level='agent-pair')

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -270,8 +270,18 @@ def test_sort_default():
             evidence=[Evidence(text="Bar phosphorylates Baz")]
         ),
         Conversion(Agent('Fez'), [Agent('Far'), Agent('Faz')],
-                   [Agent('Bar'), Agent('Baz')])
+                   [Agent('Bar'), Agent('Baz')],
+                   evidence=[Evidence(text='Fez converts Far and Faz into Bar '
+                                           'and Baz.')])
     ]
     ha = HtmlAssembler(stmts)
     json_model = ha.make_json_model()
+    assert list(json_model.keys()) == ['Fez-Baz', 'Bar-Baz', 'Fez-Bar']
+    exp_stmt_counts = {'Fez-Baz': 4, 'Bar-Baz': 2, 'Fez-Bar': 2}
+    assert all(len(json_model[k]['stmts_formatted']) == n
+               for k, n in exp_stmt_counts.items())
+    ev_counts = {k: sum(len(s['evidence']) for r in m['stmts_formatted']
+                        for s in r['stmt_info_list'])
+                 for k, m in json_model.items()}
+    assert ev_counts == {'Fez-Baz': 6, 'Bar-Baz': 5, 'Fez-Bar': 3}, ev_counts
     ha.make_model()

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -63,9 +63,9 @@ def test_assembler():
         ev_counts={stmt.get_hash(): 1, stmt2.get_hash(): 1},
         db_rest_url='test.db.url')
     ha.add_statements([stmt, stmt2])
-    result = ha.make_model(with_grouping=True)
+    result = ha.make_model(grouping_level='agent-pair')
     assert isinstance(result, str)
-    result = ha.make_model(with_grouping=False)
+    result = ha.make_model(grouping_level='statement')
     assert isinstance(result, str)
     # Make sure warning can be appended
     ha.append_warning('warning')

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -60,7 +60,7 @@ def test_assembler():
     ha = HtmlAssembler(
         source_counts={stmt.get_hash(): {'test': 1},
                        stmt2.get_hash(): {'test': 1}},
-        ev_totals={stmt.get_hash(): 1, stmt2.get_hash(): 1},
+        ev_counts={stmt.get_hash(): 1, stmt2.get_hash(): 1},
         db_rest_url='test.db.url')
     ha.add_statements([stmt, stmt2])
     result = ha.make_model(with_grouping=True)

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -3,6 +3,7 @@ from indra.statements import *
 from indra.assemblers.english import AgentWithCoordinates
 from indra.assemblers.html.assembler import HtmlAssembler, tag_text, loader, \
     _format_evidence_text, tag_agents
+from indra.util.statement_presentation import AveStats, StmtStat, StmtStatGather
 
 
 def make_stmt():
@@ -260,7 +261,7 @@ def _get_sort_corpus():
         ),
         Complex(
             [Agent('Fez'), Agent('Baz'), Agent('Bar')],
-            evidence=[Evidence('terrible', text="Fez-Baz-Bar complex"),
+            evidence=[Evidence('sparser', text="Fez-Baz-Bar complex"),
                       Evidence('reach', text="Complex of Fez, Baz, & Bar")]
         ),
         Phosphorylation(
@@ -352,3 +353,24 @@ def test_sort_group_by_statement_sort_by_none():
     inp_h_list = [s.get_hash() for s in stmts]
     assert got_h_list == inp_h_list
 
+
+def test_sort_group_by_statement_custom_ordering():
+    stmts = _get_sort_corpus()
+
+    custom_values = [0.1, 0.2, 0.15, 0.6, 0.3, 0.8]
+    val_dict = {s.get_hash(): v for v, s in zip(custom_values, stmts)}
+
+    custom_stat = StmtStat('value', val_dict, float, AveStats)
+    stmt_gather = StmtStatGather.from_stmt_stats(custom_stat)
+
+    ha = HtmlAssembler(stmts, sort_by='value', stmt_stat_gather=stmt_gather)
+    json_model = ha.make_json_model(grouping_level='statement')
+
+    statements = \
+        json_model['all-statements']['stmts_formatted'][0]['stmt_info_list']
+    got_h_list = [int(s['hash']) for s in statements]
+    exp_h_list = sorted((h for h in val_dict.keys()), key=lambda h: val_dict[h],
+                        reverse=True)
+    assert got_h_list == exp_h_list
+
+    ha.make_model(grouping_level='statement')

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -366,7 +366,7 @@ def test_sort_group_by_statement_custom_ordering():
     custom_stat = StmtStat('value', val_dict, float, AveAggregator)
     stmt_gather = StmtGroup.from_stmt_stats(custom_stat)
 
-    ha = HtmlAssembler(stmts, sort_by='value', stmt_stat_gather=stmt_gather)
+    ha = HtmlAssembler(stmts, sort_by='value', stmt_data=stmt_gather)
     json_model = ha.make_json_model(grouping_level='statement')
 
     statements = \
@@ -388,7 +388,7 @@ def test_sort_group_by_relation_custom_ordering():
     custom_stat = StmtStat('value', val_dict, float, AveAggregator)
     stmt_gather = StmtGroup.from_stmt_stats(custom_stat)
 
-    ha = HtmlAssembler(stmts, sort_by='value', stmt_stat_gather=stmt_gather)
+    ha = HtmlAssembler(stmts, sort_by='value', stmt_data=stmt_gather)
     json_model = ha.make_json_model(grouping_level='relation')
     assert list(json_model.keys()) == ['all-relations']
     relations = json_model['all-relations']['stmts_formatted']
@@ -416,7 +416,7 @@ def test_sort_group_by_agent_custom_ordering():
     custom_stat = StmtStat('value', val_dict, float, AveAggregator)
     stmt_gather = StmtGroup.from_stmt_stats(custom_stat)
 
-    ha = HtmlAssembler(stmts, sort_by='value', stmt_stat_gather=stmt_gather)
+    ha = HtmlAssembler(stmts, sort_by='value', stmt_data=stmt_gather)
     json_model = ha.make_json_model(grouping_level='agent-pair')
     assert len(json_model.keys()) == 4
 

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -339,3 +339,16 @@ def test_sort_group_by_statement():
 
     # Make sure the html assembly works.
     ha.make_model(grouping_level='statement')
+
+
+def test_sort_group_by_statement_sort_by_none():
+    stmts = _get_sort_corpus()
+    ha = HtmlAssembler(stmts, sort_by=None)
+
+    json_model = ha.make_json_model(grouping_level='statement')
+    statements = \
+        json_model['all-statements']['stmts_formatted'][0]['stmt_info_list']
+    got_h_list = [int(s['hash']) for s in statements]
+    inp_h_list = [s.get_hash() for s in stmts]
+    assert got_h_list == inp_h_list
+

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -364,9 +364,8 @@ def test_sort_group_by_statement_custom_ordering():
     val_dict = {s.get_hash(): v for v, s in zip(custom_values, stmts)}
 
     custom_stat = StmtStat('value', val_dict, float, AveAggregator)
-    stmt_gather = StmtGroup.from_stmt_stats(custom_stat)
 
-    ha = HtmlAssembler(stmts, sort_by='value', stmt_data=stmt_gather)
+    ha = HtmlAssembler(stmts, sort_by='value', custom_stats=[custom_stat])
     json_model = ha.make_json_model(grouping_level='statement')
 
     statements = \
@@ -386,9 +385,8 @@ def test_sort_group_by_relation_custom_ordering():
     val_dict = {s.get_hash(): v for v, s in zip(custom_values, stmts)}
 
     custom_stat = StmtStat('value', val_dict, float, AveAggregator)
-    stmt_gather = StmtGroup.from_stmt_stats(custom_stat)
 
-    ha = HtmlAssembler(stmts, sort_by='value', stmt_data=stmt_gather)
+    ha = HtmlAssembler(stmts, sort_by='value', custom_stats=[custom_stat])
     json_model = ha.make_json_model(grouping_level='relation')
     assert list(json_model.keys()) == ['all-relations']
     relations = json_model['all-relations']['stmts_formatted']
@@ -414,9 +412,8 @@ def test_sort_group_by_agent_custom_ordering():
     val_dict = {s.get_hash(): v for v, s in zip(custom_values, stmts)}
 
     custom_stat = StmtStat('value', val_dict, float, AveAggregator)
-    stmt_gather = StmtGroup.from_stmt_stats(custom_stat)
 
-    ha = HtmlAssembler(stmts, sort_by='value', stmt_data=stmt_gather)
+    ha = HtmlAssembler(stmts, sort_by='value', custom_stats=[custom_stat])
     json_model = ha.make_json_model(grouping_level='agent-pair')
     assert len(json_model.keys()) == 4
 

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -247,27 +247,30 @@ def test_migration():
 def test_sort_default():
     stmts = [
         Inhibition(
-            Agent('DUSP4'), Agent('MAPK1'),
-            evidence=[Evidence("DUSP4-|MAPK1"), Evidence("MAPK1|-DUSP4")]
+            Agent('Fez'), Agent('Baz'),
+            evidence=[Evidence(text="Fez-|Baz"), Evidence(text="Baz|-Fez")]
         ),
         DecreaseAmount(
-            Agent('DUSP4'), Agent('MAPK1'),
-            evidence=[Evidence("DUSP4->MAPK1")]
+            Agent('Fez'), Agent('Baz'),
+            evidence=[Evidence(text="Fez->Baz")]
         ),
         Complex(
-            [Agent('DUSP4'), Agent('MAPK1'), Agent('MAP2K1')],
-            evidence=[Evidence("DUSP4-MAPK1-MAP2K1 complex"),
-                      Evidence("Complex of DUSP4, MAPK1, & MAP2K1")]
+            [Agent('Fez'), Agent('Baz'), Agent('Bar')],
+            evidence=[Evidence(text="Fez-Baz-Bar complex"),
+                      Evidence(text="Complex of Fez, Baz, & Bar")]
         ),
         Phosphorylation(
-            Agent('MAP2K1'), Agent('MAPK1'), 'T', '185',
-            evidence=[Evidence("MAP2K1 phosphorylates MAPK1 on T 185"),
-                      Evidence("MAP2K1 phosphorylate MAPK1 on Tyrosine 185")]
+            Agent('Bar'), Agent('Baz'), 'T', '185',
+            evidence=[Evidence(text="Bar phosphorylates Baz on T 46"),
+                      Evidence(text="Bar phosphorylate Baz on Tyrosine "
+                                    "forty-six")]
         ),
         Phosphorylation(
-            Agent('MAP2K1'), Agent('MAPK1'),
-            evidence=[Evidence("MAP2K1 phosphorylates MAPK1")]
-        )
+            Agent('Bar'), Agent('Baz'),
+            evidence=[Evidence(text="Bar phosphorylates Baz")]
+        ),
+        Conversion(Agent('Fez'), [Agent('Far'), Agent('Faz')],
+                   [Agent('Bar'), Agent('Baz')])
     ]
     ha = HtmlAssembler(stmts)
     json_model = ha.make_json_model()

--- a/indra/tests/test_util.py
+++ b/indra/tests/test_util.py
@@ -5,7 +5,7 @@ from indra.statements import Statement
 
 from indra.util import unicode_strs
 from indra.util import UnicodeXMLTreeBuilder as UTB
-from indra.util.statement_presentation import _get_keyed_stmts
+from indra.util.statement_presentation import _get_relation_keyed_stmts
 
 
 def test_unicode_tree_builder():
@@ -26,6 +26,6 @@ def test_conversion_keying():
                  "id": "d2361669-dfe5-45e0-914a-c96a82ad25fb"}
     stmt_list = [Statement._from_json(stmt_json)]
     stmt_list[0].agent_list()
-    list(_get_keyed_stmts(stmt_list))
+    list(_get_relation_keyed_stmts(stmt_list))
     return
 

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -622,9 +622,8 @@ def group_and_sort_statements(stmt_list, sort_by='default', stmt_data=None,
 
                 yield sort_key, rel_key, stmts, rel_m.get_dict()
 
-    sorted_groups = sorted(processed_rows(relation_stmts),
-                           key=lambda tpl: tpl[0], reverse=True)
-    return sorted_groups
+    return sorted(processed_rows(relation_stmts), key=lambda tpl: tpl[0],
+                  reverse=True)
 
 
 def make_stmt_from_relation_key(relation_key, agents=None):

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -697,10 +697,11 @@ def stmt_to_english(stmt):
     return ea.make_model()[:-1]
 
 
-def make_string_from_sort_key(rel_key):
-    """Make a Statement string via EnglishAssembler from the sort key.
+def make_string_from_relation_key(rel_key):
+    """Make a Statement string via EnglishAssembler from the relation key.
 
-    Specifically, the sort key used by `group_and_sort_statements`.
+    Specifically, the key used by `group_and_sort_statements` for contents
+    grouped at the relation level.
     """
     stmt = make_stmt_from_relation_key(rel_key)
     return stmt_to_english(stmt)

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -419,6 +419,7 @@ class BasicStats(StmtStatRow):
         self._count = 0
         self.__stmt_hashes = set()
         self.__frozen = False
+        self.__dict = None
 
     @classmethod
     def from_array(cls, keys, arr, original_types, stmt_metrics=None):
@@ -460,9 +461,15 @@ class BasicStats(StmtStatRow):
         return self._keys[:]
 
     def get_dict(self):
-        return {key: value.astype(original_type)
-                for key, value, original_type
-                in zip(self._keys, self._values, self._original_types)}
+        if not self.__frozen:
+            raise RuntimeError("Cannot load source dict until frozen.")
+
+        if self.__dict is None:
+            self.__dict = {key: value.astype(original_type)
+                           for key, value, original_type
+                           in zip(self._keys, self._values,
+                                  self._original_types)}
+        return self.__dict
 
 
 class SumStats(BasicStats):

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -554,9 +554,13 @@ def group_and_sort_statements(stmt_list, sort_by='default', stmt_data=None,
 
     # Return the sorted statements, if that's all you want.
     if grouping_level == 'statement':
-        return sorted(stmt_list,
-                      key=lambda s: _sort_func(stmt_data[s.get_hash()]
-                                               .get_dict()))
+        sorted_stmts = sorted(
+            ((_sort_func(stmt_data[s.get_hash()].get_dict()), s,
+              stmt_data[s.get_hash()].get_dict())
+             for s in stmt_list),
+            key=lambda t: t[0]
+        )
+        return sorted_stmts
 
     # Create gathering metrics from the statement data.
     relation_metrics = stmt_data.get_new_instance()

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -25,12 +25,12 @@ The primary work horse of the module is `group_and_sort_statements`, and if you
 want statements grouped into agent-pairs, then by relations, sorted by evidence
 count, you can simply use this function with its defaults:
 
->>> for _, ag_key, rels, ag_metrics in group_and_sort_statements(stmts):
->>>     print(ag_key)
->>>     for _, rel_key, stmt_data, rel_metrics in rels:
->>>         print('\t', rel_key)
->>>         for _, stmt_hash, stmt_obj, stmt_metrics in stmt_data:
->>>             print('\t\t', stmt_obj)
+>> for _, ag_key, rels, ag_metrics in group_and_sort_statements(stmts):
+>>     print(ag_key)
+>>     for _, rel_key, stmt_data, rel_metrics in rels:
+>>         print('\t', rel_key)
+>>         for _, stmt_hash, stmt_obj, stmt_metrics in stmt_data:
+>>             print('\t\t', stmt_obj)
 
 Advanced Example
 ----------------
@@ -40,30 +40,30 @@ to the level of relations, and want to sort the statements and relations
 separately, you can do that. Suppose also that your measurement is the same
 at the level of relations, and you don't want it aggregated.
 
->>> # Define a new aggregator that takes the last metric (a noop given the
->>> # nature of the data)
->>> class NoopAggregator(BasicAggregator):
->>>     def _merge(self, metric_array):
->>>         self.values = metric_array
->>>
->>> # Create your StmtStat
->>> my_stat = StmtStat('my_stat', my_data, int, NoopAggregator)
->>>
->>> # Define a custom sort function using my stat and the default available
->>> # ev_count. In effect this will sort relations by the custom stat, and then
->>> # sort the statements within that relation (for which my_stat is by design
->>> # the same) using their evidence counts.
->>> def my_sort(metrics):
->>>     return metrics['my_stat'], metrics['ev_count']
->>>
->>> # Iterate over the results.
->>> groups = group_and_sort_statements(stmts, sort_by=my_sort,
->>>                                    custom_stats=[my_stat],
->>>                                    grouping_level='relation')
->>> for _, rel_key, rel_stmts, rel_metrics in groups:
->>>     print(rel_key, rel_metrics['my_stat'])
->>>     for _, stmt_hash, stmt, metrics in rel_stmts:
->>>         print('\t', stmt, metrics['ev_count'])
+>> # Define a new aggregator that takes the last metric (a noop given the
+>> # nature of the data)
+>> class NoopAggregator(BasicAggregator):
+>>     def _merge(self, metric_array):
+>>         self.values = metric_array
+>>
+>> # Create your StmtStat
+>> my_stat = StmtStat('my_stat', my_data, int, NoopAggregator)
+>>
+>> # Define a custom sort function using my stat and the default available
+>> # ev_count. In effect this will sort relations by the custom stat, and then
+>> # sort the statements within that relation (for which my_stat is by design
+>> # the same) using their evidence counts.
+>> def my_sort(metrics):
+>>     return metrics['my_stat'], metrics['ev_count']
+>>
+>> # Iterate over the results.
+>> groups = group_and_sort_statements(stmts, sort_by=my_sort,
+>>                                    custom_stats=[my_stat],
+>>                                    grouping_level='relation')
+>> for _, rel_key, rel_stmts, rel_metrics in groups:
+>>     print(rel_key, rel_metrics['my_stat'])
+>>     for _, stmt_hash, stmt, metrics in rel_stmts:
+>>         print('\t', stmt, metrics['ev_count'])
 """
 
 import logging
@@ -202,9 +202,9 @@ class StmtStat:
         """Generate a list of StmtStat's from a dict of dicts.
 
         Example Usage:
-        >>> source_counts = {9623812756876: {'reach': 1, 'sparser': 2},
-        >>>                  -39877587165298: {'reach': 3, 'sparser': 0}}
-        >>> stmt_stats = StmtStat.from_dicts(source_counts, int, SumAggregator)
+        >> source_counts = {9623812756876: {'reach': 1, 'sparser': 2},
+        >>                  -39877587165298: {'reach': 3, 'sparser': 0}}
+        >> stmt_stats = StmtStat.from_dicts(source_counts, int, SumAggregator)
 
         Parameters
         ----------
@@ -237,7 +237,7 @@ class StmtStat:
         but a more limited selection may be specified using `values`.
 
         Example usage:
-        >>> stmt_stats = StmtStat.from_stmts(stmt_list, ('ag_count', 'belief'))
+        >> stmt_stats = StmtStat.from_stmts(stmt_list, ('ag_count', 'belief'))
 
         Parameters
         ----------
@@ -293,27 +293,27 @@ class StmtGroup:
     See the methods for more details on their purpose and usage.
 
     Example usage:
-    >>> # Get ev_count, belief, and ag_count from a list of statements.
-    >>> stmt_stats = StmtStat.from_stmts(stmt_list)
-    >>>
-    >>> # Add another stat for a measure of relevance
-    >>> stmt_stats.append(
-    >>>     StmtStat('relevance', relevance_dict, float, AveAggregator)
-    >>> )
-    >>>
-    >>> # Create the Group
-    >>> sg = StmtGroup.from_stmt_stats(*stmt_stats)
-    >>>
-    >>> # Load it full of Statements, grouped by agents.
-    >>> sg.fill_from_stmt_stats()
-    >>> sg.start()
-    >>> for s in stmt_list:
-    >>>    key = (ag.get_grounding() for ag in s.agent_list())
-    >>>    sg[key].include(s)
-    >>> sg.finish()
-    >>>
-    >>> # Now the stats for each group are aggregated and available for use.
-    >>> metrics = sg[(('FPLX', 'MEK'), ('FPLX', 'ERK'))].get_dict()
+    >> # Get ev_count, belief, and ag_count from a list of statements.
+    >> stmt_stats = StmtStat.from_stmts(stmt_list)
+    >>
+    >> # Add another stat for a measure of relevance
+    >> stmt_stats.append(
+    >>     StmtStat('relevance', relevance_dict, float, AveAggregator)
+    >> )
+    >>
+    >> # Create the Group
+    >> sg = StmtGroup.from_stmt_stats(*stmt_stats)
+    >>
+    >> # Load it full of Statements, grouped by agents.
+    >> sg.fill_from_stmt_stats()
+    >> sg.start()
+    >> for s in stmt_list:
+    >>    key = (ag.get_grounding() for ag in s.agent_list())
+    >>    sg[key].include(s)
+    >> sg.finish()
+    >>
+    >> # Now the stats for each group are aggregated and available for use.
+    >> metrics = sg[(('FPLX', 'MEK'), ('FPLX', 'ERK'))].get_dict()
 
     This class helps manage the accumulation of statistics for statements and
     statement-like objects, such as agent pairs. Working with AggregatorGroup and

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -461,6 +461,7 @@ class BasicStats(StmtStatRow):
             return
         assert self._stmt_metrics and h in self._stmt_metrics
         self._merge(self._stmt_metrics[h])
+        self._count += 1
         self.__stmt_hashes.add(h)
 
     def _merge(self, metric_array):

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -522,22 +522,27 @@ def group_and_sort_statements(stmt_list, sort_by='default', stmt_metrics=None,
     stmt_list : list[Statement]
         A list of INDRA statements.
     sort_by : str or function or None
-        If str, it indicates which parameter in metric_dict to sort by, or
-        either 'belief' or 'ev_count' which are calculated from the statement
-        objects themselves. The default, 'default', is mostly a sort by ev_count
-        but also favors statements with fewer agents. Alternatively, you may
-        give a function that takes a dict as its single argument, where that
-        dict is an value of the `metric_dict`. If no metric dict is given,
-        the argument to the function will receive a dict with values for
-        `belief` and `ev_count`. The value may also be None, in which case the
-        sort function will return the same value for all elements, and thus
-        the original order of elements will be preserved. This could have
-        strange effects when statements are grouped (i.e. when `grouping_level`
-        is not 'statement').
+        If str, it indicates which parameter to sort by, such as 'belief' or
+        'ev_count', or 'ag_count'. Those are the default options because they
+        can be derived from a list of statements, however if you give a custom
+        `stmt_metrics`, you may use any of the parameters used to build it.
+        The default, 'default', is mostly a sort by ev_count but also favors
+        statements with fewer agents. Alternatively, you may give a function
+        that takes a dict as its single argument, a dictionary of metrics. These
+        metrics are determined by the contents of the `stmt_metrics` passed
+        as an argument (see StmtStatGather for details), or else will contain
+        the default metrics that can be derived from the statements themselves,
+        namely `ev_count`, `belief`, and `ag_count`. The value may also
+        be None, in which case the sort function will return the
+        same value for all elements, and thus the original order of elements
+        will be preserved. This could have strange effects when statements are
+        grouped (i.e. when `grouping_level` is not 'statement'); such
+        functionality is untested and we make no guarantee that it will work.
     stmt_metrics : StmtStatGather
         A statement statistics gatherer loaded with data from the corpus of
         statements. If None, a new one will be formed with basic statics
-        derived from the list of Statements itself.
+        derived from the list of Statements itself. See the docs for
+        StmtStatGather for details on how to create one.
     grouping_level : str
         The options are 'agent-pair', 'relation', and 'statement'. These
         correspond to grouping by agent pairs, agent and type relationships, and
@@ -546,13 +551,16 @@ def group_and_sort_statements(stmt_list, sort_by='default', stmt_metrics=None,
     Returns
     -------
     sorted_groups : list[tuple]
-        A list of tuples containing a sort key, the statement type, and a list
-        of statements, also sorted by evidence count, for that key and type.
-        The sort key contains a count of statements with those argument, the
-        arguments (normalized strings), the count of statements with those
-        arguments and type, and then the statement type.
+        A list of tuples of the form (sort_param, key, contents, metrics), where
+        the sort param is whatever value was calculated to sort the results,
+        the key is the unique key for the agent pair, relation, or statements,
+        and the contents are either relations, statements, or statement JSON,
+        depending on the level. This structure is recursive, so the each list
+        of relations will also follow this structure, all the way down to
+        the lowest level (statement JSON). The metrics a dict of the aggregated
+        metrics for the entry (e.g. source counts, evidence counts, etc).
     """
-    # Validate the grouping level paramater.
+    # Validate the grouping level parameter.
     if grouping_level not in ['agent-pair', 'relation', 'statement']:
         raise ValueError(f"Invalid grouping level: \"{grouping_level}\".")
 

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -172,6 +172,20 @@ class StmtStat:
                 for k, d in data.items()]
 
 
+class EvCount(StmtStat):
+    def __init__(self, ev_counts):
+        super(EvCount, self).__init__('ev_count', ev_counts, int, SumStats)
+
+
+class Belief(StmtStat):
+    def __init__(self, beliefs):
+        super(Belief, self).__init__('belief', beliefs, float, MaxStats)
+
+
+def source_count_list(source_counts):
+    return StmtStat.from_dicts(source_counts, int, SumStats)
+
+
 class StmtStatGather:
     """Gather metrics for items that are derived from statements.
 

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -337,7 +337,7 @@ class StmtGroup:
 
     @classmethod
     def from_stmt_stats(cls, *stmt_stats):
-        """Create a stat gatherer from StmtStat objects.
+        """Create a stmt group from StmtStat objects.
 
         Return a StmtGroup constructed existing StmtStat objects. This
         method offers the user the most control and customizability.
@@ -358,7 +358,7 @@ class StmtGroup:
 
     @classmethod
     def from_dicts(cls, ev_counts=None, beliefs=None, source_counts=None):
-        """Init a stat gatherer from dicts keyed by hash.
+        """Init a stmt group from dicts keyed by hash.
 
         Return a StmtStatsGather constructed from the given keyword arguments.
         The dict keys of `source_counts` will be broken out into their own
@@ -794,7 +794,7 @@ def group_and_sort_statements(stmt_list, sort_by='default', custom_stats=None,
         else:
             grouped_stmts[rel_key].append((stmt.get_hash(), stmt))
 
-    # Stop filling these stat gatherers. No more "new" keys.
+    # Stop filling these stmt groups. No more "new" keys.
     relation_metrics.finish()
     if grouping_level == 'agent-pair':
         agent_pair_metrics.finish()

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -68,6 +68,28 @@ illustrated in the example below:
 >>     print(rel_key, rel_metrics['my_stat'])
 >>     for _, stmt_hash, stmt, metrics in rel_stmts:
 >>         print('\t', stmt, metrics['ev_count'])
+
+Class Overview
+--------------
+
+Statements have many metrics associated with them,
+most commonly belief, evidence counts, and source counts, although other metrics
+may also be applied, sometimes on the fly. Such metrics imply an order on the
+body of Statements, and a user should be able to apply that order to them, to
+sort them. These types of metric, or "stat", are represented by `StmtStat`
+classes.
+
+Statements can be grouped based on the information they represent: by their
+agents (e.g. subject is MEK and object is ERK), and by their type
+(e.g. Phosphorylation). These groups are represented by `StmtGroup` objects,
+which on their surface behave much like `defaultdict(list)` would, though more
+is going on behind the scenes.
+
+A user should be able to sort these groups as well. That requires that the
+`StmtStat`s be aggregated over the statements in a group. The Aggregator classes
+serve this purpose, using numpy to do sums over arrays of metrics as Statements
+are "included" in the `StmtGroup`. Each `StmtStat` must declare how its data
+should be aggregated, as different kinds of data aggregate differently.
 """
 
 import logging

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -475,6 +475,15 @@ def group_and_sort_statements(stmt_list, sort_by='default', stmt_data=None,
                 return metric['ev_count'] + 1/(1 + metric['ag_count'])
             return metric[sort_by]
     else:
+        # Check that the sort function is a valid function.
+        sample_dict = dict.fromkeys(stmt_data.list_rows(), 0)
+        try:
+            n = sort_by(sample_dict)
+            n < n
+        except Exception as e:
+            raise ValueError(f"Invalid sort function: {e}")
+
+        # Assign the function.
         _sort_func = sort_by
 
     # Sort the rows by count and agent names.

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -201,7 +201,7 @@ class StmtStatGather:
     a Statement you might wish to use in sorting them.
     """
 
-    def __init__(self, stat_groups, fill_stats=False):
+    def __init__(self, stat_groups):
 
         self.__stats = {}
         self.__filling = True

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -384,11 +384,13 @@ class BasicStats(StmtStatRow):
 
 
 class SumStats(BasicStats):
+    """A stats aggregator that executes a sum."""
     def _merge(self, metric_array):
         self._values += metric_array
 
 
 class AveStats(BasicStats):
+    """A stats aggregator averages the included statement metrics."""
     def _merge(self, metric_array):
         self._values += metric_array
 
@@ -397,6 +399,7 @@ class AveStats(BasicStats):
 
 
 class MaxStats(BasicStats):
+    """A stats aggregator that takes the max of statement metrics."""
     def _merge(self, metric_array):
         self._values = maximum(self._values, metric_array)
 

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -591,7 +591,7 @@ def group_and_sort_statements(stmt_list, sort_by='default', stmt_data=None,
 
     if grouping_level == 'agent-pair':
         def processed_rows(stmt_rows):
-            for ag_key, rel_key, stmts in stmt_rows.items():
+            for (ag_key, rel_key), stmts in stmt_rows.items():
                 verb = rel_key[0]
                 rel_m = relation_metrics[rel_key]
                 agp_m = agent_pair_metrics[ag_key]

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
-from itertools import permutations
-from numpy import array, concatenate, zeros
+from itertools import permutations, product
+from numpy import array, zeros
 
 from indra.assemblers.english import EnglishAssembler
 from indra.statements import Agent, Influence, Event, get_statement_by_name, \
@@ -340,7 +340,7 @@ def group_and_sort_statements(stmt_list, sort_by='default', metric_dict=None,
                 return _sort_func(metrics)
 
             stmts = sorted(stmts, key=stmt_sorter, reverse=True)
-            yield agent_pair_sort_key, verb, stmts, \
+            yield agent_pair_sort_key, inps, verb, stmts, \
                 agent_pair_metrics[inps].get_dict(), \
                 relation_metrics[key].get_dict()
 
@@ -350,7 +350,7 @@ def group_and_sort_statements(stmt_list, sort_by='default', metric_dict=None,
     return sorted_groups
 
 
-def make_stmt_from_sort_key(key, verb, agents=None):
+def make_stmt_from_sort_key(inps, verb, agents=None):
     """Make a Statement from the sort key.
 
     Specifically, the sort key used by `group_and_sort_statements`.
@@ -362,7 +362,6 @@ def make_stmt_from_sort_key(key, verb, agents=None):
         return Agent(name)
 
     StmtClass = get_statement_by_name(verb)
-    inps = list(key[1])
     if agents is None:
         agents = []
     if verb == 'Complex':
@@ -394,19 +393,20 @@ def stmt_to_english(stmt):
     return ea.make_model()[:-1]
 
 
-def make_string_from_sort_key(key, verb):
+def make_string_from_sort_key(inps, verb):
     """Make a Statement string via EnglishAssembler from the sort key.
 
     Specifically, the sort key used by `group_and_sort_statements`.
     """
-    stmt = make_stmt_from_sort_key(key, verb)
+    stmt = make_stmt_from_sort_key(inps, verb)
     return stmt_to_english(stmt)
 
 
 def get_simplified_stmts(stmts):
     simple_stmts = []
     for key, s in _get_relation_keyed_stmts(stmts):
-        simple_stmts.append(make_stmt_from_sort_key(key, s.__class__.__name__))
+        simple_stmts.append(make_stmt_from_sort_key(key[1:],
+                                                    s.__class__.__name__))
     return simple_stmts
 
 

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -286,6 +286,18 @@ class StmtStatGather:
                 stat_groups[stat.agg_class]['stats'][h].append(v)
         return cls(stat_groups)
 
+    @classmethod
+    def from_dicts(cls, ev_counts=None, beliefs=None, source_counts=None):
+        """Init a stat gatherer from dicts keyed by hash."""
+        stats = []
+        if ev_counts:
+            stats.append(EvCount(ev_counts))
+        if beliefs:
+            stats.append(Belief(beliefs))
+        if source_counts:
+            stats.extend(source_count_list(source_counts))
+        return cls.from_stmt_stats(*stats)
+
     def __getitem__(self, key):
         if key not in self.__stats:
             if not self.__started:

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -357,8 +357,8 @@ def group_and_sort_statements(stmt_list, sort_by='default', metric_dict=None,
     return sorted_groups
 
 
-def make_stmt_from_sort_key(inps, verb, agents=None):
-    """Make a Statement from the sort key.
+def make_stmt_from_relation_key(relation_key, agents=None):
+    """Make a Statement from the relation key.
 
     Specifically, the sort key used by `group_and_sort_statements`.
     """
@@ -368,6 +368,8 @@ def make_stmt_from_sort_key(inps, verb, agents=None):
             return None
         return Agent(name)
 
+    verb = relation_key[0]
+    inps = relation_key[1:]
     StmtClass = get_statement_by_name(verb)
     if agents is None:
         agents = []
@@ -375,6 +377,8 @@ def make_stmt_from_sort_key(inps, verb, agents=None):
         agents.extend([make_agent(name) for name in inps])
         stmt = StmtClass(agents[:])
     elif verb == 'Conversion':
+        if isinstance(inps[1], str):
+            pass
         names_from = [make_agent(name) for name in inps[1]]
         names_to = [make_agent(name) for name in inps[2]]
         agents.extend(names_from + names_to)
@@ -400,20 +404,19 @@ def stmt_to_english(stmt):
     return ea.make_model()[:-1]
 
 
-def make_string_from_sort_key(inps, verb):
+def make_string_from_sort_key(rel_key):
     """Make a Statement string via EnglishAssembler from the sort key.
 
     Specifically, the sort key used by `group_and_sort_statements`.
     """
-    stmt = make_stmt_from_sort_key(inps, verb)
+    stmt = make_stmt_from_relation_key(rel_key)
     return stmt_to_english(stmt)
 
 
 def get_simplified_stmts(stmts):
     simple_stmts = []
-    for key, s in _get_relation_keyed_stmts(stmts):
-        simple_stmts.append(make_stmt_from_sort_key(key[1:],
-                                                    s.__class__.__name__))
+    for rel_key, _, _ in _get_relation_keyed_stmts(stmts):
+        simple_stmts.append(make_stmt_from_relation_key(rel_key))
     return simple_stmts
 
 


### PR DESCRIPTION
This PR completely re-tools the `statement_presentation` module to enable sorting by arbitrary parameters, or functions of parameters, that are associated with statements and groupings of statements. The key new features are:
- Allow arbitrary data to be aggregated for groups of statements by arbitrary methods (e.g. sum, max, ave, custom model)
- Allow for sorting by any of the given parameters, e.g. 'ev_count' or 'belief'.
- Allow for sorting by an arbitrary function of the given parameters.
- Allow for arbitrary levels of statement grouping, at least at the `statement_presentation` level.

EDIT: Since the original PR, some more features have been added:
- Fix a bug in the isolated statement display's expand/collapse all feature
- Allow the collapse of statement evidence
- Allow `sort_by=None` option to maintain input order of statements. No guarantees made about the results when using this feature along with grouping by relation or agent-pair.