### PR TITLE
Fix HGNC reverse name lookup from ontology

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,8 +36,8 @@ jobs:
         pip install pydot jsonschema coverage nose-timer doctest-ignore-unicode awscli pycodestyle
         mkdir -p $HOME/.pybel/data
         aws s3 cp s3://bigmech/travis/pybel_cache.db $HOME/.pybel/data/ --no-sign-request  --source-region us-east-1
-        mkdir -p $HOME/.indra/bio_ontology/1.8
-        aws s3 cp s3://bigmech/travis/bio_ontology/1.8/mock_ontology.pkl $HOME/.indra/bio_ontology/1.8/bio_ontology.pkl --no-sign-request  --source-region us-east-1
+        mkdir -p $HOME/.indra/bio_ontology/1.9
+        aws s3 cp s3://bigmech/travis/bio_ontology/1.9/mock_ontology.pkl $HOME/.indra/bio_ontology/1.9/bio_ontology.pkl --no-sign-request  --source-region us-east-1
         # PySB and dependencies
         wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" -O bionetgen.tar.gz -nv
         tar xzf bionetgen.tar.gz

--- a/indra/ontology/bio/ontology.py
+++ b/indra/ontology/bio/ontology.py
@@ -19,7 +19,7 @@ class BioOntology(IndraOntology):
     # should be incremented to "force" rebuilding the ontology to be consistent
     # with the underlying resource files.
     name = 'bio'
-    version = '1.8'
+    version = '1.9'
 
     def __init__(self):
         super().__init__()
@@ -89,7 +89,9 @@ class BioOntology(IndraOntology):
 
     def add_hgnc_nodes(self):
         from indra.databases import hgnc_client
-        nodes = [(self.label('HGNC', hid), {'name': hname})
+        withdrawns = set(hgnc_client.hgnc_withdrawn)
+        nodes = [(self.label('HGNC', hid),
+                  {'name': hname, 'obsolete': (hid in withdrawns)})
                  for (hid, hname) in hgnc_client.hgnc_names.items()]
         self.add_nodes_from(nodes)
 

--- a/indra/ontology/ontology_graph.py
+++ b/indra/ontology/ontology_graph.py
@@ -553,6 +553,7 @@ class IndraOntology(networkx.DiGraph):
             (self.get_ns(node), data['name']): self.get_ns_id(node)
             for node, data in self.nodes(data=True)
             if 'name' in data
+            and not data.get('obsolete', False)
         }
 
     @with_initialize

--- a/indra/tests/test_ontology.py
+++ b/indra/tests/test_ontology.py
@@ -332,3 +332,10 @@ def test_world_ontology_add_entry():
 def test_efo_bfo_relations():
     assert set(bio_ontology.get_parents('EFO', '0004542')) == \
         {('BFO', '0000015'), ('EFO', '0000001')}
+
+
+def test_name_lookup_obsolete():
+    # This is a regression test to make sure we don't return another node
+    # with the same name but which is obsolete (HGNC:11093)
+    assert bio_ontology.get_id_from_name('HGNC', 'ALDH3A2') == \
+        ('HGNC', '403')


### PR DESCRIPTION
This PR handles obsolete HGNC entries when constructing name to ID lookups to avoid returning obsolete IDs.