### PR TITLE
Implement a pretty print function for stmt lists.

### DIFF
--- a/indra/statements/io.py
+++ b/indra/statements/io.py
@@ -4,7 +4,7 @@ __all__ = ['stmts_from_json', 'stmts_from_json_file', 'stmts_to_json',
 
 import json
 import logging
-from typing import List
+from typing import List, Optional
 
 from indra.statements.statements import Statement, Unresolved
 
@@ -221,8 +221,9 @@ def draw_stmt_graph(stmts):
     plt.show()
 
 
-def pretty_print_stmts(stmt_list: List[Statement], stmt_limit: int = None,
-                       ev_limit: int = 5) -> None:
+def pretty_print_stmts(stmt_list: List[Statement],
+                       stmt_limit: Optional[int] = None,
+                       ev_limit: Optional[int] = 5) -> None:
     """Print a list of statements to the commandline in a neatly formatted way.
 
     Parameters
@@ -233,6 +234,7 @@ def pretty_print_stmts(stmt_list: List[Statement], stmt_limit: int = None,
         The maximum number of INDRA Statements to be printed. (Default is None)
     ev_limit :
         The maximum number of Evidence to print for each Statement.
+        (Default is 5)
     """
     # Import some modules helpful for ext formatting.
     from textwrap import TextWrapper

--- a/indra/statements/io.py
+++ b/indra/statements/io.py
@@ -237,7 +237,9 @@ def pretty_print_stmts(stmt_list: List[Statement],
                        stmt_limit: Optional[int] = None,
                        ev_limit: Optional[int] = 5,
                        width: Optional[int] = None) -> None:
-    """Print a list of statements to the commandline in a neatly formatted way.
+    """Print a formatted list of statements along with evidence text.
+
+    Requires the tabulate package (https://pypi.org/project/tabulate).
 
     Parameters
     ----------
@@ -251,18 +253,22 @@ def pretty_print_stmts(stmt_list: List[Statement],
         evidence will be printed for each Statement. (Default is 5)
     width : Optional[int]
         Manually set the width of the table. If `None` the function will try to
-        match the current terminal width, and if that is not possible it will
-        use :data:`pretty_print_default_width`, which can be adjusted using the
-        :func:`set_pretty_print_default_width` function. (Default is None)
-        """
-    # Import some modules helpful for ext formatting.
+        match the current terminal width using `os.get_terminal_size()`.  If
+        this fails the width defaults to 80 characters. The maximum width can
+        be controlled by setting :data:`pretty_print_max_width` using the
+        :func:`set_pretty_print_max_width` function. This is useful in 
+        Jupyter notebooks where the environment returns a terminal size
+        of 80 characters regardless of the width of the window. (Default
+        is None).
+    """
+    # Import some modules helpful for text formatting.
     from textwrap import TextWrapper
     from tabulate import tabulate
     from os import get_terminal_size
 
     # Try to get the actual number of columns in the terminal.
     if width is None:
-        width = 66
+        width = 80
         try:
             width = get_terminal_size().columns
         except Exception as e:

--- a/indra/statements/io.py
+++ b/indra/statements/io.py
@@ -246,14 +246,13 @@ def pretty_print_stmts(stmt_list: List[Statement],
         Statements are printed. (Default is None)
     ev_limit : Optional[int]
         The maximum number of Evidence to print for each Statement. If None, all
-        evidence will be printed for each Statement. (Default is 5).
+        evidence will be printed for each Statement. (Default is 5)
     width : Optional[int]
-        Manually set the width of the table. Default is None, in which case
-        the function will try to match the current terminal width, and if that
-        is not possible it will use :data:`pretty_print_default_width`, which
-        can be adjusted using the :func:`set_pretty_print_default_width`
-        function.
-    """
+        Manually set the width of the table. If `None` the function will try to
+        match the current terminal width, and if that is not possible it will
+        use :data:`pretty_print_default_width`, which can be adjusted using the
+        :func:`set_pretty_print_default_width` function. (Default is None)
+        """
     # Import some modules helpful for ext formatting.
     from textwrap import TextWrapper
     from tabulate import tabulate

--- a/indra/statements/io.py
+++ b/indra/statements/io.py
@@ -1,7 +1,7 @@
 __all__ = ['stmts_from_json', 'stmts_from_json_file', 'stmts_to_json',
            'stmts_to_json_file', 'draw_stmt_graph', 'pretty_print_stmts',
            'UnresolvedUuidError', 'InputError',
-           'set_pretty_print_default_width']
+           'set_pretty_print_max_width']
 
 import json
 import logging
@@ -222,13 +222,13 @@ def draw_stmt_graph(stmts):
     plt.show()
 
 
-pretty_print_default_width = 66
+pretty_print_max_width = 80
 
 
-def set_pretty_print_default_width(new_default):
-    """Set the default display width for pretty prints, in characters."""
-    global pretty_print_default_width
-    pretty_print_default_width = new_default
+def set_pretty_print_max_width(new_max):
+    """Set the max display width for pretty prints, in characters."""
+    global pretty_print_max_width
+    pretty_print_max_width = new_max
 
 
 def pretty_print_stmts(stmt_list: List[Statement],
@@ -260,9 +260,9 @@ def pretty_print_stmts(stmt_list: List[Statement],
 
     # Try to get the actual number of columns in the terminal.
     if width is None:
-        width = pretty_print_default_width
+        width = 66
         try:
-            width = get_terminal_size().columns
+            width = min(get_terminal_size().columns, pretty_print_max_width)
         except Exception as e:
             logger.debug(f"Failed to get terminal size (using default "
                          f"{width}): {e}.")

--- a/indra/statements/io.py
+++ b/indra/statements/io.py
@@ -239,18 +239,20 @@ def pretty_print_stmts(stmt_list: List[Statement],
 
     Parameters
     ----------
-    stmt_list :
+    stmt_list : List[Statement]
         The list of INDRA Statements to be printed.
-    stmt_limit :
-        The maximum number of INDRA Statements to be printed. (Default is None)
-    ev_limit :
-        The maximum number of Evidence to print for each Statement.
-        (Default is 5)
-    width :
+    stmt_limit : Optional[int]
+        The maximum number of INDRA Statements to be printed. If None, all
+        Statements are printed. (Default is None)
+    ev_limit : Optional[int]
+        The maximum number of Evidence to print for each Statement. If None, all
+        evidence will be printed for each Statement. (Default is 5).
+    width : Optional[int]
         Manually set the width of the table. Default is None, in which case
         the function will try to match the current terminal width, and if that
-        is not possible it will use `pretty_print_default_width`, which can be
-        adjusted using the `set_pretty_print_default_width` function.
+        is not possible it will use :data:`pretty_print_default_width`, which
+        can be adjusted using the :func:`set_pretty_print_default_width`
+        function.
     """
     # Import some modules helpful for ext formatting.
     from textwrap import TextWrapper

--- a/indra/statements/io.py
+++ b/indra/statements/io.py
@@ -226,7 +226,7 @@ pretty_print_default_width = 66
 
 
 def set_pretty_print_default_width(new_default):
-    """Set the default column width for pretty prints."""
+    """Set the default display width for pretty prints, in characters."""
     global pretty_print_default_width
     pretty_print_default_width = new_default
 

--- a/indra/statements/io.py
+++ b/indra/statements/io.py
@@ -222,12 +222,14 @@ def draw_stmt_graph(stmts):
     plt.show()
 
 
-pretty_print_max_width = 80
+pretty_print_max_width = None
 
 
 def set_pretty_print_max_width(new_max):
     """Set the max display width for pretty prints, in characters."""
     global pretty_print_max_width
+    if new_max is not None and not isinstance(new_max, int):
+        raise ValueError("Max width must be an integer or None.")
     pretty_print_max_width = new_max
 
 
@@ -262,10 +264,15 @@ def pretty_print_stmts(stmt_list: List[Statement],
     if width is None:
         width = 66
         try:
-            width = min(get_terminal_size().columns, pretty_print_max_width)
+            width = get_terminal_size().columns
         except Exception as e:
             logger.debug(f"Failed to get terminal size (using default "
                          f"{width}): {e}.")
+
+        # Apply the maximum.
+        if pretty_print_max_width is not None:
+            assert isinstance(pretty_print_max_width, int)
+            width = min(width, pretty_print_max_width)
 
     # Parameterize the text wrappers that format the ev text and the metadata.
     stmt_tr = TextWrapper(width=width)

--- a/indra/statements/io.py
+++ b/indra/statements/io.py
@@ -278,7 +278,10 @@ def pretty_print_stmts(stmt_list: List[Statement],
                                      for line in metadata_tr.wrap(f"{k}: {v}"))
 
             # Form the evidence string.
-            text_str = evidence_tr.fill(ev.text)
+            if ev.text:
+                text_str = evidence_tr.fill(ev.text)
+            else:
+                text_str = evidence_tr.fill("(No evidence text)")
 
             # Print the entire thing
             full_str = tabulate([[metadata_str, text_str]], tablefmt='plain')

--- a/indra/statements/statements.py
+++ b/indra/statements/statements.py
@@ -228,7 +228,7 @@ __all__ = [
     'modtype_to_modclass',
     'modclass_to_modtype', 'modtype_conditions', 'modtype_to_inverse',
     'modclass_to_inverse', 'get_statement_by_name', 'make_hash', 'stmt_type',
-    'default_ns_order', 'mk_str'
+    'default_ns_order', 'mk_str', 'pretty_print_stmts',
     ]
 
 import abc

--- a/indra/statements/statements.py
+++ b/indra/statements/statements.py
@@ -229,7 +229,7 @@ __all__ = [
     'modclass_to_modtype', 'modtype_conditions', 'modtype_to_inverse',
     'modclass_to_inverse', 'get_statement_by_name', 'make_hash', 'stmt_type',
     'default_ns_order', 'mk_str', 'pretty_print_stmts',
-    'set_pretty_print_default_width'
+    'set_pretty_print_max_width'
     ]
 
 import abc

--- a/indra/statements/statements.py
+++ b/indra/statements/statements.py
@@ -229,6 +229,7 @@ __all__ = [
     'modclass_to_modtype', 'modtype_conditions', 'modtype_to_inverse',
     'modclass_to_inverse', 'get_statement_by_name', 'make_hash', 'stmt_type',
     'default_ns_order', 'mk_str', 'pretty_print_stmts',
+    'set_pretty_print_default_width'
     ]
 
 import abc


### PR DESCRIPTION
This PR adds a function to `indra.statements.io` that prints Statements and their evidence to the terminal prettily. This can be extremely useful when browsing Statements in the command line. In future this could in principal be integrated with all the ordering and sorting tools developed for the HTML Assembler. There are also numerous ways in which the display could be tweaked.

Some key features:
- The line width is adaptive to the current terminal width (should work on most OSs)
- The evidence text is wrapped neatly
- The metadata for each evidence is displayed along side the text using `tabular`.

Some good features that could be added:
- The ability to select what metadata is shown
- The ability to use the English form of the statements in the headings
- The ability to sort and group Statements a la the HTML Assembler (although I think there is a compelling argument that perhaps keeping it simpler is better).