### PR TITLE
Use PyStow for INDRA ontology location

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,8 +36,8 @@ jobs:
         pip install pydot jsonschema coverage nose-timer doctest-ignore-unicode awscli pycodestyle
         mkdir -p $HOME/.pybel/data
         wget -nv https://bigmech.s3.amazonaws.com/travis/pybel_cache.db -O $HOME/.pybel/data/pybel_cache.db
-        mkdir -p $HOME/.indra/bio_ontology/1.11
-        wget -nv https://bigmech.s3.amazonaws.com/travis/bio_ontology/1.11/mock_ontology.pkl -O $HOME/.indra/bio_ontology/1.11/bio_ontology.pkl
+        mkdir -p $HOME/.data/indra/bio_ontology/1.11
+        wget -nv https://bigmech.s3.amazonaws.com/travis/bio_ontology/1.11/mock_ontology.pkl -O $HOME/.data/indra/bio_ontology/1.11/bio_ontology.pkl
         # PySB and dependencies
         wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" -O bionetgen.tar.gz -nv
         tar xzf bionetgen.tar.gz

--- a/indra/ontology/bio/ontology.py
+++ b/indra/ontology/bio/ontology.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+import pystow
 import logging
 from indra.config import get_config
 from ..ontology_graph import IndraOntology
@@ -493,8 +494,8 @@ class BioOntology(IndraOntology):
             logger.warning('Invalid node: %s' % e)
 
 
-CACHE_DIR = os.path.join((get_config('INDRA_RESOURCES') or
-                          os.path.join(os.path.expanduser('~'), '.indra')),
+INDRA_HOME = get_config('INDRA_RESOURCES') or pystow.join('indra')
+CACHE_DIR = os.path.join(INDRA_HOME,
                          '%s_ontology' % BioOntology.name,
                          BioOntology.version)
 CACHE_FILE = os.path.join(CACHE_DIR, 'bio_ontology.pkl')

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def main():
                     'requests>=2.11', 'lxml', 'ipython', 'future',
                     'networkx>=2', 'pandas', 'ndex2==2.0.1', 'jinja2',
                     'protmapper>=0.0.21', 'obonet', 'sympy==1.3',
-                    'tqdm', 'pybiopax>=0.0.5']
+                    'tqdm', 'pybiopax>=0.0.5', 'pystow']
 
     extras_require = {
                       # Inputs and outputs


### PR DESCRIPTION
This PR uses PyStow for automating the placement of the INDRA ontology. It doesn't add any docs like when we did this for ProtMapper or Adeft because it seems like the user shouldn't be interacting with this anyway