### PR TITLE
Filter edge

### DIFF
--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -50,7 +50,8 @@ class IndraNetAssembler():
 
     def make_model(self, exclude_stmts=None, complex_members=3,
                    graph_type='multi_graph', sign_dict=None,
-                   belief_flattening=None, weight_flattening=None):
+                   belief_flattening=None, weight_flattening=None,
+                   extra_columns=None):
         """Assemble an IndraNet graph object.
 
         Parameters
@@ -106,7 +107,7 @@ class IndraNetAssembler():
         model : IndraNet
             IndraNet graph object.
         """
-        df = self.make_df(exclude_stmts, complex_members)
+        df = self.make_df(exclude_stmts, complex_members, extra_columns)
         if graph_type == 'multi_graph':
             model = IndraNet.from_df(df)
         elif graph_type == 'digraph':

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -125,7 +125,8 @@ class IndraNetAssembler():
                             'type.')
         return model
 
-    def make_df(self, exclude_stmts=None, complex_members=3):
+    def make_df(self, exclude_stmts=None, complex_members=3,
+                extra_columns=None):
         """Create a dataframe containing information extracted from assembler's
         list of statements necessary to build an IndraNet.
 
@@ -138,13 +139,17 @@ class IndraNetAssembler():
             data frame. All complexes larger than complex_members will be
             rejected. For accepted complexes, all permutations of their
             members will be added as dataframe records. Default is `3`.
+        extra_columns : list[tuple(str, function)]
+            A list of tuples defining columns to add to the dataframe in
+            addition to the required columns. Each tuple contains the column
+            name and a function to generate a value from a statement.
 
         Returns
         -------
         df : pd.DataFrame
             Pandas DataFrame object containing information extracted from
             statements. It contains the following columns:
-            
+
             *agA_name*
                 The first Agent's name.
             *agA_ns*
@@ -179,6 +184,8 @@ class IndraNetAssembler():
                 statement if the statement type has implied polarity.
                 To facilitate weighted path finding, the sign is represented
                 as 0 for positive polarity and 1 for negative polarity.
+
+            More columns can be added by providing the extra_columns parameter.
         """
         rows = []
         if exclude_stmts:
@@ -265,6 +272,9 @@ class IndraNetAssembler():
                     ('belief', stmt.belief),
                     ('source_counts', _get_source_counts(stmt)),
                     ('initial_sign', sign)])
+                if extra_columns:
+                    for col_name, func in extra_columns:
+                        row[col_name] = func(stmt)
                 rows.append(row)
         df = pd.DataFrame.from_dict(rows)
         df = df.where((pd.notnull(df)), None)

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -264,7 +264,8 @@ class ModelChecker(object):
         return results
 
     def check_statement(self, stmt, max_paths=1, max_path_length=5,
-                        agent_filter_func=None, node_filter_func=None):
+                        agent_filter_func=None, node_filter_func=None,
+                        edge_filter_func=None):
         """Check a single Statement against the model.
 
         Parameters
@@ -290,7 +291,7 @@ class ModelChecker(object):
         result : indra.explanation.modelchecker.PathResult
             A PathResult object containing the result of a test.
         """
-        self.get_graph()
+        self.get_graph(edge_filter_func=edge_filter_func)
         subj_nodes, obj_nodes, result_code = self.process_statement(stmt)
         if result_code:
             return self.make_false_result(result_code, max_paths,

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -230,7 +230,7 @@ class ModelChecker(object):
         self.statements += stmts
 
     def check_model(self, max_paths=1, max_path_length=5,
-                    agent_filter_func=None):
+                    agent_filter_func=None, edge_filter_func_name=None):
         """Check all the statements added to the ModelChecker.
 
         Parameters
@@ -258,14 +258,16 @@ class ModelChecker(object):
             logger.info('---')
             logger.info('Checking statement (%d/%d): %s' %
                         (idx + 1, len(self.statements), stmt))
-            result = self.check_statement(stmt, max_paths, max_path_length,
-                                          node_filter_func=node_filter_func)
+            result = self.check_statement(
+                stmt, max_paths, max_path_length,
+                node_filter_func=node_filter_func,
+                edge_filter_func_name=edge_filter_func_name)
             results.append((stmt, result))
         return results
 
     def check_statement(self, stmt, max_paths=1, max_path_length=5,
                         agent_filter_func=None, node_filter_func=None,
-                        edge_filter_func=None):
+                        edge_filter_func_name=None):
         """Check a single Statement against the model.
 
         Parameters
