### PR TITLE
Add base assembler class

### DIFF
--- a/indra/assemblers/utils.py
+++ b/indra/assemblers/utils.py
@@ -1,0 +1,22 @@
+"""Utilities for INDRA assemblers."""
+
+from typing import Generic, TypeVar
+from abc import ABC, abstractmethod
+
+__all__ = [
+  "Assembler",
+]
+
+X = TypeVar("X")
+
+class Assembler(ABC, Generic[X]):
+    """A base class for INDRA assemblers."""
+
+    @classmethod
+    def model_from_stmts(cls, statements: Optional[Statement] = None, **kwargs) -> X:
+        assembler = cls(statements, **kwargs)
+        return assembler.make_model()
+
+    @abstractmethod
+    def make_model(*args, **kwargs) -> X:
+        raise NotImplementedError


### PR DESCRIPTION
Adding a base assembler class allows for other assemblers to inherit some shared functionality (or at least unify the interface a bit).

For example, I find myself doing this quite a bit:

```
from indra.assemblers import SomethingAssembler

assembler = SomethingAssembler(stmts)
model = assembler.make_model()
```

And with the base class, it's possible to just do

```
from indra.assemblers import SomethingAssembler

model = SomethingAssembler.model_from_stmts(stmts)
```