### PR TITLE
Single quotes don't work for Windows

### DIFF
--- a/indra/sources/reach/__init__.py
+++ b/indra/sources/reach/__init__.py
@@ -15,7 +15,7 @@ Setup and usage: Follow standard instructions to install
 
     git clone https://github.com/clulab/reach.git
     cd reach
-    sbt 'runMain org.clulab.reach.export.server.ApiServer'
+    sbt "runMain org.clulab.reach.export.server.ApiServer"
 
 Then read text by specifying the url parameter when using
 `indra.sources.reach.process_text`.


### PR DESCRIPTION
They are OK for PowerShell, but don't work on the old command prompt.