### PR TITLE
Improve BioPAX conversion processing and extend API

### DIFF
--- a/indra/sources/biopax/api.py
+++ b/indra/sources/biopax/api.py
@@ -1,10 +1,10 @@
 __all__ = ['process_pc_neighborhood', 'process_pc_pathsbetween',
            'process_pc_pathsfromto', 'process_owl', 'process_owl_str',
-           'process_model']
+           'process_owl_gz', 'process_model']
 
 import itertools
 from pybiopax import model_from_owl_file, model_from_owl_str, \
-    model_from_pc_query
+    model_from_pc_query, model_from_owl_gz
 from .processor import BiopaxProcessor
 
 default_databases = ['wp', 'smpdb', 'reconx', 'reactome', 'psp', 'pid',
@@ -173,6 +173,23 @@ def process_owl(owl_filename, encoding=None):
         A BiopaxProcessor containing the obtained BioPAX model in bp.model.
     """
     model = model_from_owl_file(owl_filename, encoding=encoding)
+    return process_model(model)
+
+
+def process_owl_gz(owl_gz_filename):
+    """Returns a BiopaxProcessor for a gzipped BioPAX OWL file.
+
+    Parameters
+    ----------
+    owl_gz_filename : str
+        The name of the gzipped OWL file to process.
+
+    Returns
+    -------
+    bp : BiopaxProcessor
+        A BiopaxProcessor containing the obtained BioPAX model in bp.model.
+    """
+    model = model_from_owl_gz(owl_gz_filename)
     return process_model(model)
 
 

--- a/indra/sources/biopax/processor.py
+++ b/indra/sources/biopax/processor.py
@@ -153,10 +153,10 @@ class BiopaxProcessor(object):
         return BiopaxProcessor.find_matching_entities(left_simple, right_simple)
 
     @staticmethod
-    def find_matching_entities(left_simple, right_simple):
-        """Find matching entities between two lists of simple entities."""
+    def find_matching_entities(left_entities, right_entities):
+        """Find matching entities between two lists of entities."""
         matches = []
-        for inp, outp in itertools.product(left_simple, right_simple):
+        for inp, outp in itertools.product(left_entities, right_entities):
             # If these are the exact same object instances, then they are
             # trivially matching. This covers 'complex' and 'complex_named'
             # physical entity types as well.


### PR DESCRIPTION
This PR adds a convenient function to the BioPAX API to allow processing gzipped OWL files directly. It also improves how conversions (e.g., biochemical reactions) are processed. Namely, it handles a corner case in which the ordering of simple entities on the left and right hand sides are inconsistent and therefore need to be combinatorially matched to find corresponding left and right hand side entities.