@@ -291,7 +293,7 @@ class ModelChecker(object):
         result : indra.explanation.modelchecker.PathResult
             A PathResult object containing the result of a test.
         """
-        self.get_graph(edge_filter_func=edge_filter_func)
+        self.get_graph(edge_filter_func_name=edge_filter_func_name)
         subj_nodes, obj_nodes, result_code = self.process_statement(stmt)
         if result_code:
             return self.make_false_result(result_code, max_paths,

--- a/indra/explanation/model_checker/model_checker.py
+++ b/indra/explanation/model_checker/model_checker.py
@@ -230,7 +230,7 @@ class ModelChecker(object):
         self.statements += stmts
 
     def check_model(self, max_paths=1, max_path_length=5,
-                    agent_filter_func=None, edge_filter_func_name=None):
+                    agent_filter_func=None, edge_filter_func=None):
         """Check all the statements added to the ModelChecker.
 
         Parameters
@@ -244,6 +244,11 @@ class ModelChecker(object):
             A function to constrain the intermediate nodes in the path. A
             function should take an agent as a parameter and return True if the
             agent is allowed to be in a path and False otherwise.
+        edge_filter_func : Optional[function]
+            A function to filter out edges from the graph. A function should
+            take nodes (and key in case of MultiGraph) as parameters and
+            return True if an edge can be in the graph and False if it should
+            be filtered out.
 
         Returns
         -------
@@ -261,13 +266,13 @@ class ModelChecker(object):
             result = self.check_statement(
                 stmt, max_paths, max_path_length,
                 node_filter_func=node_filter_func,
-                edge_filter_func_name=edge_filter_func_name)
+                edge_filter_func=edge_filter_func)
             results.append((stmt, result))
         return results
 
     def check_statement(self, stmt, max_paths=1, max_path_length=5,
                         agent_filter_func=None, node_filter_func=None,
-                        edge_filter_func_name=None):
+                        edge_filter_func=None):
         """Check a single Statement against the model.
 
         Parameters
@@ -287,13 +292,18 @@ class ModelChecker(object):
             Similar to agent_filter_func but it takes a node as a parameter
             instead of agent. If not provided, node_filter_func will be
             generated from agent_filter_func.
+        edge_filter_func : Optional[function]
+            A function to filter out edges from the graph. A function should
+            take nodes (and key in case of MultiGraph) as parameters and
+            return True if an edge can be in the graph and False if it should
+            be filtered out.
 
         Returns
         -------
         result : indra.explanation.modelchecker.PathResult
             A PathResult object containing the result of a test.
         """
-        self.get_graph(edge_filter_func_name=edge_filter_func_name)
+        self.get_graph(edge_filter_func=edge_filter_func)
         subj_nodes, obj_nodes, result_code = self.process_statement(stmt)
         if result_code:
             return self.make_false_result(result_code, max_paths,

--- a/indra/explanation/model_checker/pybel.py
+++ b/indra/explanation/model_checker/pybel.py
@@ -37,13 +37,14 @@ class PybelModelChecker(ModelChecker):
 
     def get_graph(self, include_variants=False, symmetric_variant_links=False,
                   include_components=True, symmetric_component_links=True,
-                  edge_filter_func=None):
+                  edge_filter_func_name=None):
         """Convert a PyBELGraph to a graph with signed nodes."""
         # This import is done here rather than at the top level to avoid
         # making pybel an implicit dependency of the model checker
         from indra.assemblers.pybel.assembler import belgraph_to_signed_graph
         if self.graph:
             return self.graph
