### PR TITLE
Precompile patterns from Identifiers.org

### DIFF
--- a/indra/databases/identifiers.py
+++ b/indra/databases/identifiers.py
@@ -368,6 +368,8 @@ def _load_identifiers_registry():
     identifiers_registry = load_resource_json('identifiers_patterns.json')
     # Override pattern otherwise patterns like 1.1 can't be used
     identifiers_registry['ec-code']['pattern'] = '^\\d{1,2}(\\.\\d{0,3}){0,3}$'
+    for value in identifiers_registry.values():
+        value["pattern_compiled"] = re.compile(value["pattern"])
     return identifiers_registry
 
 

--- a/indra/statements/validate.py
+++ b/indra/statements/validate.py
@@ -142,8 +142,8 @@ def assert_valid_id(db_ns, db_id):
         raise MissingIdentifier(db_ns, None)
     identifiers_ns = identifiers_mappings.get(db_ns, db_ns.lower())
     if identifiers_ns in identifiers_registry:
-        pattern = identifiers_registry[identifiers_ns]['pattern']
-        if re.match(pattern, db_id):
+        pattern = identifiers_registry[identifiers_ns]['pattern_compiled']
+        if pattern.match(db_id):
             return
         else:
             raise InvalidIdentifier(db_ns, db_id, pattern)


### PR DESCRIPTION
This will give a slight performance increase since re.match(pattern, s) requires recompiling the pattern every time. Additionally, this does some implicit checking that all of the patterns are right on startup rather than waiting for the validation functions to get called ahead of time. This should not change any current functionality and hopefully requires no testing