### PR TITLE
Add GtpActivation to indranet signed graph

### DIFF
--- a/indra/assemblers/indranet/net.py
+++ b/indra/assemblers/indranet/net.py
@@ -19,7 +19,8 @@ simple_scorer = SimpleScorer()
 default_sign_dict = {'Activation': 0,
                      'Inhibition': 1,
                      'IncreaseAmount': 0,
-                     'DecreaseAmount': 1}
+                     'DecreaseAmount': 1,
+                     'GtpActivation': 0}
 
 INDRA_ROOT = path.abspath(path.dirname(path.abspath(indra.__file__)))
 INDRA_RESOURCES = path.join(INDRA_ROOT, 'resources')


### PR DESCRIPTION
This PR explicitly adds GtpActivation into default sign dict for signed graph assembly (with df implementation the GtpActivation edges were excluded from signed graph, with preassembly method they were included but the assembly was failing because the sign wasn't explicitly set in the dict).