+        # NOTE edge_filter_func_name is not currently used in PyBEL
         signed_edges = belgraph_to_signed_graph(
             self.model,
             include_variants=include_variants,

--- a/indra/explanation/model_checker/pybel.py
+++ b/indra/explanation/model_checker/pybel.py
@@ -36,7 +36,8 @@ class PybelModelChecker(ModelChecker):
         super().__init__(model, statements, do_sampling, seed, nodes_to_agents)
 
     def get_graph(self, include_variants=False, symmetric_variant_links=False,
-                  include_components=True, symmetric_component_links=True):
+                  include_components=True, symmetric_component_links=True,
+                  edge_filter_func=None):
         """Convert a PyBELGraph to a graph with signed nodes."""
         # This import is done here rather than at the top level to avoid
         # making pybel an implicit dependency of the model checker

--- a/indra/explanation/model_checker/pybel.py
+++ b/indra/explanation/model_checker/pybel.py
@@ -37,14 +37,14 @@ class PybelModelChecker(ModelChecker):
 
     def get_graph(self, include_variants=False, symmetric_variant_links=False,
                   include_components=True, symmetric_component_links=True,
-                  edge_filter_func_name=None):
+                  edge_filter_func=None):
         """Convert a PyBELGraph to a graph with signed nodes."""
         # This import is done here rather than at the top level to avoid
         # making pybel an implicit dependency of the model checker
         from indra.assemblers.pybel.assembler import belgraph_to_signed_graph
         if self.graph:
             return self.graph
-        # NOTE edge_filter_func_name is not currently used in PyBEL
+        # NOTE edge_filter_func is not currently used in PyBEL
         signed_edges = belgraph_to_signed_graph(
             self.model,
             include_variants=include_variants,

--- a/indra/explanation/model_checker/pysb.py
+++ b/indra/explanation/model_checker/pysb.py
@@ -265,10 +265,11 @@ class PysbModelChecker(ModelChecker):
 
     def get_graph(self, prune_im=True, prune_im_degrade=True,
                   prune_im_subj_obj=False, add_namespaces=False,
-                  edge_filter_func=None):
+                  edge_filter_func_name=None):
         """Get influence map and convert it to a graph with signed nodes."""
         if self.graph:
             return self.graph
+        # NOTE edge_filter_func_name is not currently used in PySB
         im = self.get_im(force_update=True)
         if prune_im:
             self.prune_influence_map()

--- a/indra/explanation/model_checker/pysb.py
+++ b/indra/explanation/model_checker/pysb.py
@@ -265,11 +265,11 @@ class PysbModelChecker(ModelChecker):
 
     def get_graph(self, prune_im=True, prune_im_degrade=True,
                   prune_im_subj_obj=False, add_namespaces=False,
-                  edge_filter_func_name=None):
+                  edge_filter_func=None):
         """Get influence map and convert it to a graph with signed nodes."""
         if self.graph:
             return self.graph
-        # NOTE edge_filter_func_name is not currently used in PySB
+        # NOTE edge_filter_func is not currently used in PySB
         im = self.get_im(force_update=True)
         if prune_im:
             self.prune_influence_map()

--- a/indra/explanation/model_checker/pysb.py
+++ b/indra/explanation/model_checker/pysb.py
@@ -264,7 +264,8 @@ class PysbModelChecker(ModelChecker):
         return self._im
 
     def get_graph(self, prune_im=True, prune_im_degrade=True,
-                  prune_im_subj_obj=False, add_namespaces=False):
+                  prune_im_subj_obj=False, add_namespaces=False,
+                  edge_filter_func=None):
         """Get influence map and convert it to a graph with signed nodes."""
         if self.graph:
             return self.graph

--- a/indra/explanation/model_checker/signed_graph.py
+++ b/indra/explanation/model_checker/signed_graph.py
@@ -34,7 +34,7 @@ class SignedGraphModelChecker(ModelChecker):
                  nodes_to_agents=None):
         super().__init__(model, statements, do_sampling, seed, nodes_to_agents)
 
