### PR TITLE
Html assembly updates

### DIFF
--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -638,7 +638,8 @@ def _format_evidence_text(stmt, curation_dict=None, correct_tags=None):
                         'original_json': ev.to_json(),
                         'num_curations': num_curations,
                         'num_correct': num_correct,
-                        'num_incorrect': num_incorrect
+                        'num_incorrect': num_incorrect,
+                        'source_url': ev.annotations.get('source_url', '')
                         })
 
     return ev_list

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -739,14 +739,18 @@ def id_url(ag):
 
 def src_url(ev: Evidence) -> str:
     """Given an Evidence object, provide the URL for the source"""
-    # Get source url from evidence or from SOURCE_INFO as backup.
+    # Get source url from evidence or from SOURCE_INFO as backup if source
+    # is a database.
     # SOURCE_INFO contains the names as they are in INDRA,
     # while source_api is as the source name appear in the database
 
     url = ev.annotations.get('source_url')
     if not url:
         rev_src = reverse_source_mappings.get(ev.source_api, ev.source_api)
-        url = SOURCE_INFO.get(rev_src, {}).get('link', '')
+        if SOURCE_INFO.get(rev_src, {}).get('type', '') == 'database':
+            url = SOURCE_INFO[rev_src]['link']
+        else:
+            url = ''
     return url
 
 

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -371,7 +371,7 @@ class HtmlAssembler(object):
 
                 ret.append({'hash': str(key), 'english': english,
                             'evidence': ev_list,
-                            'belief': stmt.belief,
+                            'belief': float('%.5f' % stmt.belief),  # => 0.1234
                             'evidence_count': evidence_count_str,
                             'source_count': src_counts})
             return ret, all_level_hashes

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -23,7 +23,7 @@ from indra.util.statement_presentation import group_and_sort_statements, \
     make_top_level_label_from_names_key, make_stmt_from_relation_key, \
     reader_sources, db_sources, all_sources, get_available_source_counts, \
     get_available_ev_counts, standardize_counts, get_available_beliefs, \
-    StmtGroup, make_standard_stats
+    StmtGroup, make_standard_stats, reverse_source_mappings
 from indra.literature import id_lookup
 
 logger = logging.getLogger(__name__)
@@ -734,6 +734,19 @@ def id_url(ag):
                 continue
             # Finally, we return a valid identifiers.org URL
             return get_identifiers_url(db_name, db_id)
+
+
+def src_url(ev: Evidence) -> str:
+    """Given an Evidence object, provide the URL for the source"""
+    # Get source url from evidence or from SOURCE_INFO as backup.
+    # SOURCE_INFO contains the names as they are in INDRA,
+    # while source_api is as the source name appear in the database
+
+    url = ev.annotations.get('source_url')
+    if not url:
+        rev_src = reverse_source_mappings.get(ev.source_api, ev.source_api)
+        url = SOURCE_INFO.get(rev_src, {}).get('link', '')
+    return url
 
 
 def tag_text(text, tag_info_list):

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -630,6 +630,7 @@ def _format_evidence_text(stmt, curation_dict=None, correct_tags=None):
             [cur for cur in curations if cur['error_type'] in correct_tags])
         num_incorrect = num_curations - num_correct
         text_refs = {k.upper(): v for k, v in ev.text_refs.items()}
+        source_url = src_url(ev)
         ev_list.append({'source_api': source_api,
                         'pmid': ev.pmid,
                         'text_refs': text_refs,
@@ -639,7 +640,7 @@ def _format_evidence_text(stmt, curation_dict=None, correct_tags=None):
                         'num_curations': num_curations,
                         'num_correct': num_correct,
                         'num_incorrect': num_incorrect,
-                        'source_url': ev.annotations.get('source_url', '')
+                        'source_url': source_url
                         })
 
     return ev_list

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -371,6 +371,7 @@ class HtmlAssembler(object):
 
                 ret.append({'hash': str(key), 'english': english,
                             'evidence': ev_list,
+                            'belief': stmt.belief,
                             'evidence_count': evidence_count_str,
                             'source_count': src_counts})
             return ret, all_level_hashes

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -371,7 +371,7 @@ class HtmlAssembler(object):
 
                 ret.append({'hash': str(key), 'english': english,
                             'evidence': ev_list,
-                            'belief': float('%.5f' % stmt.belief),  # => 0.1234
+                            'belief': float('%.4f' % stmt.belief),  # => 0.1234
                             'evidence_count': evidence_count_str,
                             'source_count': src_counts})
             return ret, all_level_hashes

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -219,6 +219,11 @@
         color: #FFFFFF;
     }
 
+    .badge-belief {
+        background-color: #ffc266;
+        color: #FFFFFF;
+    }
+
     .curation-row {
         overflow-y: hidden;
     }
@@ -251,6 +256,13 @@
       {% endfor %}
     {% endfor %}
   {% endif %}
