### PR TITLE
Improve small molecule grounding extraction from BioPAX

### DIFF
--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -630,8 +630,7 @@ class BiopaxProcessor(object):
             # This is the "see also" relation which points to related but
             # not exact xrefs that we can skip here
             if isinstance(xref, bp.RelationshipXref) and \
-                xref.relationship_type and xref.relationship_type.uid == \
-                    'http://identifiers.org/psimi/MI:0361':
+                    xref.relationship_type in psi_mi_see_also:
                 continue
             xrefs[xref_db_ns].add(xref.id)
 
@@ -1039,4 +1038,14 @@ xref_ns_map = {
     'hugo gene nomenclature committee (hgnc)': 'HGNC',
     'ensembl': 'ENSEMBL',
     'taxonomy': 'TAXONOMY',
+}
+
+
+psi_mi_see_also = {
+    # This is an invalid URL but used in practice
+    'http://identifiers.org/psimi/MI:0361',
+    # This is a valid old style URL
+    'http://identifiers.org/mi/MI:0361',
+    # This is a valid new style URL
+    'http://identifiers.org/MI:0361',
 }

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -615,12 +615,23 @@ class BiopaxProcessor(object):
         xrefs = defaultdict(set)
         if primary_ns and primary_id:
             xrefs[primary_ns].add(primary_id)
+            # In the case of CHEBI, we return directly, no further processing
+            # of xrefs since xrefs tend to contain other related CHEBI IDs
+            # representing other chemicals
+            if primary_ns == 'CHEBI':
+                return xrefs
 
         for xref in entref.xref:
             if not xref.db:
                 continue
             xref_db_ns = xref_ns_map.get(xref.db.lower())
             if not xref_db_ns:
+                continue
+            # This is the "see also" relation which points to related but
+            # not exact xrefs that we can skip here
+            if isinstance(xref, bp.RelationshipXref) and \
+                xref.relationship_type == \
+                    'http://identifiers.org/psimi/MI:0361':
                 continue
             xrefs[xref_db_ns].add(xref.id)
 

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -630,7 +630,7 @@ class BiopaxProcessor(object):
             # This is the "see also" relation which points to related but
             # not exact xrefs that we can skip here
             if isinstance(xref, bp.RelationshipXref) and \
-                xref.relationship_type == \
+                xref.relationship_type and xref.relationship_type.uid == \
                     'http://identifiers.org/psimi/MI:0361':
                 continue
             xrefs[xref_db_ns].add(xref.id)
@@ -965,8 +965,7 @@ def sanitize_chebi_ids(chebi_ids, name):
         return []
     elif len(chebi_ids) == 1:
         return list(chebi_ids)
-    specific_chebi_id = get_specific_chebi_id(frozenset(chebi_ids),
-                                              name)
+    specific_chebi_id = get_specific_chebi_id(frozenset(chebi_ids), name)
     return specific_chebi_id
 
 

--- a/indra/tests/test_biopax.py
+++ b/indra/tests/test_biopax.py
@@ -77,6 +77,15 @@ def test_activity_regulation_extraction():
     assert all(s.obj.name == 'BRAF' for s in stmts)
 
 
+def test_chebi_grounding_extraction():
+    bpe = 'SmallMolecule_49d78305d95647ad81961ec7f6189821'
+    sm = bp.model.objects[bpe]
+    agents = bp._get_agents_from_singular_entity(sm)
+    assert len(agents) == 1
+    assert agents[0].name == 'GTP'
+    assert agents[0].db_refs['CHEBI'] == 'CHEBI:15996'
+
+
 @attr('webservice', 'slow')
 def test_pathsfromto():
     bp = biopax.process_pc_pathsfromto(['MAP2K1'], ['MAPK1'])

--- a/indra/tests/test_chebi_client.py
+++ b/indra/tests/test_chebi_client.py
@@ -60,12 +60,6 @@ def test_inchi_key():
     assert ik == 'NVKAWKQGWWIWPM-MISPCMORSA-N'
 
 
-def test_specific_chebi_ids():
-    ids = ['76971', '37045', '15996', '75771', '37121', '57600']
-    spec_id = chebi_client.get_specific_id(ids)
-    assert spec_id == 'CHEBI:15996', spec_id
-
-
 def test_hmdb_to_chebi():
     chebi_id = chebi_client.get_chebi_id_from_hmdb('HMDB0000122')
     assert chebi_id == 'CHEBI:15903', chebi_id


### PR DESCRIPTION
This PR makes two changes to how small molecule groundings are extracted from BioPAX content. First, if an entity reference happens to be an identifiers.org URL for a specific CHEBI ID, then that CHEBI ID is used even of there are xrefs to further CHEBI IDs. Second, more generally, any xref that is provided as a RelationshipXref with the "see also" relationship is skipped which often provides links to non-exact matches / higher level terms. Since I didn't notice this before, the `get_specific_chebi_id` was necessary to find the most specific ID based on all the xrefs provided for small molecules.