### PR TITLE
Hypothes.is annotations from INDRA Statements

### DIFF
--- a/doc/modules/tools/index.rst
+++ b/doc/modules/tools/index.rst
@@ -8,6 +8,12 @@ Run assembly components in a pipeline (:py:mod:`indra.tools.assemble_corpus`)
 .. automodule:: indra.tools.assemble_corpus
     :members:
 
+Annotate websites with INDRA through hypothes.is (:py:mod:`indra.tools.hypothesis_annotator`)
+---------------------------------------------------------------------------------------------
+
+.. automodule:: indra.tools.hypothesis_annotator
+    :members:
+
 Build a network from a gene list (:py:mod:`indra.tools.gene_network`)
 ---------------------------------------------------------------------
 

--- a/indra/sources/hypothesis/annotator.py
+++ b/indra/sources/hypothesis/annotator.py
@@ -1,0 +1,58 @@
+from indra.assemblers.english import EnglishAssembler
+from indra.databases import identifiers
+from indra.statements.agent import get_grounding, default_ns_order
+
+
+grounding_ns = default_ns_order + \
+    ['NCIT', 'PUBCHEM', 'CHEMBL']
+
+
+def statement_to_annotations(stmt, annotate_agents=True):
+    annotation_text = get_annotation_text(stmt,
+                                          annotate_agents=annotate_agents)
+    annotations = []
+    for ev in stmt.evidence:
+        annot = evidence_to_annotation(ev)
+        if annot is None:
+            continue
+        annot['annotation'] = annotation_text
+        annotations.append(annot)
+    return annotations
+
+
+def evidence_to_annotation(evidence):
+    if not evidence.text:
+        return None
+
+    if 'PMCID' in evidence.text_refs:
+        url = 'https://www.ncbi.nlm.nih.gov/pmc/articles/%s/' % \
+            evidence.text_refs['PMCID']
+    elif evidence.pmid:
+        url = 'https://pubmed.ncbi.nlm.nih.gov/%s/' % evidence.pmid
+    else:
+        return None
+    return {
+        'url': url,
+        'target_text': evidence.text
+    }
+
+
+def get_annotation_text(stmt, annotate_agents=True):
+    ea = EnglishAssembler(stmts=[stmt])
+    annotation_text = ea.make_model()
+    if annotate_agents:
+        inserts = []
+        for agent_wc in ea.stmt_agents[0]:
+            for insert_begin, insert_len in inserts:
+                if insert_begin < agent_wc.coords[0]:
+                    agent_wc.update_coords(insert_len)
+            db_ns, db_id = get_grounding(agent_wc.db_refs)
+            if not db_ns:
+                continue
+            grounding_text = '[%s:%s]' % (db_ns, db_id)
+            inserts.append((agent_wc.coords[1], len(grounding_text)))
+            before_part = annotation_text[:agent_wc.coords[1]]
+            after_part = annotation_text[agent_wc.coords[1]:]
+            annotation_text = ''.join([before_part, grounding_text,
+                                       after_part])
+    return annotation_text

--- a/indra/sources/hypothesis/annotator.py
+++ b/indra/sources/hypothesis/annotator.py
@@ -31,6 +31,8 @@ def evidence_to_annotation(evidence):
             evidence.text_refs['PMCID']
     elif evidence.pmid:
         url = 'https://pubmed.ncbi.nlm.nih.gov/%s/' % evidence.pmid
