### PR TITLE
Allow extracting all Agents from Reach entities

### DIFF
--- a/indra/sources/reach/__init__.py
+++ b/indra/sources/reach/__init__.py
@@ -169,6 +169,7 @@ from .api import (process_pmc,
                   process_nxml_file,
                   process_json_str,
                   process_json_file,
+                  process_agents_from_entities,
                   process_fries_json_group,
                   reach_text_url, reach_nxml_url,
                   local_text_url, local_nxml_url)

--- a/indra/sources/reach/api.py
+++ b/indra/sources/reach/api.py
@@ -429,6 +429,21 @@ def process_json_str(json_str, citation=None, organism_priority=None):
         A ReachProcessor containing the extracted INDRA Statements
         in rp.statements.
     """
+    json_dict = _preprocess_json_str(json_str)
+    if json_dict is None:
+        return None
+    rp = ReachProcessor(json_dict, pmid=citation,
+                        organism_priority=organism_priority)
+    rp.get_modifications()
+    rp.get_complexes()
+    rp.get_activation()
+    rp.get_translocation()
+    rp.get_regulate_amounts()
+    rp.get_conversion()
+    return rp
+
+
+def _preprocess_json_str(json_str):
     fields = ['frame-id', 'argument-label', 'object-meta',
               'doc-id', 'is-hypothesis', 'is-negated',
               'is-direct', 'found-by']
@@ -440,15 +455,15 @@ def process_json_str(json_str, citation=None, organism_priority=None):
         logger.error('Could not decode JSON string.')
         logger.exception(e)
         return None
-    rp = ReachProcessor(json_dict, pmid=citation,
-                        organism_priority=organism_priority)
-    rp.get_modifications()
-    rp.get_complexes()
-    rp.get_activation()
-    rp.get_translocation()
-    rp.get_regulate_amounts()
-    rp.get_conversion()
-    return rp
+    return json_dict
+
+
+def process_agents_from_entities(file_name, organism_priority=None):
+    with open(file_name, 'rb') as fh:
+        json_str = fh.read().decode('utf-8')
+    json_dict = _preprocess_json_str(json_str)
+    rp = ReachProcessor(json_dict, organism_priority=organism_priority)
+    return rp.get_agents_from_entities()
 
 
 def _read_content_offline(content, content_type='text'):

--- a/indra/sources/reach/api.py
+++ b/indra/sources/reach/api.py
@@ -443,6 +443,32 @@ def process_json_str(json_str, citation=None, organism_priority=None):
     return rp
 
 
+def process_agents_from_entities(file_name, organism_priority=None):
+    """Return INDRA Agents extracted from all entites, eve ones not appearing
+    in Statements.
+
+    Parameters
+    ----------
+    file_name : str
+        The name of the json file to be processed.
+    organism_priority : Optional[list of str]
+        A list of Taxonomy IDs providing prioritization among organisms
+        when choosing protein grounding. If not given, the default behavior
+        takes the first match produced by Reach, which is prioritized to be
+        a human protein if such a match exists.
+
+    Returns
+    -------
+    list[Agent] :
+        A list of INDRA Agents processed from all extracted entities.
+    """
+    with open(file_name, 'rb') as fh:
+        json_str = fh.read().decode('utf-8')
+    json_dict = _preprocess_json_str(json_str)
+    rp = ReachProcessor(json_dict, organism_priority=organism_priority)
+    return rp.get_agents_from_entities()
+
+
 def _preprocess_json_str(json_str):
     fields = ['frame-id', 'argument-label', 'object-meta',
               'doc-id', 'is-hypothesis', 'is-negated',
@@ -456,14 +482,6 @@ def _preprocess_json_str(json_str):
         logger.exception(e)
         return None
     return json_dict
-
-
-def process_agents_from_entities(file_name, organism_priority=None):
-    with open(file_name, 'rb') as fh:
-        json_str = fh.read().decode('utf-8')
-    json_dict = _preprocess_json_str(json_str)
-    rp = ReachProcessor(json_dict, organism_priority=organism_priority)
-    return rp.get_agents_from_entities()
 
 
 def _read_content_offline(content, content_type='text'):

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -90,6 +90,8 @@ class ReachProcessor(object):
         return self.tree.execute("$.entities.frames")
 
     def get_agents_from_entities(self):
+        """Return INDRA Agents extracted from all entities, even ones not
+        part of events."""
         entities = self.get_all_entities()
         agents = [
             self._get_agent_from_entity(e['frame_id'])[0]

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -85,6 +85,18 @@ class ReachProcessor(object):
             except KeyError:
                 self.all_events[event_type] = [frame_id]
 
+    def get_all_entities(self):
+        """Return all entities extracted, even ones not part of events."""
+        return self.tree.execute("$.entities.frames")
+
+    def get_agents_from_entities(self):
+        entities = self.get_all_entities()
+        agents = [
+            self._get_agent_from_entity(e['frame_id'])[0]
+            for e in entities
+        ]
+        return agents
+
     def print_regulations(self):
         qstr = "$.events.frames[(@.type is 'regulation')]"
         res = self.tree.execute(qstr)

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -4,7 +4,7 @@ from indra.sources import reach
 from indra.sources.reach.processor import ReachProcessor, normalize_section
 from indra.util import unicode_strs
 from indra.statements import IncreaseAmount, DecreaseAmount, \
-    Dephosphorylation, Complex, Phosphorylation, Translocation
+    Dephosphorylation, Complex, Phosphorylation, Translocation, Agent
 
 # Change this list to control what modes of
 # reading are enabled in tests
@@ -480,6 +480,14 @@ def test_phosphorylation_regulation():
     stmt = rp.statements[0]
     assert isinstance(stmt, Phosphorylation), stmt
     assert not stmt.sub.mods
+
+
+def test_process_agents():
+    here = os.path.dirname(os.path.abspath(__file__))
+    test_file = os.path.join(here, 'reach_reg_phos.json')
+    agents = reach.process_agents_from_entities(test_file)
+    assert all(isinstance(a, Agent) for a in agents)
+    assert len(agents) == 2
 
 
 def test_organism_prioritization():


### PR DESCRIPTION
This PR adds a function to allow extracting all entities found by Reach as INDRA Agents (even ones not part of Statements).