### PR TITLE
Fix bug in preassembly splitting.

### DIFF
--- a/indra/preassembler/__init__.py
+++ b/indra/preassembler/__init__.py
@@ -395,7 +395,7 @@ class Preassembler(object):
         if split_idx:
             # This dict maps statement hashes to a bool value based on which
             # of the two groups the statement belongs to.
-            hash_to_split_group = {sh: (idx <= split_idx) for sh, idx
+            hash_to_split_group = {sh: (idx < split_idx) for sh, idx
                                    in stmt_to_idx.items()}
         else:
             hash_to_split_group = None

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -1020,7 +1020,7 @@ def test_split_idx():
     assert (2, 0) in maps, maps
     assert pa._comparison_counter == 2
     pa = Preassembler(bio_ontology)
-    maps = pa._generate_id_maps([st1, st2, st3], split_idx=1)
+    maps = pa._generate_id_maps([st1, st2, st3], split_idx=2)
     assert (2, 0) in maps, maps
     assert (1, 0) not in maps, maps
     assert pa._comparison_counter == 1


### PR DESCRIPTION
Fix a minor bug in the preassembly code in which `<=` was used in place of `<`, causing a few statements at the edge to not be compared appropriately. This bug was discovered over the course of resurrecting database test code,