-    def get_graph(self):
+    def get_graph(self, edge_filter_func=None):
         if self.graph:
             return self.graph
         self.graph = signed_edges_to_signed_nodes(

--- a/indra/explanation/model_checker/signed_graph.py
+++ b/indra/explanation/model_checker/signed_graph.py
@@ -1,4 +1,6 @@
 import logging
+import networkx as nx
+
 from . import ModelChecker
 from indra.statements import *
 from indra.ontology.bio import bio_ontology
@@ -37,8 +39,13 @@ class SignedGraphModelChecker(ModelChecker):
     def get_graph(self, edge_filter_func=None):
         if self.graph:
             return self.graph
+        if edge_filter_func:
+            filtered_model = nx.subgraph_view(
+                self.model, filter_edge=edge_filter_func)
+        else:
+            filtered_model = self.model
         self.graph = signed_edges_to_signed_nodes(
-            self.model, copy_edge_data={'belief'})
+            filtered_model, copy_edge_data={'belief'})
         self.get_nodes_to_agents()
         return self.graph
 

--- a/indra/explanation/model_checker/signed_graph.py
+++ b/indra/explanation/model_checker/signed_graph.py
@@ -36,21 +36,24 @@ class SignedGraphModelChecker(ModelChecker):
                  nodes_to_agents=None):
         super().__init__(model, statements, do_sampling, seed, nodes_to_agents)
 
-    def get_graph(self, edge_filter_func_name=None, copy_edge_data=None):
+    def get_graph(self, edge_filter_func=None, copy_edge_data=None):
         """Get a signed nodes graph to search for paths in.
 
         Parameters
         ----------
-        edge_filter_func_name : str
-            A name of a edge filter function to filter the original model.
+        edge_filter_func : Optional[function]
+            A function to filter out edges from the graph. A function should
+            take nodes (and key in case of MultiGraph) as parameters and
+            return True if an edge can be in the graph and False if it should
+            be filtered out.
         copy_edge_data : set(str)
             A set of keys to copy from original model edge data to the graph
             edge data. If None, only belief data is copied by default.
         """
         if self.graph:
             return self.graph
-        if edge_filter_func_name:
-            filtered_model = get_subgraph(self.model, edge_filter_func_name)
+        if edge_filter_func:
+            filtered_model = get_subgraph(self.model, edge_filter_func)
         else:
             filtered_model = self.model
         if not copy_edge_data:

--- a/indra/explanation/model_checker/unsigned_graph.py
+++ b/indra/explanation/model_checker/unsigned_graph.py
@@ -1,8 +1,8 @@
 import logging
-import networkx as nx
 from . import ModelChecker, NodesContainer
 from indra.statements import *
 from indra.ontology.bio import bio_ontology
+from indra.explanation.pathfinding.util import get_subgraph
 
 
 logger = logging.getLogger(__name__)
@@ -35,12 +35,21 @@ class UnsignedGraphModelChecker(ModelChecker):
                  nodes_to_agents=None):
         super().__init__(model, statements, do_sampling, seed, nodes_to_agents)
 
-    def get_graph(self, edge_filter_func=None):
+    def get_graph(self, edge_filter_func_name=None, copy_edge_data=None):
+        """Get a signed nodes graph to search for paths in.
+
+        Parameters
+        ----------
+        edge_filter_func_name : str
+            A name of a edge filter function to filter the original model.
+        copy_edge_data : set(str)
+            A set of keys to copy from original model edge data to the graph
+            edge data. If None, only belief data is copied by default.
+        """
         if self.graph:
             return self.graph
-        if edge_filter_func:
-            filtered_model = nx.subgraph_view(
-                self.model, filter_edge=edge_filter_func)
+        if edge_filter_func_name:
+            filtered_model = get_subgraph(self.model, edge_filter_func_name)
         else:
             filtered_model = self.model
         self.graph = nx.DiGraph()
@@ -48,8 +57,11 @@ class UnsignedGraphModelChecker(ModelChecker):
         for node, node_data in filtered_model.nodes(data=True):
             nodes.append(((node, 0), node_data))
         self.graph.add_nodes_from(nodes)
+        if not copy_edge_data:
+            copy_edge_data = {'belief'}
         for (u, v, data) in filtered_model.edges(data=True):
-            self.graph.add_edge((u, 0), (v, 0), belief=data['belief'])
+            edge_data = {k: data[k] for k in copy_edge_data}
+            self.graph.add_edge((u, 0), (v, 0), **edge_data)
         self.get_nodes_to_agents()
         return self.graph
 

