### PR TITLE
Get more complex titles

### DIFF
--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -264,7 +264,7 @@ def _get_title_from_article_element(article):
     if title_tag is not None:
         title = title_tag.text
         if hasattr(title_tag, 'itertext'):
-            title = ' '.join(list(title_tag.itertext()))
+            title = ''.join(list(title_tag.itertext()))
     return title
 
 

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -263,7 +263,7 @@ def _get_title_from_article_element(article):
     title = None
     if title_tag is not None:
         title = title_tag.text
-        if title is None and hasattr(title_tag, 'itertext'):
+        if hasattr(title_tag, 'itertext'):
             title = ' '.join(list(title_tag.itertext()))
     return title
 

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -75,6 +75,14 @@ def test_get_title_prefix():
 
 
 @attr('webservice')
+def test_get_complex_title():
+    time.sleep(0.5)
+    title = pubmed_client.get_title('33463523')
+    assert title
+    assert title.lower().startswith('atomic structures')
+    assert title.lower().endswith('vascular plants.')
+
+@attr('webservice')
 def test_expand_pagination():
     time.sleep(0.5)
     pages = '456-7'


### PR DESCRIPTION
This PR fixes an edge case in pubmed_client when we need to iterate to get full title even when the tag.text contains some text.