### PR TITLE
Fix reuse of matched bound conditions in refinement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         mkdir -p $HOME/.pybel/data
         wget -nv https://bigmech.s3.amazonaws.com/travis/pybel_cache.db -O $HOME/.pybel/data/pybel_cache.db
         mkdir -p $HOME/.indra/bio_ontology/1.9
-        wget -nv https://bigmech.s3.amazonaws.com/travis/mock_ontology.pkl -O $HOME/.indra/bio_ontology/1.9/bio_ontology.pkl
+        wget -nv https://bigmech.s3.amazonaws.com/travis/bio_ontology/1.9/mock_ontology.pkl -O $HOME/.indra/bio_ontology/1.9/bio_ontology.pkl
         # PySB and dependencies
         wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" -O bionetgen.tar.gz -nv
         tar xzf bionetgen.tar.gz

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,9 +35,9 @@ jobs:
         # Install test/Travis-specific dependencies not covered elsewhere
         pip install pydot jsonschema coverage nose-timer doctest-ignore-unicode awscli pycodestyle
         mkdir -p $HOME/.pybel/data
-        aws s3 cp s3://bigmech/travis/pybel_cache.db $HOME/.pybel/data/ --no-sign-request  --source-region us-east-1
+        wget -nv https://bigmech.s3.amazonaws.com/travis/pybel_cache.db -O $HOME/.pybel/data/pybel_cache.db
         mkdir -p $HOME/.indra/bio_ontology/1.9
-        aws s3 cp s3://bigmech/travis/bio_ontology/1.9/mock_ontology.pkl $HOME/.indra/bio_ontology/1.9/bio_ontology.pkl --no-sign-request  --source-region us-east-1
+        wget -nv https://bigmech.s3.amazonaws.com/travis/mock_ontology.pkl -O $HOME/.indra/bio_ontology/1.9/bio_ontology.pkl
         # PySB and dependencies
         wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" -O bionetgen.tar.gz -nv
         tar xzf bionetgen.tar.gz
@@ -46,7 +46,7 @@ jobs:
         pip install cython
         # Now install INDRA with all its extras
         pip install .[all]
-        aws s3 cp s3://bigmech/travis/Phosphorylation_site_dataset.tsv indra/resources/ --no-sign-request  --source-region us-east-1
+        wget -nv https://bigmech.s3.amazonaws.com/travis/Phosphorylation_site_dataset.tsv -O indra/resources/Phosphorylation_site_dataset.tsv
         # Run slow tests only if we're in the cron setting
         #- |
         #  if [[ $TRAVIS_EVENT_TYPE == "cron" ]]; then
@@ -68,8 +68,8 @@ jobs:
         #export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify;
         # Download adeft models
         python -m adeft.download
-        aws s3 cp s3://bigmech/travis/reach-82631d-biores-e9ee36.jar . --no-sign-request  --source-region us-east-1
-        aws s3 cp s3://bigmech/travis/eidos.jar . --no-sign-request --source-region us-east-1
+        wget -nv https://bigmech.s3.amazonaws.com/travis/reach-82631d-biores-e9ee36.jar
+        wget -nv https://bigmech.s3.amazonaws.com/travis/eidos.jar
     - name: Run unit tests
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/indra/statements/agent.py
+++ b/indra/statements/agent.py
@@ -153,18 +153,19 @@ class Agent(Concept):
         # bound conditions in the other agent, and add additional context.
         # TODO: For now, we do not check the bound conditions of the bound
         # conditions.
-        # FIXME: This matching procedure will get confused if the same
-        # entity is included more than once in one of the sets--this will
-        # be picked up as a match
         # Iterate over the bound conditions in the other agent, and make sure
         # they are all matched in self.
+        used_idx = set()
         for bc_other in other.bound_conditions:
             # Iterate over the bound conditions in self to find a match
             bc_found = False
-            for bc_self in self.bound_conditions:
-                if (bc_self.is_bound == bc_other.is_bound) and \
+            for idx, bc_self in enumerate(self.bound_conditions):
+                if (idx not in used_idx) and \
+                        (bc_self.is_bound == bc_other.is_bound) and \
                         bc_self.agent.refinement_of(bc_other.agent, ontology):
                     bc_found = True
+                    used_idx.add(idx)
+                    break
             # If we didn't find a match for this bound condition in self, then
             # no refinement
             if not bc_found:

--- a/indra/tests/test_rest_api.py
+++ b/indra/tests/test_rest_api.py
@@ -914,6 +914,7 @@ def test_reach_process_json():
     assert stmts[0].obj is not None
 
 
+@attr('notravis')
 def test_reach_process_pmc():
     res = _call_api('post', 'reach/process_pmc', json={'pmcid': 'PMC4338247'})
     res_json = json.loads(res.get_data())

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -666,6 +666,11 @@ def test_agent_boundcondition_refinement():
     assert not nras3.refinement_of(nras5, bio_ontology)
     assert not nras4.refinement_of(nras5, bio_ontology)
 
+    nras6 = Agent('NRAS', db_refs={'HGNC': '7989'},
+                  bound_conditions=[bc1, bc1])
+    assert nras6.refinement_of(nras1, bio_ontology)
+    assert not nras1.refinement_of(nras6, bio_ontology)
+
 
 def test_agent_modification_refinement():
     """A gene-level statement should be supported by a family-level


### PR DESCRIPTION
This PR fixes a known limitation of refinement finding with multiple bound conditions where a single bound condition in `self` could be matched with multiple bound conditions in `other`. The PR adds a set to keep track of which bound conditions in `self` have already been used for a match/refinement against a bound condition in `other` and avoids reusing these.