### PR TITLE
Update interpretation of DrugBank actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ indra/tests/tempfile.html
 .pytest_cache
 .DS_Store
 .noseids
+.venv

--- a/indra/sources/drugbank/api.py
+++ b/indra/sources/drugbank/api.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional, Sequence, Union
 from xml.etree import ElementTree
+
 from .processor import DrugbankProcessor
 
 logger = logging.getLogger(__name__)

--- a/indra/sources/drugbank/api.py
+++ b/indra/sources/drugbank/api.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Optional, Sequence, Union
 from xml.etree import ElementTree
-
 from .processor import DrugbankProcessor
 
 logger = logging.getLogger(__name__)

--- a/indra/sources/drugbank/processor.py
+++ b/indra/sources/drugbank/processor.py
@@ -178,18 +178,48 @@ def _complex(a, b, evidence):
     return Complex([a, b], evidence=evidence)
 
 
-activation_actions = {'inducer', 'potentiator',
-                      'stimulator', 'cofactor', 'activator',
-                      'protector',
-                      'positive allosteric modulator', 'positive modulator'}
+activation_actions = {
+    'inducer',
+    'potentiator',
+    'stimulator',
+    'cofactor',
+    'activator',
+    'protector',
+    'positive allosteric modulator',
+    'positive modulator',
+    # All agonists activate receptors, The only differences are potency,
+    # how efficiently they bind and how long they stay at the receptor site
+    'agonist',
+    'partial agonist',
+}
 
