### PR TITLE
Assembling IndraNet with custom preassembly

### DIFF
--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -288,8 +288,7 @@ class IndraNetAssembler():
                 logger.debug('Skipping a statement of a type %s.'
                              % type(stmt).__name__)
                 continue
-            agents = stmt.agent_list()
-            not_none_agents = [a for a in agents if a is not None]
+            not_none_agents = stmt.real_agent_list()
 
             # Exclude statements with less than 2 agents
             if len(not_none_agents) < 2:
@@ -417,8 +416,8 @@ class IndraNetAssembler():
             IndraNet graph object.
         """
         # Filter out statements with one agent or with None subject
-        stmts = [stmt for stmt in self.statements if len(
-            [ag for ag in stmt.agent_list() if ag is not None]) > 1]
+        stmts = [stmt for stmt in self.statements
+                 if len(stmt.real_agent_list()) > 1]
         if exclude_stmts:
             exclude_types = tuple(
                 get_statement_by_name(st_type) for st_type in exclude_stmts)
@@ -452,7 +451,7 @@ class IndraNetAssembler():
             graph_stmts = [stmt for stmt in stmts if stmt not in complex_stmts
                            and stmt not in conv_stmts]
             for stmt in complex_stmts:
-                agents = [ag for ag in stmt.agent_list() if ag is not None]
+                agents = stmt.real_agent_list()
                 if len(agents) > complex_members:
                     continue
                 for a, b in permutations(agents, 2):

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -443,6 +443,7 @@ class IndraNetAssembler():
             # Only keep statements with explicit signs
             for stmt_type in sign_dict:
                 graph_stmts += ac.filter_by_type(stmts, stmt_type)
+            graph_stmts += ac.filter_by_type(stmts, Influence)
             # Conversion statements can also be turned into two types of signed
             conv_stmts = ac.filter_by_type(stmts, Conversion)
             for stmt in conv_stmts:
@@ -505,7 +506,16 @@ class IndraNetAssembler():
                     unique_stmts[edge_data['stmt_hash']] = edge_data
             statement_data = list(unique_stmts.values())
             if graph_type == 'signed':
-                sign = sign_dict[type(stmt).__name__]
+                if isinstance(stmt, Influence):
+                    stmt_pol = stmt.overall_polarity()
+                    if stmt_pol == 1:
+                        sign = 0
+                    elif stmt_pol == -1:
+                        sign = 1
+                    else:
+                        continue
+                else:
+                    sign = sign_dict[type(stmt).__name__]
                 G.add_edge(agents[0].name, agents[1].name, sign,
                            statements=statement_data)
             elif graph_type == 'unsigned':

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -517,7 +517,8 @@ class IndraNetAssembler():
                 else:
                     sign = sign_dict[type(stmt).__name__]
                 G.add_edge(agents[0].name, agents[1].name, sign,
-                           statements=statement_data, belief=stmt.belief)
+                           statements=statement_data, belief=stmt.belief,
+                           sign=sign)
             elif graph_type == 'digraph':
                 G.add_edge(agents[0].name, agents[1].name,
                            statements=statement_data, belief=stmt.belief)

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -53,8 +53,8 @@ class IndraNetAssembler():
         """
         self.statements += stmts
 
