### PR TITLE
Function to retrieve PubMedIDs for given PubChem CID 

### DIFF
--- a/indra/databases/pubchem_client.py
+++ b/indra/databases/pubchem_client.py
@@ -78,18 +78,21 @@ def get_preferred_compound_ids(pubchem_cid):
 
 
 def get_pmids(pubchem_cid: str) -> List[str]:
-    """Return xref PMIDs for a given PubChem CID.
+    """Return depositor provided PMIDs for a given PubChem CID.
+
+    Note that this information can also be obtained via PubMed
+    at https://www.ncbi.nlm.nih.gov/sites/entrez?LinkName=pccompound_pubmed&db=pccompound&cmd=Link&from_uid=<pubchem_cid>.
 
     Parameters
     ----------
     pubchem_cid :
-        The PubChem CID whose xref PubMedID's will be returned.
+        The PubChem CID whose PMIDs will be returned.
 
     Returns
     -------
-    list of str
-        PubMedIDs corresponding to the given PubChem CID. If none present,
-        an empty list is returned.
+    :
+        PMIDs corresponding to the given PubChem CID. If none present,
+        or the query fails, an empty list is returned.
     """
     url = '%s/compound/cid/%s/xrefs/PubMedID/JSON' % \
           (pubchem_url, pubchem_cid)
@@ -98,5 +101,6 @@ def get_pmids(pubchem_cid: str) -> List[str]:
         logger.error('Could not retrieve PMIDs for %s' % pubchem_cid)
         return []
     res_json = res.json()
-    pmids_list = [str(pmid) for pmid in res_json['InformationList']['Information'][0]['PubMedID']]
+    pmids_list = [str(pmid) for pmid in
+                  res_json['InformationList']['Information'][0]['PubMedID']]
     return pmids_list

--- a/indra/databases/pubchem_client.py
+++ b/indra/databases/pubchem_client.py
@@ -74,3 +74,25 @@ def get_preferred_compound_ids(pubchem_cid):
                 pref_ids |= set(pref_cpd['Value']['Number'])
     pref_ids = sorted([str(pid) for pid in pref_ids])
     return pref_ids
+
+
+def get_pmids(pubchem_cid):
+    """Return xref PMIDs for a given PubChem CID.
+
+    Parameters
+    ----------
+    pubchem_cid : str
+        The PubChem CID whose xref PubMedID's will be returned.
+
+    Returns
+    -------
+    list
+        PubMedIDs corresponding to the given PubChem CID. If none present,
+        an empty list is returned.
+    """
+    url = '%s/compound/cid/%s/xrefs/PubMedID/JSON' % \
+          (pubchem_url, pubchem_cid)
+    res = requests.get(url)
+    res_json = res.json()
+    pmids_list = res_json['InformationList']['Information'][0]['PubMedID']
+    return pmids_list

--- a/indra/databases/pubchem_client.py
+++ b/indra/databases/pubchem_client.py
@@ -87,7 +87,7 @@ def get_pmids(pubchem_cid: str) -> List[str]:
 
     Returns
     -------
-    list
+    list of str
         PubMedIDs corresponding to the given PubChem CID. If none present,
         an empty list is returned.
     """
@@ -98,5 +98,5 @@ def get_pmids(pubchem_cid: str) -> List[str]:
         logger.error('Could not retrieve PMIDs for %s' % pubchem_cid)
         return []
     res_json = res.json()
-    pmids_list = res_json['InformationList']['Information'][0]['PubMedID']
+    pmids_list = [str(pmid) for pmid in res_json['InformationList']['Information'][0]['PubMedID']]
     return pmids_list

--- a/indra/databases/pubchem_client.py
+++ b/indra/databases/pubchem_client.py
@@ -1,5 +1,6 @@
 import logging
 import requests
+from typing import List
 from functools import lru_cache
 
 
@@ -76,7 +77,7 @@ def get_preferred_compound_ids(pubchem_cid):
     return pref_ids
 
 
-def get_pmids(pubchem_cid):
+def get_pmids(pubchem_cid: str) -> List[str]:
     """Return xref PMIDs for a given PubChem CID.
 
     Parameters
@@ -95,7 +96,7 @@ def get_pmids(pubchem_cid):
     res = requests.get(url)
     if res.status_code != 200:
         logger.error('Could not retrieve PMIDs for %s' % pubchem_cid)
-        return None
+        return []
     res_json = res.json()
     pmids_list = res_json['InformationList']['Information'][0]['PubMedID']
     return pmids_list

--- a/indra/databases/pubchem_client.py
+++ b/indra/databases/pubchem_client.py
@@ -82,7 +82,7 @@ def get_pmids(pubchem_cid: str) -> List[str]:
 
     Parameters
     ----------
-    pubchem_cid : str
+    pubchem_cid :
         The PubChem CID whose xref PubMedID's will be returned.
 
     Returns

--- a/indra/databases/pubchem_client.py
+++ b/indra/databases/pubchem_client.py
@@ -93,6 +93,9 @@ def get_pmids(pubchem_cid):
     url = '%s/compound/cid/%s/xrefs/PubMedID/JSON' % \
           (pubchem_url, pubchem_cid)
     res = requests.get(url)
+    if res.status_code != 200:
+        logger.error('Could not retrieve PMIDs for %s' % pubchem_cid)
+        return None
     res_json = res.json()
     pmids_list = res_json['InformationList']['Information'][0]['PubMedID']
     return pmids_list

--- a/indra/tests/test_pubchem_client.py
+++ b/indra/tests/test_pubchem_client.py
@@ -1,7 +1,6 @@
 from indra.databases import pubchem_client
 
 
-
 def test_get_inchi_key():
     ik = pubchem_client.get_inchi_key('5280613')
     assert ik == 'JLVSPVFPBBFMBE-HXSWCURESA-O', ik

--- a/indra/tests/test_pubchem_client.py
+++ b/indra/tests/test_pubchem_client.py
@@ -9,4 +9,4 @@ def test_get_inchi_key():
 def test_get_pmids():
     pmids = pubchem_client.get_pmids('2244')
     example_pmid = '19036898'
-    assert pmids[0] == example_pmid
+    assert example_pmid in pmids

--- a/indra/tests/test_pubchem_client.py
+++ b/indra/tests/test_pubchem_client.py
@@ -9,4 +9,6 @@ def test_get_inchi_key():
 def test_get_pmids():
     pmids = pubchem_client.get_pmids('2244')
     example_pmid = '19036898'
+    wrong_pmid = '17410596'
     assert example_pmid in pmids
+    assert wrong_pmid not in pmids

--- a/indra/tests/test_pubchem_client.py
+++ b/indra/tests/test_pubchem_client.py
@@ -1,6 +1,13 @@
 from indra.databases import pubchem_client
 
 
+
 def test_get_inchi_key():
     ik = pubchem_client.get_inchi_key('5280613')
     assert ik == 'JLVSPVFPBBFMBE-HXSWCURESA-O', ik
+
+
+def test_get_pmids():
+    pmids = pubchem_client.get_pmids('2244')
+    example_pmid = '19036898'
+    assert pmids[0] == example_pmid


### PR DESCRIPTION
This PR consists of a new function that takes PubChem CID as an input and returns back a list of PMIDs corresponding to it.
```
from indra.databases.pubchem_client import get_pmids 
pmids = get_pmids('22442') # aspirin
```