### PR TITLE
Python 3.9 compatibility and other improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,12 +16,6 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - uses: actions/cache@v2
-      with:
-        path: ./indra/cache
-        key: ${{ runner.os }}-eidos-geonames-${{ hashFiles('**/test_eidos.py') }}
-        restore-keys: |
-          ${{ runner.os }}-eidos-geonames-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -73,6 +67,11 @@ jobs:
         python -m adeft.download
         wget -nv https://bigmech.s3.amazonaws.com/travis/reach-82631d-biores-e9ee36.jar
         wget -nv https://bigmech.s3.amazonaws.com/travis/eidos.jar
+        wget -nv https://bigmech.s3.amazonaws.com/travis/geonames%2Bworedas.zip
+        mkdir -p /home/runner/work/indra/indra/cache/geonames/index
+        mv geonames%2Bworedas.zip /home/runner/work/indra/indra/cache/geonames/index
+        cd /home/runner/work/indra/indra/cache/geonames/index
+        unzip geonames%2Bworedas.zip
     - name: Run unit tests
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,9 +69,9 @@ jobs:
         wget -nv https://bigmech.s3.amazonaws.com/travis/eidos.jar
         wget -nv https://bigmech.s3.amazonaws.com/travis/geonames%2Bworedas.zip
         mkdir -p /home/runner/work/indra/indra/cache/geonames/index
-        mv geonames%2Bworedas.zip /home/runner/work/indra/indra/cache/geonames/index
+        mv geonames+woredas.zip /home/runner/work/indra/indra/cache/geonames/index
         cd /home/runner/work/indra/indra/cache/geonames/index
-        unzip geonames%2Bworedas.zip
+        unzip geonames+woredas.zip
     - name: Run unit tests
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.9]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -19,10 +22,10 @@ jobs:
         key: ${{ runner.os }}-eidos-geonames-${{ hashFiles('**/test_eidos.py') }}
         restore-keys: |
           ${{ runner.os }}-eidos-geonames-
-    - name: Set up Python 3.6
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: ${{ matrix.python-version }}
     - name: Setup java
       uses: actions/setup-java@v1
       with:

--- a/indra/assemblers/pysb/kappa_util.py
+++ b/indra/assemblers/pysb/kappa_util.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
+import json
 from networkx import MultiDiGraph, Graph, cycle_basis
 from pygraphviz import AGraph
 
@@ -17,6 +18,10 @@ def im_json_to_graph(im_json):
     graph : networkx.MultiDiGraph
         A graph representing the influence map.
     """
+    # This is for kappy compatibility: as of 4.1.2, im_json is a string,
+    # whereas before it was a json object
+    if isinstance(im_json, str):
+        im_json = json.loads(im_json)
     imap_data = im_json['influence map']['map']
 
     # Initialize the graph

--- a/indra/assemblers/pysb/kappa_util.py
+++ b/indra/assemblers/pysb/kappa_util.py
@@ -188,6 +188,8 @@ def cm_json_to_graph(cm_json):
             # As of kappy 4.1.2, the format of port links have changed
             # Old format: [[1, 0]], New format: [[[0, 1], 0]]
             for port_link in site['site_type'][1]['port_links']:
+                port_link = tuple([link[1] if isinstance(link, list) else link
+                                   for link in port_link])
                 if isinstance(port_link, list):
                     port_link = port_link[1]
                 edge = (site_key, tuple(port_link))

--- a/indra/assemblers/pysb/kappa_util.py
+++ b/indra/assemblers/pysb/kappa_util.py
@@ -159,7 +159,15 @@ def cm_json_to_graph(cm_json):
     graph : pygraphviz.Agraph
         A graph representing the contact map.
     """
+    # This is for kappy compatibility: as of 4.1.2, im_json is a string,
+    # whereas before it was a json object
+    if isinstance(cm_json, str):
+        cm_json = json.loads(cm_json)
     cmap_data = cm_json['contact map']['map']
+    # There also seems to be an additional level of nesting in a one-element
+    # list that we can unpack here
+    if len(cmap_data) == 1 and isinstance(cmap_data[0], list):
+        cmap_data = cmap_data[0]
 
     # Initialize the graph
     graph = AGraph()

--- a/indra/sources/trips/processor.py
+++ b/indra/sources/trips/processor.py
@@ -1457,7 +1457,7 @@ class TripsProcessor(object):
         if components is None:
             components = site_term.find('components')
         if components is not None:
-            for member in components.getchildren():
+            for member in components:
                 residue, pos = self._get_site_by_id(member.attrib['id'])
                 if residue is None:
                     residue = [None]

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def main():
                       # Tools and analysis
                       'machine': ['pytz', 'tzlocal', 'tweepy', 'pyyaml>=5.1.0',
                                   'click'],
-                      'explanation': ['kappy==4.0.0rc1', 'paths-graph'],
+                      'explanation': ['kappy==4.1.2', 'paths-graph'],
                       'grounding': ['adeft', 'gilda'],
                       # AWS interface and database
                       'aws': ['boto3', 'reportlab'],


### PR DESCRIPTION
This PR adds testing for Python 3.9 and makes some compatibility and general improvements:
- Compatibility with kappy versions up to the current latest (4.1.2) which has a Python 3.9 release. This involved some complications due to the structure of the JSON representing the contact map having changed in various ways. The code is now compatible with both old and new versions.
- Uses of ElemenTree's getchildren removed (these error in Python 3.9)
- More robust approach to downloading Geonames for Eidos tests