### PR TITLE
Small fix for CREEDS processor and statement I/O

### DIFF
--- a/indra/sources/creeds/api.py
+++ b/indra/sources/creeds/api.py
@@ -75,8 +75,6 @@ def process_from_file(
     """
     with open(path) as file:
         records = json.load(file)
-    if len(records) != 1:
-        raise ValueError
     return process_records(records, entity_type)
 
 

--- a/indra/statements/io.py
+++ b/indra/statements/io.py
@@ -5,8 +5,10 @@ __all__ = ['stmts_from_json', 'stmts_from_json_file', 'stmts_to_json',
 
 import json
 import logging
+import os
+import pathlib
 from collections import Counter
-from typing import Collection, List, Optional
+from typing import Collection, List, Optional, Union
 
 from indra.statements.statements import Statement, Unresolved
 
@@ -65,12 +67,14 @@ def stmts_from_json(json_in, on_missing_support='handle'):
     return stmts
 
 
-def stmts_from_json_file(fname, format='json'):
+def stmts_from_json_file(
+    fname: Union[str, pathlib.Path, os.PathLike], format='json',
+):
     """Return a list of statements loaded from a JSON file.
 
     Parameters
     ----------
-    fname : str
+    fname :
         Path to the JSON file to load statements from.
     format : Optional[str]
         One of 'json' to assume regular JSON formatting or
@@ -89,14 +93,19 @@ def stmts_from_json_file(fname, format='json'):
                                     for line in fh.readlines()])
 
 
-def stmts_to_json_file(stmts, fname, format='json', **kwargs):
+def stmts_to_json_file(
+    stmts,
+    fname: Union[str, pathlib.Path, os.PathLike],
+    format='json',
+    **kwargs,
+):
     """Serialize a list of INDRA Statements into a JSON file.
 
     Parameters
     ----------
     stmts : list[indra.statement.Statements]
         The list of INDRA Statements to serialize into the JSON file.
-    fname : str
+    fname :
         Path to the JSON file to serialize Statements into.
     format : Optional[str]
         One of 'json' to use regular JSON with indent=1 formatting or


### PR DESCRIPTION
This PR does 2 small things:

1. Remove record length check in CREEDs processor. Not sure why this is here, the data structure is a list of several elements, so this always raises.
2. Update type checking on statements I/O. I was getting mypy errors in downstream usage of these. Luckily, the open() function is typed very loosely, and now these functions reflect that.

Note: these changes are not related other than that I needed to make them for the CREEDS analysis