### PR TITLE
Handle UPPRO and PR entries from Reach

### DIFF
--- a/indra/databases/identifiers.py
+++ b/indra/databases/identifiers.py
@@ -28,6 +28,7 @@ identifiers_mappings = {
     'PUBCHEM': 'pubchem.compound',
     'CHEMBL': 'chembl.compound',
     'CTD': 'ctd.chemical',
+    'CVCL': 'cellosaurus',
 }
 
 # These are namespaces used by INDRA that don't have corresponding

--- a/indra/sources/reach/__init__.py
+++ b/indra/sources/reach/__init__.py
@@ -36,7 +36,7 @@ reach clone folder and add
       server {
       // ...
       parsing {
-        max-uri-length = 16k
+        max-uri-length = 256k
       }
       // ...
       }

--- a/indra/sources/reach/__init__.py
+++ b/indra/sources/reach/__init__.py
@@ -25,6 +25,25 @@ Then read text by specifying the url parameter when using
    from indra.sources import reach
    rp = reach.process_text('MEK binds ERK', url=reach.local_text_url)
 
+One limitation here is that the REACH sever is configured by default to
+limit the input to 2048 characters. To change this, edit the
+file `export/src/main/resources/reference.conf` in your local
+reach clone folder and add
+
+.. code-block:: json
+
+    http {
+      server {
+      // ...
+      parsing {
+        max-uri-length = 16k
+      }
+      // ...
+      }
+    }
+
+to increase the character limit.
+
 It is also possible to read NXML (string or file) and process the text of a
 paper given its PMC ID or PubMed ID using other API methods in
 :py:mod:`indra.sources.reach.api`. Note that `reach.local_nxml_url` needs

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -449,7 +449,6 @@ class ReachProcessor(object):
                 up_id = xr['id']
                 if '#' in up_id:
                     parts = up_id.split('#')
-                    db_refs['UP'] = parts[0]
                     db_refs['UPPRO'] = parts[1]
                 else:
                     db_refs['UP'] = up_id

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -446,7 +446,13 @@ class ReachProcessor(object):
         for xr in entity_term['xrefs']:
             ns = xr['namespace']
             if ns == 'uniprot':
-                db_refs['UP'] = xr['id']
+                up_id = xr['id']
+                if '#' in up_id:
+                    parts = up_id.split('#')
+                    db_refs['UP'] = parts[0]
+                    db_refs['UPPRO'] = parts[1]
+                else:
+                    db_refs['UP'] = up_id
             elif ns == 'hgnc':
                 db_refs['HGNC'] = xr['id']
             elif ns == 'pfam':
@@ -480,6 +486,8 @@ class ReachProcessor(object):
             # We handle "be" here for compatibility with older versions
             elif ns in ('fplx', 'be'):
                 db_refs['FPLX'] = xr['id']
+            elif ns == 'proonto':
+                db_refs['PR'] = xr['id']
             # These name spaces are ignored
             elif ns in ['uaz']:
                 pass

--- a/indra/statements/evidence.py
+++ b/indra/statements/evidence.py
@@ -212,6 +212,8 @@ class Evidence(object):
             _format_dict(self.context.to_json(), 'context')
         if self.epistemics:
             _format_dict(self.epistemics, 'epistemics')
+        if self.text_refs:
+            _format_dict(self.text_refs, 'text_refs')
 
         div = ',\n' + ' '*9
         ev_str += div.join(lines)


### PR DESCRIPTION
This PR adapts to recent additions to Reach for extracting entities grounded to PR or UPPRO. It also makes some other small changes like display text_refs in the Evidence string representation which has been missing.