--- a/indra/explanation/model_checker/unsigned_graph.py
+++ b/indra/explanation/model_checker/unsigned_graph.py
@@ -35,7 +35,7 @@ class UnsignedGraphModelChecker(ModelChecker):
                  nodes_to_agents=None):
         super().__init__(model, statements, do_sampling, seed, nodes_to_agents)
 
-    def get_graph(self):
+    def get_graph(self, edge_filter_func=None):
         if self.graph:
             return self.graph
         self.graph = nx.DiGraph()

--- a/indra/explanation/model_checker/unsigned_graph.py
+++ b/indra/explanation/model_checker/unsigned_graph.py
@@ -38,12 +38,17 @@ class UnsignedGraphModelChecker(ModelChecker):
     def get_graph(self, edge_filter_func=None):
         if self.graph:
             return self.graph
+        if edge_filter_func:
+            filtered_model = nx.subgraph_view(
+                self.model, filter_edge=edge_filter_func)
+        else:
+            filtered_model = self.model
         self.graph = nx.DiGraph()
         nodes = []
-        for node, node_data in self.model.nodes(data=True):
+        for node, node_data in filtered_model.nodes(data=True):
             nodes.append(((node, 0), node_data))
         self.graph.add_nodes_from(nodes)
-        for (u, v, data) in self.model.edges(data=True):
+        for (u, v, data) in filtered_model.edges(data=True):
             self.graph.add_edge((u, 0), (v, 0), belief=data['belief'])
         self.get_nodes_to_agents()
         return self.graph

--- a/indra/explanation/model_checker/unsigned_graph.py
+++ b/indra/explanation/model_checker/unsigned_graph.py
@@ -1,4 +1,5 @@
 import logging
+import networkx as nx
 from . import ModelChecker, NodesContainer
 from indra.statements import *
 from indra.ontology.bio import bio_ontology

--- a/indra/explanation/model_checker/unsigned_graph.py
+++ b/indra/explanation/model_checker/unsigned_graph.py
@@ -36,21 +36,24 @@ class UnsignedGraphModelChecker(ModelChecker):
                  nodes_to_agents=None):
         super().__init__(model, statements, do_sampling, seed, nodes_to_agents)
 
-    def get_graph(self, edge_filter_func_name=None, copy_edge_data=None):
+    def get_graph(self, edge_filter_func=None, copy_edge_data=None):
         """Get a signed nodes graph to search for paths in.
 
         Parameters
         ----------
-        edge_filter_func_name : str
-            A name of a edge filter function to filter the original model.
+        edge_filter_func : Optional[function]
+            A function to filter out edges from the graph. A function should
+            take nodes (and key in case of MultiGraph) as parameters and
+            return True if an edge can be in the graph and False if it should
+            be filtered out.
         copy_edge_data : set(str)
             A set of keys to copy from original model edge data to the graph
             edge data. If None, only belief data is copied by default.
         """
         if self.graph:
             return self.graph
-        if edge_filter_func_name:
-            filtered_model = get_subgraph(self.model, edge_filter_func_name)
+        if edge_filter_func:
+            filtered_model = get_subgraph(self.model, edge_filter_func)
         else:
             filtered_model = self.model
         self.graph = nx.DiGraph()

--- a/indra/explanation/pathfinding/util.py
+++ b/indra/explanation/pathfinding/util.py
@@ -1,6 +1,6 @@
 __all__ = ['path_sign_to_signed_nodes', 'signed_nodes_to_signed_edge',
            'get_sorted_neighbors', 'get_subgraph', 'register_edge_filter',
-           'filter_to_internal_edges']
+           'filter_to_internal_edges', 'edge_filter_functions']
 import logging
 import networkx as nx
 
@@ -133,14 +133,14 @@ def register_edge_filter(function):
     return function
 
 
-def get_subgraph(g, filter_func_name):
+def get_subgraph(g, edge_filter_func):
     """Get a subgraph of original graph filtered by a provided function."""
     # Updating global variable here to handle NetworkX implementation of
     # closures used in subgraph_view
     global G
     G = g
