### PR TITLE
Update documentation and type hints

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,6 @@ jobs:
         pip install cython
         # Now install INDRA with all its extras
         pip install .[all]
-        pip install tox
         wget -nv https://bigmech.s3.amazonaws.com/travis/Phosphorylation_site_dataset.tsv -O indra/resources/Phosphorylation_site_dataset.tsv
         # Run slow tests only if we're in the cron setting
         #- |
@@ -73,8 +72,6 @@ jobs:
         mv geonames+woredas.zip /home/runner/work/indra/indra/cache/geonames/index
         cd /home/runner/work/indra/indra/cache/geonames/index
         unzip geonames+woredas.zip
-    - name: Linting
-      run: tox -e mypy
     - name: Run unit tests
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
         pip install cython
         # Now install INDRA with all its extras
         pip install .[all]
+        pip install tox
         wget -nv https://bigmech.s3.amazonaws.com/travis/Phosphorylation_site_dataset.tsv -O indra/resources/Phosphorylation_site_dataset.tsv
         # Run slow tests only if we're in the cron setting
         #- |
@@ -72,6 +73,8 @@ jobs:
         mv geonames+woredas.zip /home/runner/work/indra/indra/cache/geonames/index
         cd /home/runner/work/indra/indra/cache/geonames/index
         unzip geonames+woredas.zip
+    - name: Linting
+      run: tox -e mypy
     - name: Run unit tests
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -150,7 +150,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,6 +36,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
+    'sphinx.ext.intersphinx',
     'sphinxarg.ext',
     'sphinx.ext.autosummary',
     'IPython.sphinxext.ipython_directive',
@@ -321,3 +322,10 @@ for mod_name in MOCK_MODULES:
 # from our code that uses it.
 jnius_config = sys.modules['jnius_config']
 jnius_config.vm_running = False
+
+# Example configuration for intersphinx: refer to the Python standard library.
+intersphinx_mapping = {
+    'https://docs.python.org/3/': None,
+    'pybel': ('https://pybel.readthedocs.io/en/latest/', None),
+    'boto3': ('https://boto3.amazonaws.com/v1/documentation/api/latest/', None),
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,6 +39,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinxarg.ext',
     'sphinx.ext.autosummary',
+    'sphinx_autodoc_typehints',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
     'citations'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -60,9 +60,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'INDRA'
-copyright = u'2020, B. M. Gyori, J. A. Bachman'
-author = u'B. M. Gyori, J. A. Bachman'
+project = 'INDRA'
+copyright = '2020, B. M. Gyori, J. A. Bachman'
+author = 'B. M. Gyori, J. A. Bachman'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -236,8 +236,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'indra.tex', u'INDRA Documentation',
-   u'B. M. Gyori, J. A. Bachman', 'manual'),
+  (master_doc, 'indra.tex', 'INDRA Documentation',
+   'B. M. Gyori, J. A. Bachman', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -266,7 +266,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'INDRA', u'INDRA Documentation',
+    (master_doc, 'INDRA', 'INDRA Documentation',
      [author], 1)
 ]
 
@@ -283,7 +283,7 @@ numpydoc_show_class_members = False
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'INDRA', u'INDRA Documentation',
+  (master_doc, 'INDRA', 'INDRA Documentation',
    author, 'INDRA', 'Integrated Network and Dynamical Reasoning Assembler.',
    'Miscellaneous'),
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -329,4 +329,5 @@ intersphinx_mapping = {
     'https://docs.python.org/3/': None,
     'pybel': ('https://pybel.readthedocs.io/en/latest/', None),
     'boto3': ('https://boto3.amazonaws.com/v1/documentation/api/latest/', None),
+    'pysb': ('https://docs.pysb.org/en/latest/', None),
 }

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,7 @@
 sphinx_rtd_theme
 sphinx
 sphinx-argparse
+sphinx_autodoc_typehints
 mock
 ipython
 matplotlib

--- a/indra/__init__.py
+++ b/indra/__init__.py
@@ -23,7 +23,7 @@ import lib2to3.pgen2.driver
 class Lib2to3LoggingModuleShim(object):
     def getLogger(self):
         return logging.getLogger('lib2to3')
