### PR TITLE
Add .mailmap to improve git analysis 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -18,3 +18,4 @@ John Bachman <bachmanjohn@gmail.com> John A. Bachman <bachmanjohn@gmail.com>
 Klas Karis <karis.klas@gmail.com> kkaris <karis.klas@gmail.com>
 Priti Shaw <pritishaw0103@gmail.com> PritiShaw <pritishaw0103@gmail.com>
 Priti Shaw <pritishaw0103@gmail.com> Priti Shaw <34039705+PritiShaw@users.noreply.github.com>
+Askar Kolushev <19ak97@gmail.com> kolusask <19ak97@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,21 @@
+Adarsh Pyarelal <adarsh.pyarelal@gmail.com> Adarsh <adarsh.pyarelal@gmail.com> 
+Adarsh Pyarelal <adarsh.pyarelal@gmail.com> Adarsh Pyarelal <adarsh@email.arizona.edu>
+Albert Steppi <albert_steppi@hms.harvard.edu> Albert Steppi <albertsteppi@Alberts-MacBook-Pro.local>
+Albert Steppi <albert_steppi@hms.harvard.edu> steppi <albert_steppi@hms.harvard.edusdfjdifjijs>
+Albert Steppi <albert_steppi@hms.harvard.edu> steppi <albert_steppi@hms.harvard.edu>
+Ben Gyori <ben.gyori@gmail.com> Ben <ben@lspbgyorimbp.private.wireless.med.harvard.edu> 
+Ben Gyori <ben.gyori@gmail.com> bgyori <ben.gyori@gmail.com>
+Ben Gyori <ben.gyori@gmail.com> Benjamin M. Gyori <ben.gyori@gmail.com>
+Daniel Milstein <djmilstein@gmail.com> Daniel Milstein <djmilstein (at) gmail period com>
+Diana Kolusheva <dianakolusheva@gmail.com> Diana Kolusheva <35860871+dianakolusheva@users.noreply.github.com>
+Diana Kolusheva <dianakolusheva@gmail.com> dianakolusheva <dianakolusheva@gmail.com>
+Diana Kolusheva <dianakolusheva@gmail.com> kolusask <19ak97@gmail.com>
+Patrick Greene <patrick.anton.greene@gmail.com> Patrick Greene <phystheory4fun@gmail.com>
+Patrick Greene <patrick.anton.greene@gmail.com> P. Greene <patrick.anton.greene@gmail.com>
+Patrick Greene <patrick.anton.greene@gmail.com> pagreene <patrick.anton.greene@gmail.com>
+Petar Todorov <petar.v.todorov@gmail.com> pvtodorov <petar.v.todorov@gmail.com>
+Petar Todorov <petar.v.todorov@gmail.com> Unknown <petar.v.todorov@gmail.com>
+John Bachman <bachmanjohn@gmail.com> John A. Bachman <bachmanjohn@gmail.com>
+Klas Karis <karis.klas@gmail.com> kkaris <karis.klas@gmail.com>
+Priti Shaw <pritishaw0103@gmail.com> PritiShaw <pritishaw0103@gmail.com>
+Priti Shaw <pritishaw0103@gmail.com> Priti Shaw <34039705+PritiShaw@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -9,7 +9,6 @@ Ben Gyori <ben.gyori@gmail.com> Benjamin M. Gyori <ben.gyori@gmail.com>
 Daniel Milstein <djmilstein@gmail.com> Daniel Milstein <djmilstein (at) gmail period com>
 Diana Kolusheva <dianakolusheva@gmail.com> Diana Kolusheva <35860871+dianakolusheva@users.noreply.github.com>
 Diana Kolusheva <dianakolusheva@gmail.com> dianakolusheva <dianakolusheva@gmail.com>
-Diana Kolusheva <dianakolusheva@gmail.com> kolusask <19ak97@gmail.com>
 Patrick Greene <patrick.anton.greene@gmail.com> Patrick Greene <phystheory4fun@gmail.com>
 Patrick Greene <patrick.anton.greene@gmail.com> P. Greene <patrick.anton.greene@gmail.com>
 Patrick Greene <patrick.anton.greene@gmail.com> pagreene <patrick.anton.greene@gmail.com>


### PR DESCRIPTION
I made some charts using [`git-of-theseus`](https://github.com/erikbern/git-of-theseus), but it required a `.mailmap` file to make it useful. I learned how it's formatted by reading this https://improveandrepeat.com/2019/06/little-git-tricks-use-mailmap-to-merge-different-authors/, the git documentation doesn't document it where it says it does. This is the code I ran to make the charts:

```bash
$ pip install git-of-theseus
$ git clone https://github.com/sorgerlab/indra
$ cd indra
$ git-of-theseus-analyze .
$ git-of-theseus-stack-plot cohorts.json
$ mv stack_plot.png yearly.png
$ git-of-theseus-stack-plot authors.json
$ mv stack_plot.png authors.png
$ git-of-theseus-stack-plot exts.json
$ mv stack_plot.png exts.png
```

![authors](https://user-images.githubusercontent.com/5069736/121570072-80311880-c9ef-11eb-898b-7677da285a3a.png)

![yearly](https://user-images.githubusercontent.com/5069736/121570103-88895380-c9ef-11eb-9fce-5282842892db.png)

![exts](https://user-images.githubusercontent.com/5069736/121570109-8d4e0780-c9ef-11eb-8726-cc48b4a3169c.png)


