### PR TITLE
Add option for local text content DB for grounding mapping

### DIFF
--- a/indra/preassembler/grounding_mapper/disambiguate.py
+++ b/indra/preassembler/grounding_mapper/disambiguate.py
@@ -237,14 +237,24 @@ class DisambManager(object):
         # available since this is the fastest option
         if self.has_local_text_db:
             try:
-                from indra_db_lite import get_plaintexts_for_text_ref_ids
+                from indra_db_lite import get_plaintexts_for_text_ref_ids, \
+                    get_text_ref_ids_for_pmids
                 refs = stmt.evidence[0].text_refs
                 trid = refs.get('TRID')
+                pmid = refs.get('PMID')
                 if trid:
                     text_content = get_plaintexts_for_text_ref_ids([trid])
                     _, content = next(text_content.trid_content_pairs())
                     if content:
                         return content
+                elif pmid:
+                    mappings = get_text_ref_ids_for_pmids([int(pmid)])
+                    if int(pmid) in mappings:
+                        trid = mappings[int(pmid)]
+                        text_content = get_plaintexts_for_text_ref_ids([trid])
+                        _, content = next(text_content.trid_content_pairs())
+                        if content:
+                            return content
             except Exception as e:
                 logger.info('Could not get text from local DB: %s' % e)
         # If the above is not available or fails, we try the INDRA DB

--- a/indra/preassembler/grounding_mapper/disambiguate.py
+++ b/indra/preassembler/grounding_mapper/disambiguate.py
@@ -27,12 +27,13 @@ class DisambManager(object):
     of this class uses a single database connection.
     """
     def __init__(self):
+        self.has_local_text_db = False
         if has_config('INDRA_DB_LITE_LOCATION'):
             try:
                 from indra_db_lite import get_plaintexts_for_text_ref_ids
                 self.has_local_text_db = True
             except Exception as e:
-                self.has_local_text_db = False
+                pass
         try:
             from indra_db.util.content_scripts import TextContentSessionHandler
             self.__tc = TextContentSessionHandler()

--- a/indra/tests/test_groundingmapper.py
+++ b/indra/tests/test_groundingmapper.py
@@ -444,7 +444,6 @@ def test_gilda_disambiguation():
     stmt2 = Inhibition(None, er2,
                        evidence=[Evidence(pmid=pmid2,
                                           text_refs={'PMID': pmid2})])
-
     mapped_stmts1 = gm.map_stmts([stmt1])
     assert mapped_stmts1[0].sub.name == 'STK38', mapped_stmts1[0].sub.name
     assert mapped_stmts1[0].sub.db_refs['HGNC'] == '17847', \


### PR DESCRIPTION
This PR adds another layer to getting text from disambiguation using a local text content DB which is the fastest option.