+{%- endmacro %}
+
+{% macro belief_badge(belief_score) -%}
+  <small
+      class="badge badge-pill badge-belief"
+      title="Belief score for this statement"
+  >{{ belief_score }}</small>
 {%- endmacro %}
 
 {% block header_desc %}

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -414,10 +414,19 @@
                                           &#10166;
                                       </a>
                                   </div>
-                                  <div class="col-9 nvm src-api"
-                                       title="{{ ev['source_api'] }}">
+                                {% if ev.annotations.get('source_url') %}
+                                  <a href="{{ ev.annotations['source_url'] }}">
+                                {% else %}
+                                  <div
+                                {% endif %}
+                                      class="col-9 nvm src-api"
+                                      title="{{ ev['source_api'] }}">
                                       {{ ev['source_api'] }}
+                                {% if evidence.annotations.get('source_url') %}
+                                  </a>
+                                {% else %}
                                   </div>
+                                {% endif %}
                                 </div>
                               </div>
 

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -414,15 +414,15 @@
                                           &#10166;
                                       </a>
                                   </div>
-                                {% if ev.annotations.get('source_url') %}
-                                  <a href="{{ ev.annotations['source_url'] }}">
+                                {% if ev.get('source_url') %}
+                                  <a href="{{ ev['source_url'] }}" target="_blank"
                                 {% else %}
                                   <div
                                 {% endif %}
                                       class="col-9 nvm src-api"
                                       title="{{ ev['source_api'] }}">
                                       {{ ev['source_api'] }}
-                                {% if evidence.annotations.get('source_url') %}
+                                {% if ev.get('source_url') %}
                                   </a>
                                 {% else %}
                                   </div>

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -261,8 +261,7 @@
 {% macro belief_badge(belief_score) -%}
   <small
       class="badge badge-pill badge-belief"
-      title="Belief score for this statement"
-  >{{ belief_score }}</small>
+      title="Belief score for this statement">{{ belief_score }}</small>
 {%- endmacro %}
 
 {% block header_desc %}
@@ -384,6 +383,9 @@
                              {% if db_rest_url %}target="_blank"{% endif %}>
                             <small class="badge badge-secondary badge-pill">{{ stmt_info['evidence_count'] }}</small>
                           </a>
+                          {% if show_belief %}
+                            {{ belief_badge(stmt_info['belief']) }}
+                          {% endif %}
                         </h5>
                       </div>
                       <div class="col text-right nvp">

--- a/indra/resources/source_info.json
+++ b/indra/resources/source_info.json
@@ -97,7 +97,7 @@
     },
     "tas": {
         "name": "Target Affinity Spectrum",
-        "link": "https://doi.org/10.1101/358978",
+        "link": "https://labsyspharm.shinyapps.io/smallmoleculesuite/",
         "type": "database",
         "domain": "biology"
     },