-inhibition_actions = {'inhibitor', 'antibody',
-                      'inactivator', 'blocker', 'negative modulator',
-                      'neutralizer', 'weak inhibitor',
-                      'suppressor', 'disruptor', 'chelator',
-                      'inhibitory allosteric modulator',
-                      'translocation inhibitor', 'nucleotide exchange blocker',
-                      }
+inhibition_actions = {
+    'inhibitor',
+    'antibody',
+    'inactivator',
+    'blocker',
+    'negative modulator',
+    'neutralizer',
+    'weak inhibitor',
+    'suppressor',
+    'disruptor',
+    'chelator',
+    'inhibitory allosteric modulator',
+    'translocation inhibitor',
+    'nucleotide exchange blocker',
+    # Antagonists can either bind to the receptor and do nothing and prevent
+    # physiologic agonists to bind (which can be overcome with higher agonist
+    # dosage [except in the case of irreversible antagonism which obviously
+    # can't be competed with]) or can be a noncompetitive antagonist that will
+    # change the structure of the active site and prevent agonist binding.
+    'antagonist',
+    'partial antagonist',
+    # Inverse agonists act exactly the same as competitive antagonists
+    # unless there is a basal physiological agonism. In which case the
+    # inverse agonist will have more of an opposite effect than just a
+    # pure antagonist would have.
+    'inverse agonist',
+}
 
 decrease_amount_actions = {
     'downregulator',
@@ -198,6 +228,7 @@ decrease_amount_actions = {
     'incorporation into and destabilization',
     'cleavage',
     'inhibition of synthesis',
+    'antisense oligonucleotide',
 }
 
 increase_amount_actions = {'stabilization', 'chaperone'}
@@ -207,18 +238,12 @@ neutral_actions = {
     'binding',
     'modulator',
     'regulator',
-    'antagonist',
     'substrate',
-    'agonist',
     'ligand',
     # e.g., Doxorubicin intercalates DNA to prevent transcription
     'intercalation',
-    'inverse agonist',
     # e.g., inhibits process on a protein's aggregation (like APP or LRRK)
     'aggregation inhibitor',
-    'partial agonist',
-    'partial antagonist',
-    'antisense oligonucleotide',
     'adduct',
     'component of',
     'product of',
@@ -229,7 +254,7 @@ neutral_actions = {
     'acetylation',
     'allosteric modulator',
     'deoxidizer',
-    'cross-linking/alkylation', # e.g. Busulfan (DB01008) alkalytes DNA
+    'cross-linking/alkylation',  # e.g. Busulfan (DB01008) alkalytes DNA
 }
 
 skip_actions = {

--- a/indra/sources/drugbank/processor.py
+++ b/indra/sources/drugbank/processor.py
@@ -72,7 +72,7 @@ class DrugbankProcessor:
         elif action in increase_amount_actions:
             return IncreaseAmount
         elif action == 'N/A':
-            return Inhibition
+            return _complex
         elif action in neutral_actions:
             return _complex
         elif action in skip_actions:

--- a/indra/sources/drugbank/processor.py
+++ b/indra/sources/drugbank/processor.py
@@ -49,7 +49,14 @@ class DrugbankProcessor:
             actions = {a.text for a in db_findall(target_element,
                                                   'db:actions/db:action')}
             if not actions:
-                actions = {'N/A'}
+                # See https://dev.drugbank.com/guides/terms/pharmacological-action
+                pharm_action = db_find(target_element, 'db:known-action')
+                # Skip if it's not known that it's a direct interaction
+                if pharm_action.text in {'no', 'unknown'}:
+                    actions = set()
+                # Otherwise use the N/A action which ultimately maps to Complex
+                else:
+                    actions = {'N/A'}
             for action in actions:
                 stmt_type = DrugbankProcessor._get_statement_type(action)
                 if not stmt_type:

--- a/indra/sources/drugbank/processor.py
+++ b/indra/sources/drugbank/processor.py
@@ -69,7 +69,9 @@ class DrugbankProcessor:
             return DecreaseAmount
         elif action in increase_amount_actions:
             return IncreaseAmount
-        elif action in neutral_actions or action == 'N/A':
+        elif action == 'N/A':
+            return Inhibition
+        elif action in neutral_actions:
             return _complex
         elif action in skip_actions:
             return None
@@ -176,7 +178,9 @@ inhibition_actions = {'inhibitor', 'binder', 'antibody',
                       'inactivator', 'binding', 'blocker', 'negative modulator',
                       'neutralizer', 'weak inhibitor',
                       'suppressor', 'disruptor', 'chelator',
-                      'inhibitory allosteric modulator', 'translocation inhibitor'}
+                      'inhibitory allosteric modulator', 'translocation inhibitor',
+                      'nucleotide exchange blocker',
+                      }
 
 decrease_amount_actions = {
     'downregulator',
@@ -208,6 +212,9 @@ neutral_actions = {
     'reducer',
     'oxidizer',
     'acetylation',  # map to Ac INDRA statement?, but I'm not convinced by the idea of splitting up actions
+    'allosteric modulator',
+    'deoxidizer',
+    'cross-linking/alkylation', # e.g. Busulfan (DB01008) alkalytes DNA
 }
 
 skip_actions = {

--- a/indra/sources/drugbank/processor.py
+++ b/indra/sources/drugbank/processor.py
@@ -1,9 +1,11 @@
 import logging
 from xml.etree import ElementTree
 
-from indra.databases.identifiers import ensure_chebi_prefix, ensure_chembl_prefix
+from indra.databases.identifiers import ensure_chebi_prefix,\
+    ensure_chembl_prefix
 from indra.ontology.standardize import get_standard_agent
-from indra.statements import Activation, Complex, DecreaseAmount, Evidence, IncreaseAmount, Inhibition
+from indra.statements import Activation, Complex, DecreaseAmount, Evidence,\
+    IncreaseAmount, Inhibition
 from indra.statements.validate import assert_valid_db_refs
 
 logger = logging.getLogger(__name__)
@@ -178,8 +180,8 @@ inhibition_actions = {'inhibitor', 'binder', 'antibody',
                       'inactivator', 'binding', 'blocker', 'negative modulator',
                       'neutralizer', 'weak inhibitor',
                       'suppressor', 'disruptor', 'chelator',
-                      'inhibitory allosteric modulator', 'translocation inhibitor',
-                      'nucleotide exchange blocker',
+                      'inhibitory allosteric modulator',
+                      'translocation inhibitor', 'nucleotide exchange blocker',
                       }
 
 decrease_amount_actions = {
@@ -200,9 +202,11 @@ neutral_actions = {
     'substrate',
     'agonist',
     'ligand',
-    'intercalation',  # e.g., Doxorubicin intercalates DNA to prevent transcription
+    # e.g., Doxorubicin intercalates DNA to prevent transcription
+    'intercalation',
     'inverse agonist',
-    'aggregation inhibitor',  # e.g., inhibits process on a protein's aggregation (like APP or LRRK)
+    # e.g., inhibits process on a protein's aggregation (like APP or LRRK)
+    'aggregation inhibitor',
     'partial agonist',
     'partial antagonist',
     'antisense oligonucleotide',
@@ -211,7 +215,9 @@ neutral_actions = {
     'product of',
     'reducer',
     'oxidizer',
-    'acetylation',  # map to Ac INDRA statement?, but I'm not convinced by the idea of splitting up actions
+    # map to Ac INDRA statement?, but I'm not convinced by the idea of
+    # splitting up actions
+    'acetylation',
     'allosteric modulator',
     'deoxidizer',
     'cross-linking/alkylation', # e.g. Busulfan (DB01008) alkalytes DNA

--- a/indra/sources/drugbank/processor.py
+++ b/indra/sources/drugbank/processor.py
@@ -1,6 +1,5 @@
-from xml.etree import ElementTree
-
 import logging
+from xml.etree import ElementTree
 
 from indra.databases.identifiers import ensure_chebi_prefix, ensure_chembl_prefix
 from indra.ontology.standardize import get_standard_agent

--- a/indra/sources/drugbank/processor.py
+++ b/indra/sources/drugbank/processor.py
@@ -176,7 +176,7 @@ inhibition_actions = {'inhibitor', 'binder', 'antibody',
                       'inactivator', 'binding', 'blocker', 'negative modulator',
                       'neutralizer', 'weak inhibitor',
                       'suppressor', 'disruptor', 'chelator',
-                      'inhibitory allosteric modulator'}
+                      'inhibitory allosteric modulator', 'translocation inhibitor'}
 
 decrease_amount_actions = {
     'downregulator',

--- a/indra/sources/drugbank/processor.py
+++ b/indra/sources/drugbank/processor.py
@@ -176,8 +176,8 @@ activation_actions = {'inducer', 'potentiator',
                       'protector',
                       'positive allosteric modulator', 'positive modulator'}
 
-inhibition_actions = {'inhibitor', 'binder', 'antibody',
-                      'inactivator', 'binding', 'blocker', 'negative modulator',
+inhibition_actions = {'inhibitor', 'antibody',
+                      'inactivator', 'blocker', 'negative modulator',
                       'neutralizer', 'weak inhibitor',
                       'suppressor', 'disruptor', 'chelator',
                       'inhibitory allosteric modulator',
@@ -196,6 +196,8 @@ decrease_amount_actions = {
 increase_amount_actions = {'stabilization', 'chaperone'}
 
 neutral_actions = {
+    'binder',
+    'binding',
     'modulator',
     'regulator',
     'antagonist',

--- a/indra/sources/drugbank/processor.py
+++ b/indra/sources/drugbank/processor.py
@@ -206,6 +206,7 @@ inhibition_actions = {
     'chelator',
     'inhibitory allosteric modulator',
     'translocation inhibitor',
+    'inhibits downstream inflammation cascades',
     'nucleotide exchange blocker',
     # Antagonists can either bind to the receptor and do nothing and prevent
     # physiologic agonists to bind (which can be overcome with higher agonist
@@ -231,7 +232,11 @@ decrease_amount_actions = {
     'antisense oligonucleotide',
 }
 
-increase_amount_actions = {'stabilization', 'chaperone'}
+increase_amount_actions = {
+    'stabilization',
+    'chaperone',
+    'gene replacement',
+}
 
 neutral_actions = {
     'binder',
@@ -255,6 +260,7 @@ neutral_actions = {
     'allosteric modulator',
     'deoxidizer',
     'cross-linking/alkylation',  # e.g. Busulfan (DB01008) alkalytes DNA
+    'multitarget',
 }
 
 skip_actions = {


### PR DESCRIPTION
This PR closes #1263 by updating some of the interpretations made in DrugBank's action field. 

It's most likely the case that all curated interactions in DrugBank imply binding between an active molecule and the target. For example, some actions like agonist, partial agonist, antagonist, partial antagonist, and inverse agonist do not give enough information to infer activates or inhibits, because they are with respect to the native ligand. Therefore, the best we can do is say that these chemicals bind to their targets (in the absence a more generic INDRA Statement for apolar regulates activity).

This PR also does the following:
- adds several interpretations that were missing 
- reorganizes the order of priority of mapping to statement types
- small style updates in the DrugBank processor code

## Statistics

### Before

| Action     | Count |
|----------|-------:|
| Inhibition | 16,026 |
| Activation | 2,569 |
| DecreaseAmount | 69 |
| IncreaseAmount | 8 |

### After

| Statement Type   |   Count |
|------------------|--------:|
| Inhibition       |    5,012 |
| Activation       |    2,088 |
| Complex          |    1,325 |
| DecreaseAmount   |      73 |
| IncreaseAmount   |      27 |