-    filter_edge = edge_filter_functions.get(filter_func_name)
-    view = nx.subgraph_view(g, filter_edge=filter_edge)
+    logger.info('Getting subgraph with %s function' % edge_filter_func)
+    view = nx.subgraph_view(g, filter_edge=edge_filter_func)
     # Copying to get a graph object instead of view
     new_g = view.copy()
     return new_g

--- a/indra/explanation/pathfinding/util.py
+++ b/indra/explanation/pathfinding/util.py
@@ -1,5 +1,6 @@
 __all__ = ['path_sign_to_signed_nodes', 'signed_nodes_to_signed_edge',
-           'get_sorted_neighbors']
+           'get_sorted_neighbors', 'get_subgraph', 'register_edge_filter',
+           'filter_to_internal_edges']
 import logging
 import networkx as nx
 
@@ -147,6 +148,9 @@ def get_subgraph(g, filter_func_name):
 
 @register_edge_filter
 def filter_to_internal_edges(u, v, *args):
+    """Return True if an edge is internal. NOTE it returns True if any of the
+    statements associated with an edge is internal.
+    """
     if args:
         edge = G[u][v][args[0]]
     else:

--- a/indra/explanation/pathfinding/util.py
+++ b/indra/explanation/pathfinding/util.py
@@ -146,12 +146,12 @@ def get_subgraph(g, filter_func_name):
 
 
 @register_edge_filter
-def filter_edge_by_source_tag(u, v, *args):
+def filter_to_internal_edges(u, v, *args):
     if args:
         edge = G[u][v][args[0]]
     else:
         edge = G[u][v]
-    source_tags = set()
     for stmts_dict in edge['statements']:
-        source_tags = source_tags.union(stmts_dict['source_tags'])
-    return 'internal' in source_tags
+        if stmts_dict['internal']:
+            return True
+    return False

--- a/indra/explanation/pathfinding/util.py
+++ b/indra/explanation/pathfinding/util.py
@@ -1,6 +1,5 @@
 __all__ = ['path_sign_to_signed_nodes', 'signed_nodes_to_signed_edge',
-           'get_sorted_neighbors', 'get_subgraph', 'register_edge_filter',
-           'filter_to_internal_edges', 'edge_filter_functions']
+           'get_sorted_neighbors', 'get_subgraph']
 import logging
 import networkx as nx
 import functools
@@ -118,20 +117,6 @@ def get_sorted_neighbors(G, node, reverse, force_edges=None):
             reverse=True)
 
 
-edge_filter_functions = {}
-
-
-def register_edge_filter(function):
-    """
-    Decorator to register a function as an edge filter for getting subgraphs.
-    Edge filter function should take two (u, v - for DiGraph) or three
-    (u, v, k -  for MultiDiGraph) parameters and return True if the edge
-    should be in the graph and False otherwise.
-    """
-    edge_filter_functions[function.__name__] = function
-    return function
-
-
 def get_subgraph(g, edge_filter_func):
     """Get a subgraph of original graph filtered by a provided function."""
     logger.info('Getting subgraph with %s function' % edge_filter_func)
@@ -140,18 +125,3 @@ def get_subgraph(g, edge_filter_func):
     # Copying to get a graph object instead of view
     new_g = view.copy()
     return new_g
-
-
-@register_edge_filter
-def filter_to_internal_edges(g, u, v, *args):
-    """Return True if an edge is internal. NOTE it returns True if any of the
-    statements associated with an edge is internal.
-    """
-    if args:
-        edge = g[u][v][args[0]]
-    else:
-        edge = g[u][v]
-    for stmts_dict in edge['statements']:
-        if stmts_dict['internal']:
-            return True
-    return False

--- a/indra/tests/test_indranet_assembler.py
+++ b/indra/tests/test_indranet_assembler.py
@@ -75,6 +75,14 @@ def test_make_df():
         'initial_sign', 'residue', 'position'}
     assert df.residue.isna().sum() == 9  # Check that all but one row is NaN
     assert df.position.isna().sum() == 9  # Check that all but one row is NaN
