### PR TITLE
Optimize handling split groups in refinement filter

### DIFF
--- a/indra/preassembler/refinement.py
+++ b/indra/preassembler/refinement.py
@@ -383,11 +383,13 @@ class SplitGroupFilter(RefinementFilter):
         # return all of them of possibly_related is None (i.e., there
         # was no previous filter), or if the given statement is
         # also possibly related
-        related = {stmt_hash for stmt_hash
-                   in self.shared_data['stmts_by_hash']
-                   if self.split_groups[stmt_hash] != group
-                   and (possibly_related is None
-                        or stmt_hash in possibly_related)}
+        if possibly_related is not None:
+            related = {stmt_hash for stmt_hash in possibly_related
+                       if self.split_groups[stmt_hash] != group}
+        else:
+            related = {stmt_hash for stmt_hash
+                       in self.shared_data['stmts_by_hash']
+                       if self.split_groups[stmt_hash] != group}
         return related
 
 

--- a/indra/preassembler/refinement.py
+++ b/indra/preassembler/refinement.py
@@ -380,16 +380,14 @@ class SplitGroupFilter(RefinementFilter):
         sh = stmt.get_hash()
         group = self.split_groups.get(sh)
         # We take all the hashes that are in a different group, and
-        # return all of them of possibly_related is None (i.e., there
+        # return all of them if possibly_related is None (i.e., there
         # was no previous filter), or if the given statement is
         # also possibly related
-        if possibly_related is not None:
-            related = {stmt_hash for stmt_hash in possibly_related
-                       if self.split_groups[stmt_hash] != group}
-        else:
-            related = {stmt_hash for stmt_hash
-                       in self.shared_data['stmts_by_hash']
-                       if self.split_groups[stmt_hash] != group}
+        possibly_related_prior = possibly_related \
+            if possibly_related is not None \
+            else self.shared_data['stmts_by_hash']
+        related = {stmt_hash for stmt_hash in possibly_related_prior
+                   if self.split_groups[stmt_hash] != group}
         return related
 
 


### PR DESCRIPTION
This PR makes the `SplitGroupFilter` much more efficient in case a `possibly_related` set is already available making refinement finding for large batches with a split index significantly faster.