### PR TITLE
Automate downloading DrugBank

### DIFF
--- a/indra/sources/drugbank/__init__.py
+++ b/indra/sources/drugbank/__init__.py
@@ -17,4 +17,4 @@ Alternatively, the latest DrugBank data can be automatically loaded via
     with open('drugbank_indra_statements.pkl', 'wb') as file:
         pickle.dump(processor.statements, file, protocol=pickle.HIGHEST_PROTOCOL)
 """
-from .api import get_drugbank_processor, process_xml
+from .api import process_from_web, process_xml, process_element_tree

--- a/indra/sources/drugbank/__init__.py
+++ b/indra/sources/drugbank/__init__.py
@@ -4,4 +4,4 @@ the XML file to be available locally. The full DrugBank download
 can be obtained at: https://www.drugbank.ca/releases/latest. Once the
 XML file is decompressed, it can be processed using the process_xml
 function."""
-from .api import process_xml
+from .api import get_drugbank_processor, process_xml

--- a/indra/sources/drugbank/__init__.py
+++ b/indra/sources/drugbank/__init__.py
@@ -3,5 +3,18 @@ It builds on the XML-formatted data schema of DrugBank and expects
 the XML file to be available locally. The full DrugBank download
 can be obtained at: https://www.drugbank.ca/releases/latest. Once the
 XML file is decompressed, it can be processed using the process_xml
-function."""
+function.
+
+Alternatively, the latest DrugBank data can be automatically loaded via
+:mod:`drugbank_downloader` with the following code after doing
+``pip install drugbank_downloader bioversions``:
+
+.. code-block:: python
+
+    import pickle
+    import indra.sources.drugbank
+    processor = indra.sources.drugbank.get_drugbank_processor()
+    with open('drugbank_indra_statements.pkl', 'wb') as file:
+        pickle.dump(processor.statements, file, protocol=pickle.HIGHEST_PROTOCOL)
+"""
 from .api import get_drugbank_processor, process_xml

--- a/indra/sources/drugbank/api.py
+++ b/indra/sources/drugbank/api.py
@@ -6,7 +6,7 @@ from .processor import DrugbankProcessor
 logger = logging.getLogger(__name__)
 
 
-def get_drugbank_processor(
+def process_from_web(
     username: Optional[str] = None,
     password: Optional[str] = None,
     version: Optional[str] = None,
@@ -43,11 +43,11 @@ def get_drugbank_processor(
         version=version,
         prefix=prefix,
     )
-    return _help_extract(et)
+    return process_element_tree(et)
 
 
 def process_xml(fname):
-    """Return a processor by extracting Statement from DrugBank XML.
+    """Return a processor by extracting Statements from DrugBank XML.
 
     Parameters
     ----------
@@ -63,10 +63,24 @@ def process_xml(fname):
     """
     logger.info('Loading %s...' % fname)
     et = ElementTree.parse(fname)
-    return _help_extract(et)
+    return process_element_tree(et)
 
 
-def _help_extract(et):
+def process_element_tree(et):
+    """Return a processor by extracting Statement from DrugBank XML.
+
+    Parameters
+    ----------
+    et : xml.etree.ElementTree
+        An ElementTree loaded from the DrugBank XML file to process.
+
+    Returns
+    -------
+    DrugbankProcessor
+        A DrugbankProcessor instance which contains a list of INDRA
+        Statements in its statements attribute that were extracted
+        from the given ElementTree.
+    """
     logger.info('Extracting DrugBank statements...')
     dp = DrugbankProcessor(et)
     dp.extract_statements()

--- a/indra/sources/drugbank/api.py
+++ b/indra/sources/drugbank/api.py
@@ -1,8 +1,49 @@
 import logging
+from typing import Optional, Sequence, Union
 from xml.etree import ElementTree
 from .processor import DrugbankProcessor
 
 logger = logging.getLogger(__name__)
+
+
+def get_drugbank_processor(
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    version: Optional[str] = None,
+    prefix: Union[None, str, Sequence[str]] = None,
+) -> DrugbankProcessor:
+    """Get a processor using :func:`process_xml` with :mod:`drugbank_downloader`.
+
+    Parameters
+    ----------
+    username :
+        The DrugBank username. If not passed, looks up in the environment
+        ``DRUGBANK_USERNAME``. If not found, raises a ValueError.
+    password :
+        The DrugBank password. If not passed, looks up in the environment
+        ``DRUGBANK_PASSWORD``. If not found, raises a ValueError.
+    version :
+        The DrugBank version. If not passed, uses :mod:`bioversions` to
+        look up the most recent version.
+    prefix :
+        The prefix and subkeys passed to :func:`pystow.ensure` to specify
+        a non-default location to download the data to.
+
+    Returns
+    -------
+    DrugbankProcessor
+        A DrugbankProcessor instance which contains a list of INDRA
+        Statements in its statements attribute that were extracted
+        from the given DrugBank version
+    """
+    import drugbank_downloader
+    et = drugbank_downloader.parse_drugbank(
+        username=username,
+        password=password,
+        version=version,
+        prefix=prefix,
+    )
+    return _help_extract(et)
 
 
 def process_xml(fname):
@@ -22,6 +63,10 @@ def process_xml(fname):
     """
     logger.info('Loading %s...' % fname)
     et = ElementTree.parse(fname)
+    return _help_extract(et)
+
+
+def _help_extract(et):
     logger.info('Extracting DrugBank statements...')
     dp = DrugbankProcessor(et)
     dp.extract_statements()


### PR DESCRIPTION
This PR automates downloading DrugBank using `drugbank_downloader`  (explanation here https://cthoyt.com/2020/12/14/taming-drugbank.html)

Originally I was going to add automation for CTD, but it looks like that's already there