### PR TITLE
Remove rdflib requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(readme_path, 'r', encoding='utf-8') as fh:
 
 
 def main():
-    install_list = ['pysb>=1.3.0,<=1.9.1', 'objectpath', 'rdflib==4.2.2',
+    install_list = ['pysb>=1.3.0,<=1.9.1', 'objectpath',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
                     'networkx>=2', 'pandas<1.3', 'ndex2==2.0.1', 'jinja2',
                     'protmapper>=0.0.22', 'obonet', 'sympy==1.3',


### PR DESCRIPTION
This PR removes rdflib as an INDRA requirement. It is required indirectly by some other dependencies like protmapper and pybel, but is not used by INDRA directly anymore.