### PR TITLE
Organism prioritization in Reach processor

### DIFF
--- a/indra/sources/reach/api.py
+++ b/indra/sources/reach/api.py
@@ -33,7 +33,8 @@ default_output_fname = 'reach_output.json'
 
 
 def process_pmc(pmc_id, offline=False, url=None,
-                output_fname=default_output_fname):
+                output_fname=default_output_fname,
+                organism_priority=None):
     """Return a ReachProcessor by processing a paper with a given PMC id.
 
     Uses the PMC client to obtain the full text. If it's not available,
@@ -82,7 +83,8 @@ def process_pmc(pmc_id, offline=False, url=None,
     # Now process the NXML file with the provided arguments
     logger.info('Processing %s with REACH' % pmc_id)
     rp = process_nxml_file(fname, citation=pmid, offline=offline, url=url,
-                           output_fname=output_fname)
+                           output_fname=output_fname,
+                           organism_priority=organism_priority)
     return rp
 
 
@@ -138,7 +140,8 @@ def process_pubmed_abstract(pubmed_id, offline=False, url=None,
 
 
 def process_text(text, citation=None, offline=False, url=None,
-                 output_fname=default_output_fname, timeout=None):
+                 output_fname=default_output_fname, timeout=None,
+                 organism_priority=None):
     """Return a ReachProcessor by processing the given text.
 
     Parameters
@@ -183,11 +186,13 @@ def process_text(text, citation=None, offline=False, url=None,
     if json_str:
         with open(output_fname, 'wb') as fh:
             fh.write(json_str)
-        return process_json_str(json_str.decode('utf-8'), citation)
+        return process_json_str(json_str.decode('utf-8'), citation=citation,
+                                organism_priority=organism_priority)
 
 
 def process_nxml_str(nxml_str, citation=None, offline=False,
-                     url=None, output_fname=default_output_fname):
+                     url=None, output_fname=default_output_fname,
+                     organism_priority=None):
     """Return a ReachProcessor by processing the given NXML string.
 
     NXML is the format used by PubmedCentral for papers in the open
@@ -241,11 +246,13 @@ def process_nxml_str(nxml_str, citation=None, offline=False,
     if json_str:
         with open(output_fname, 'wb') as fh:
             fh.write(json_str)
-        return process_json_str(json_str.decode('utf-8'), citation)
+        return process_json_str(json_str.decode('utf-8'), citation=citation,
+                                organism_priority=organism_priority)
 
 
 def process_nxml_file(file_name, citation=None, offline=False,
-                      url=None, output_fname=default_output_fname):
+                      url=None, output_fname=default_output_fname,
+                      organism_priority=None):
     """Return a ReachProcessor by processing the given NXML file.
 
     NXML is the format used by PubmedCentral for papers in the open