--- a/indra/statements/statements.py
+++ b/indra/statements/statements.py
@@ -594,7 +594,7 @@ class Statement(object):
     def make_generic_copy(self, deeply=False):
         """Make a new matching Statement with no provenance.
 
-        All agents and other attributes besides evidence, belief, supports, and
+        All agents and other attributes besides evidence, uuid, supports, and
         supported_by will be copied over, and a new uuid will be assigned.
         Thus, the new Statement will satisfy `new_stmt.matches(old_stmt)`.
 
@@ -606,9 +606,10 @@ class Statement(object):
             kwargs = deepcopy(self.__dict__)
         else:
             kwargs = self.__dict__.copy()
-        for attr in ['evidence', 'belief', 'uuid', 'supports', 'supported_by',
+        for attr in ['evidence', 'uuid', 'supports', 'supported_by',
                      'is_activation']:
             kwargs.pop(attr, None)
+        my_belief = kwargs.pop('belief', 1)
         my_hash = kwargs.pop('_full_hash', None)
         my_shallow_hash = kwargs.pop('_shallow_hash', None)
         for attr in self._agent_order:
@@ -618,6 +619,7 @@ class Statement(object):
         new_instance = self.__class__(**kwargs)
         new_instance._full_hash = my_hash
         new_instance._shallow_hash = my_shallow_hash
+        new_instance.belief = my_belief
         return new_instance
 
     def flip_polarity(self, agent_idx=None):

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -2,7 +2,7 @@ import re
 from indra.statements import *
 from indra.assemblers.english import AgentWithCoordinates
 from indra.assemblers.html.assembler import HtmlAssembler, tag_text, loader, \
-    _format_evidence_text, tag_agents
+    _format_evidence_text, tag_agents, src_url, SOURCE_INFO
 from indra.util.statement_presentation import AveAggregator, StmtStat, StmtGroup
 
 
@@ -47,6 +47,23 @@ def test_format_evidence_text():
                           'was able to phosphorylate '
                           '<span class="badge badge-object">'
                           'Ras proteins</span>.'), ev['text']
+
+
+def test_source_url():
+    # Test getting URL from annotations
+    stmt = make_stmt()
+    url = src_url(stmt.evidence[0])
+    assert url == 'http://www.causalbionet.com/'
+
+    # Test getting from SOURCE_INFO
+    ev = Evidence(source_api='trrust')
+    url = src_url(ev)
+    assert url == SOURCE_INFO['trrust']['link']
+
+    # Test getting from source that needs reverse mapping
+    ev = Evidence(source_api='vhn')  # vhn => virhostnet
+    url = src_url(ev)
+    assert url == SOURCE_INFO['virhostnet']['link']
 
 
 def test_assembler():

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -13,7 +13,8 @@ def make_stmt():
                        "phosphorylate Ras proteins.",
                   source_api='test', pmid='1234567',
                   annotations={'agents': {'raw_text': ['Src kinase',
-                                                       'Ras proteins']}})
+                                                       'Ras proteins']},
+                               'source_url': 'http://www.causalbionet.com/'})
     st = Phosphorylation(src, ras, 'tyrosine', '32', evidence=[ev])
     return st
 
@@ -24,7 +25,8 @@ def make_bad_stmt():
     ras = Agent('', db_refs={'FPLX': {'RAS', 'Ras'}, 'TEXT': 'RAS'})
     ev = Evidence(text="Ras is phosphorylated",
                   source_api='test', pmid='1234',
-                  annotations={'agents': {'raw_text': [None, None]}})  # no raw
+                  annotations={'agents': {'raw_text': [None, None]},  # no raw
+                               'source_url': ''})
     st = Phosphorylation(subj, ras, 'tyrosine', '32', evidence=[ev])
     return st
 
@@ -78,7 +80,10 @@ def test_assembler():
     assert isinstance(result, str)
     assert '<small\n' \
            '      class="badge badge-pill badge-belief"\n' \
-           '      title="Belief score for this statement">1</small>' not in result
+           '      title="Belief score for this statement">1</small>' \
+           not in result
+    # Test if source URL exists
+    assert 'http://www.causalbionet.com/' in result
     # Make sure warning can be appended
     ha.append_warning('warning')
     assert ('\t<span style="color:red;">(CAUTION: warning occurred when '

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -92,7 +92,7 @@ def test_assembler():
     assert isinstance(result, str)
     assert '<small\n' \
            '      class="badge badge-pill badge-belief"\n' \
-           '      title="Belief score for this statement">1</small>' in result
+           '      title="Belief score for this statement">1.0</small>' in result
     result = ha.make_model(grouping_level='statement', show_belief=False)
     assert isinstance(result, str)
     assert '<small\n' \

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -68,6 +68,17 @@ def test_assembler():
     assert isinstance(result, str)
     result = ha.make_model(grouping_level='statement')
     assert isinstance(result, str)
+    # Test belief badges
+    result = ha.make_model(grouping_level='statement', show_belief=True)
+    assert isinstance(result, str)
+    assert '<small\n' \
+           '      class="badge badge-pill badge-belief"\n' \
+           '      title="Belief score for this statement">1</small>' in result
+    result = ha.make_model(grouping_level='statement', show_belief=False)
+    assert isinstance(result, str)
+    assert '<small\n' \
+           '      class="badge badge-pill badge-belief"\n' \
+           '      title="Belief score for this statement">1</small>' not in result
     # Make sure warning can be appended
     ha.append_warning('warning')
     assert ('\t<span style="color:red;">(CAUTION: warning occurred when '

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -39,7 +39,7 @@ def test_format_evidence_text():
     assert isinstance(ev, dict)
     assert set(ev.keys()) == {'source_api', 'text_refs', 'text', 'source_hash',
                               'pmid', 'num_curations', 'num_correct',
-                              'num_incorrect', 'original_json'}
+                              'num_incorrect', 'original_json', 'source_url'}
     assert ev['source_api'] == 'test'
     assert ev['text_refs']['PMID'] == '1234567'
     assert ev['text'] == ('We noticed that the '

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -2004,3 +2004,10 @@ def test_real_agent_list():
     agents = Phosphorylation(None, x).real_agent_list()
     assert len(agents) == 1
     assert agents[0] == x
+
+
+def test_make_generic_copy():
+    stmt = Activation(Agent('x'), Agent('y'))
+    stmt.belief = 0.55
+    new_stmt = stmt.make_generic_copy()
+    assert new_stmt.belief == 0.55

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -134,6 +134,7 @@ internal_source_mappings = {
     'virhostnet': 'vhn',
     'phosphosite': 'psp',
 }
+reverse_source_mappings = {v: k for k, v in internal_source_mappings.items()}
 
 all_sources = db_sources + reader_sources
 


### PR DESCRIPTION
This PR makes two updates to the `HtmlAssembler`:
- A belief badge is added as an option to the output. The badge is added if the argument `show_belief` is set to `True` when the html model is generated with `HtmlAssembler.make_model()` or `HtmlAssembler.save_model()`.
- The source name for each evidence is now a link to the source, if `source_url` is set in `Evidence.annotations`.

`indra/tests/test_html_assembler.py::test_assembler` is extended to check for the updates.