### PR TITLE
Updates to CRoG statements

### DIFF
--- a/indra/sources/crog/processor.py
+++ b/indra/sources/crog/processor.py
@@ -39,4 +39,4 @@ class CrogProcessor(RemoteProcessor):
             # have the EC prefix in their name
             for agent in stmt.real_agent_list():
                 if agent.name == agent.db_refs.get('ECCODE'):
-                    agent.name = 'EC%s' % agent.name
+                    agent.name = 'EC %s' % agent.name

--- a/indra/sources/crog/processor.py
+++ b/indra/sources/crog/processor.py
@@ -29,7 +29,8 @@ class CrogProcessor(RemoteProcessor):
     def __init__(self, url: Optional[str] = None):
         super().__init__(url=url or CROG_URL)
 
-        new_stmts = []
+    def extract_statements(self):
+        super().extract_statements()
         for stmt in self.statements:
             # We remap the source API to crog to align with the belief model
             for ev in stmt.evidence:
@@ -39,5 +40,3 @@ class CrogProcessor(RemoteProcessor):
             for agent in stmt.real_agent_list():
                 if agent.name == agent.db_refs.get('ECCODE'):
                     agent.name = 'EC%s' % agent.name
-            new_stmts.append(stmt)
-        self.statements = new_stmts

--- a/indra/sources/crog/processor.py
+++ b/indra/sources/crog/processor.py
@@ -28,3 +28,16 @@ class CrogProcessor(RemoteProcessor):
 
     def __init__(self, url: Optional[str] = None):
         super().__init__(url=url or CROG_URL)
+
+        new_stmts = []
+        for stmt in self.statements:
+            # We remap the source API to crog to align with the belief model
+            for ev in stmt.evidence:
+                ev.source_api = 'crog'
+            # We also change the name of targets whose names are ECCODEs to
+            # have the EC prefix in their name
+            for agent in stmt.real_agent_list():
+                if agent.name == agent.db_refs.get('ECCODE'):
+                    agent.name = 'EC%s' % agent.name
+            new_stmts.append(stmt)
+        self.statements = new_stmts


### PR DESCRIPTION
This PR sets the `source_api` to `crog` and adds `EC` prefixes to target Agents that don't have a proper name beyond an EC code. Fixes #1286.