### PR TITLE
Improve NXML processing in REST API

### DIFF
--- a/indra/sources/reach/api.py
+++ b/indra/sources/reach/api.py
@@ -45,7 +45,7 @@ def process_pmc(pmc_id, offline=False, url=None,
     pmc_id : str
         The ID of a PubmedCentral article. The string may start with PMC but
         passing just the ID also works.
-        Examples: 3717945, PMC3717945
+        Examples: 8511698, PMC8511698
         https://www.ncbi.nlm.nih.gov/pmc/
     offline : Optional[bool]
         If set to True, the REACH system is run offline via a JAR file.

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -305,7 +305,7 @@ reach_text_model = api.inherit('ReachText', bio_text_model, {
 })
 reach_json_model = api.model('ReachJSON', {'json': fields.String(example='{}')})
 reach_pmc_model = api.model('ReachPMC', {
-    'pmc_id': fields.String(example='PMC3717945'),
+    'pmc_id': fields.String(example='PMC8511698'),
     'offline': fields.Boolean(default=False),
     'url': fields.String(example=reach_nxml_url)
 })
@@ -407,7 +407,7 @@ class ReachProcessPmc(Resource):
         pmc_id : str
             The ID of a PubmedCentral article. The string may start with PMC
             but passing just the ID also works.
-            Examples: 3717945, PMC3717945
+            Examples: 8511698, PMC8511698
             https://www.ncbi.nlm.nih.gov/pmc/
 
         offline : Optional[bool]


### PR DESCRIPTION
Fixes #1332. This PR fixes an argument in the REST API specifying PMC IDs. It also changes the example ID in the documentation to point to a shorter paper to avoid Reach service timeouts.