-lib2to3.pgen2.driver.logging = Lib2to3LoggingModuleShim()
+lib2to3.pgen2.driver.logging = Lib2to3LoggingModuleShim()  # type: ignore
 logging.getLogger('lib2to3').setLevel(logging.ERROR)
 
 logger = logging.getLogger('indra')

--- a/indra/sources/dgi/processor.py
+++ b/indra/sources/dgi/processor.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""Processor for the `Drug Gene Interaction DB<http://www.dgidb.org>`_."""
+"""Processor for the `Drug Gene Interaction DB <http://www.dgidb.org>`_."""
 
 import logging
 from typing import Iterable, List, Optional, Set, Type

--- a/indra/util/aws.py
+++ b/indra/util/aws.py
@@ -584,8 +584,8 @@ if __name__ == '__main__':
     if args.task == 'run_in_batch':
         ret_code = run_in_batch(args.command.split(), args.project,
                                 args.purpose)
-        if ret_code is 0:
-            logger.info('Job endend well.')
+        if ret_code == 0:
+            logger.info('Job ended well.')
         else:
             logger.error('Job failed!')
             import sys

--- a/indra/util/nested_dict.py
+++ b/indra/util/nested_dict.py
@@ -8,20 +8,20 @@ class NestedDict(dict):
     More specifically, this acts like a recursive defaultdict, allowing, for
     example:
 
-    >> nd = NestedDict()
-    >> nd['a']['b']['c'] = 'foo'
+    >>> nd = NestedDict()
+    >>> nd['a']['b']['c'] = 'foo'
 
     In addition, useful methods have been defined that allow the user to search
     the data structure. Note that the are not particularly optimized methods at
     this time. However, for convenience, you can for example simply call
     `get_path` to get the path to a particular key:
 
-    >> nd.get_path('c')
+    >>> nd.get_path('c')
     (('a', 'b', 'c'), 'foo')
 
     and the value at that key. Similarly:
 
-    >> nd.get_path('b')
+    >>> nd.get_path('b')
     (('a', 'b'), NestedDict(
       'c': 'foo'
     ))

--- a/tox.ini
+++ b/tox.ini
@@ -24,4 +24,4 @@ description = Run the mypy tool to check static typing on the project.
 deps = mypy
 skip_install = true
 commands = mypy --ignore-missing-imports \
-           indra/ontology/ontology_graph.py
+           indra/sources/dgi/

--- a/tox.ini
+++ b/tox.ini
@@ -18,3 +18,10 @@ deps =
 extras =
     bel
     explanation
+
+[testenv:mypy]
+description = Run the mypy tool to check static typing on the project.
+deps = mypy
+skip_install = true
+commands = mypy --ignore-missing-imports \
+           indra/ontology/ontology_graph.py


### PR DESCRIPTION
This PR does not introduce any new code functionality, but rather is a pilot on a few improvements to code and document maintenance. It does the following:

- introduces a MyPy static typing test configuration in `tox.ini` that can be run with `tox -e py`. Right now, it's only running on the one file, `/indra/ontology/ontology_graph.py`, that's used as an example in this PR.
- turns on the intersphinx Sphinx extension for mappings in the documentation (this makes links to other packages' docs when possible, such as PyBEL)
- introduces the `sphinx_autodoc_typehints` Sphinx extension, which takes the type annotations from a function and uses them while generating the docs (so they don't need to be written in free text to get parsed by Napoleon)
- demonstration can be found in in newly added code in `indra.sources.dgi`
- a few random cleanups in the docs

Considerations:
- the `ClassVar`-style type annotation changes the order compared to using the Napoleon `Attributes` header in the class docstring
- I haven't exactly figured out how to get it to play nice with functions that annotate their return types with an explanation (napoleon seems to break when there's no name, and if there's a name, it gets interpreted as the type). Update: after reading the Sphinx guide on Napoleon (both the Google and Numpy variants), I don't think there's a way around this.