### PR TITLE
Add module for fixing common statement invalidities

### DIFF
--- a/indra/databases/identifiers.py
+++ b/indra/databases/identifiers.py
@@ -35,7 +35,7 @@ identifiers_mappings = {
 # identifiers.org entries
 non_registry = {
     'SDIS', 'SCHEM', 'SFAM', 'SCOMP', 'SIGNOR', 'HMS-LINCS', 'NXPFA',
-    'OMIM', 'LSPCI', 'UPLOC', 'BFO', 'CCLE'
+    'OMIM', 'LSPCI', 'UPLOC', 'BFO', 'CCLE', 'CLO'
 }
 
 # These are namespaces that can appear in db_refs but are actually not

--- a/indra/databases/identifiers.py
+++ b/indra/databases/identifiers.py
@@ -35,7 +35,8 @@ identifiers_mappings = {
 # identifiers.org entries
 non_registry = {
     'SDIS', 'SCHEM', 'SFAM', 'SCOMP', 'SIGNOR', 'HMS-LINCS', 'NXPFA',
-    'OMIM', 'LSPCI', 'UPLOC', 'BFO', 'CCLE', 'CLO'
+    'OMIM', 'LSPCI', 'UPLOC', 'BFO', 'CCLE', 'CLO', 'GENBANK',
+    'DRUGBANK.SALT'
 }
 
 # These are namespaces that can appear in db_refs but are actually not

--- a/indra/statements/validate.py
+++ b/indra/statements/validate.py
@@ -22,7 +22,7 @@ text_ref_patterns = {
     # See https://www.crossref.org/blog/dois-and-matching-regular-expressions/
     # here I added a-z to allow non-capitalized DOI text, we could
     # change this is we want strict capital letters in the DOI
-    'DOI':  re.compile(r'^10.\d{4,9}/[-._;()/:A-Za-z0-9]+$'),
+    'DOI':  re.compile(r'^10.\d{4,9}/[-._;()/:A-Za-z0-9]+'),
 }
 
 

--- a/indra/tests/test_fix_invalidities.py
+++ b/indra/tests/test_fix_invalidities.py
@@ -15,6 +15,10 @@ def test_fix_db_refs():
            {'UP': 'P12345'}
     assert fix_invalidities_db_refs({'UNIPROT': 'SL-123'}) == \
            {'UPLOC': 'SL-123'}
+    assert fix_invalidities_db_refs({'MGI': 'Mgi:Abcd1'}) == \
+           {}
+    assert fix_invalidities_db_refs({'RGD': 'Abcd1'}) == \
+           {}
 
 
 def test_fix_evidence():

--- a/indra/tests/test_fix_invalidities.py
+++ b/indra/tests/test_fix_invalidities.py
@@ -1,5 +1,6 @@
 from indra.statements import Agent, Evidence, Translocation, Phosphorylation
 from indra.tools.fix_invalidities import *
+import indra.tools.assemble_corpus as ac
 
 
 def test_fix_db_refs():
@@ -32,6 +33,11 @@ def test_fix_stmts():
     stmts = [Translocation(Agent('x'), to_location=None, from_location=None),
              Phosphorylation(Agent('a', db_refs={'TEXT': None,
                                                  'FPLX': 'ERK'}), Agent('b'))]
-    stmts = fix_invalidities(stmts)
-    assert len(stmts) == 1
-    assert stmts[0].enz.db_refs == {'FPLX': 'ERK'}
+    stmts_out = fix_invalidities(stmts)
+    assert len(stmts_out) == 1
+    assert stmts_out[0].enz.db_refs == {'FPLX': 'ERK'}
+
+    stmts_out = ac.fix_invalidities(stmts)
+
+    assert len(stmts_out) == 1
+    assert stmts_out[0].enz.db_refs == {'FPLX': 'ERK'}

--- a/indra/tests/test_fix_invalidities.py
+++ b/indra/tests/test_fix_invalidities.py
@@ -1,0 +1,33 @@
+from indra.statements import Agent, Evidence, Translocation, Phosphorylation
+from indra.tools.fix_invalidities import *
+
+
+def test_fix_db_refs():
+    assert fix_invalidities_db_refs({'CHEBI': '123'}) == \
+           {'CHEBI': 'CHEBI:123'}
+    assert fix_invalidities_db_refs({'CHEMBL': '123'}) == \
+           {'CHEMBL': 'CHEMBL123'}
+    assert fix_invalidities_db_refs({'PUBCHEM': 'CID: 123'}) == \
+           {'PUBCHEM': '123'}
+    assert fix_invalidities_db_refs({'ECCODE': '1.2.-.-'}) == \
+           {'ECCODE': '1.2'}
+    assert fix_invalidities_db_refs({'UNIPROT': 'P12345'}) == \
+           {'UP': 'P12345'}
+    assert fix_invalidities_db_refs({'UNIPROT': 'SL-123'}) == \
+           {'UPLOC': 'SL-123'}
+
+
+def test_fix_evidence():
+    ev = Evidence(pmid='123', text_refs={'pmcid': 'PMC1234'})
+    fix_invalidities_evidence(ev)
+    assert ev.pmid == '123'
+    assert ev.text_refs == {'PMCID': 'PMC1234', 'PMID': '123'}
+
+
+def test_fix_stmts():
+    stmts = [Translocation(Agent('x'), to_location=None, from_location=None),
+             Phosphorylation(Agent('a', db_refs={'TEXT': None,
+                                                 'FPLX': 'ERK'}), Agent('b'))]
+    stmts = fix_invalidities(stmts)
+    assert len(stmts) == 1
+    assert stmts[0].enz.db_refs == {'FPLX': 'ERK'}

--- a/indra/tests/test_fix_invalidities.py
+++ b/indra/tests/test_fix_invalidities.py
@@ -32,7 +32,8 @@ def test_fix_evidence():
 def test_fix_stmts():
     stmts = [Translocation(Agent('x'), to_location=None, from_location=None),
              Phosphorylation(Agent('a', db_refs={'TEXT': None,
-                                                 'FPLX': 'ERK'}), Agent('b'))]
+                                                 'FPLX': 'ERK'}), Agent('b'),
+                             evidence=[Evidence(text='x')])]
     stmts_out = fix_invalidities(stmts)
     assert len(stmts_out) == 1
     assert stmts_out[0].enz.db_refs == {'FPLX': 'ERK'}
