### PR TITLE
Fix feature matrix generation in CountsScorer when not including supports evidences

### DIFF
--- a/indra/belief/__init__.py
+++ b/indra/belief/__init__.py
@@ -509,11 +509,11 @@ class BeliefEngine(object):
     def _hierarchy_probs_from_evidences(
         self,
         statements: Sequence[Statement],
-        extra_evidences: List[List[Evidence]],
+        extra_evidence: List[List[Evidence]],
     ) -> Dict[int, float]:
         """Use the Scorer to get stmt beliefs with supports evidences."""
         # Get the list of beliefs matching the statements we passed in
-        beliefs = self.scorer.score_statements(statements, extra_evidences)
+        beliefs = self.scorer.score_statements(statements, extra_evidence)
         # Convert to a dict of beliefs keyed by hash and return
         hashes = [s.get_hash(matches_fun=self.matches_fun) for s in statements]
         beliefs_by_hash = dict(zip(hashes, beliefs))

--- a/indra/belief/skl.py
+++ b/indra/belief/skl.py
@@ -471,10 +471,10 @@ class CountsScorer(SklearnScorer):
                              "in the statement data.")
         # Get source count features
         # If we have extra_evidence, we double the source count features
-        if extra_evidence is None:
-            num_cols = len(self.source_list)
-        else:
+        if self.include_more_specific: 
             num_cols = len(self.source_list) * 2
+        else:
+            num_cols = len(self.source_list)
         num_rows = len(stmts)
         x_arr = np.zeros((num_rows, num_cols))
         for stmt_ix, stmt in enumerate(stmts):

--- a/indra/tests/test_belief_sklearn.py
+++ b/indra/tests/test_belief_sklearn.py
@@ -354,6 +354,19 @@ def test_set_hierarchy_probs():
             assert stmt.belief != prior_prob
 
 
+def test_set_hierarchy_probs_specific_false():
+    # Get probs for a set of statements, and a belief engine instance
+    be, test_stmts_copy, prior_probs = setup_belief(include_more_specific=False)
+    # Set beliefs on the flattened statements
+    top_level = ac.filter_top_level(test_stmts_copy)
+    be.set_hierarchy_probs(test_stmts_copy)
+    # Compare hierarchy probs to prior probs
+    for stmt, prior_prob in zip(test_stmts_copy, prior_probs):
+        # Because we haven't included any supports, the beliefs should
+        # not have changed
+        assert stmt.belief == prior_prob
+
+
 def test_hybrid_scorer():
     # First instantiate and train the SimpleScorer on readers
     # Make a model
@@ -402,4 +415,3 @@ def test_hybrid_scorer():
             print(expected_beliefs[ix], hybrid_beliefs[ix])
 
     assert np.allclose(hybrid_beliefs, expected_beliefs)
-


### PR DESCRIPTION
There was a bug in #1295 where setting `include_more_specific=False` in CountsScorer led to an error in subsequent use of the scorer to when called with `BeliefEngine.set_hierarchy_probs`. Where the statement feature matrix should have simply ignored any evidences from more specific statements it was instead expanding the feature matrix with additional columns which then did not match the trained classifier within the CountsScorer.

This PR adds a fix and a regression test for this error.