### PR TITLE
Update testing to pass

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,7 @@ jobs:
         wget -nv https://bigmech.s3.amazonaws.com/travis/reach-82631d-biores-e9ee36.jar
         # Get INDRA Bioontology
         BIOONTOLOGY_VERSION=$(python -m indra.ontology.bio version)
+        echo $BIOONTOLOGY_VERSION
         mkdir -p $HOME/.indra/bio_ontology/$BIOONTOLOGY_VERSION
         wget -nv https://bigmech.s3.amazonaws.com/travis/bio_ontology/$BIOONTOLOGY_VERSION/mock_ontology.pkl -O $HOME/.indra/bio_ontology/$BIOONTOLOGY_VERSION/bio_ontology.pkl
     - name: Run unit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,8 @@ jobs:
         echo $NOSEATTR
         #- cd $TRAVIS_BUILD_DIR
         # Now run all INDRA tests
-        nosetests -v -a $NOSEATTR --exclude='.*tees.*' --exclude='.*isi.*' --with-coverage --cover-inclusive --cover-package=indra --with-doctest --with-doctest-ignore-unicode --with-timer --timer-top-n 10 --processes=0
+        nosetests -v -a $NOSEATTR --exclude='.*tees.*' --exclude='.*isi.*' --exclude='.*test_reach.*' --with-coverage --cover-inclusive --cover-package=indra --with-doctest --with-doctest-ignore-unicode --with-timer --timer-top-n 10 --processes=0
+        nosetests -v -a $NOSEATTR indra/tests/test_reach.py
         # TEES tests
         #- python -m nose_notify indra/tests/test_tees.py --slack_hook $SLACK_NOTIFY_HOOK
         #  --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR --process-restartworker;

--- a/indra/tests/test_preassembler.py
+++ b/indra/tests/test_preassembler.py
@@ -7,7 +7,8 @@ from indra.sources import reach
 from indra.statements import *
 from indra.ontology.bio import bio_ontology
 try:
-    from indra_world.ontology import world_ontology
+    from indra_world.ontology import load_world_ontology
+    world_ontology = load_world_ontology(default_type='flat')
     has_indra_world = True
 except ImportError:
     has_indra_world = False


### PR DESCRIPTION
This PR separates out Reach tests again since they have resulted in build failures seemingly due to resource constraints. It also updates a test for changes in https://github.com/indralab/indra_world/pull/38.