### PR TITLE
Catch underflow error in simple_scorer

### DIFF
--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -319,7 +319,17 @@ def _simple_scorer_update(G, edge):
                 s = k
             for _ in range(v):
                 evidence_list.append(Evidence(source_api=s))
-    return simple_scorer.score_statement(st=Statement(evidence=evidence_list))
+
+    try:
+        ag_belief = simple_scorer.score_statement(st=Statement(evidence=evidence_list))
+    # Catch underflow
+    except FloatingPointError as err:
+        # Numpy precision
+        NP_PRECISION = 10 ** -np.finfo(np.longfloat).precision
+        logger.warning('%s: Resetting ag_belief to 10*np.longfloat precision '
+                       '(%.0e)' % (err, Decimal(NP_PRECISION * 10)))
+        ag_belief = NP_PRECISION * 10
+    return ag_belief
 
 
 def _complementary_belief(G, edge):


### PR DESCRIPTION
I ran into underflow errors when calculating belief over the IndraNet built from the Bioexp paper statements using the SimpleScorer (for combining belief from the multiple edges between a pair of nodes). This catches the error and resets the combined belief following the same logic as the complementary_belief fucntion.