### PR TITLE
Grounding mapping priority

### DIFF
--- a/indra/preassembler/grounding_mapper/mapper.py
+++ b/indra/preassembler/grounding_mapper/mapper.py
@@ -170,8 +170,10 @@ class GroundingMapper(object):
                     logger.error(e)
 
             gilda_success = False
+            # Gilda is not used if agent text is in the grounding map
             if not adeft_success and self.gilda_mode and \
-                    agent_txts & set(self.gilda_models):
+               not agent_txts & set(self.grounding_map) and \
+               agent_txts & set(self.gilda_models):
                 try:
                     # Us the longest match for disambiguation
                     txt_for_gilda = sorted(agent_txts & set(self.gilda_models),

--- a/indra/tests/test_groundingmapper.py
+++ b/indra/tests/test_groundingmapper.py
@@ -501,6 +501,22 @@ def test_gilda_disambiguation_local():
     assert annotations['agents']['gilda'][1][0]['term']['db'] == 'HGNC'
 
 
+def test_grounding_map_gilda_priority():
+    gm.gilda_mode = 'web'
+    fetal_bovine_serum = Agent('FBS', db_refs={'TEXT': 'FBS'})
+    pmid = '28536624'
+    stmt = Phosphorylation(None, fetal_bovine_serum,
+                           evidence=[Evidence(pmid=pmid,
+                                              text_refs={'PMID': pmid})])
+    mapped_stmts = gm.map_stmts([stmt])
+    annotations = mapped_stmts[0].evidence[0].annotations
+    # agents should not be in annotations if gilda is run. Second condition
+    # added as future proofing in case some future change causes this mapping
+    # to add agent annotations in the future.
+    assert 'agents' not in annotations or \
+        'gilda' not in annotations['agents']
+
+
 def test_text_and_norm_text():
     gm.gilda_mode = 'local'
 


### PR DESCRIPTION
This PR changes the priority of grounding updates in the grounding mapper from Adeft > Gilda > Grounding Map, to
Adeft > Grounding Map > Gilda. This is because grounding map entries are typically manually reviewed to check for unambiguity and because some Gilda models are missing some groundings that actually appear in the wild.