### PR TITLE
Extensions to refinement filter classes and belief engine

### DIFF
--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -351,7 +351,7 @@ class BeliefEngine(object):
         Returns
         -------
         float
-            The belief scrore for this statement.
+            The belief score for this statement.
         """
         all_evidences = set()
         refiners = [] if not refiners else refiners


### PR DESCRIPTION
This PR adds an `extend` method to the `RefinementFilter` class which can be used to incrementally update the internal data structures of a refinement filter with a set of new statements (it only needs to be implemented if there are custom internal data-structures used by the filter). It also implements this extension capability for the `OntologyRefinementFilter`. Finally, through some refactoring, a `get_hierarchy_probs` function is exposed in the BeliefEngine which returns beliefs without setting them on statement objects.