@@ -41,3 +42,14 @@ def test_fix_stmts():
 
     assert len(stmts_out) == 1
     assert stmts_out[0].enz.db_refs == {'FPLX': 'ERK'}
+
+    stmts_out = ac.fix_invalidities(stmts,
+                                    in_place=True,
+                                    print_report_before=True,
+                                    print_report_after=True,
+                                    prior_hash_annots=True)
+    # Check the in-place effect
+    assert stmts[1].enz.db_refs == {'FPLX': 'ERK'}
+    assert stmts_out[0].enz.db_refs == {'FPLX': 'ERK'}
+
+    assert stmts_out[0].evidence[0].annotations['prior_hash']

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -20,6 +20,8 @@ from indra.databases import hgnc_client
 from indra.ontology.bio import bio_ontology
 from indra.preassembler import Preassembler, flatten_evidence
 from indra.resources import get_resource_path
+from indra.statements.validate import print_validation_report
+import indra.tools.fix_invalidities
 
 
 logger = logging.getLogger(__name__)
@@ -2202,3 +2204,18 @@ def filter_inconsequential(
             break
         num_stmts = len(stmts)
     return stmts
+
+
+@register_pipeline
+def fix_invalidities(stmts, print_report_before=False,
+                     print_report_after=False):
+    logger.info('Fixing invalidities in %d statements' % len(stmts))
+    if print_report_before:
+        logger.info('Any invalidities detected before fixing are printed below')
+        print_validation_report(stmts)
+    stmts_out = indra.tools.fix_invalidities.fix_invalidities(stmts)
+    if print_report_after:
+        logger.info('Any remaining detected invalidities are printed below')
+        print_validation_report(stmts_out)
+    logger.info('%d statements after validity fixing' % len(stmts_out))
+    return stmts_out

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -2212,7 +2212,8 @@ def filter_inconsequential(
 def fix_invalidities(stmts: List[Statement],
                      in_place: bool = False,
                      print_report_before: bool = False,
-                     print_report_after: bool = False) -> List[Statement]:
+                     print_report_after: bool = False,
+                     prior_hash_annots: bool = False) -> List[Statement]:
     """Fix invalidities in a list of statements.
 
     Parameters
@@ -2229,6 +2230,13 @@ def fix_invalidities(stmts: List[Statement],
         Run and print a validation report on the statements after running
         fixing to check if any issues remain that weren't handled by the
         fixing module.
+    prior_hash_annots :
+        If True, an annotation is added to each evidence of a statement
+        with the hash of the statement prior to any fixes being applied.
+        This is useful if this function is applied as a post-processing
+        step on assembled statements and it is necessary to refer back
+        to the original hash of statements before an invalidity fix
+        here potentially changes it. Default: False
 
     Returns
     -------
@@ -2243,6 +2251,12 @@ def fix_invalidities(stmts: List[Statement],
     if not in_place:
         logger.info('Making deepcopy of statements')
         stmts = deepcopy(stmts)
+    # If desired, we add prior hash annotations to each evidence
+    if prior_hash_annots:
+        for stmt in stmts:
+            for ev in stmt.evidence:
+                ev.annotations['prior_hash'] = stmt.get_hash()
+    # And now apply the fixing function
     stmts_out = indra.tools.fix_invalidities.fix_invalidities(stmts)
     if print_report_after:
         logger.info('Any remaining detected invalidities are printed below')

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -8,7 +8,9 @@ try:
 except ImportError:
     # Python 3
     import pickle
+
 import logging
+from typing import List
 from collections import defaultdict
 from copy import deepcopy, copy
 from indra.statements import *
@@ -2207,12 +2209,40 @@ def filter_inconsequential(
 
 
 @register_pipeline
-def fix_invalidities(stmts, print_report_before=False,
-                     print_report_after=False):
+def fix_invalidities(stmts: List[Statement],
+                     in_place: bool = False,
+                     print_report_before: bool = False,
+                     print_report_after: bool = False) -> List[Statement]:
+    """Fix invalidities in a list of statements.
+
+    Parameters
+    ----------
+    stmts :
+        A list of statements to fix invalidities in
+    in_place :
+        If True, the statement objects are changed in place if an invalidity
+        is fixed. Otherwise, a deepcopy is done before running fixes.
+    print_report_before :
+        Run and print a validation report on the statements before running
+        fixing.
+    print_report_after :
+        Run and print a validation report on the statements after running
+        fixing to check if any issues remain that weren't handled by the
+        fixing module.
+
+    Returns
+    -------
+    :
+        The list of statements with validation issues fixed and some
+        invalid statements filtered out.
+    """
     logger.info('Fixing invalidities in %d statements' % len(stmts))
     if print_report_before:
         logger.info('Any invalidities detected before fixing are printed below')
         print_validation_report(stmts)
+    if not in_place:
+        logger.info('Making deepcopy of statements')
+        stmts = deepcopy(stmts)
     stmts_out = indra.tools.fix_invalidities.fix_invalidities(stmts)
     if print_report_after:
         logger.info('Any remaining detected invalidities are printed below')

--- a/indra/tools/fix_invalidities.py
+++ b/indra/tools/fix_invalidities.py
@@ -93,14 +93,31 @@ def fix_invalidities_db_refs(db_refs: Mapping[str, str]) -> Mapping[str, str]:
             db_refs['ECCODE'] = db_refs['ECCODE'].replace('.-', '')
         elif k == 'UNIPROT':
             db_refs.pop(k)
+            # This is really a location
             if v.startswith('SL-'):
                 db_refs['UPLOC'] = v
+            # Otherwise we just fix the invalid key
             else:
                 db_refs['UP'] = v
+        elif k == 'UP':
+            # There are cases where this is an empty string
+            if not v.strip():
+                db_refs.pop('UP', None)
+            # Sometimes we have two IDs separated by a comma
+            if ',' in v:
+                db_refs['UP'] = v.split(',')[0]
         elif k == 'UAZ':
             db_refs.pop('UAZ')
             if v.startswith('CVCL'):
                 db_refs['CVCL'] = v
+        elif k == 'TAXONOMY' and v == '-1':
+            db_refs.pop('TAXONOMY', None)
+        elif k == 'LINCS' and re.match(r'\d+-\d+', v):
+            db_refs['HMS-LINCS'] = db_refs.pop('LINCS')
+        elif k == 'CVCL' and re.match(r'^\d+$', v):
+            db_refs['CVCL'] = 'CVCL_%s' % v
+        elif k == 'CO':
+            db_refs['CL'] = 'CL:%s' % db_refs.pop('CO')
         else:
             new_val = ensure_prefix_if_needed(k, v)
             db_refs[k] = new_val

--- a/indra/tools/fix_invalidities.py
+++ b/indra/tools/fix_invalidities.py
@@ -57,9 +57,9 @@ def fix_invalidities_evidence(ev: Evidence):
             ev.text_refs.pop(k)
             ev.text_refs[k.upper()] = v
 
-    if ev.pmid and not re.match(r'^\d+$', ev.pmid):
+    if ev.pmid and not re.match(text_ref_patterns['PMID'], ev.pmid):
         ev.pmid = None
-    if ev.text_refs.get('PMID') and not re.match(r'^\d+$',
+    if ev.text_refs.get('PMID') and not re.match(text_ref_patterns['PMID'],
                                                  ev.text_refs['PMID']):
         ev.text_refs.pop('PMID', None)
 
@@ -71,6 +71,9 @@ def fix_invalidities_evidence(ev: Evidence):
     if 'DOI' in ev.text_refs and not re.match(text_ref_patterns['DOI'],
                                               ev.text_refs['DOI']):
         ev.text_refs.pop('DOI', None)
+    if 'PMC' in ev.text_refs and not re.match(text_ref_patterns['PMC'],
+                                              ev.text_refs['PMC']):
+        ev.text_refs.pop('PMC', None)
 
     if ev.context is not None:
         fix_invalidities_context(ev.context)
@@ -121,12 +124,14 @@ def fix_invalidities_db_refs(db_refs: Mapping[str, str]) -> Mapping[str, str]:
             db_refs.pop('TAXONOMY', None)
         elif k == 'LINCS' and re.match(r'\d+-\d+', v):
             db_refs['HMS-LINCS'] = db_refs.pop('LINCS')
-        elif k == 'CVCL' and re.match(r'^\d+$', v):
+        elif k == 'CVCL' and re.match(r'^[A-Z0-9]{4}$', v):
             db_refs['CVCL'] = 'CVCL_%s' % v
         elif k == 'CO':
             db_refs['CL'] = 'CL:%s' % db_refs.pop('CO')
         elif k == 'FPLX' and '-' in v:
             db_refs['FPLX'] = v.replace('-', '_')
+        elif k == 'DRUGBANK' and v.startswith('DBSALT'):
+            db_refs['DRUGBANK.SALT'] = db_refs.pop('DRUGBANK')
         else:
             new_val = ensure_prefix_if_needed(k, v)
             db_refs[k] = new_val

--- a/indra/tools/fix_invalidities.py
+++ b/indra/tools/fix_invalidities.py
@@ -10,10 +10,8 @@ from indra.databases.identifiers import ensure_prefix_if_needed, \
 from indra.statements.validate import text_ref_patterns
 from indra.statements import Evidence, Statement, Agent, BioContext, \
     Translocation
-from indra.pipeline import register_pipeline
 
 
-@register_pipeline
 def fix_invalidities(stmts: List[Statement]) -> List[Statement]:
     """Fix invalidities in a list of Statements.
 

--- a/indra/tools/fix_invalidities.py
+++ b/indra/tools/fix_invalidities.py
@@ -1,0 +1,91 @@
+import re
+import copy
+from typing import List
+from indra.databases.identifiers import ensure_prefix_if_needed
+from indra.statements import Evidence, Statement, Agent, BioContext, \
+    Translocation
+from indra.pipeline import register_pipeline
+
+
+@register_pipeline
+def fix_invalidities(stmts: List[Statement]) -> List[Statement]:
+    new_stmts = []
+    for stmt in stmts:
+        if isinstance(stmt, Translocation) and not stmt.from_location and \
+                not stmt.to_location:
+            continue
+        fix_invalidities_stmt(stmt)
+        new_stmts.append(stmt)
+    return new_stmts
+
+
+def fix_invalidities_stmt(stmt: Statement):
+    for ev in stmt.evidence:
+        fix_invalidities_evidence(ev)
+    for agent in stmt.real_agent_list():
+        fix_invalidities_agent(agent)
+
+
+def fix_invalidities_evidence(ev: Evidence):
+    for k, v in copy.deepcopy(ev.text_refs).items():
+        if v is None:
+            ev.text_refs.pop(k, None)
+        elif not k.isupper():
+            ev.text_refs.pop(k)
+            ev.text_refs[k.upper()] = v
+
+    if ev.pmid and not re.match(r'^\d+$', ev.pmid):
+        ev.pmid = None
+    if ev.text_refs.get('PMID') and not re.match(r'^\d+$',
+                                                 ev.text_refs['PMID']):
+        ev.text_refs.pop('PMID', None)
+
+    if ev.pmid is None and ev.text_refs.get('PMID') is not None:
+        ev.pmid = ev.text_refs['PMID']
+    elif ev.text_refs.get('PMID') is None and ev.pmid is not None:
+        ev.text_refs['PMID'] = ev.pmid
+
+    if ev.context is not None:
+        fix_invalidities_context(ev.context)
+
+
+def fix_invalidities_agent(agent: Agent):
+    agent.db_refs = fix_invalidities_db_refs(agent.db_refs)
+
+
+def fix_invalidities_db_refs(db_refs):
+    if 'PUBCHEM' in db_refs and \
+            db_refs['PUBCHEM'].startswith('CID'):
+        db_refs['PUBCHEM'] = \
+            db_refs['PUBCHEM'].replace('CID:', '').strip()
+
+    db_refs = {k: v for k, v in db_refs.items()
+               if v is not None}
+
+    for k, v in copy.deepcopy(db_refs).items():
+        if k == 'CHEMBL' and not v.startswith('CHEMBL'):
+            db_refs[k] = 'CHEMBL%s' % v
+        elif k == 'ECCODE':
+            db_refs['ECCODE'] = db_refs['ECCODE'].replace('.-', '')
+        elif k == 'UNIPROT':
+            db_refs.pop(k)
+            if v.startswith('SL-'):
+                db_refs['UPLOC'] = v
+            else:
+                db_refs['UP'] = v
+        elif k == 'UAZ':
+            db_refs.pop('UAZ')
+            if v.startswith('CVCL'):
+                db_refs['CVCL'] = v
+        else:
+            new_val = ensure_prefix_if_needed(k, v)
+            db_refs[k] = new_val
+    return db_refs
+
+
+def fix_invalidities_context(context: BioContext):
+    entries = [context.species, context.cell_line, context.disease,
+               context.cell_type, context.organ, context.location]
+    for entry in entries:
+        if entry is not None:
+            entry.db_refs = fix_invalidities_db_refs(entry.db_refs)


### PR DESCRIPTION
This PR adds a new module to fix some common invalidities in INDRA Statements. It's important to note that these have all been addressed in #1172 at the level of source processors. However, many invalidities "live on" in various places where old statements are persisted so it's useful to have these in-memory statement fixing functions in place as well.