+    elif 'URL' in evidence.text_refs:
+        url = evidence.text_refs['URL']
     else:
         return None
     return {

--- a/indra/sources/hypothesis/annotator.py
+++ b/indra/sources/hypothesis/annotator.py
@@ -33,7 +33,8 @@ def evidence_to_annotation(evidence):
         return None
     return {
         'url': url,
-        'target_text': evidence.text
+        'target_text': evidence.text,
+        'tags': [evidence.source_api]
     }
 
 

--- a/indra/sources/hypothesis/annotator.py
+++ b/indra/sources/hypothesis/annotator.py
@@ -1,3 +1,5 @@
+__all__ = ['statement_to_annotations']
+
 from indra.assemblers.english import EnglishAssembler
 from indra.databases import identifiers
 from indra.statements.agent import get_grounding, default_ns_order

--- a/indra/sources/hypothesis/annotator.py
+++ b/indra/sources/hypothesis/annotator.py
@@ -46,12 +46,17 @@ def get_annotation_text(stmt, annotate_agents=True):
             for insert_begin, insert_len in inserts:
                 if insert_begin < agent_wc.coords[0]:
                     agent_wc.update_coords(insert_len)
-            db_ns, db_id = get_grounding(agent_wc.db_refs)
+            db_ns, db_id = get_grounding(agent_wc.db_refs,
+                                         grounding_ns)
             if not db_ns:
                 continue
-            grounding_text = '[%s:%s]' % (db_ns, db_id)
-            inserts.append((agent_wc.coords[1], len(grounding_text)))
-            before_part = annotation_text[:agent_wc.coords[1]]
+            identifiers_url = \
+                identifiers.get_identifiers_url(db_ns, db_id)
+            grounding_text = '[%s](%s)' % (agent_wc.name, identifiers_url)
+            insert_len = len(grounding_text) - agent_wc.coords[1] + \
+                agent_wc.coords[0]
+            inserts.append((agent_wc.coords[0], insert_len))
+            before_part = annotation_text[:agent_wc.coords[0]]
             after_part = annotation_text[agent_wc.coords[1]:]
             annotation_text = ''.join([before_part, grounding_text,
                                        after_part])

--- a/indra/sources/hypothesis/annotator.py
+++ b/indra/sources/hypothesis/annotator.py
@@ -26,12 +26,12 @@ def evidence_to_annotation(evidence):
     if not evidence.text:
         return None
 
-    if 'PMCID' in evidence.text_refs:
+    if evidence.text_refs.get('PMCID'):
         url = 'https://www.ncbi.nlm.nih.gov/pmc/articles/%s/' % \
             evidence.text_refs['PMCID']
     elif evidence.pmid:
         url = 'https://pubmed.ncbi.nlm.nih.gov/%s/' % evidence.pmid
-    elif 'URL' in evidence.text_refs:
+    elif evidence.text_refs.get('URL'):
         url = evidence.text_refs['URL']
     else:
         return None

--- a/indra/sources/hypothesis/api.py
+++ b/indra/sources/hypothesis/api.py
@@ -1,4 +1,5 @@
-__all__ = ['process_annotations', 'get_annotations']
+__all__ = ['process_annotations', 'get_annotations', 'upload_annotation',
+           'upload_statement_annotation', 'statement_to_annotations']
 
 import requests
 from indra.config import get_config

--- a/indra/sources/hypothesis/api.py
+++ b/indra/sources/hypothesis/api.py
@@ -119,14 +119,18 @@ def upload_statement_annotation(stmt, annotate_agents=True):
     annotate_agents : Optional[bool]
         If True, the agents in the annotation text are linked to outside
         databases based on their grounding. Default: True
+
+    Returns
+    -------
+    list of dict
+        A list of annotation structures that were uploaded to hypothes.is.
     """
     annotations = statement_to_annotations(stmt,
                                            annotate_agents=annotate_agents)
     for annotation in annotations:
         annotation['tags'].append('indra_upload')
         upload_annotation(**annotation)
-    if annotations:
-        return annotations[0]['url']
+    return annotations
 
 
 def get_annotations(group=None):

--- a/indra/sources/hypothesis/api.py
+++ b/indra/sources/hypothesis/api.py
@@ -13,7 +13,7 @@ headers = {'Authorization': 'Bearer %s' % api_key,
 indra_group = get_config('HYPOTHESIS_GROUP')
 
 
-def send_request(endpoint, **params):
+def send_get_request(endpoint, **params):
     """Send a request to the hypothes.is web service and return JSON response.
 
     Note that it is assumed that `HYPOTHESIS_API_KEY` is set either as a
@@ -25,7 +25,7 @@ def send_request(endpoint, **params):
         The endpoint to call, e.g., `search`.
     params : kwargs
         A set of keyword arguments that are passed to the `requests.get` call
-        as `params.
+        as `params`.
     """
     if api_key is None:
         return ValueError('No API key set in HYPOTHESIS_API_KEY')
@@ -33,6 +33,55 @@ def send_request(endpoint, **params):
                        params=params)
     res.raise_for_status()
     return res.json()
+
+
+def send_post_request(endpoint, **params):
+    """Send a request to the hypothes.is web service and return JSON response.
+
+    Note that it is assumed that `HYPOTHESIS_API_KEY` is set either as a
+    configuration entry or as an environmental variable.
+
+    Parameters
+    ----------
+    endpoint : str
+        The endpoint to call, e.g., `search`.
+    params : kwargs
+        A set of keyword arguments that are passed to the `requests.post` call
+        as `json`.
+    """
+    if api_key is None:
+        return ValueError('No API key set in HYPOTHESIS_API_KEY')
+    res = requests.post(base_url + endpoint, headers=headers,
+                        json=params)
+    res.raise_for_status()
+    return res.json()
+
+
+def upload_annotation(url, annotation, target_text=None, tags=None,
+                      group=None):
+    if group is None:
+        if indra_group:
+            group = indra_group
+        else:
+            raise ValueError('No group provided and HYPOTHESIS_GROUP '
+                             'is not set.')
+    params = {
+        'uri': url,
+        'group': group,
+        'text': annotation,
+    }
+    if target_text:
+        params['target'] = [{
+            'source': [url],
+            'selector': [
+                {'type': 'TextQuoteSelector',
+                 'exact': target_text}
+            ]
+        }]
+    if tags:
+        params['tags'] = tags
+    res = send_post_request('annotations', **params)
+    return res
 
 
 def get_annotations(group=None):
@@ -51,7 +100,7 @@ def get_annotations(group=None):
         else:
             raise ValueError('No group provided and HYPOTHESIS_GROUP '
                              'is not set.')
-    res = send_request('search', group=group, limit=200)
+    res = send_get_request('search', group=group, limit=200)
     annotations = res.get('rows', [])
     return annotations
 

--- a/indra/sources/hypothesis/api.py
+++ b/indra/sources/hypothesis/api.py
@@ -37,7 +37,8 @@ def send_get_request(endpoint, **params):
 
 
 def send_post_request(endpoint, **params):
-    """Send a request to the hypothes.is web service and return JSON response.
+    """Send a post request to the hypothes.is web service and return JSON
+    response.
 
     Note that it is assumed that `HYPOTHESIS_API_KEY` is set either as a
     configuration entry or as an environmental variable.
@@ -60,6 +61,28 @@ def send_post_request(endpoint, **params):
 
 def upload_annotation(url, annotation, target_text=None, tags=None,
                       group=None):
+    """Upload an annotation to hypothes.is.
+
+    Parameters
+    ----------
+    url : str
+        The URL of the resource being annotated.
+    annotation : str
+        The text content of the annotation itself.
+    target_text : Optional[str]
+        The specific span of text that the annotation applies to.
+    tags : list[str]
+        A list of tags to apply to the annotation.
+    group : Optional[str]
+        The hypothesi.is key of the group (not its name). If not given, the
+        HYPOTHESIS_GROUP configuration in the config file or an environmental
+        variable is used.
+
+    Returns
+    -------
+    json
+        The full response JSON from the web service.
+    """
     if group is None:
         if indra_group:
             group = indra_group
@@ -85,8 +108,19 @@ def upload_annotation(url, annotation, target_text=None, tags=None,
     return res
 
 
-def upload_statement_annotation(stmt):
-    annotations = statement_to_annotations(stmt, annotate_agents=True)
+def upload_statement_annotation(stmt, annotate_agents=True):
+    """Construct and upload all annotations for a given INDRA Statement.
+
+    Parameters
+    ----------
+    stmt : indra.statements.Statement
+        An INDRA Statement.
+    annotate_agents : Optional[bool]
+        If True, the agents in the annotation text are linked to outside
+        databases based on their grounding. Default: True
+    """
+    annotations = statement_to_annotations(stmt,
+                                           annotate_agents=annotate_agents)
     for annotation in annotations:
         annotation['tags'].append('indra_upload')
         upload_annotation(**annotation)

--- a/indra/sources/hypothesis/api.py
+++ b/indra/sources/hypothesis/api.py
@@ -86,10 +86,9 @@ def upload_annotation(url, annotation, target_text=None, tags=None,
 
 
 def upload_statement_annotation(stmt):
-    tags = ['indra_upload']
     annotations = statement_to_annotations(stmt, annotate_agents=True)
     for annotation in annotations:
-        annotation['tags'] = tags
+        annotation['tags'].append('indra_upload')
         upload_annotation(**annotation)
 
 

--- a/indra/sources/hypothesis/api.py
+++ b/indra/sources/hypothesis/api.py
@@ -3,6 +3,7 @@ __all__ = ['process_annotations', 'get_annotations']
 import requests
 from indra.config import get_config
 from .processor import HypothesisProcessor
+from .annotator import statement_to_annotations
 
 
 base_url = 'https://api.hypothes.is/api/'
@@ -85,23 +86,11 @@ def upload_annotation(url, annotation, target_text=None, tags=None,
 
 
 def upload_statement_annotation(stmt):
-    from indra.assemblers.english import EnglishAssembler
-    ea = EnglishAssembler(stmts=[stmt])
-    annotation = ea.make_model()
-    for ev in stmt.evidence:
-        if not ev.text:
-            continue
-        if 'PMCID' in ev.text_refs:
-            url = 'https://www.ncbi.nlm.nih.gov/pmc/articles/%s/' % \
-                  ev.text_refs['PMCID']
-        elif ev.pmid:
-            url = 'https://pubmed.ncbi.nlm.nih.gov/%s/' % ev.pmid
-        else:
-            continue
-        target_text = ev.text
-        tags = ['indra_upload']
-        upload_annotation(url, annotation, target_text, tags)
-
+    tags = ['indra_upload']
+    annotations = statement_to_annotations(stmt, annotate_agents=True)
+    for annotation in annotations:
+        annotation['tags'] = tags
+        upload_annotation(**annotation)
 
 
 def get_annotations(group=None):

--- a/indra/sources/hypothesis/api.py
+++ b/indra/sources/hypothesis/api.py
@@ -105,6 +105,8 @@ def upload_annotation(url, annotation, target_text=None, tags=None,
         }]
     if tags:
         params['tags'] = tags
+    permissions = {'read': ['group:%s' % group]}
+    params['permissions'] = permissions
     res = send_post_request('annotations', **params)
     return res
 

--- a/indra/sources/hypothesis/api.py
+++ b/indra/sources/hypothesis/api.py
@@ -125,6 +125,8 @@ def upload_statement_annotation(stmt, annotate_agents=True):
     for annotation in annotations:
         annotation['tags'].append('indra_upload')
         upload_annotation(**annotation)
+    if annotations:
+        return annotations[0]['url']
 
 
 def get_annotations(group=None):

--- a/indra/sources/hypothesis/api.py
+++ b/indra/sources/hypothesis/api.py
@@ -84,6 +84,26 @@ def upload_annotation(url, annotation, target_text=None, tags=None,
     return res
 
 
+def upload_statement_annotation(stmt):
+    from indra.assemblers.english import EnglishAssembler
+    ea = EnglishAssembler(stmts=[stmt])
+    annotation = ea.make_model()
+    for ev in stmt.evidence:
+        if not ev.text:
+            continue
+        if 'PMCID' in ev.text_refs:
+            url = 'https://www.ncbi.nlm.nih.gov/pmc/articles/%s/' % \
+                  ev.text_refs['PMCID']
+        elif ev.pmid:
+            url = 'https://pubmed.ncbi.nlm.nih.gov/%s/' % ev.pmid
+        else:
+            continue
+        target_text = ev.text
+        tags = ['indra_upload']
+        upload_annotation(url, annotation, target_text, tags)
+
+
+
 def get_annotations(group=None):
     """Return annotations in hypothes.is in a given group.
 

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -148,7 +148,7 @@ def test_famplex_namespace():
         + ', '.join({s.agent_list()[1].name for s in stmts})
 
 
-@attr('nonpublic')
+@attr('nonpublic', 'notravis')
 def test_paper_query():
     stmts_1 = dbr.get_statements_for_paper([('pmcid', 'PMC5770457'),
                                             ('pmid', '27014235')],

--- a/indra/tools/hypothesis_annotator.py
+++ b/indra/tools/hypothesis_annotator.py
@@ -1,0 +1,43 @@
+import logging
+from indra.sources import indra_db_rest
+from indra.pipeline import AssemblyPipeline
+from indra.sources.hypothesis import upload_statement_annotation
+
+ref_priority = ['TRID', 'PMCID', 'PMID']
+
+logger = logging.getLogger(__name__)
+
+
+def annotate_paper(text_refs, pipeline=None):
+    """Upload INDRA Statements as annotations for a given paper.
+
+    Parameters
+    ----------
+    text_refs : dict
+        A dict of text references, following the same format as
+        the INDRA Evidence text_refs attribute.
+
+    pipeline : Optional[json]
+        A list of pipeline steps (typically filters) that are applied
+        before uploading statements to hypothes.is as annotations.
+    """
+    for ref_ns in ref_priority:
+        ref_id = text_refs.get(ref_ns)
+        if ref_id:
+            break
+    else:
+        logger.info('Could not find appropriate text refs')
+        return
+    ip = indra_db_rest.get_statements_for_paper([(ref_ns.lower(), ref_id)])
+    stmts = ip.statements
+    # Cut down evidences to ones just from this paper
+    for stmt in stmts:
+        stmt.evidence = [ev for ev in stmt.evidence if
+                         ev.text_refs.get(ref_ns) == ref_id]
+    if pipeline:
+        ap = AssemblyPipeline(pipeline)
+        stmts = ap.run(stmts)
+
+    logger.info('Uploading %d statements to hypothes.is' % len(stmts))
+    for stmt in stmts:
+        upload_statement_annotation(stmt, annotate_agents=True)

--- a/indra/tools/hypothesis_annotator.py
+++ b/indra/tools/hypothesis_annotator.py
@@ -1,3 +1,9 @@
+"""This module exposes functions that annotate websites (including
+PubMed and PubMedCentral pages, or any other text-based website) with INDRA
+Statements through hypothes.is. Features include reading the content of the
+website 'de-novo', and generating new INDRA Statements for annotation, and
+fetching existing statements for a paper from the INDRA DB and using
+those for annotation."""
 import logging
 import requests
 from indra.sources import indra_db_rest
@@ -45,8 +51,9 @@ def annotate_paper_from_db(text_refs, pipeline=None):
         upload_statement_annotation(stmt, annotate_agents=True)
 
 
-def annotate_paper_from_api(text_refs, text_extractor=None, pipeline=None):
-    """Read a paper and upload annotations derived from it to hypothes.is.
+def read_and_annotate(text_refs, text_extractor=None, pipeline=None):
+    """Read a paper/website and upload annotations derived from it to
+    hypothes.is.
 
     Parameters
     ----------
@@ -90,6 +97,8 @@ def annotate_paper_from_api(text_refs, text_extractor=None, pipeline=None):
             return
         if text_extractor:
             text = text_extractor(site_content)
+            logger.info('Extracted text of length %d from site content' %
+                        len(text))
         else:
             text = site_content
         res = requests.post(api_url + 'process_text', json={'text': text})
@@ -97,6 +106,8 @@ def annotate_paper_from_api(text_refs, text_extractor=None, pipeline=None):
         return
     jstmts = res.json().get('statements')
     logger.info('Got %d statements from reading' % len(jstmts))
+    if not jstmts:
+        return
     stmts = stmts_from_json(res.json().get('statements'))
 
     if pipeline:

--- a/indra/tools/hypothesis_annotator.py
+++ b/indra/tools/hypothesis_annotator.py
@@ -3,12 +3,11 @@ from indra.sources import indra_db_rest
 from indra.pipeline import AssemblyPipeline
 from indra.sources.hypothesis import upload_statement_annotation
 
-ref_priority = ['TRID', 'PMCID', 'PMID']
 
 logger = logging.getLogger(__name__)
 
 
-def annotate_paper(text_refs, pipeline=None):
+def annotate_paper_from_db(text_refs, pipeline=None):
     """Upload INDRA Statements as annotations for a given paper.
 
     Parameters
@@ -21,6 +20,7 @@ def annotate_paper(text_refs, pipeline=None):
         A list of pipeline steps (typically filters) that are applied
         before uploading statements to hypothes.is as annotations.
     """
+    ref_priority = ['TRID', 'PMCID', 'PMID']
     for ref_ns in ref_priority:
         ref_id = text_refs.get(ref_ns)
         if ref_id:
@@ -34,6 +34,63 @@ def annotate_paper(text_refs, pipeline=None):
     for stmt in stmts:
         stmt.evidence = [ev for ev in stmt.evidence if
                          ev.text_refs.get(ref_ns) == ref_id]
+    if pipeline:
+        ap = AssemblyPipeline(pipeline)
+        stmts = ap.run(stmts)
+
+    logger.info('Uploading %d statements to hypothes.is' % len(stmts))
+    for stmt in stmts:
+        upload_statement_annotation(stmt, annotate_agents=True)
+
+
+def annotate_paper_from_api(text_refs, pipeline=None):
+    """Read a paper and upload annotations derived from it to hypothes.is.
+
+    Parameters
+    ----------
+    text_refs : dict
+        A dict of text references, following the same format as
+        the INDRA Evidence text_refs attribute.
+
+    pipeline : Optional[json]
+        A list of pipeline steps (typically filters) that are applied
+        before uploading statements to hypothes.is as annotations.
+    """
+    import requests
+    from indra.literature import pubmed_client
+    from indra.statements import stmts_from_json
+    api_url = 'http://api.indra.bio:8000/reach/'
+    ref_priority = ['PMCID', 'PMID', 'URL']
+    for ref_ns in ref_priority:
+        ref_id = text_refs.get(ref_ns)
+        if ref_id:
+            break
+    else:
+        logger.info('Could not find appropriate text refs')
+        return
+    logger.info('Selected the following paper ID: %s:%s' % (ref_ns, ref_id))
+    # Get text content and the read the text
+    if ref_ns == 'PMCID':
+        res = requests.post(api_url + 'process_pmc', json={'pmc_id': ref_id})
+    elif ref_ns == 'PMID':
+        abstract = pubmed_client.get_abstract(ref_id)
+        if not abstract:
+            logger.info('Could not get abstract from PubMed')
+            return
+        logger.info('Got abstract')
+        res = requests.post(api_url + 'process_text', json={'text': abstract})
+    elif ref_ns == 'URL':
+        text = requests.get(ref_id).text
+        if not text:
+            logger.info('Could not get text from website')
+            return
+        res = requests.post(api_url + 'process_text', json={'text': text})
+    else:
+        return
+    jstmts = res.json().get('statements')
+    logger.info('Got %d statements from reading' % len(jstmts))
+    stmts = stmts_from_json(res.json().get('statements'))
+
     if pipeline:
         ap = AssemblyPipeline(pipeline)
         stmts = ap.run(stmts)

--- a/indra/tools/hypothesis_annotator.py
+++ b/indra/tools/hypothesis_annotator.py
@@ -1,21 +1,23 @@
 import logging
+import requests
 from indra.sources import indra_db_rest
+from indra.literature import pubmed_client
 from indra.pipeline import AssemblyPipeline
+from indra.statements import stmts_from_json
 from indra.sources.hypothesis import upload_statement_annotation
-
 
 logger = logging.getLogger(__name__)
 
 
 def annotate_paper_from_db(text_refs, pipeline=None):
-    """Upload INDRA Statements as annotations for a given paper.
+    """Upload INDRA Statements as annotations for a given paper based on content
+    for that paper in the INDRA DB.
 
     Parameters
     ----------
     text_refs : dict
         A dict of text references, following the same format as
         the INDRA Evidence text_refs attribute.
-
     pipeline : Optional[json]
         A list of pipeline steps (typically filters) that are applied
         before uploading statements to hypothes.is as annotations.
@@ -61,9 +63,6 @@ def annotate_paper_from_api(text_refs, text_extractor=None, pipeline=None):
         A list of pipeline steps (typically filters) that are applied
         before uploading statements to hypothes.is as annotations.
     """
-    import requests
-    from indra.literature import pubmed_client
-    from indra.statements import stmts_from_json
     api_url = 'http://api.indra.bio:8000/reach/'
     ref_priority = ['PMCID', 'PMID', 'URL']
     for ref_ns in ref_priority:


### PR DESCRIPTION
This PR implements a new set of features for the hypothes.is integration including the ability to upload annotations derived from a single INDRA Statements. The PR also adds a separate module under tools which allows running de-novo reading and assembly for a given paper or website, and uploading annotations, as well as annotations for existing statements we have already generated.