### PR TITLE
Improve YAML ontology loading

### DIFF
--- a/indra/ontology/world/ontology.py
+++ b/indra/ontology/world/ontology.py
@@ -42,12 +42,12 @@ class WorldOntology(IndraOntology):
     Parameters
     ----------
     url : str
-        The URL pointing to a World Modelers ontology YAML.
+        The URL or file path pointing to a World Modelers ontology YAML.
 
     Attributes
     ----------
     url : str
-        The URL pointing to a World Modelers ontology YAML.
+        The URL or file path pointing to a World Modelers ontology YAML.
     yml : list
         The ontology YAML as loaded by the yaml package from the
         URL.
@@ -101,7 +101,7 @@ class WorldOntology(IndraOntology):
         this_prefix = prefix + '/' + node if prefix else node
         for entry in tree:
             # This is typically a list of examples which we don't need to
-            # independently psocess
+            # independently process
             if isinstance(entry, str):
                 continue
             # This is the case of an entry with multiple attributes
@@ -241,6 +241,7 @@ class WorldOntology(IndraOntology):
 
 @register_pipeline
 def load_world_ontology(url=wm_ont_url):
+    """Load the world ontology from a given URL or file path."""
     return WorldOntology(url)
 
 

--- a/indra/tests/test_ontology.py
+++ b/indra/tests/test_ontology.py
@@ -1,7 +1,5 @@
-import copy
 from indra.statements import Agent
 from indra.ontology.bio import bio_ontology
-from indra.ontology.world import world_ontology
 from indra.databases import go_client, hgnc_client
 from indra.ontology.standardize import \
     standardize_agent_name, standardize_db_refs, standardize_name_db_refs
@@ -133,19 +131,6 @@ def test_chebi_isa():
 #    c1 = ent_hierarchy.components[uri_prkag1]
 #    c2 = ent_hierarchy.components[uri_ampk]
 #    assert c1 == c2
-
-
-def test_hm_opposite_polarity():
-    concept1 = 'wm/concept/causal_factor/food_insecurity/food_instability'
-    concept2 = 'wm/concept/causal_factor/food_security/food_stability'
-    concept3 = ('wm/concept/causal_factor/environmental/meteorologic/'
-                'precipitation/flooding')
-    assert world_ontology.is_opposite('WM', concept1, 'WM', concept2)
-    assert world_ontology.is_opposite('WM', concept2, 'WM', concept1)
-    assert not world_ontology.is_opposite('WM', concept1, 'WM', concept3)
-    assert world_ontology.get_polarity('WM', concept1) == -1
-    assert world_ontology.get_polarity('WM', concept2) == 1
-    assert world_ontology.get_polarity('UN', 'something') is None
 
 
 def test_name_standardize_hgnc_up():
@@ -315,18 +300,6 @@ def test_standardize_chembl():
     db_refs = standardize_db_refs({'DRUGBANK': 'DB00305'})
     assert 'CHEMBL' in db_refs, db_refs
     assert db_refs['CHEMBL'] == 'CHEMBL105', db_refs
-
-
-def test_world_ontology_add_entry():
-    ont = copy.deepcopy(world_ontology)
-    nat_dis = ('wm/concept/causal_factor/crisis_and_disaster/'
-               'environmental_disasters/natural_disaster')
-
-    new_node = nat_dis + '/floods'
-    assert not ont.isa('WM', new_node, 'WM', nat_dis)
-    ont.add_entry(new_node, examples=['floods'])
-    assert ont.isa('WM', new_node, 'WM', nat_dis)
-    ont_yml = ont.dump_yml_str()
 
 
 def test_efo_bfo_relations():

--- a/indra/tests/test_world_ontology.py
+++ b/indra/tests/test_world_ontology.py
@@ -34,3 +34,14 @@ def test_load_intermediate_nodes():
            'wm_posneg_metadata.yml')
     wo = WorldOntology(url)
     wo.initialize()
+    assert wo.is_opposite('WM', 'wm/concept/causal_factor/food_insecurity',
+                          'WM', 'wm/concept/causal_factor/food_security')
+    assert wo.is_opposite('WM', 'wm/concept/causal_factor/food_security',
+                          'WM', 'wm/concept/causal_factor/food_insecurity')
+
+    assert wo.get_polarity('WM',
+                           'wm/concept/causal_factor/food_insecurity') == -1
+    wo.add_entry('wm/concept', examples=['xxx'], neg_examples=['yyy'])
+    entry = wo.yml[0]['wm'][0]['concept'][0]
+    assert 'xxx' in entry['examples']
+    assert 'yyy' in entry['neg_examples']

--- a/indra/tests/test_world_ontology.py
+++ b/indra/tests/test_world_ontology.py
@@ -1,0 +1,36 @@
+import copy
+from indra.ontology.world import world_ontology
+from indra.ontology.world.ontology import WorldOntology
+
+
+def test_hm_opposite_polarity():
+    concept1 = 'wm/concept/causal_factor/food_insecurity/food_instability'
+    concept2 = 'wm/concept/causal_factor/food_security/food_stability'
+    concept3 = ('wm/concept/causal_factor/environmental/meteorologic/'
+                'precipitation/flooding')
+    assert world_ontology.is_opposite('WM', concept1, 'WM', concept2)
+    assert world_ontology.is_opposite('WM', concept2, 'WM', concept1)
+    assert not world_ontology.is_opposite('WM', concept1, 'WM', concept3)
+    assert world_ontology.get_polarity('WM', concept1) == -1
+    assert world_ontology.get_polarity('WM', concept2) == 1
+    assert world_ontology.get_polarity('UN', 'something') is None
+
+
+def test_world_ontology_add_entry():
+    ont = copy.deepcopy(world_ontology)
+    nat_dis = ('wm/concept/causal_factor/crisis_and_disaster/'
+               'environmental_disasters/natural_disaster')
+
+    new_node = nat_dis + '/floods'
+    assert not ont.isa('WM', new_node, 'WM', nat_dis)
+    ont.add_entry(new_node, examples=['floods'])
+    assert ont.isa('WM', new_node, 'WM', nat_dis)
+    ont_yml = ont.dump_yml_str()
+
+
+def test_load_intermediate_nodes():
+    url = ('https://raw.githubusercontent.com/clulab/eidos/posneg/src/main/'
+           'resources/org/clulab/wm/eidos/english/ontologies/'
+           'wm_posneg_metadata.yml')
+    wo = WorldOntology(url)
+    wo.initialize()


### PR DESCRIPTION
This PR adds handling for the new `InnerOntologyNode` entries in YAML ontologies. It handles polarities and opposites associated with these intermediate nodes. It also adds support for negative examples that can be added to the ontology during runtime.