### PR TITLE
Refactor instantiation of agents

### DIFF
--- a/indra/ontology/standardize.py
+++ b/indra/ontology/standardize.py
@@ -1,5 +1,5 @@
 __all__ = ['standardize_agent_name', 'standardize_db_refs', 'get_standard_name',
-           'standardize_name_db_refs']
+           'standardize_name_db_refs', 'get_standard_agent']
 
 import logging
 from copy import deepcopy

--- a/indra/ontology/standardize.py
+++ b/indra/ontology/standardize.py
@@ -5,6 +5,8 @@ import logging
 from copy import deepcopy
 from collections import defaultdict
 from indra.statements.agent import default_ns_order, get_grounding, Agent
+from indra.statements.validate import assert_valid_db_refs
+from .bio import bio_ontology
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +53,8 @@ def get_standard_agent(name, db_refs, ontology=None, ns_order=None, **kwargs):
     Agent
         A standard agent
     """
-    ontology = bio_ontology if not ontology else ontology
+    if ontology is None:
+        ontology = bio_ontology
     standard_name, db_refs = standardize_name_db_refs(db_refs, ontology=ontology, ns_order=ns_order)
     if standard_name:
         name = standard_name

--- a/indra/ontology/standardize.py
+++ b/indra/ontology/standardize.py
@@ -4,7 +4,7 @@ __all__ = ['standardize_agent_name', 'standardize_db_refs', 'get_standard_name',
 import logging
 from copy import deepcopy
 from collections import defaultdict
-from indra.statements.agent import default_ns_order, get_grounding
+from indra.statements.agent import default_ns_order, get_grounding, Agent
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +27,36 @@ def _get_mappings_dict(mappings):
     for db_ns, db_id in mappings:
         md[db_ns].append(db_id)
     return md
+
+
+def get_standard_agent(name, db_refs, ontology=None, ns_order=None, **kwargs):
+    """Get a standard agent based on the name, db_refs, and a any other kwargs.
+
+    name : str
+        The name of the agent that may not be standardized.
+    db_refs : dict
+        A dict of db refs that may not be standardized, i.e., may be
+        missing an available UP ID corresponding to an existing HGNC ID.
+    ontology : Optional[indra.ontology.IndraOntology]
+        An IndraOntology object, if not provided, the default BioOntology
+        is used.
+    ns_order : Optional[list]
+        A list of namespaces which are in order of priority with higher
+        priority namespaces appearing earlier in the list.
+    kwargs :
+        Keyword arguments to pass to :func:`Agent.__init__`.
+
+    Returns
+    -------
+    Agent
+        A standard agent
+    """
+    ontology = bio_ontology if not ontology else ontology
+    standard_name, db_refs = standardize_name_db_refs(db_refs, ontology=ontology, ns_order=ns_order)
+    if standard_name:
+        name = standard_name
+    assert_valid_db_refs(db_refs)
+    return Agent(name, db_refs=db_refs, **kwargs)
 
 
 def standardize_db_refs(db_refs, ontology=None, ns_order=None):

--- a/indra/ontology/standardize.py
+++ b/indra/ontology/standardize.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 from collections import defaultdict
 from indra.statements.agent import default_ns_order, get_grounding, Agent
 from indra.statements.validate import assert_valid_db_refs
-from .bio import bio_ontology
 
 logger = logging.getLogger(__name__)
 
@@ -53,9 +52,9 @@ def get_standard_agent(name, db_refs, ontology=None, ns_order=None, **kwargs):
     Agent
         A standard agent
     """
-    if ontology is None:
-        ontology = bio_ontology
-    standard_name, db_refs = standardize_name_db_refs(db_refs, ontology=ontology, ns_order=ns_order)
+    standard_name, db_refs = standardize_name_db_refs(db_refs,
+                                                      ontology=ontology,
+                                                      ns_order=ns_order)
     if standard_name:
         name = standard_name
     assert_valid_db_refs(db_refs)

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -470,36 +470,24 @@ class BiopaxProcessor(object):
         # One protein coded by many genes
         if nhgnc_ids > 1 and nup_ids == 1:
             for hgnc_id in xrefs['HGNC']:
-                standard_name, db_refs = \
-                    standardize_name_db_refs({'HGNC': hgnc_id})
-                if standard_name:
-                    name = standard_name
-                agents.append(Agent(name, db_refs=db_refs, mods=mcs))
+                agent = Agent.from_refs(name, {'HGNC': hgnc_id}, mods=mcs)
+                agents.append(agent)
         # One gene coding for many proteins
         elif nhgnc_ids == 1 and nup_ids > 1:
             for up_id in xrefs['UP']:
-                standard_name, db_refs = \
-                    standardize_name_db_refs({'UP': up_id})
-                if standard_name:
-                    name = standard_name
-                agents.append(Agent(name, db_refs=db_refs, mods=mcs))
+                agent = Agent.from_refs(name, {'UP': up_id}, mods=mcs)
+                agents.append(agent)
         # This is secretly a family, i.e., we have more than one
         # gene/protein IDs and so we can go by one of the ID sets and
         # standardize from there
         elif nhgnc_ids > 1 and nhgnc_ids == nup_ids:
             for up_id in xrefs['UP']:
-                standard_name, db_refs = \
-                    standardize_name_db_refs({'UP': up_id})
-                if standard_name:
-                    name = standard_name
-                agents.append(Agent(name, db_refs=db_refs, mods=mcs))
+                agent = Agent.from_refs(name, {'UP': up_id}, mods=mcs)
+                agents.append(agent)
         # Otherwise it's just a regular Agent
         else:
-            standard_name, db_refs = \
-                standardize_name_db_refs(clean_up_xrefs(xrefs))
-            if standard_name:
-                name = standard_name
-            agents.append(Agent(name, db_refs=db_refs, mods=mcs))
+            agent = Agent.from_refs(name, clean_up_xrefs(xrefs), mods=mcs)
+            agents.append(agent)
         # Since there are so many cases above, we fix UP / UPISO issues
         # in a single loop here
         for agent in agents:

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -11,7 +11,7 @@ from pybiopax import model_to_owl_file
 from indra.statements import *
 from indra.util import flatten
 from indra.statements.validate import print_validation_report
-from indra.ontology.standardize import standardize_name_db_refs, get_standard_agent
+from indra.ontology.standardize import get_standard_agent
 from indra.databases import hgnc_client, uniprot_client, chebi_client, \
     parse_identifiers_url
 

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -11,7 +11,7 @@ from pybiopax import model_to_owl_file
 from indra.statements import *
 from indra.util import flatten
 from indra.statements.validate import print_validation_report
-from indra.ontology.standardize import standardize_name_db_refs
+from indra.ontology.standardize import standardize_name_db_refs, get_standard_agent
 from indra.databases import hgnc_client, uniprot_client, chebi_client, \
     parse_identifiers_url
 
@@ -470,23 +470,23 @@ class BiopaxProcessor(object):
         # One protein coded by many genes
         if nhgnc_ids > 1 and nup_ids == 1:
             for hgnc_id in xrefs['HGNC']:
-                agent = Agent.from_refs(name, {'HGNC': hgnc_id}, mods=mcs)
+                agent = get_standard_agent(name, {'HGNC': hgnc_id}, mods=mcs)
                 agents.append(agent)
         # One gene coding for many proteins
         elif nhgnc_ids == 1 and nup_ids > 1:
             for up_id in xrefs['UP']:
-                agent = Agent.from_refs(name, {'UP': up_id}, mods=mcs)
+                agent = get_standard_agent(name, {'UP': up_id}, mods=mcs)
                 agents.append(agent)
         # This is secretly a family, i.e., we have more than one
         # gene/protein IDs and so we can go by one of the ID sets and
         # standardize from there
         elif nhgnc_ids > 1 and nhgnc_ids == nup_ids:
             for up_id in xrefs['UP']:
