### PR TITLE
Additional event extraction option for Eidos

### DIFF
--- a/indra/sources/eidos/processor.py
+++ b/indra/sources/eidos/processor.py
@@ -75,6 +75,19 @@ class EidosProcessor(object):
                 evidence.context = None
             self.statements.append(event)
 
+    def extract_all_events(self):
+        events = [e for e in self.doc.extractions if
+                  {'Concept', 'Concept-Expanded'} & set(e['labels'])]
+        for event_entry in events:
+            event = self.get_event(event_entry)
+            evidence = self.get_evidence(event_entry)
+            event.evidence = [evidence]
+            if not event.context and evidence.context:
+                event.context = copy.deepcopy(evidence.context)
+                evidence.context = None
+            self.statements.append(event)
+
+
     def get_event_by_id(self, event_id):
         # Resolve coreferences by ID
         event_id = self.doc.coreferences.get(event_id, event_id)


### PR DESCRIPTION
This PR adds a new option for extracting Events from Eidos where the evidences for the Events (including ones that are subsumed by other relations) are the original ones extracted for that Event (i.e., not adopted from the relation by which they are subsumed). This is useful for grounding analysis at the Event level.