@@ -292,10 +299,11 @@ def process_nxml_file(file_name, citation=None, offline=False,
     if json_str:
         with open(output_fname, 'wb') as fh:
             fh.write(json_str)
-        return process_json_str(json_str.decode('utf-8'), citation)
+        return process_json_str(json_str.decode('utf-8'), citation=citation,
+                                organism_priority=organism_priority)
 
 
-def process_json_file(file_name, citation=None):
+def process_json_file(file_name, citation=None, organism_priority=None):
     """Return a ReachProcessor by processing the given REACH json file.
 
     The output from the REACH parser is in this json format. This function is
@@ -319,12 +327,13 @@ def process_json_file(file_name, citation=None):
     try:
         with open(file_name, 'rb') as fh:
             json_str = fh.read().decode('utf-8')
-            return process_json_str(json_str, citation)
+            return process_json_str(json_str, citation=citation,
+                                    organism_priority=organism_priority)
     except IOError:
         logger.error('Could not read file %s.' % file_name)
 
 
-def process_json_str(json_str, citation=None):
+def process_json_str(json_str, citation=None, organism_priority=None):
     """Return a ReachProcessor by processing the given REACH json string.
 
     The output from the REACH parser is in this json format.
@@ -355,7 +364,8 @@ def process_json_str(json_str, citation=None):
         logger.error('Could not decode JSON string.')
         logger.exception(e)
         return None
-    rp = ReachProcessor(json_dict, citation)
+    rp = ReachProcessor(json_dict, pmid=citation,
+                        organism_priority=organism_priority)
     rp.get_modifications()
     rp.get_complexes()
     rp.get_activation()

--- a/indra/sources/reach/api.py
+++ b/indra/sources/reach/api.py
@@ -59,6 +59,11 @@ def process_pmc(pmc_id, offline=False, url=None,
     output_fname : Optional[str]
         The file to output the REACH JSON output to.
         Defaults to reach_output.json in current working directory.
+    organism_priority : Optional[list of str]
+        A list of Taxonomy IDs providing prioritization among organisms
+        when choosing protein grounding. If not given, the default behavior
+        takes the first match produced by Reach, which is prioritized to be
+        a human protein if such a match exists.
 
     Returns
     -------
@@ -114,6 +119,11 @@ def process_pubmed_abstract(pubmed_id, offline=False, url=None,
     output_fname : Optional[str]
         The file to output the REACH JSON output to.
         Defaults to reach_output.json in current working directory.
+    organism_priority : Optional[list of str]
+        A list of Taxonomy IDs providing prioritization among organisms
+        when choosing protein grounding. If not given, the default behavior
+        takes the first match produced by Reach, which is prioritized to be
+        a human protein if such a match exists.
     **kwargs : keyword arguments
         All other keyword arguments are passed directly to `process_text`.
 
@@ -167,6 +177,11 @@ def process_text(text, citation=None, offline=False, url=None,
     timeout : Optional[float]
         This only applies when reading online (`offline=False`). Only wait for
         `timeout` seconds for the api to respond.
+    organism_priority : Optional[list of str]
+        A list of Taxonomy IDs providing prioritization among organisms
+        when choosing protein grounding. If not given, the default behavior
+        takes the first match produced by Reach, which is prioritized to be
+        a human protein if such a match exists.
 
     Returns
     -------
@@ -217,6 +232,11 @@ def process_nxml_str(nxml_str, citation=None, offline=False,
     output_fname : Optional[str]
         The file to output the REACH JSON output to.
         Defaults to reach_output.json in current working directory.
+    organism_priority : Optional[list of str]
+        A list of Taxonomy IDs providing prioritization among organisms
+        when choosing protein grounding. If not given, the default behavior
+        takes the first match produced by Reach, which is prioritized to be
+        a human protein if such a match exists.
 
     Returns
     -------
@@ -277,6 +297,11 @@ def process_nxml_file(file_name, citation=None, offline=False,
     output_fname : Optional[str]
         The file to output the REACH JSON output to.
         Defaults to reach_output.json in current working directory.
+    organism_priority : Optional[list of str]
+        A list of Taxonomy IDs providing prioritization among organisms
+        when choosing protein grounding. If not given, the default behavior
+        takes the first match produced by Reach, which is prioritized to be
+        a human protein if such a match exists.
 
     Returns
     -------
@@ -317,6 +342,11 @@ def process_json_file(file_name, citation=None, organism_priority=None):
     citation : Optional[str]
         A PubMed ID passed to be used in the evidence for the extracted INDRA
         Statements. Default: None
+    organism_priority : Optional[list of str]
+        A list of Taxonomy IDs providing prioritization among organisms
+        when choosing protein grounding. If not given, the default behavior
+        takes the first match produced by Reach, which is prioritized to be
+        a human protein if such a match exists.
 
     Returns
     -------
@@ -346,6 +376,11 @@ def process_json_str(json_str, citation=None, organism_priority=None):
     citation : Optional[str]
         A PubMed ID passed to be used in the evidence for the extracted INDRA
         Statements. Default: None
+    organism_priority : Optional[list of str]
+        A list of Taxonomy IDs providing prioritization among organisms
+        when choosing protein grounding. If not given, the default behavior
+        takes the first match produced by Reach, which is prioritized to be
+        a human protein if such a match exists.
 
     Returns
     -------

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -965,13 +965,13 @@ def determine_reach_subtype(event_name):
 def prioritize_organism_grounding(first_id, xrefs, organism_priority):
     """Pick a prioritized organism-specific UniProt ID for a protein."""
     # We find the organism for the first ID picked by Reach
-    first_organism = uniprot_client.get_organism_id(first_id)
+    first_organism = uniprot_client.get_organism_id(first_id.split('#')[0])
     # We take only UniProt groundings from the xrefs list
     uniprot_ids = [xr[1] for xr in xrefs if xr[0] == 'uniprot']
     # We group UniProt IDs by their organism ID
     groundings_by_organism = defaultdict(list)
     for up_id in uniprot_ids:
-        organism_id = uniprot_client.get_organism_id(up_id)
+        organism_id = uniprot_client.get_organism_id(up_id.split('#')[0])
         groundings_by_organism[organism_id].append(up_id)
     # We then go down the list of prioritized organisms and if we find a match
     # we return immediately

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -448,7 +448,7 @@ class ReachProcessor(object):
         return agent, coords
 
     @staticmethod
-    def _get_db_refs(entity_term, organism_priority):
+    def _get_db_refs(entity_term, organism_priority=None):
         db_refs = {}
         for xr in entity_term['xrefs']:
             ns = xr['namespace']

--- a/indra/tests/reach_uppro_organisms.json
+++ b/indra/tests/reach_uppro_organisms.json
@@ -1,0 +1,379 @@
+{
+  "events" : {
+    "frames" : [ {
+      "frame-id" : "evem-api14-UAZ-r1-Reach-0-673",
+      "text" : "bradykinin leads to inflammation",
+      "arguments" : [ {
+        "text" : "inflammation",
+        "argument-type" : "entity",
+        "type" : "controlled",
+        "object-type" : "argument",
+        "index" : 0,
+        "arg" : "ment-api14-UAZ-r1-Reach-0-7834"
+      }, {
+        "text" : "bradykinin",
+        "argument-type" : "entity",
+        "type" : "controller",
+        "object-type" : "argument",
+        "index" : 0,
+        "arg" : "ment-api14-UAZ-r1-Reach-0-7833"
+      } ],
+      "type" : "activation",
+      "frame-type" : "event-mention",
+      "subtype" : "positive-activation",
+      "is-direct" : false,
+      "end-pos" : {
+        "reference" : "pass-api14-UAZ-r1-Reach",
+        "offset" : 32,
+        "object-type" : "relative-pos"
+      },
+      "trigger" : "leads",
+      "object-type" : "frame",
+      "start-pos" : {
+        "reference" : "pass-api14-UAZ-r1-Reach",
+        "offset" : 0,
+        "object-type" : "relative-pos"
+      },
+      "sentence" : "sent-api14-UAZ-r1-Reach-0",
+      "found-by" : "Positive_activation_syntax_7_verb",
+      "verbose-text" : "bradykinin leads to inflammation"
+    } ],
+    "object-type" : "frame-collection",
+    "object-meta" : {
+      "processing-end" : "2020-12-20T03:20:47Z",
+      "doc-id" : "api14",
+      "component-type" : "machine",
+      "component" : "Reach",
+      "processing-start" : "2020-12-20T03:20:47Z",
+      "object-type" : "meta-info",
+      "organization" : "UAZ"
+    }
+  },
+  "entities" : {
+    "frames" : [ {
+      "text" : "bradykinin",
+      "frame-id" : "ment-api14-UAZ-r1-Reach-0-7833",
+      "type" : "protein",
+      "frame-type" : "entity-mention",
+      "end-pos" : {
+        "reference" : "pass-api14-UAZ-r1-Reach",
+        "offset" : 10,
+        "object-type" : "relative-pos"
+      },
+      "xrefs" : [ {
+        "namespace" : "uniprot",
+        "species" : "homo sapiens",
+        "object-type" : "db-reference",
+        "id" : "P01042#PRO_0000006688"
+      } ],
+      "object-type" : "frame",
+      "start-pos" : {
+        "reference" : "pass-api14-UAZ-r1-Reach",
+        "offset" : 0,
+        "object-type" : "relative-pos"
+      },
+      "sentence" : "sent-api14-UAZ-r1-Reach-0",
+      "alt-xrefs" : [ {
+        "namespace" : "uniprot",
+        "species" : "human",
+        "object-type" : "db-reference",
+        "id" : "P01042#PRO_0000006688"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "anarhichas minor",
+        "object-type" : "db-reference",
+        "id" : "P83857#PRO_0000006707"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "arctic spotted wolffish",
+        "object-type" : "db-reference",
+        "id" : "P83857#PRO_0000006707"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "ascaphus truei",
+        "object-type" : "db-reference",
+        "id" : "P84825"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "atlantic cod",
+        "object-type" : "db-reference",
+        "id" : "P83856#PRO_0000006708"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bombina maxima",
+        "object-type" : "db-reference",
+        "id" : "P83055#PRO_0000003427"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bombina maxima",
+        "object-type" : "db-reference",
+        "id" : "Q7T3L1#PRO_0000003387"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bombina maxima",
+        "object-type" : "db-reference",
+        "id" : "Q90W88#PRO_0000003418"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bombina maxima",
+        "object-type" : "db-reference",
+        "id" : "Q90WZ1#PRO_0000003405"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bombina orientalis",
+        "object-type" : "db-reference",
+        "id" : "P83060#PRO_0000003430"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bos taurus",
+        "object-type" : "db-reference",
+        "id" : "P01044#PRO_0000006678"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bos taurus",
+        "object-type" : "db-reference",
+        "id" : "P01045#PRO_0000006683"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bovine",
+        "object-type" : "db-reference",
+        "id" : "P01044#PRO_0000006678"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "bovine",
+        "object-type" : "db-reference",
+        "id" : "P01045#PRO_0000006683"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "chinese red belly toad",
+        "object-type" : "db-reference",
+        "id" : "P83055#PRO_0000003427"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "chinese red belly toad",
+        "object-type" : "db-reference",
+        "id" : "Q7T3L1#PRO_0000003387"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "chinese red belly toad",
+        "object-type" : "db-reference",
+        "id" : "Q90W88#PRO_0000003418"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "chinese red belly toad",
+        "object-type" : "db-reference",
+        "id" : "Q90WZ1#PRO_0000003405"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "coastal tailed frog",
+        "object-type" : "db-reference",
+        "id" : "P84825"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "cuyaba dwarf frog",
+        "object-type" : "db-reference",
+        "id" : "A0A088MIT0#PRO_0000438954"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "eupemphix nattereri",
+        "object-type" : "db-reference",
+        "id" : "A0A088MIT0#PRO_0000438954"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "gadus morhua",
+        "object-type" : "db-reference",
+        "id" : "P83856#PRO_0000006708"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "giant fire-bellied toad",
+        "object-type" : "db-reference",
+        "id" : "P83055#PRO_0000003427"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "giant fire-bellied toad",
+        "object-type" : "db-reference",
+        "id" : "Q7T3L1#PRO_0000003387"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "giant fire-bellied toad",
+        "object-type" : "db-reference",
+        "id" : "Q90W88#PRO_0000003418"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "giant fire-bellied toad",
+        "object-type" : "db-reference",
+        "id" : "Q90WZ1#PRO_0000003405"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "golden silk orbweaver",
+        "object-type" : "db-reference",
+        "id" : "P0DM76"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "jandaia leaf frog",
+        "object-type" : "db-reference",
+        "id" : "P86627"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "marsh frog",
+        "object-type" : "db-reference",
+        "id" : "P86156#PRO_0000361082"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "mouse",
+        "object-type" : "db-reference",
+        "id" : "O08677#PRO_0000006693"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "mus musculus",
+        "object-type" : "db-reference",
+        "id" : "O08677#PRO_0000006693"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "nephila clavipes",
+        "object-type" : "db-reference",
+        "id" : "P0DM76"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "orange-legged leaf frog",
+        "object-type" : "db-reference",
+        "id" : "P84895"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "oriental fire-bellied toad",
+        "object-type" : "db-reference",
+        "id" : "P83060#PRO_0000003430"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "pelophylax ridibundus",
+        "object-type" : "db-reference",
+        "id" : "P86156#PRO_0000361082"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "phasmahyla jandaia",
+        "object-type" : "db-reference",
+        "id" : "P86627"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "phyllomedusa hypochondrialis",
+        "object-type" : "db-reference",
+        "id" : "P84895"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "phyllomedusa sauvagei",
+        "object-type" : "db-reference",
+        "id" : "P84697#PRO_0000043220"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "physalaemus nattereri",
+        "object-type" : "db-reference",
+        "id" : "A0A088MIT0#PRO_0000438954"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "rana ridibunda",
+        "object-type" : "db-reference",
+        "id" : "P86156#PRO_0000361082"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "rat",
+        "object-type" : "db-reference",
+        "id" : "P08934#PRO_0000006697"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "rattus norvegicus",
+        "object-type" : "db-reference",
+        "id" : "P08934#PRO_0000006697"
+      }, {
+        "namespace" : "uniprot",
+        "species" : "sauvage's leaf frog",
+        "object-type" : "db-reference",
+        "id" : "P84697#PRO_0000043220"
+      } ]
+    }, {
+      "text" : "inflammation",
+      "frame-id" : "ment-api14-UAZ-r1-Reach-0-7834",
+      "type" : "bioprocess",
+      "frame-type" : "entity-mention",
+      "end-pos" : {
+        "reference" : "pass-api14-UAZ-r1-Reach",
+        "offset" : 32,
+        "object-type" : "relative-pos"
+      },
+      "xrefs" : [ {
+        "namespace" : "go",
+        "species" : "human",
+        "object-type" : "db-reference",
+        "id" : "GO:0006954"
+      } ],
+      "object-type" : "frame",
+      "start-pos" : {
+        "reference" : "pass-api14-UAZ-r1-Reach",
+        "offset" : 20,
+        "object-type" : "relative-pos"
+      },
+      "sentence" : "sent-api14-UAZ-r1-Reach-0",
+      "alt-xrefs" : [ {
+        "namespace" : "go",
+        "species" : "human",
+        "object-type" : "db-reference",
+        "id" : "GO:0006954"
+      } ]
+    } ],
+    "object-type" : "frame-collection",
+    "object-meta" : {
+      "processing-end" : "2020-12-20T03:20:47Z",
+      "doc-id" : "api14",
+      "component-type" : "machine",
+      "component" : "Reach",
+      "processing-start" : "2020-12-20T03:20:47Z",
+      "object-type" : "meta-info",
+      "organization" : "UAZ"
+    }
+  },
+  "sentences" : {
+    "frames" : [ {
+      "text" : "bradykinin leads to inflammation",
+      "frame-id" : "pass-api14-UAZ-r1-Reach",
+      "section-id" : "NoSection",
+      "frame-type" : "passage",
+      "is-title" : false,
+      "section-name" : "NoSection",
+      "object-type" : "frame",
+      "index" : "Reach",
+      "object-meta" : {
+        "component" : "nxml2fries",
+        "object-type" : "meta-info"
+      }
+    }, {
+      "text" : "bradykinin leads to inflammation",
+      "frame-id" : "sent-api14-UAZ-r1-Reach-0",
+      "passage" : "pass-api14-UAZ-r1-Reach",
+      "frame-type" : "sentence",
+      "end-pos" : {
+        "reference" : "pass-api14-UAZ-r1-Reach",
+        "offset" : 32,
+        "object-type" : "relative-pos"
+      },
+      "object-type" : "frame",
+      "start-pos" : {
+        "reference" : "pass-api14-UAZ-r1-Reach",
+        "offset" : 0,
+        "object-type" : "relative-pos"
+      },
+      "object-meta" : {
+        "component" : "BioNLPProcessor",
+        "object-type" : "meta-info"
+      }
+    } ],
+    "object-type" : "frame-collection",
+    "object-meta" : {
+      "processing-end" : "2020-12-20T03:20:47Z",
+      "doc-id" : "api14",
+      "component-type" : "machine",
+      "component" : "Reach",
+      "processing-start" : "2020-12-20T03:20:47Z",
+      "object-type" : "meta-info",
+      "organization" : "UAZ"
+    }
+  }
+}

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -486,9 +486,23 @@ def test_phosphorylation_regulation():
 def test_organism_prioritization():
     here = os.path.dirname(os.path.abspath(__file__))
     test_file = os.path.join(here, 'reach_reg_phos.json')
-    rp = reach.process_json_file(test_file)
-    assert rp is not None
-    assert len(rp.statements) == 1
-    stmt = rp.statements[0]
-    assert isinstance(stmt, Phosphorylation), stmt
-    assert not stmt.sub.mods
+
+    def process(organism_priority, expected_up_id):
+        rp = reach.process_json_file(test_file,
+                                     organism_priority=organism_priority)
+        assert rp.statements[0].enz.db_refs['UP'] == expected_up_id, \
+            rp.statements[0].enz.db_refs['UP']
+
+    # These should all default to the Human protein being prioritized
+    process(None, 'P05019')
+    process(['9606'], 'P05019')
+    # Here we prioritize xenopus
+    process(['8355'], 'P16501')
+    # We now use a list of priorities
+    process(['8355', '9606'], 'P16501')
+    process(['9606', '8355'], 'P05019')
+    # Here 1513314 is not an available organism in the list of groundings
+    process(['1513314'], 'P05019')
+    process(['1513314', '9606'], 'P05019')
+    process(['1513314', '8355'], 'P16501')
+

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -481,3 +481,14 @@ def test_phosphorylation_regulation():
     stmt = rp.statements[0]
     assert isinstance(stmt, Phosphorylation), stmt
     assert not stmt.sub.mods
+
+
+def test_organism_prioritization():
+    here = os.path.dirname(os.path.abspath(__file__))
+    test_file = os.path.join(here, 'reach_reg_phos.json')
+    rp = reach.process_json_file(test_file)
+    assert rp is not None
+    assert len(rp.statements) == 1
+    stmt = rp.statements[0]
+    assert isinstance(stmt, Phosphorylation), stmt
+    assert not stmt.sub.mods

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -501,8 +501,32 @@ def test_organism_prioritization():
     # We now use a list of priorities
     process(['8355', '9606'], 'P16501')
     process(['9606', '8355'], 'P05019')
-    # Here 1513314 is not an available organism in the list of groundings
+    # Here Arctic fox amdovirus (1513314) is not an available organism
+    # in the list of groundings so we expect prioritization to fall back
+    # correctly to the first match or another organism in the list
     process(['1513314'], 'P05019')
     process(['1513314', '9606'], 'P05019')
     process(['1513314', '8355'], 'P16501')
 
+
+def test_organism_prioritization_uppro():
+    here = os.path.dirname(os.path.abspath(__file__))
+    test_file = os.path.join(here, 'reach_uppro_organisms.json')
+
+    def process(organism_priority, expected_up_id):
+        rp = reach.process_json_file(test_file,
+                                     organism_priority=organism_priority)
+        assert rp.statements[0].subj.db_refs['UPPRO'] == expected_up_id, \
+            rp.statements[0].subj.db_refs['UPPRO']
+
+    # This is the human protein chain
+    process(None, 'PRO_0000006688')
+    process(['9606'], 'PRO_0000006688')
+    process(['9606', '161274'], 'PRO_0000006688')
+    # Let's try the giant fire-bellied toad next
+    process(['161274'], 'PRO_0000003387')
+    process(['161274', '9606'], 'PRO_0000003427')
+    # Now someting non-existent
+    process(['1513314'], 'PRO_0000006688')
+    process(['1513314', '9606'], 'PRO_0000006688')
+    process(['1513314', '161274'], 'PRO_0000003427')

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -524,9 +524,10 @@ def test_organism_prioritization_uppro():
     process(['9606'], 'PRO_0000006688')
     process(['9606', '161274'], 'PRO_0000006688')
     # Let's try the giant fire-bellied toad next
-    process(['161274'], 'PRO_0000003387')
+    process(['161274'], 'PRO_0000003427')
     process(['161274', '9606'], 'PRO_0000003427')
-    # Now someting non-existent
+    # Now someting non-existent in the groundings to test correct
+    # fallback behavior
     process(['1513314'], 'PRO_0000006688')
     process(['1513314', '9606'], 'PRO_0000006688')
     process(['1513314', '161274'], 'PRO_0000003427')

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def main():
     install_list = ['pysb>=1.3.0,<=1.9.1', 'objectpath', 'rdflib==4.2.2',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
                     'networkx>=2', 'pandas', 'ndex2==2.0.1', 'jinja2',
-                    'protmapper>=0.0.16', 'obonet', 'sympy==1.3',
+                    'protmapper>=0.0.19', 'obonet', 'sympy==1.3',
                     'tqdm', 'pybiopax>=0.0.5']
 
     extras_require = {


### PR DESCRIPTION
This PR implements handling user-supplied organism prioritization when processing Reach output. Reach supplies both an `xrefs` (typically a single element) and an `alt-xrefs` list of groundings for entities it extracts. In the case of proteins, `xrefs` is prioritized to be a human protein and `alt-xrefs` is a (sometimes long) list of alternative matches to proteins that can sometimes include other human proteins or non-human proteins. Before this PR, we didn't make use of the `alt-xrefs` list, and instead took what was given in `xrefs`.

This PR adds an optional `organism_priority` argument to the REACH API functions and the Processor class which allows re-prioritizing organisms when extracting the UniProt ID for proteins in the given reading/processing call. The `organism_priority` is a list of Taxonomy IDs which https://github.com/indralab/protmapper/pull/32 allows checking for each protein in the grounding list to choose the prioritized one.