### PR TITLE
Handle more UP/HGNC corner cases in BioPAX

### DIFF
--- a/indra/tests/test_biopax.py
+++ b/indra/tests/test_biopax.py
@@ -108,3 +108,10 @@ def assert_source_sub_id(stmts):
         for ev in stmt.evidence:
             assert 'source_sub_id' in ev.annotations
             assert ev.annotations['source_sub_id']
+
+
+def test_valid_agent():
+    agent = bpc.get_standard_agent('x', {'HGNC': '1097', 'EGID': '---'})
+    assert agent.name == 'BRAF'
+    assert agent.db_refs.get('EGID') != '---'
+    assert agent.db_refs['HGNC'] == '1097'


### PR DESCRIPTION
This PR handles some corner cases in BioPAX content where xrefs provided for a Protein contain multiple HGNC and UniProt IDs but not the same number, and also the case where there are more than one UniProt IDs but no HGNC IDs at all.

Fixes #1389 