### PR TITLE
Eliminate isa/partof ontology cycles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,7 @@ jobs:
         #export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify;
         # Download adeft models
         python -m adeft.download
+        python -m gilda.resources
         # Get INDRA World
         git clone https://github.com/indralab/indra_world.git
         wget -nv https://bigmech.s3.amazonaws.com/travis/reach-82631d-biores-e9ee36.jar

--- a/indra/ontology/bio/ontology.py
+++ b/indra/ontology/bio/ontology.py
@@ -19,13 +19,13 @@ class BioOntology(IndraOntology):
     # should be incremented to "force" rebuilding the ontology to be consistent
     # with the underlying resource files.
     name = 'bio'
-    version = '1.26'
+    version = '1.27'
     ontology_namespaces = [
         'go', 'efo', 'hp', 'doid', 'chebi', 'ido', 'mondo', 'eccode',
     ]
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def initialize(self, rebuild=False):
         if rebuild or not os.path.exists(CACHE_FILE):
@@ -589,8 +589,8 @@ class BioOntology(IndraOntology):
         super().add_nodes_from(nodes_for_adding, **attr)
 
     def add_edges_from(self, ebunch_to_add, **attr):
-        for source, target, _ in ebunch_to_add:
-            for label in [source, target]:
+        for edge_info in ebunch_to_add:
+            for label in edge_info[:2]:
                 self.assert_valid_node(label)
         super().add_edges_from(ebunch_to_add, **attr)
 

--- a/indra/ontology/ontology_graph.py
+++ b/indra/ontology/ontology_graph.py
@@ -31,8 +31,8 @@ class IndraOntology(networkx.DiGraph):
     version = None
     name = None
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._initialized = False
         self.name_to_grounding = {}
         self.transitive_closure = set()

--- a/indra/tests/test_biolookup_client.py
+++ b/indra/tests/test_biolookup_client.py
@@ -4,8 +4,9 @@ from indra.databases import biolookup_client
 def test_lookup_curie():
     curie = 'pubchem.compound:40976'
     res = biolookup_client.lookup_curie(curie)
-    assert res['name'] == '(17alpha)-13-Ethyl-17-hydroxy-11-methylene' \
-        '-18,19-dinorpregn-4-en-20-yn-3-one', res
+    assert res['name'] == '(17R)-13-ethyl-17-ethynyl-17-hydroxy-11-' \
+        'methylidene-2,6,7,8,9,10,12,14,15,16-decahydro-1H-' \
+        'cyclopenta[a]phenanthren-3-one', res
 
 
 def test_lookup():

--- a/indra/tests/test_ontology.py
+++ b/indra/tests/test_ontology.py
@@ -1,3 +1,4 @@
+from unittest import skip
 from indra.statements import Agent
 from indra.ontology.bio import bio_ontology
 from indra.databases import go_client, hgnc_client
@@ -314,6 +315,7 @@ def test_name_lookup_obsolete():
         ('HGNC', '403')
 
 
+@skip('CHEBI partof relations currently excluded')
 def test_chebi_refinements():
     assert bio_ontology.partof('CHEBI', 'CHEBI:136692',
                                'CHEBI', 'CHEBI:365')

--- a/indra/tools/analyze_ontology.py
+++ b/indra/tools/analyze_ontology.py
@@ -53,8 +53,8 @@ if __name__ == '__main__':
         print(ns, len(problems_ns))
 
 
-    # Next, find cycles in the isa/partof subgraph meaning circilar hierarchical
-    # relationships.
+    # Next, find cycles in the isa/partof subgraph meaning circular
+    # hierarchical relationships.
     hierarchy = [(e[0], e[1]) for e in bio_ontology.edges(data=True) if
                  e[2]['type'] in {'isa', 'partof'}]
     hierarchyg = bio_ontology.edge_subgraph(hierarchy)

--- a/indra/tools/analyze_ontology.py
+++ b/indra/tools/analyze_ontology.py
@@ -15,7 +15,18 @@ def plot_problem(problem):
     plt.show()
 
 
+def print_cycle(cycle):
+    for n1, n2 in zip(cycle, cycle[1:] + cycle[:1]):
+        print('%s (%s)-[%s]-%s (%s)' % (
+            bio_ontology.get_name(*bio_ontology.get_ns_id(n1)), n1,
+            bio_ontology.edges[n1, n2]['type'],
+            bio_ontology.get_name(*bio_ontology.get_ns_id(n2)), n2
+            )
+        )
+
 if __name__ == '__main__':
+    # First, find strongly connected components in the xref graph where
+    # a given namespace appears more than once.
     bio_ontology.initialize()
     xrefs = [(e[0], e[1]) for e in bio_ontology.edges(data=True) if
              e[2]['type'] == 'xref']
@@ -40,3 +51,14 @@ if __name__ == '__main__':
 
     for ns, problems_ns in problems_by_ns.items():
         print(ns, len(problems_ns))
+
+
+    # Next, find cycles in the isa/partof subgraph meaning circilar hierarchical
+    # relationships.
+    hierarchy = [(e[0], e[1]) for e in bio_ontology.edges(data=True) if
+                 e[2]['type'] in {'isa', 'partof'}]
+    hierarchyg = bio_ontology.edge_subgraph(hierarchy)
+    cycles = networkx.simple_cycles(hierarchyg)
+    for cycle in cycles:
+        print('---')
+        print_cycle(cycle)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def main():
                       'trips_offline': ['pykqml'],
                       'reach_offline': ['cython', 'pyjnius==1.1.4'],
                       'eidos_offline': ['cython', 'pyjnius==1.1.4'],
-                      'hypothesis': ['gilda'],
+                      'hypothesis': ['gilda>=0.10.2'],
                       'geneways': ['stemming', 'nltk<3.6'],
                       'bel': ['pybel>=0.15.0,<0.16.0'],
                       'sbml': ['python-libsbml'],
@@ -29,7 +29,7 @@ def main():
                       'machine': ['pytz', 'tzlocal', 'tweepy', 'pyyaml>=5.1.0',
                                   'click'],
                       'explanation': ['kappy==4.1.2', 'paths-graph'],
-                      'grounding': ['adeft', 'gilda'],
+                      'grounding': ['adeft', 'gilda>=0.10.2'],
                       # AWS interface and database
                       'aws': ['boto3', 'reportlab'],
                       # Utilities

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ with open(readme_path, 'r', encoding='utf-8') as fh:
 
 
 def main():
-    install_list = ['pysb>=1.3.0,<=1.9.1', 'objectpath',
+    install_list = ['pysb>=1.3.0', 'objectpath',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
                     'networkx>=2', 'pandas<1.3', 'ndex2==2.0.1', 'jinja2',
                     'markupsafe<2.1.0',
-                    'protmapper>=0.0.27', 'obonet', 'sympy==1.3',
+                    'protmapper>=0.0.27', 'obonet',
                     'tqdm', 'pybiopax>=0.0.5']
 
     extras_require = {


### PR DESCRIPTION
This PR adds some exclusion criteria to eliminate any directed cycles in the isa/partof subgraph of the BioOntology graph which can induce cycles during Statement refinement finding.