### PR TITLE
Add wheel to CI dependencies installation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,8 +42,6 @@ jobs:
         pip install cython
         # Now install INDRA with all its extras
         pip install .[all]
-        # Fixing rdflib 5 issue
-        pip install "pyparsing<3"
         wget -nv https://bigmech.s3.amazonaws.com/travis/Phosphorylation_site_dataset.tsv -O indra/resources/Phosphorylation_site_dataset.tsv
         # Run slow tests only if we're in the cron setting
         #- |

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def main():
     install_list = ['pysb>=1.3.0,<=1.9.1', 'objectpath',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
                     'networkx>=2', 'pandas<1.3', 'ndex2==2.0.1', 'jinja2',
-                    'protmapper>=0.0.22', 'obonet', 'sympy==1.3',
+                    'protmapper>=0.0.23', 'obonet', 'sympy==1.3',
                     'tqdm', 'pybiopax>=0.0.5']
 
     extras_require = {


### PR DESCRIPTION
This PR does the following:

- [x] Add `pip install wheel` to CI dependencies installation. This should make it go much faster, since apparently it's not available on the current config by default
- [x] Remove special installation of pyparsing (this should no longer be necessary since rdflib isn't a requirement anymore as of the changes in https://github.com/indralab/protmapper/pull/41 that were released in protmapper v0.0.24 yesterday)
- [ ] Remove special installation of cython (this should be handled by pyjnius since https://github.com/kivy/pyjnius/pull/594 made it to the 1.4.0 release at the end of August 2021)