### PR TITLE
Add single BEL statement processor and integrate with Hypothes.is processor

### DIFF
--- a/indra/sources/bel/__init__.py
+++ b/indra/sources/bel/__init__.py
@@ -1,4 +1,4 @@
 from .api import process_large_corpus, process_small_corpus, \
     process_belscript, process_pybel_graph, process_json_file, \
     process_pybel_neighborhood, process_cbn_jgif_file, \
-    process_text
+    process_bel_stmt

--- a/indra/sources/bel/__init__.py
+++ b/indra/sources/bel/__init__.py
@@ -1,4 +1,4 @@
 from .api import process_large_corpus, process_small_corpus, \
     process_belscript, process_pybel_graph, process_json_file, \
     process_pybel_neighborhood, process_cbn_jgif_file, \
-    process_bel_statement
+    process_text

--- a/indra/sources/bel/__init__.py
+++ b/indra/sources/bel/__init__.py
@@ -1,3 +1,4 @@
 from .api import process_large_corpus, process_small_corpus, \
     process_belscript, process_pybel_graph, process_json_file, \
-    process_pybel_neighborhood, process_cbn_jgif_file
+    process_pybel_neighborhood, process_cbn_jgif_file, \
+    process_bel_statement

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -161,7 +161,7 @@ def process_text(bel: str, squeeze: bool = False):
     >>> from indra.sources.bel import process_text
     >>> bel_s = 'kin(p(FPLX:MEK)) -> kin(p(FPLX:ERK))'
     >>> indra_s = process_text(bel_s, squeeze=True)
-    IncreaseAmount(MEK(), ERK())
+    Activation(MEK(kinase), ERK(), kinase)
     """
     r = pybel.parse(bel)
     graph = pybel.BELGraph()

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -9,6 +9,7 @@ import logging
 import requests
 from functools import lru_cache
 
+import pybel.constants as pc
 from pybel.io.sbel import add_sbel_row
 
 from .processor import PybelProcessor
@@ -164,6 +165,12 @@ def process_text(bel: str, squeeze: bool = False):
     Activation(MEK(kinase), ERK(), kinase)
     """
     r = pybel.parse(bel)
