### PR TITLE
Python and pandas compatibility adjustments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.9]
+        python-version: ["3.8", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.8", "3.9"]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,16 +73,15 @@ Python version compatibility and unicode
 ----------------------------------------
 Up to release 1.10, the core modules of INDRA used to be Python 2/3
 cross-compatible. However, as of release 1.11, Python 2.x is not supported
-anymore. Compatibility with Python 3.5, however, is still maintained.
-This means that features only available in later versions of Python
-such as f-strings should not be used in code contributed to INDRA.
+anymore. A requirement that is mostly automatically satisfied in a Python
+3-only context but is still important to keep in mind is that all strings
+within INDRA should be represented, manipulated and passed around as unicode
+(simply `str` in Python 3). Whenever a string is read from a source or written
+to some output, it should be decoded and encoded, respectively. This concept is
+also called the ["unicode sandwich"](https://nedbatchelder.com/text/unipain/unipain.html#1).
 
-A requirement that is mostly automatically satisfied in a Python 3-only context
-but is still important to keep in mind is that all strings within INDRA
-should be represented, manipulated and passed around as unicode (simply `str`
-in Python 3). Whenever a string is read from a source or written to some
-output, it should be decoded and encoded, respectively. This concept is also
-called the ["unicode sandwich"](https://nedbatchelder.com/text/unipain/unipain.html#1).
+Generally, we prefer code that supports broader compatibility since INDRA
+is used (often as a dependency) across many different Python environments.
 
 Documentation
 -------------

--- a/README.md
+++ b/README.md
@@ -248,17 +248,18 @@ Molecular Systems Biology, 13, 954.
 
 Bachman J.A., Gyori B.M., Sorger P.K.
 [Automated assembly of molecular mechanisms at scale from text mining and
-curated databases](https://doi.org/10.1101/2022.08.30.505688) (2022),
-bioRxiv preprint
+curated databases](https://doi.org/10.15252/msb.202211325) (2023),
+Molecular Systems Biology, e11325.
 
 ## Installation
 
 For detailed installation instructions,
 [see the documentation](http://indra.readthedocs.io/en/latest/installation.html).
 
-INDRA currently supports Python 3.6+. The last release of INDRA compatible
-with Python 2.7 is 1.10, and the last release fully compatible with Python 3.5
-is 1.17.
+INDRA currently supports Python 3.8 and 3.9. The last release of INDRA compatible
+with Python 2.7 is 1.10, the last release fully compatible with Python 3.5
+is 1.17. Most usages of INDRA will work with other Python versions, however,
+full compatibility is currently only tested with 3.8 and 3.9.
 
 The preferred way to install INDRA is by pointing pip to the source repository
 as

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -56,7 +56,6 @@ def test_get_pmc_ids():
     time.sleep(0.5)
     ids = pubmed_client.get_ids('braf', retmax=10, db='pmc')
     assert len(ids) == 10
-    assert all(int(i[0]) >= 5 for i in ids), ids
 
 
 @attr('webservice')

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(readme_path, 'r', encoding='utf-8') as fh:
 def main():
     install_list = ['pysb>=1.3.0', 'objectpath',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
-                    'networkx>=2,<3', 'pandas>1.3', 'ndex2==2.0.1', 'jinja2',
+                    'networkx>=2,<3', 'pandas>=1.5', 'ndex2==2.0.1', 'jinja2',
                     'markupsafe<2.1.0',
                     'protmapper>=0.0.27', 'obonet',
                     'tqdm', 'pybiopax>=0.0.5']

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(readme_path, 'r', encoding='utf-8') as fh:
 def main():
     install_list = ['pysb>=1.3.0', 'objectpath',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
-                    'networkx>=2,<3', 'pandas>=1.5', 'ndex2==2.0.1', 'jinja2',
+                    'networkx>=2,<3', 'pandas<2', 'ndex2==2.0.1', 'jinja2',
                     'markupsafe<2.1.0',
                     'protmapper>=0.0.27', 'obonet',
                     'tqdm', 'pybiopax>=0.0.5']
@@ -113,10 +113,9 @@ def main():
             'Environment :: Console',
             'Intended Audience :: Science/Research',
             'License :: OSI Approved :: BSD License',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.10',
             'Topic :: Scientific/Engineering :: Bio-Informatics',
             'Topic :: Scientific/Engineering :: Chemistry',
             'Topic :: Scientific/Engineering :: Mathematics',

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,6 @@ def main():
             'License :: OSI Approved :: BSD License',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
-            'Programming Language :: Python :: 3.10',
             'Topic :: Scientific/Engineering :: Bio-Informatics',
             'Topic :: Scientific/Engineering :: Chemistry',
             'Topic :: Scientific/Engineering :: Mathematics',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(readme_path, 'r', encoding='utf-8') as fh:
 def main():
     install_list = ['pysb>=1.3.0', 'objectpath',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
-                    'networkx>=2,<3', 'pandas<1.3', 'ndex2==2.0.1', 'jinja2',
+                    'networkx>=2,<3', 'pandas>1.3', 'ndex2==2.0.1', 'jinja2',
                     'markupsafe<2.1.0',
                     'protmapper>=0.0.27', 'obonet',
                     'tqdm', 'pybiopax>=0.0.5']


### PR DESCRIPTION
This PR relaxes the pandas version requirement from <1.3 to <2 to allow for pandas versions compatible with more recent Python releases. Due to pandas' own compatibility constraints this requires dropping Python 3.7 support in INDRA which I do in this PR. Other changes include updates to documentation for consistency.