-    def make_model(self, method='df', exclude_stmts=None, complex_members=3,
-                   graph_type='multi_graph', sign_dict=None,
+    def make_model(self, method='preassembly', exclude_stmts=None,
+                   complex_members=3, graph_type='multi_graph', sign_dict=None,
                    belief_flattening=None, belief_scorer=None,
                    weight_flattening=None, extra_columns=None):
         """Assemble an IndraNet graph object.

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -517,10 +517,10 @@ class IndraNetAssembler():
                 else:
                     sign = sign_dict[type(stmt).__name__]
                 G.add_edge(agents[0].name, agents[1].name, sign,
-                           statements=statement_data)
+                           statements=statement_data, belief=stmt.belief)
             elif graph_type == 'digraph':
                 G.add_edge(agents[0].name, agents[1].name,
-                           statements=statement_data)
+                           statements=statement_data, belief=stmt.belief)
             else:
                 if statement_data:
                     edge_data = statement_data[0]

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -457,7 +457,8 @@ class IndraNetAssembler():
                 graph_stmts, return_toplevel=False,
                 belief_scorer=belief_scorer,
                 matches_fun=partial(agent_name_polarity_matches,
-                                    sign_dict=sign_dict))
+                                    sign_dict=sign_dict),
+                run_refinement=False)
             G = nx.MultiDiGraph()
         elif graph_type in ['unsigned', 'multi_graph']:
             # Keep Complex and Conversion aside
@@ -484,7 +485,8 @@ class IndraNetAssembler():
                 graph_stmts = ac.run_preassembly(
                     graph_stmts, return_toplevel=False,
                     belief_scorer=belief_scorer,
-                    matches_fun=agent_name_stmt_matches)
+                    matches_fun=agent_name_stmt_matches,
+                    run_refinement=False)
                 G = nx.DiGraph()
             else:
                 G = nx.MultiGraph()

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -461,7 +461,7 @@ class IndraNetAssembler():
                                     sign_dict=sign_dict),
                 run_refinement=False)
             G = nx.MultiDiGraph()
-        elif graph_type in ['unsigned', 'multi_graph']:
+        elif graph_type in ['digraph', 'multi_graph']:
             # Keep Complex and Conversion aside
             complex_stmts = ac.filter_by_type(stmts, Complex)
             conv_stmts = ac.filter_by_type(stmts, Conversion)
@@ -481,7 +481,7 @@ class IndraNetAssembler():
                     for obj in stmt.obj_to:
                         graph_stmts.append(
                             IncreaseAmount(stmt.subj, obj, stmt.evidence))
-            if graph_type == 'unsigned':
+            if graph_type == 'digraph':
                 # Merge statements by agent names
                 graph_stmts = ac.run_preassembly(
                     graph_stmts, return_toplevel=False,
@@ -518,7 +518,7 @@ class IndraNetAssembler():
                     sign = sign_dict[type(stmt).__name__]
                 G.add_edge(agents[0].name, agents[1].name, sign,
                            statements=statement_data)
-            elif graph_type == 'unsigned':
+            elif graph_type == 'digraph':
                 G.add_edge(agents[0].name, agents[1].name,
                            statements=statement_data)
             else:

--- a/indra/assemblers/indranet/assembler.py
+++ b/indra/assemblers/indranet/assembler.py
@@ -472,12 +472,13 @@ class IndraNetAssembler():
                 for a, b in permutations(agents, 2):
                     graph_stmts.append(IncreaseAmount(a, b, stmt.evidence))
             for stmt in conv_stmts:
-                for obj in stmt.obj_from:
-                    graph_stmts.append(
-                        DecreaseAmount(stmt.subj, obj, stmt.evidence))
-                for obj in stmt.obj_to:
-                    graph_stmts.append(
-                        IncreaseAmount(stmt.subj, obj, stmt.evidence))
+                if stmt.subj:
+                    for obj in stmt.obj_from:
+                        graph_stmts.append(
+                            DecreaseAmount(stmt.subj, obj, stmt.evidence))
+                    for obj in stmt.obj_to:
+                        graph_stmts.append(
+                            IncreaseAmount(stmt.subj, obj, stmt.evidence))
             if graph_type == 'unsigned':
                 # Merge statements by agent names
                 graph_stmts = ac.run_preassembly(

--- a/indra/preassembler/custom_preassembly.py
+++ b/indra/preassembler/custom_preassembly.py
@@ -2,8 +2,12 @@
 useful for building custom preassembly logic for some applications.
 They are typically used as matches_fun or refinement_fun arguments
 to the Preassembler and other modules."""
+import logging
 from indra.statements import *
 from indra.pipeline import register_pipeline
+
+
+logger = logging.getLogger(__name__)
 
 
 @register_pipeline
@@ -48,13 +52,11 @@ def agent_name_stmt_matches(stmt):
 
 
 @register_pipeline
-def agent_name_polarity_matches(stmt):
+def agent_name_polarity_matches(stmt, sign_dict):
     """Return a key for normalized agent names and polarity."""
-    default_sign_dict = {'Activation': 0,
-                         'Inhibition': 1,
-                         'IncreaseAmount': 0,
-                         'DecreaseAmount': 1}
     agents = [agent_name_matches(a) for a in stmt.agent_list()]
-    pol = default_sign_dict[type(stmt).__name__]
+    pol = sign_dict.get(type(stmt).__name__)
+    if not pol:
+        logger.debug('Unknown polarity for %s' % type(stmt).__name__)
     key = str((agents, pol))
     return key

--- a/indra/preassembler/custom_preassembly.py
+++ b/indra/preassembler/custom_preassembly.py
@@ -55,7 +55,16 @@ def agent_name_stmt_matches(stmt):
 def agent_name_polarity_matches(stmt, sign_dict):
     """Return a key for normalized agent names and polarity."""
     agents = [ag.name for ag in stmt.real_agent_list()]
-    pol = sign_dict.get(type(stmt).__name__)
+    if isinstance(stmt, Influence):
+        stmt_pol = stmt.overall_polarity()
+        if stmt_pol == 1:
+            pol = 0
+        elif stmt_pol == -1:
+            pol = 1
+        else:
+            pol = None
+    else:
+        pol = sign_dict.get(type(stmt).__name__)
     if not pol:
         logger.debug('Unknown polarity for %s' % type(stmt).__name__)
     key = str((agents, pol))

--- a/indra/preassembler/custom_preassembly.py
+++ b/indra/preassembler/custom_preassembly.py
@@ -46,7 +46,7 @@ def agent_name_stmt_type_matches(stmt):
 @register_pipeline
 def agent_name_stmt_matches(stmt):
     """Return the normalized agent names."""
-    agents = [agent_name_matches(a) for a in stmt.agent_list()]
+    agents = [ag.name for ag in stmt.real_agent_list()]
     key = str(agents)
     return key
 
@@ -54,7 +54,7 @@ def agent_name_stmt_matches(stmt):
 @register_pipeline
 def agent_name_polarity_matches(stmt, sign_dict):
     """Return a key for normalized agent names and polarity."""
-    agents = [agent_name_matches(a) for a in stmt.agent_list()]
+    agents = [ag.name for ag in stmt.real_agent_list()]
     pol = sign_dict.get(type(stmt).__name__)
     if not pol:
         logger.debug('Unknown polarity for %s' % type(stmt).__name__)

--- a/indra/preassembler/custom_preassembly.py
+++ b/indra/preassembler/custom_preassembly.py
@@ -37,3 +37,24 @@ def agent_name_stmt_type_matches(stmt):
     agents = [agent_name_matches(a) for a in stmt.agent_list()]
     key = str((stmt.__class__.__name__, agents))
     return key
+
+
+@register_pipeline
+def agent_name_stmt_matches(stmt):
+    """Return the normalized agent names."""
+    agents = [agent_name_matches(a) for a in stmt.agent_list()]
+    key = str(agents)
+    return key
+
+
+@register_pipeline
+def agent_name_polarity_matches(stmt):
+    """Return a key for normalized agent names and polarity."""
+    default_sign_dict = {'Activation': 0,
+                         'Inhibition': 1,
+                         'IncreaseAmount': 0,
+                         'DecreaseAmount': 1}
+    agents = [agent_name_matches(a) for a in stmt.agent_list()]
+    pol = default_sign_dict[type(stmt).__name__]
+    key = str((agents, pol))
+    return key

--- a/indra/tests/test_docs_code.py
+++ b/indra/tests/test_docs_code.py
@@ -282,7 +282,7 @@ def test_getting_started9_10():
     # Chunk 10
     from indra.assemblers.indranet import IndraNetAssembler
     indranet_assembler = IndraNetAssembler(statements=gn_stmts)
-    indranet = indranet_assembler.make_model()
+    indranet = indranet_assembler.make_model(method='df')
     assert len(indranet.nodes) > 0, 'indranet contains no nodes'
     assert len(indranet.edges) > 0, 'indranet contains no edges'
 

--- a/indra/tests/test_model_checker.py
+++ b/indra/tests/test_model_checker.py
@@ -1566,6 +1566,8 @@ st7 = DecreaseAmount(Agent('B', db_refs={'HGNC': '2'}),
 st8 = IncreaseAmount(Agent('E', db_refs={'HGNC': '5'}),
                      Agent('B', db_refs={'HGNC': '2'}))
 statements = [st1, st2, st3, st4, st5, st6, st7, st8]
+for stmt in statements:
+    stmt.evidence = [Evidence(source_api='assertion')]
 
 test_st1 = Activation(Agent('A', db_refs={'HGNC': '1'}),
                       Agent('E', db_refs={'HGNC': '5'}))
@@ -1726,8 +1728,11 @@ def test_refinements():
     mek = Agent('MEK', db_refs={'TEXT': 'MEK', 'FPLX': 'MEK'})
     erk = Agent('ERK', db_refs={'TEXT': 'ERK', 'FPLX': 'ERK'})
     # Model statements are refined versions of test statements
-    model_stmts = [Phosphorylation(prkcb, gsk3b, 'S', '9'),
-                   Phosphorylation(map2k1, mapk1)]
+    model_stmts = [
+        Phosphorylation(prkcb, gsk3b, 'S', '9',
+                        evidence=[Evidence(source_api='assertion')]),
+        Phosphorylation(map2k1, mapk1,
+                        evidence=[Evidence(source_api='assertion')])]
     test_stmts = [Phosphorylation(prkcb, gsk3b, 'S'),
                   Phosphorylation(mek, erk)]
     gsk3b_s_phos = deepcopy(gsk3b)
@@ -1792,7 +1797,8 @@ def test_refinements():
     assert path_stmts == [[mek_ref], [model_stmts[1]], [erk_ref]], path_stmts
     # Test signed graph
     # Can't use phosphorylations for signed graph, using activations
-    model_stmts = [Activation(map2k1, mapk1)]
+    model_stmts = [Activation(map2k1, mapk1,
+                              evidence=[Evidence(source_api='assertion')])]
     test_stmts = [Activation(mek, erk)]
     ia = IndraNetAssembler(model_stmts)
     signed_model = ia.make_model(graph_type='signed')


### PR DESCRIPTION
This PR extends the IndranetAssembler class by adding an alternative method to assemble networks utilizing custom preassembly functionality. It also adds two custom preassembly functions to assemble signed and unsigned graphs. Graphs assembled with data frame method and with preassembly method are identical except for the edge beliefs. Preassembly method allows for more robust belief calculation using any belief scorer because we can work with statement objects directly.