+    # Extra column
+    df2 = ia.make_df(extra_columns=[
+        ('stmt_type_upper',
+         lambda stmt: type(stmt).__name__.upper())])
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 10
+    assert set(df2.columns) - set(df.columns) == {'stmt_type_upper'}
+    assert df2.stmt_type_upper[0] == 'ACTIVATION'
 
 
 # Test assembly from IndraNet directly

--- a/indra/tests/test_pathfinding.py
+++ b/indra/tests/test_pathfinding.py
@@ -1,9 +1,11 @@
+from copy import deepcopy
 import numpy as np
 import networkx as nx
 
 from indra.explanation.pathfinding.pathfinding import bfs_search, \
     shortest_simple_paths, bfs_search_multiple_nodes, open_dijkstra_search, \
     simple_paths_with_constraints
+from indra.explanation.pathfinding import util
 from indra.explanation.model_checker.model_checker import \
     signed_edges_to_signed_nodes
 
@@ -554,3 +556,64 @@ def test_simple_paths_with_constraints():
     paths = tuple([tuple(p) for p in simple_paths_with_constraints(
         dg, 'A3', 'D1', filter_func=_isB)])
     assert len(paths) == 0
+
+
+def test_get_subgraph_custom_filter():
+
+    @util.register_edge_filter
+    def filter_to_high_belief(u, v, *args):
+        if args:
+            edge = util.G[u][v][args[0]]
+        else:
+            edge = util.G[u][v]
+        return edge['belief'] > 0.5
+
+    # Signed graph
+    sg, _, _ = _setup_signed_graph()
+    assert len(sg.edges) == 12
+    assert ('A4', 'B2', 1) in sg.edges
+    filtered_sg = util.get_subgraph(sg, 'filter_to_high_belief')
+    assert len(filtered_sg.edges) == 10
+    assert ('A4', 'B2', 1) not in filtered_sg.edges
+
+    # Unsigned graph
+    ug, _ = _setup_unsigned_graph()
+    assert len(ug.edges) == 9
+    assert ('A4', 'B2') in ug.edges
+    filtered_ug = util.get_subgraph(ug, 'filter_to_high_belief')
+    assert len(filtered_ug.edges) == 7
+    assert ('A4', 'B2') not in filtered_ug.edges
+
+
+def test_subgraph_internal():
+    # Signed graph
+    sg, _, _ = _setup_signed_graph()
+    new_sg = deepcopy(sg)
+    # Add either internal or external or mixed edge data, should filter
+    # strictly external only
+    for i, (u, v, data) in enumerate(new_sg.edges(data=True)):
+        if i % 3 == 0:
+            data['statements'] = [{'internal': True}]
+        elif i % 3 == 1:
+            data['statements'] = [{'internal': False}]
+        else:
+            data['statements'] = [{'internal': True}, {'internal': False}]
+    assert len(new_sg.edges) == 12
+    filtered_sg = util.get_subgraph(new_sg, 'filter_to_internal_edges')
+    assert len(filtered_sg.edges) == 8
+
+    # Unsigned graph
+    ug, _ = _setup_unsigned_graph()
+    new_ug = deepcopy(ug)
+    # Add either internal or external or mixed edge data, should filter
+    # strictly external only
+    for i, (u, v, data) in enumerate(new_ug.edges(data=True)):
+        if i % 3 == 0:
+            data['statements'] = [{'internal': True}]
+        elif i % 3 == 1:
+            data['statements'] = [{'internal': False}]
+        else:
+            data['statements'] = [{'internal': True}, {'internal': False}]    
+    assert len(new_ug.edges) == 9
+    filtered_ug = util.get_subgraph(new_ug, 'filter_to_internal_edges')
+    assert len(filtered_ug.edges) == 6


### PR DESCRIPTION
This PR introduces a functionality to filter a graph to a subgraph based on any provided criteria to filter edges. This functionality is propagated to ModelChecker (currently for Signed and Unsiged graph model checkers) `get_graph` method to allow filtering the graph before searching for paths. In addition, this PR extends IndraNet assembler to allow adding any extra edge data and adds and extends relevant tests.