### PR TITLE
Extend HTML statement header width

### DIFF
--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -309,7 +309,7 @@
     <div class="row super_group_heading"
          id="tl-{{ results['html_key'] }}"
          onclick="toggler('tl-{{ results['html_key'] }}')">
-      <div class="col nvp">
+      <div class="col-auto nvp">
         <h5 class="align-middle">{{ results['label'] }}</h5>
       </div>
       <div class="col text-right nvp">
@@ -340,7 +340,7 @@
               <div class="row group_heading"
                    onclick="toggler('{{ group_dict['short_name_key'] }}');"
                    id="{{ group_dict['short_name_key'] }}_heading">
-                <div class="col text-left nvp">
+                <div class="col-auto text-left nvp">
                     <h5>{{ group_dict['short_name'] }}</h5>
                 </div>
                 <div class="col text-right nvp">


### PR DESCRIPTION
This PR changes the column class of headers in the HTML assembler template from `col` to `col-auto` to allow wider headings to extend beyond the center.

Before:
![image](https://user-images.githubusercontent.com/5939016/105131301-a98bef00-5ab6-11eb-8765-9763f1da6f6e.png)

After:
![image](https://user-images.githubusercontent.com/5939016/105131263-9547f200-5ab6-11eb-8053-214ca881db22.png)

I am not sure, however, if this has unintended consequences so have to think about that before merging.