-                agent = Agent.from_refs(name, {'UP': up_id}, mods=mcs)
+                agent = get_standard_agent(name, {'UP': up_id}, mods=mcs)
                 agents.append(agent)
         # Otherwise it's just a regular Agent
         else:
-            agent = Agent.from_refs(name, clean_up_xrefs(xrefs), mods=mcs)
+            agent = get_standard_agent(name, clean_up_xrefs(xrefs), mods=mcs)
             agents.append(agent)
         # Since there are so many cases above, we fix UP / UPISO issues
         # in a single loop here

--- a/indra/sources/ctd/processor.py
+++ b/indra/sources/ctd/processor.py
@@ -3,7 +3,7 @@ from indra.statements import *
 from indra.databases import hgnc_client
 from indra.statements.validate import assert_valid_db_refs
 from indra.ontology.standardize import standardize_db_refs, \
-    standardize_name_db_refs
+    standardize_name_db_refs, get_standard_agent
 
 
 rel_mapping = {
@@ -142,7 +142,7 @@ def get_disease_agent(name, disease_id):
     for gr in groundings:
         db_ns, db_id = gr.split(':')
         db_refs[db_ns] = db_id
-    return Agent.from_refs(name, db_refs)
+    return get_standard_agent(name, db_refs)
 
 
 def get_gene_agent(name, gene_entrez_id):
@@ -150,7 +150,7 @@ def get_gene_agent(name, gene_entrez_id):
     hgnc_id = hgnc_client.get_hgnc_id(name)
     if hgnc_id:
         db_refs['HGNC'] = hgnc_id
-    return Agent.from_refs(name, db_refs)
+    return get_standard_agent(name, db_refs)
 
 
 def get_chemical_agent(name, mesh_id, cas_id):

--- a/indra/sources/ctd/processor.py
+++ b/indra/sources/ctd/processor.py
@@ -142,11 +142,7 @@ def get_disease_agent(name, disease_id):
     for gr in groundings:
         db_ns, db_id = gr.split(':')
         db_refs[db_ns] = db_id
-    standard_name, db_refs = standardize_name_db_refs(db_refs)
-    assert_valid_db_refs(db_refs)
-    if standard_name:
-        name = standard_name
-    return Agent(name, db_refs=db_refs)
+    return Agent.from_refs(name, db_refs)
 
 
 def get_gene_agent(name, gene_entrez_id):
@@ -154,11 +150,7 @@ def get_gene_agent(name, gene_entrez_id):
     hgnc_id = hgnc_client.get_hgnc_id(name)
     if hgnc_id:
         db_refs['HGNC'] = hgnc_id
-    standard_name, db_refs = standardize_name_db_refs(db_refs)
-    assert_valid_db_refs(db_refs)
-    if standard_name:
-        name = standard_name
-    return Agent(name, db_refs=db_refs)
+    return Agent.from_refs(name, db_refs)
 
 
 def get_chemical_agent(name, mesh_id, cas_id):

--- a/indra/sources/ctd/processor.py
+++ b/indra/sources/ctd/processor.py
@@ -2,8 +2,7 @@ import tqdm
 from indra.statements import *
 from indra.databases import hgnc_client
 from indra.statements.validate import assert_valid_db_refs
-from indra.ontology.standardize import standardize_db_refs, \
-    standardize_name_db_refs, get_standard_agent
+from indra.ontology.standardize import standardize_db_refs, get_standard_agent
 
 
 rel_mapping = {

--- a/indra/sources/drugbank/processor.py
+++ b/indra/sources/drugbank/processor.py
@@ -4,7 +4,8 @@ from indra.statements import *
 from indra.databases.identifiers import ensure_chebi_prefix, \
     ensure_chembl_prefix
 from indra.statements.validate import assert_valid_db_refs
-from indra.ontology.standardize import standardize_name_db_refs
+from indra.ontology.standardize import standardize_name_db_refs, \
+    get_standard_agent
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +95,7 @@ class DrugbankProcessor:
                 db_refs['HGNC'] = identifier[5:]
             elif resource == 'UniProtKB':
                 db_refs['UP'] = identifier
-        return Agent.from_refs(name, db_refs=db_refs)
+        return get_standard_agent(name, db_refs=db_refs)
 
     @staticmethod
     def _get_drug_agent(drug_element):
@@ -128,7 +129,7 @@ class DrugbankProcessor:
             elif resource == 'ChEBI':
                 db_refs['CHEBI'] = ensure_chebi_prefix(identifier)
         assert_valid_db_refs(db_refs)
-        return Agent.from_refs(name, db_refs)
+        return get_standard_agent(name, db_refs)
 
     @staticmethod
     def _get_evidences(target_element):

--- a/indra/sources/drugbank/processor.py
+++ b/indra/sources/drugbank/processor.py
@@ -94,11 +94,7 @@ class DrugbankProcessor:
                 db_refs['HGNC'] = identifier[5:]
             elif resource == 'UniProtKB':
                 db_refs['UP'] = identifier
-        standard_name, db_refs = standardize_name_db_refs(db_refs)
-        if standard_name:
-            name = standard_name
-        agent = Agent(name, db_refs=db_refs)
-        return agent
+        return Agent.from_refs(name, db_refs=db_refs)
 
     @staticmethod
     def _get_drug_agent(drug_element):
@@ -132,12 +128,7 @@ class DrugbankProcessor:
             elif resource == 'ChEBI':
                 db_refs['CHEBI'] = ensure_chebi_prefix(identifier)
         assert_valid_db_refs(db_refs)
-        standard_name, db_refs = standardize_name_db_refs(db_refs)
-        assert_valid_db_refs(db_refs)
-        if standard_name:
-            name = standard_name
-        agent = Agent(name, db_refs=db_refs)
-        return agent
+        return Agent.from_refs(name, db_refs)
 
     @staticmethod
     def _get_evidences(target_element):

--- a/indra/sources/signor/processor.py
+++ b/indra/sources/signor/processor.py
@@ -218,10 +218,7 @@ class SignorProcessor(object):
             else:
                 name = ent_name
                 db_refs = {}
-            standard_name, db_refs = standardize_name_db_refs(db_refs)
-            if standard_name:
-                name = standard_name
-            return Agent(name, db_refs=db_refs)
+            return Agent.from_refs(name, db_refs=db_refs)
 
     def _recursively_lookup_complex(self, complex_id):
         """Looks up the constitutents of a complex. If any constituent is

--- a/indra/sources/signor/processor.py
+++ b/indra/sources/signor/processor.py
@@ -16,7 +16,8 @@ from os.path import join, dirname
 from indra.statements import *
 from indra.util import read_unicode_csv
 from indra.resources import get_resource_path
-from indra.ontology.standardize import standardize_name_db_refs
+from indra.ontology.standardize import standardize_name_db_refs, \
+    get_standard_agent
 from indra.sources.reach.processor import parse_amino_acid_string
 from indra.databases import hgnc_client, uniprot_client, chebi_client
 from indra.databases.identifiers import ensure_prefix
@@ -218,7 +219,7 @@ class SignorProcessor(object):
             else:
                 name = ent_name
                 db_refs = {}
-            return Agent.from_refs(name, db_refs=db_refs)
+            return get_standard_agent(name, db_refs=db_refs)
 
     def _recursively_lookup_complex(self, complex_id):
         """Looks up the constitutents of a complex. If any constituent is

--- a/indra/sources/tas/processor.py
+++ b/indra/sources/tas/processor.py
@@ -91,15 +91,11 @@ class TasProcessor(object):
         return drugs
 
     def _extract_protein(self, name, gene_id):
-        refs = {'EGID': gene_id}
+        db_refs = {'EGID': gene_id}
         hgnc_id = hgnc_client.get_hgnc_from_entrez(gene_id)
         if hgnc_id is not None:
-            refs['HGNC'] = hgnc_id
-        standard_name, db_refs = standardize_name_db_refs(refs)
-        if standard_name:
-            name = standard_name
-        assert_valid_db_refs(db_refs)
-        return Agent(name, db_refs=db_refs)
+            db_refs['HGNC'] = hgnc_id
+        return Agent.from_refs(name, db_refs=db_refs)
 
     def _make_evidences(self, class_min, references):
         evidences = []

--- a/indra/sources/tas/processor.py
+++ b/indra/sources/tas/processor.py
@@ -3,7 +3,8 @@ __all__ = ['TasProcessor']
 import logging
 from indra.statements import Inhibition, Agent, Evidence
 from indra.statements.validate import assert_valid_db_refs
-from indra.ontology.standardize import standardize_name_db_refs
+from indra.ontology.standardize import standardize_name_db_refs, \
+    get_standard_agent
 from indra.databases import hgnc_client, chembl_client, lincs_client
 
 
@@ -95,7 +96,7 @@ class TasProcessor(object):
         hgnc_id = hgnc_client.get_hgnc_from_entrez(gene_id)
         if hgnc_id is not None:
             db_refs['HGNC'] = hgnc_id
-        return Agent.from_refs(name, db_refs=db_refs)
+        return get_standard_agent(name, db_refs=db_refs)
 
     def _make_evidences(self, class_min, references):
         evidences = []

--- a/indra/statements/agent.py
+++ b/indra/statements/agent.py
@@ -5,7 +5,6 @@ __all__ = ['Agent', 'BoundCondition', 'MutCondition', 'ModCondition',
 import logging
 from collections import OrderedDict as _o
 from indra.statements.statements import modtype_conditions, modtype_to_modclass
-from indra.statements.validate import assert_valid_db_refs
 from .concept import Concept
 from .resources import get_valid_residue, activity_types, amino_acids
 
@@ -69,16 +68,6 @@ class Agent(Concept):
 
         self.activity = activity
         self.location = location
-
-    @classmethod
-    def from_refs(cls, name, db_refs, **kwargs) -> 'Agent':
-        """Create an agent from db_refs."""
-        from ..ontology.standardize import standardize_name_db_refs
-        standard_name, db_refs = standardize_name_db_refs(db_refs)
-        if standard_name:
-            name = standard_name
-        assert_valid_db_refs(db_refs)
-        return cls(name, db_refs=db_refs, **kwargs)
 
     def matches_key(self):
         """Return a key to identify the identity and state of the Agent."""

--- a/indra/statements/agent.py
+++ b/indra/statements/agent.py
@@ -5,6 +5,7 @@ __all__ = ['Agent', 'BoundCondition', 'MutCondition', 'ModCondition',
 import logging
 from collections import OrderedDict as _o
 from indra.statements.statements import modtype_conditions, modtype_to_modclass
+from indra.statements.validate import assert_valid_db_refs
 from .concept import Concept
 from .resources import get_valid_residue, activity_types, amino_acids
 
@@ -68,6 +69,16 @@ class Agent(Concept):
 
         self.activity = activity
         self.location = location
+
+    @classmethod
+    def from_refs(cls, name, db_refs, **kwargs) -> 'Agent':
+        """Create an agent from db_refs."""
+        from ..ontology.standardize import standardize_name_db_refs
+        standard_name, db_refs = standardize_name_db_refs(db_refs)
+        if standard_name:
+            name = standard_name
+        assert_valid_db_refs(db_refs)
+        return cls(name, db_refs=db_refs, **kwargs)
 
     def matches_key(self):
         """Return a key to identify the identity and state of the Agent."""


### PR DESCRIPTION
The code for standardizing the db_refs and name showed up in many places, so i refactored it into a classmethod for the Agent class. The only caveat is that the standardize_name_db_refs function is imported inside since it would cause circular dependencies.

Maybe this function needs a different name though, since it has the same signature as `Agent.__init__()` and I don't want to cause confusion