+    # make sure activations in the right place
+    for a, b in [(pc.SOURCE, pc.SOURCE_MODIFIER), (pc.TARGET, pc.TARGET_MODIFIER)]:
+        side = r[a]
+        for c in [pc.MODIFIER, pc.EFFECT, pc.FROM_LOC, pc.TO_LOC, pc.LOCATION]:
+            if c in side:
+                r.setdefault(b, {})[c] = side.pop(c)
     graph = pybel.BELGraph()
     add_sbel_row(graph, r)
     bp = process_pybel_graph(graph)

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -136,7 +136,7 @@ def process_pybel_neighborhood(entity_names, network_type='graph_jsongz_url',
     return bp
 
 
-def process_text(bel: str, squeeze: False = True):
+def process_text(bel: str, squeeze: bool = False):
     """Process a single BEL statement and return the PybelProcessor
     or a single statement if ``squeeze`` is True.
 

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -161,7 +161,7 @@ def process_text(bel: str, squeeze: bool = False):
     --------
     >>> from indra.sources.bel import process_text
     >>> bel_s = 'kin(p(FPLX:MEK)) -> kin(p(FPLX:ERK))'
-    >>> indra_s = process_text(bel_s, squeeze=True)
+    >>> process_text(bel_s, squeeze=True)
     Activation(MEK(kinase), ERK(), kinase)
     """
     r = pybel.parse(bel)

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -136,8 +136,9 @@ def process_pybel_neighborhood(entity_names, network_type='graph_jsongz_url',
     return bp
 
 
-def process_bel_statement(bel: str, squeeze: bool = True):
-    """Process a single BEL statement and return INDRA statement(s).
+def process_text(bel: str, squeeze: False = True):
+    """Process a single BEL statement and return the PybelProcessor
+    or a single statement if ``squeeze`` is True.
 
     Parameters
     ----------
@@ -145,21 +146,21 @@ def process_bel_statement(bel: str, squeeze: bool = True):
         A BEL statement. See example below.
 
     squeeze: bool
-        If squeeze and there's only one statement to return, it will be
-        unpacked.
+        If squeeze and there's only one statement in the processor,
+        it will be unpacked.
 
     Returns
     -------
-    statements : Union[Statementm, List[Statement]]
+    statements : Union[Statement, PybelProcessor]
         A list of INDRA statments derived from the BEL statement.
         If squeeze is true and there was only one statement, the
         unpacked INDRA statement will be returned.
 
     Examples
     --------
-    >>> from indra.sources.bel import process_bel_statement
+    >>> from indra.sources.bel import process_text
     >>> bel_s = 'kin(p(FPLX:MEK)) -> kin(p(FPLX:ERK))'
-    >>> indra_s = process_bel_statement(bel_s)
+    >>> indra_s = process_text(bel_s, squeeze=True)
     IncreaseAmount(MEK(), ERK())
     """
     r = pybel.parse(bel)
@@ -168,7 +169,7 @@ def process_bel_statement(bel: str, squeeze: bool = True):
     bp = process_pybel_graph(graph)
     if squeeze and len(bp.statements) == 1:
         return bp.statements[0]
-    return bp.statements
+    return bp
 
 
 @lru_cache(maxsize=100)

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -8,6 +8,9 @@ import pybel
 import logging
 import requests
 from functools import lru_cache
+
+from pybel.io.sbel import add_sbel_row
+
 from .processor import PybelProcessor
 
 
@@ -131,6 +134,41 @@ def process_pybel_neighborhood(entity_names, network_type='graph_jsongz_url',
     bp.statements = filtered_stmts
 
     return bp
+
+
+def process_bel_statement(bel: str, squeeze: bool = True):
+    """Process a single BEL statement and return INDRA statement(s).
+
+    Parameters
+    ----------
+    bel : str
+        A BEL statement. See example below.
+
+    squeeze: bool
+        If squeeze and there's only one statement to return, it will be
+        unpacked.
+
+    Returns
+    -------
+    statements : Union[Statementm, List[Statement]]
+        A list of INDRA statments derived from the BEL statement.
+        If squeeze is true and there was only one statement, the
+        unpacked INDRA statement will be returned.
+
+    Examples
+    --------
+    >>> from indra.sources.bel import process_bel_statement
+    >>> bel_s = 'kin(p(FPLX:MEK)) -> kin(p(FPLX:ERK))'
+    >>> indra_s = process_bel_statement(bel_s)
+    IncreaseAmount(MEK(), ERK())
+    """
+    r = pybel.parse(bel)
+    graph = pybel.BELGraph()
+    add_sbel_row(graph, r)
+    bp = process_pybel_graph(graph)
+    if squeeze and len(bp.statements) == 1:
+        return bp.statements[0]
+    return bp.statements
 
 
 @lru_cache(maxsize=100)

--- a/indra/sources/bel/api.py
+++ b/indra/sources/bel/api.py
@@ -137,7 +137,7 @@ def process_pybel_neighborhood(entity_names, network_type='graph_jsongz_url',
     return bp
 
 
-def process_text(bel: str, squeeze: bool = False):
+def process_bel_stmt(bel: str, squeeze: bool = False):
     """Process a single BEL statement and return the PybelProcessor
     or a single statement if ``squeeze`` is True.
 
@@ -145,8 +145,7 @@ def process_text(bel: str, squeeze: bool = False):
     ----------
     bel : str
         A BEL statement. See example below.
-
-    squeeze: bool
+    squeeze : Optional[bool]
         If squeeze and there's only one statement in the processor,
         it will be unpacked.
 
@@ -159,9 +158,9 @@ def process_text(bel: str, squeeze: bool = False):
 
     Examples
     --------
-    >>> from indra.sources.bel import process_text
+    >>> from indra.sources.bel import process_bel_stmt
     >>> bel_s = 'kin(p(FPLX:MEK)) -> kin(p(FPLX:ERK))'
-    >>> process_text(bel_s, squeeze=True)
+    >>> process_bel_stmt(bel_s, squeeze=True)
     Activation(MEK(kinase), ERK(), kinase)
     """
     r = pybel.parse(bel)

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -334,12 +334,12 @@ class PybelProcessor(object):
         ev_text = edge_data.get(pc.EVIDENCE)
         ev_citation = edge_data.get(pc.CITATION)
         ev_pmid = None
+        ev_ref = None
         if ev_citation:
             cit_type = ev_citation.namespace
             cit_ref = ev_citation.identifier
             if cit_type == pc.CITATION_TYPE_PUBMED:
                 ev_pmid = cit_ref
-                ev_ref = None
             else:
                 ev_pmid = None
                 ev_ref = '%s: %s' % (cit_type, cit_ref)

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -346,7 +346,7 @@ class PybelProcessor(object):
         epistemics = {'direct': _rel_is_direct(edge_data)}
         annotations = edge_data.get(pc.ANNOTATIONS, {})
         annotations['bel'] = edge_to_bel(u_data, v_data, edge_data)
-        if ev_ref:  # FIXME what if ev_citation is Falsy?
+        if ev_ref:
             annotations['citation_ref'] = ev_ref
 
         context = extract_context(annotations, self.annot_manager)

--- a/indra/sources/hypothesis/api.py
+++ b/indra/sources/hypothesis/api.py
@@ -206,10 +206,12 @@ def process_annotations(group=None, reader=None, grounder=None):
     -------
     Process all annotations that have been written in BEL with:
 
-    >>> from indra.sources import hypothesis
-    >>> processor = hypothesis.process_annotations(group='Z8RNqokY', reader='bel')
-    >>> processor.statements
-    [Phosphorylation(AKT(), PCGF2(), T, 334)]
+    .. code-block:: python
+
+        from indra.sources import hypothesis
+        processor = hypothesis.process_annotations(group='Z8RNqokY', reader='bel')
+        processor.statements
+        # returns: [Phosphorylation(AKT(), PCGF2(), T, 334)]
 
     If this example doesn't work, try joining the group with this link:
     https://hypothes.is/groups/Z8RNqokY/cthoyt-bel.

--- a/indra/sources/hypothesis/api.py
+++ b/indra/sources/hypothesis/api.py
@@ -180,13 +180,15 @@ def process_annotations(group=None, reader=None, grounder=None):
         The hypothesi.is key of the group (not its name). If not given, the
         HYPOTHESIS_GROUP configuration in the config file or an environmental
         variable is used.
-    reader : Optiona[function]
+    reader : Optional[None, str, Callable[[str], Processor]]
         A handle for a function which takes a single str argument
         (text to process) and returns a processor object with a statements
         attribute containing INDRA Statements. By default, the REACH reader's
         process_text function is used with default parameters. Note that
         if the function requires extra parameters other than the input text,
-        functools.partial can be used to set those.
+        functools.partial can be used to set those. Can be alternatively
+        set to :func:`indra.sources.bel.process_text` by using the string
+        "bel".
     grounder : Optional[function]
         A handle for a function which takes a positional str argument (entity
         text to ground) and an optional context key word argument and returns

--- a/indra/sources/hypothesis/api.py
+++ b/indra/sources/hypothesis/api.py
@@ -207,7 +207,12 @@ def process_annotations(group=None, reader=None, grounder=None):
     Process all annotations that have been written in BEL with:
 
     >>> from indra.sources import hypothesis
-    >>> processor = hypothesis.process_annotations(group='bel', reader='bel')
+    >>> processor = hypothesis.process_annotations(group='Z8RNqokY', reader='bel')
+    >>> processor.statements
+    [Phosphorylation(AKT(), PCGF2(), T, 334)]
+
+    If this example doesn't work, try joining the group with this link:
+    https://hypothes.is/groups/Z8RNqokY/cthoyt-bel.
     """
     annotations = get_annotations(group=group)
     hp = HypothesisProcessor(annotations, reader=reader, grounder=grounder)

--- a/indra/sources/hypothesis/api.py
+++ b/indra/sources/hypothesis/api.py
@@ -201,6 +201,13 @@ def process_annotations(group=None, reader=None, grounder=None):
         A HypothesisProcessor object which contains a list of extracted
         INDRA Statements in its statements attribute, and a list of extracted
         grounding curations in its groundings attribute.
+
+    Example
+    -------
+    Process all annotations that have been written in BEL with:
+
+    >>> from indra.sources import hypothesis
+    >>> processor = hypothesis.process_annotations(group='bel', reader='bel')
     """
     annotations = get_annotations(group=group)
     hp = HypothesisProcessor(annotations, reader=reader, grounder=grounder)

--- a/indra/sources/hypothesis/processor.py
+++ b/indra/sources/hypothesis/processor.py
@@ -16,7 +16,7 @@ class HypothesisProcessor:
     annotations : list[dict]
         A list of annotations fetched from hypothes.is in JSON-deserialized
         form represented as a list of dicts.
-    reader : Optiona[function]
+    reader : Union[None, str, Callable[[str],Processor]]
         A handle for a function which takes a single str argument
         (text to process) and returns a processor object with a statements
         attribute containing INDRA Statements. By default, the REACH reader's
@@ -41,9 +41,12 @@ class HypothesisProcessor:
         self.annotations = annotations
         self.statements = []
         self.groundings = {}
-        if reader is None:
+        if reader is None or reader == 'reach':
             from indra.sources import reach
             self.reader = reach.process_text
+        elif reader == 'bel':
+            from indra.sources import bel
+            self.reader = bel.process_text
         else:
             self.reader = reader
         if grounder is None:

--- a/indra/sources/hypothesis/processor.py
+++ b/indra/sources/hypothesis/processor.py
@@ -46,7 +46,7 @@ class HypothesisProcessor:
             self.reader = reach.process_text
         elif reader == 'bel':
             from indra.sources import bel
-            self.reader = bel.process_text
+            self.reader = bel.process_bel_stmt
         else:
             self.reader = reader
         if grounder is None:

--- a/indra/tests/test_pybel_api.py
+++ b/indra/tests/test_pybel_api.py
@@ -778,3 +778,19 @@ def test_complex_stmt_with_activation():
     assert stmt2.obj.name == 'MAPK1'
     assert stmt2.obj.activity is None
     assert stmt2.obj_activity == 'kinase'
+
+
+def test_process_bel_stmts():
+    bp = bel.process_bel_stmt('p(HGNC:MDM2) directlyDecreases '
+                              'tscript(p(HGNC:TP53))')
+    assert len(bp.statements) == 1
+    assert isinstance(bp.statements[0], Inhibition), bp.statements
+    assert bp.statements[0].subj.name == 'MDM2', bp.statements
+    assert bp.statements[0].obj.name == 'TP53', bp.statements
+
+    bp = bel.process_bel_stmt('a(CHEBI:lipoprotein) increases '
+                              'bp(GOBP:"inflammatory response")')
+    assert len(bp.statements) == 1
+    assert isinstance(bp.statements[0], Activation), bp.statements
+    assert bp.statements[0].subj.name == 'lipoprotein', bp.statements
+    assert bp.statements[0].obj.name == 'inflammatory response', bp.statements


### PR DESCRIPTION
This PR adds a function to `indra.sources.bel` that can turn a single BEL string into an INDRA statement. Example usage:

```python
>>> from indra.sources.bel import process_bel_statement
>>> bel_s = 'kin(p(FPLX:MEK)) -> kin(p(FPLX:ERK))'
>>> indra_s = process_bel_stmt(bel_s)
Activation(MEK(kinase), ERK(), kinase)
```

This PR also updates the Hypothes.is processor to read BEL (and gives some string-based defaults for readers). Example usage after associating your hypothesis API key with [this group](https://hypothes.is/groups/Z8RNqokY/cthoyt-bel):

```python
>>> from indra.sources import hypothesis
>>> processor = hypothesis.process_annotations(group='Z8RNqokY', reader='bel')
>>> processor.statements
[Phosphorylation(AKT(), PCGF2(), T, 334)]
```

## Tasks

- [x] wrap pre-existing functionality to quickly generate INDRA statements
- [ ] consider adding calls to Gilda to handle any entities whose namespaces are `TEXT`