### PR TITLE
Override ECCODE pattern to validate CRoG statements

### DIFF
--- a/indra/databases/identifiers.py
+++ b/indra/databases/identifiers.py
@@ -363,4 +363,11 @@ def ensure_chembl_prefix(chembl_id):
     return ensure_prefix('CHEMBL', chembl_id, with_colon=False)
 
 
-identifiers_registry = load_resource_json('identifiers_patterns.json')
+def _load_identifiers_registry():
+    identifiers_registry = load_resource_json('identifiers_patterns.json')
+    # Override pattern otherwise patterns like 1.1 can't be used
+    identifiers_registry['ec-code']['pattern'] = '^\\d{1,2}(\\.\\d{0,3}){0,3}$'
+    return identifiers_registry
+
+
+identifiers_registry = _load_identifiers_registry()

--- a/indra/tests/test_identifiers.py
+++ b/indra/tests/test_identifiers.py
@@ -1,7 +1,8 @@
+import re
 from indra.databases.identifiers import get_identifiers_url, \
     parse_identifiers_url, get_ns_from_identifiers,\
     get_ns_id_from_identifiers, get_identifiers_ns, namespace_embedded, \
-    ensure_prefix_if_needed
+    ensure_prefix_if_needed, identifiers_registry
 
 
 def test_map_ns():
@@ -189,3 +190,7 @@ def test_ensure_prefix_if_needed():
     assert ensure_prefix_if_needed('GO', '00004') == 'GO:00004'
     assert ensure_prefix_if_needed('EFO', '1234') == '1234'
     assert ensure_prefix_if_needed('XXXX', '1234') == '1234'
+
+
+def test_eccode_override():
+    assert re.match(identifiers_registry['ec-code']['pattern'], '1')


### PR DESCRIPTION
This PR adds a patch to the identifiers registry resource which improves the ECCODE identifier patterns and results in CRoG-derived statements being considered valid (for good reason). See also https://github.com/indralab/indra_db/pull/166, https://github.com/bioregistry/bioregistry/pull/142.