### PR TITLE
Migrate testing from nosetests to pytest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,8 +96,7 @@ jobs:
         echo $NOSEATTR
         #- cd $TRAVIS_BUILD_DIR
         # Now run all INDRA tests
-        cd indra
-        pytest -v -m "$NOSEATTR" --ignore-glob='*tees*' --ignore-glob='*isi*' --ignore-glob='*test_reach*' --cov=indra --cov-report=term-missing --doctest-modules --durations=10
+        pytest -v -m "$NOSEATTR" --ignore-glob='*tees*' --ignore-glob='*isi*' --ignore-glob='*test_reach*' --cov=indra --cov-report=term-missing --doctest-modules --durations=10 indra/tests
         pytest -v -m "$NOSEATTR" indra/tests/test_reach.py
         #nosetests -v -a $NOSEATTR --exclude='.*tees.*' --exclude='.*isi.*' --exclude='.*test_reach.*' --with-coverage --cover-inclusive --cover-package=indra --with-doctest --with-doctest-ignore-unicode --with-timer --timer-top-n 10 --processes=0
         #nosetests -v -a $NOSEATTR indra/tests/test_reach.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,8 +80,8 @@ jobs:
         BIOGRID_API_KEY: ${{ secrets.BIOGRID_API_KEY }}
       run: |
         # Set pytest attributes based on the context in which we are running
-        export NOSEATTR="(not notravis) and (not slow) and (not cron)";
-        export NOSEATTR=$(if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then echo $NOSEATTR and (not nonpublic); else echo $NOSEATTR; fi)
+        export NOSEATTR="(not nogha) and (not slow) and (not cron)"
+        export NOSEATTR=$(if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then echo $NOSEATTR "and (not nonpublic)"; else echo $NOSEATTR; fi)
         echo $NOSEATTR
         #echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
         #echo "$TRAVIS_EVENT_TYPE"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,7 @@ jobs:
         echo $NOSEATTR
         #- cd $TRAVIS_BUILD_DIR
         # Now run all INDRA tests
+        cd indra
         pytest -v -m "$NOSEATTR" --ignore-glob='*tees*' --ignore-glob='*isi*' --ignore-glob='*test_reach*' --cov=indra --cov-report=term-missing --doctest-modules --durations=10
         pytest -v -m "$NOSEATTR" indra/tests/test_reach.py
         #nosetests -v -a $NOSEATTR --exclude='.*tees.*' --exclude='.*isi.*' --exclude='.*test_reach.*' --with-coverage --cover-inclusive --cover-package=indra --with-doctest --with-doctest-ignore-unicode --with-timer --timer-top-n 10 --processes=0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         sudo apt-get install libstdc++6 graphviz python3-dev libgraphviz-dev pkg-config
         # Install test/CI-specific dependencies not covered elsewhere
         pip install --upgrade pip setuptools wheel
-        pip install pytest pydot jsonschema coverage nose-timer awscli pycodestyle
+        pip install pytest pytest-cov pydot jsonschema coverage nose-timer awscli pycodestyle
         mkdir -p $HOME/.pybel/data
         wget -nv https://bigmech.s3.amazonaws.com/travis/pybel_cache.db -O $HOME/.pybel/data/pybel_cache.db
         # PySB and dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         sudo apt-get install libstdc++6 graphviz python3-dev libgraphviz-dev pkg-config
         # Install test/CI-specific dependencies not covered elsewhere
         pip install --upgrade pip setuptools wheel
-        pip install pytest pydot jsonschema coverage nose-timer doctest-ignore-unicode awscli pycodestyle
+        pip install pytest pydot jsonschema coverage nose-timer awscli pycodestyle
         mkdir -p $HOME/.pybel/data
         wget -nv https://bigmech.s3.amazonaws.com/travis/pybel_cache.db -O $HOME/.pybel/data/pybel_cache.db
         # PySB and dependencies
@@ -96,7 +96,7 @@ jobs:
         echo $NOSEATTR
         #- cd $TRAVIS_BUILD_DIR
         # Now run all INDRA tests
-        pytest -v -m "$NOSEATTR" --ignore-glob='*tees*' --ignore-glob='*isi*' --ignore-glob='*test_reach*' --cov=indra --cov-report=term-missing --doctest-modules --doctest-ignore-unicode --durations=10
+        pytest -v -m "$NOSEATTR" --ignore-glob='*tees*' --ignore-glob='*isi*' --ignore-glob='*test_reach*' --cov=indra --cov-report=term-missing --doctest-modules --durations=10
         pytest -v -m "$NOSEATTR" indra/tests/test_reach.py
         #nosetests -v -a $NOSEATTR --exclude='.*tees.*' --exclude='.*isi.*' --exclude='.*test_reach.*' --with-coverage --cover-inclusive --cover-package=indra --with-doctest --with-doctest-ignore-unicode --with-timer --timer-top-n 10 --processes=0
         #nosetests -v -a $NOSEATTR indra/tests/test_reach.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,15 +57,12 @@ jobs:
         #      mv TEES ~/TEES;
         #      export TEES_SETTINGS=~/TEES/tees_local_settings.py
         #  fi
-        # Install nose notify
-        #mkdir $HOME/.nose_notify;
-        #git clone https://github.com/pagreene/nose-notify.git $HOME/.nose_notify;
-        #export PYTHONPATH=$PYTHONPATH:$HOME/.nose_notify;
         # Download adeft models
         python -m adeft.download
         python -m gilda.resources
         # Get INDRA World
         git clone https://github.com/indralab/indra_world.git
+        # Download Reach
         wget -nv https://bigmech.s3.amazonaws.com/travis/reach-82631d-biores-e9ee36.jar
         # Get INDRA Bioontology
         BIOONTOLOGY_VERSION=$(python -m indra.ontology.bio version)
@@ -83,8 +80,8 @@ jobs:
         BIOGRID_API_KEY: ${{ secrets.BIOGRID_API_KEY }}
       run: |
         # Set nose attributes based on the context in which we are running
-        export NOSEATTR="!notravis,!slow,!cron";
-        export NOSEATTR=$(if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then echo $NOSEATTR,!nonpublic; else echo $NOSEATTR; fi)
+        export NOSEATTR="(not notravis) and (not slow) and (not cron)";
+        export NOSEATTR=$(if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then echo $NOSEATTR and (not nonpublic); else echo $NOSEATTR; fi)
         echo $NOSEATTR
         #echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
         #echo "$TRAVIS_EVENT_TYPE"
@@ -99,8 +96,10 @@ jobs:
         echo $NOSEATTR
         #- cd $TRAVIS_BUILD_DIR
         # Now run all INDRA tests
-        nosetests -v -a $NOSEATTR --exclude='.*tees.*' --exclude='.*isi.*' --exclude='.*test_reach.*' --with-coverage --cover-inclusive --cover-package=indra --with-doctest --with-doctest-ignore-unicode --with-timer --timer-top-n 10 --processes=0
-        nosetests -v -a $NOSEATTR indra/tests/test_reach.py
+        pytest -v -m "$NOSEATTR" --ignore-glob='*tees*' --ignore-glob='*isi*' --ignore-glob='*test_reach*' --cov=indra --cov-report=term-missing --doctest-modules --doctest-ignore-unicode --durations=10
+        pytest -v -m "$NOSEATTR" indra/tests/test_reach.py
+        #nosetests -v -a $NOSEATTR --exclude='.*tees.*' --exclude='.*isi.*' --exclude='.*test_reach.*' --with-coverage --cover-inclusive --cover-package=indra --with-doctest --with-doctest-ignore-unicode --with-timer --timer-top-n 10 --processes=0
+        #nosetests -v -a $NOSEATTR indra/tests/test_reach.py
         # TEES tests
         #- python -m nose_notify indra/tests/test_tees.py --slack_hook $SLACK_NOTIFY_HOOK
         #  --label "$TRAVIS_REPO_SLUG - $TRAVIS_BRANCH" -v -a $NOSEATTR --process-restartworker;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         sudo apt-get install libstdc++6 graphviz python3-dev libgraphviz-dev pkg-config
         # Install test/CI-specific dependencies not covered elsewhere
         pip install --upgrade pip setuptools wheel
-        pip install pydot jsonschema coverage nose-timer doctest-ignore-unicode awscli pycodestyle
+        pip install pytest pydot jsonschema coverage nose-timer doctest-ignore-unicode awscli pycodestyle
         mkdir -p $HOME/.pybel/data
         wget -nv https://bigmech.s3.amazonaws.com/travis/pybel_cache.db -O $HOME/.pybel/data/pybel_cache.db
         # PySB and dependencies
@@ -79,7 +79,7 @@ jobs:
         ELSEVIER_INST_KEY: ${{ secrets.ELSEVIER_INST_KEY }}
         BIOGRID_API_KEY: ${{ secrets.BIOGRID_API_KEY }}
       run: |
-        # Set nose attributes based on the context in which we are running
+        # Set pytest attributes based on the context in which we are running
         export NOSEATTR="(not notravis) and (not slow) and (not cron)";
         export NOSEATTR=$(if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then echo $NOSEATTR and (not nonpublic); else echo $NOSEATTR; fi)
         echo $NOSEATTR

--- a/indra/assemblers/pybel/assembler.py
+++ b/indra/assemblers/pybel/assembler.py
@@ -77,7 +77,7 @@ class PybelAssembler(object):
     >>> stmt = Phosphorylation(map2k1, mapk1, 'T', '185')
     >>> pba = PybelAssembler([stmt])
     >>> belgraph = pba.make_model()
-    >>> sorted(node.as_bel() for node in belgraph) # doctest:+IGNORE_UNICODE
+    >>> sorted(node.as_bel() for node in belgraph)
     ['p(HGNC:6840 ! MAP2K1)', 'p(HGNC:6871 ! MAPK1)', 'p(HGNC:6871 ! MAPK1, pmod(go:0006468 ! "protein phosphorylation", Thr, 185))']
     >>> len(belgraph)
     3

--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -228,7 +228,7 @@ def extract_text(xml_string):
     """Get text from the body of the given Elsevier xml."""
     paragraphs = extract_paragraphs(xml_string)
     if paragraphs:
-        return '\n'.join(re.sub('\s+', ' ', p) for p in paragraphs) + '\n'
+        return '\n'.join(re.sub(r'\s+', ' ', p) for p in paragraphs) + '\n'
     else:
         return None
 

--- a/indra/preassembler/sitemapper.py
+++ b/indra/preassembler/sitemapper.py
@@ -98,7 +98,7 @@ class SiteMapper(ProtMapper):
     >>> (valid, mapped) = default_mapper.map_sites([stmt])
     >>> valid
     []
-    >>> mapped  # doctest:+IGNORE_UNICODE
+    >>> mapped
     [
     MappedStatement:
         original_stmt: Phosphorylation(MAP2K1(mods: (phosphorylation, S, 217), (phosphorylation, S, 221)), MAPK1(), T, 183)
@@ -110,7 +110,7 @@ class SiteMapper(ProtMapper):
     >>> ms = mapped[0]
     >>> ms.original_stmt
     Phosphorylation(MAP2K1(mods: (phosphorylation, S, 217), (phosphorylation, S, 221)), MAPK1(), T, 183)
-    >>> ms.mapped_mods # doctest:+IGNORE_UNICODE
+    >>> ms.mapped_mods
     [MappedSite(up_id='Q02750', error_code=None, valid=False, orig_res='S', orig_pos='217', mapped_id='Q02750', mapped_res='S', mapped_pos='218', description='off by one', gene_name='MAP2K1'), MappedSite(up_id='Q02750', error_code=None, valid=False, orig_res='S', orig_pos='221', mapped_id='Q02750', mapped_res='S', mapped_pos='222', description='off by one', gene_name='MAP2K1'), MappedSite(up_id='P28482', error_code=None, valid=False, orig_res='T', orig_pos='183', mapped_id='P28482', mapped_res='T', mapped_pos='185', description='INFERRED_MOUSE_SITE', gene_name='MAPK1')]
     >>> ms.mapped_stmt
     Phosphorylation(MAP2K1(mods: (phosphorylation, S, 218), (phosphorylation, S, 222)), MAPK1(), T, 185)

--- a/indra/tests/conftest.py
+++ b/indra/tests/conftest.py
@@ -1,0 +1,2 @@
+def pytest_configure(config):
+    config.addinivalue_line("markers", "webservice: Test using web service")

--- a/indra/tests/conftest.py
+++ b/indra/tests/conftest.py
@@ -1,2 +1,5 @@
 def pytest_configure(config):
     config.addinivalue_line("markers", "webservice: Test using web service")
+    config.addinivalue_line("markers", "slow: Test is slow for regular testing")
+    config.addinivalue_line("markers", "cron: Test should only run on scheduled test")
+    config.addinivalue_line("markers", "nonpublic: Test requires nonpublic environmental variables")

--- a/indra/tests/conftest.py
+++ b/indra/tests/conftest.py
@@ -3,3 +3,4 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "slow: Test is slow for regular testing")
     config.addinivalue_line("markers", "cron: Test should only run on scheduled test")
     config.addinivalue_line("markers", "nonpublic: Test requires nonpublic environmental variables")
+    config.addinivalue_line("markers", "nogha: Test shouldn't be run on GitHub actions")

--- a/indra/tests/test_adeft_tools.py
+++ b/indra/tests/test_adeft_tools.py
@@ -1,6 +1,6 @@
 import logging
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from indra.literature.adeft_tools import universal_extract_paragraphs, \
     filter_paragraphs
 from indra.literature import pmc_client, elsevier_client, pubmed_client
@@ -8,7 +8,8 @@ from indra.literature import pmc_client, elsevier_client, pubmed_client
 logger = logging.getLogger(__name__)
 
 
-@attr('nonpublic', 'webservice')
+@pytest.mark.nonpublic
+@pytest.mark.webservice
 @unittest.skip('Elsevier credentials currently not operational')
 def test_universal_extract_paragraphs_elsevier():
     doi = '10.1016/B978-0-12-416673-8.00004-6'
@@ -20,7 +21,7 @@ def test_universal_extract_paragraphs_elsevier():
     assert len(paragraphs) > 1
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_universal_extract_paragraphs_pmc():
     pmc_id = 'PMC3262597'
     xml_str = pmc_client.get_xml(pmc_id)
@@ -28,7 +29,7 @@ def test_universal_extract_paragraphs_pmc():
     assert len(paragraphs) > 1, paragraphs
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_universal_extract_paragraphs_abstract():
     pmid = '16511588'
     abstract = pubmed_client.get_abstract(pmid)

--- a/indra/tests/test_belief_engine.py
+++ b/indra/tests/test_belief_engine.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from nose.tools import raises
+import pytest
 from indra.statements import *
 from indra.belief import BeliefEngine, load_default_probs, \
     sample_statements, evidence_random_noise_prior, tag_evidence_subtype, \
@@ -204,12 +204,12 @@ def test_sample_statements():
     assert st3 not in stmts
 
 
-@raises(Exception)
 def test_check_prior_probs():
-    be = BeliefEngine()
-    st = Phosphorylation(None, Agent('ERK'),
-                         evidence=[Evidence(source_api='xxx')])
-    be.set_prior_probs([st])
+    with pytest.raises(Exception):
+        be = BeliefEngine()
+        st = Phosphorylation(None, Agent('ERK'),
+                             evidence=[Evidence(source_api='xxx')])
+        be.set_prior_probs([st])
 
 
 def test_evidence_subtype_tagger():
@@ -341,16 +341,16 @@ def test_bayesian_scorer():
     assert scorer.subtype_probs['eidos']['rule2'] == 0.75
 
 
-@raises(AssertionError)
 def test_cycle():
-    st1 = Phosphorylation(Agent('B'), Agent('A1'))
-    st2 = Phosphorylation(None, Agent('A1'))
-    st1.supports = [st2]
-    st1.supported_by = [st2]
-    st2.supports = [st1]
-    st2.supported_by = [st1]
-    engine = BeliefEngine()
-    engine.set_hierarchy_probs([st1, st2])
+    with pytest.raises(AssertionError):
+        st1 = Phosphorylation(Agent('B'), Agent('A1'))
+        st2 = Phosphorylation(None, Agent('A1'))
+        st1.supports = [st2]
+        st1.supported_by = [st2]
+        st2.supports = [st1]
+        st2.supported_by = [st1]
+        engine = BeliefEngine()
+        engine.set_hierarchy_probs([st1, st2])
 
 
 def assert_close_enough(b1, b2):

--- a/indra/tests/test_belief_sklearn.py
+++ b/indra/tests/test_belief_sklearn.py
@@ -209,15 +209,15 @@ def test_fit_df_pred_stmts():
         'prediction results should have dimension (# stmts)'
 
 
-@raises(ValueError)
 def test_check_missing_source_counts():
-    lr = LogisticRegression()
-    source_list = ['reach', 'sparser']
-    cw = CountsScorer(lr, source_list)
-    # Drop the source_counts column
-    df_no_sc = test_df.drop('source_counts', axis=1)
-    # Should error
-    cw.fit(df_no_sc, y_arr_df)
+    with pytest.raises(ValueError):
+        lr = LogisticRegression()
+        source_list = ['reach', 'sparser']
+        cw = CountsScorer(lr, source_list)
+        # Drop the source_counts column
+        df_no_sc = test_df.drop('source_counts', axis=1)
+        # Should error
+        cw.fit(df_no_sc, y_arr_df)
 
 
 def test_check_source_columns():
@@ -244,15 +244,15 @@ def test_matrix_to_matrix():
             'If passed a numpy array to_matrix should return it back.'
 
 
-@raises(ValueError)
 def test_use_members_with_df():
     """Check that we can't set use_num_members when passing a DataFrame."""
-    lr = LogisticRegression()
-    source_list = ['reach', 'sparser', 'signor']
-    cw = CountsScorer(lr, source_list, use_num_members=True)
-    # This should error because stmt DataFrame doesn't contain num_members
-    # info
-    stmt_arr = cw.to_matrix(test_df)
+    with pytest.raises(ValueError):
+        lr = LogisticRegression()
+        source_list = ['reach', 'sparser', 'signor']
+        cw = CountsScorer(lr, source_list, use_num_members=True)
+        # This should error because stmt DataFrame doesn't contain num_members
+        # info
+        stmt_arr = cw.to_matrix(test_df)
 
 
 def test_use_members_with_stmts():
@@ -305,36 +305,36 @@ def test_set_prior_probs():
            "Statement beliefs should be set to predicted probabilities."
 
 
-@raises(NotImplementedError)
 def test_df_extra_ev_value_error():
     """to_matrix should raise NotImplementError if given a DataFrame and extra
        evidence (for now)."""
-    lr = LogisticRegression()
-    source_list = ['reach', 'sparser', 'signor']
-    cs = CountsScorer(lr, source_list)
-    cs.to_matrix(test_df, extra_evidence=[[5]])
+    with pytest.raises(NotImplementedError):
+        lr = LogisticRegression()
+        source_list = ['reach', 'sparser', 'signor']
+        cs = CountsScorer(lr, source_list)
+        cs.to_matrix(test_df, extra_evidence=[[5]])
 
 
-@raises(ValueError)
 def test_extra_evidence_length():
     """Should raise ValueError because the extra_evidence list is not the
     same length as the list of statements."""
-    lr = LogisticRegression()
-    source_list = ['reach', 'sparser', 'signor']
-    cs = CountsScorer(lr, source_list)
-    extra_ev = [[5]]
-    x_arr = cs.stmts_to_matrix(test_stmts, extra_evidence=extra_ev)
+    with pytest.raises(ValueError):
+        lr = LogisticRegression()
+        source_list = ['reach', 'sparser', 'signor']
+        cs = CountsScorer(lr, source_list)
+        extra_ev = [[5]]
+        x_arr = cs.stmts_to_matrix(test_stmts, extra_evidence=extra_ev)
 
 
-@raises(ValueError)
 def test_extra_evidence_content():
     """Should raise ValueError if extra_evidence list entries are not
     Evidence objects or empty lists."""
-    lr = LogisticRegression()
-    source_list = ['reach', 'sparser', 'signor']
-    cs = CountsScorer(lr, source_list)
-    extra_ev = ([[5]] * (len(test_stmts) - 1)) + [[]]
-    x_arr = cs.stmts_to_matrix(test_stmts, extra_evidence=extra_ev)
+    with pytest.raises(ValueError):
+        lr = LogisticRegression()
+        source_list = ['reach', 'sparser', 'signor']
+        cs = CountsScorer(lr, source_list)
+        extra_ev = ([[5]] * (len(test_stmts) - 1)) + [[]]
+        x_arr = cs.stmts_to_matrix(test_stmts, extra_evidence=extra_ev)
 
 
 def test_set_hierarchy_probs():

--- a/indra/tests/test_belief_sklearn.py
+++ b/indra/tests/test_belief_sklearn.py
@@ -4,12 +4,11 @@ import numpy as np
 from copy import copy
 from os.path import join, abspath, dirname
 from collections import defaultdict, Counter
-from nose.tools import raises
+import pytest
 from sklearn.linear_model import LogisticRegression
 from indra.sources import signor
 from indra.belief import BeliefEngine, default_scorer
 from indra.tools import assemble_corpus as ac
-from indra.statements import Evidence
 from indra.belief.skl import CountsScorer, HybridScorer
 
 
@@ -130,13 +129,13 @@ def test_fit_stmts_predict_stmts():
         'prediction results should have dimension (# stmts)'
 
 
-@raises(ValueError)
 def test_check_df_cols_err():
     """Drop a required column and make sure we get a ValueError."""
-    lr = LogisticRegression()
-    source_list = ['reach', 'sparser', 'signor']
-    cw = CountsScorer(lr, source_list)
-    cw.df_to_matrix(test_df.drop('stmt_type', axis=1))
+    with pytest.raises(ValueError):
+        lr = LogisticRegression()
+        source_list = ['reach', 'sparser', 'signor']
+        cw = CountsScorer(lr, source_list)
+        cw.df_to_matrix(test_df.drop('stmt_type', axis=1))
 
 
 def test_check_df_cols_noerr():

--- a/indra/tests/test_benchmarks.py
+++ b/indra/tests/test_benchmarks.py
@@ -5,7 +5,7 @@ from indra.benchmarks import bioprocesses as bp
 # from indra.benchmarks import complexes as cp
 from indra.benchmarks import phosphorylations as phos
 from indra.util import unicode_strs
-from nose.plugins.attrib import attr
+import pytest
 import unittest
 
 eval_file = join(dirname(abspath(__file__)),
@@ -22,7 +22,8 @@ eval_file = join(dirname(abspath(__file__)),
 #    assert gene_set
 #    assert unicode_strs(gene_set)
 
-@attr('nonpublic', 'webservice')
+@pytest.mark.nonpublic
+@pytest.mark.webservice
 @unittest.skip('Complex analysis has been removed, test should be too, later.')
 def test_complexes():
     """Smoke test to see if complexes analysis works."""

--- a/indra/tests/test_biopax.py
+++ b/indra/tests/test_biopax.py
@@ -4,7 +4,7 @@ from indra.sources import biopax
 from indra.statements import *
 import indra.sources.biopax.processor as bpc
 from indra.util import unicode_strs
-from nose.plugins.attrib import attr
+import pytest
 
 model_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                           'biopax_test.owl')
@@ -86,7 +86,8 @@ def test_chebi_grounding_extraction():
     assert agents[0].db_refs['CHEBI'] == 'CHEBI:15996'
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_pathsfromto():
     bp = biopax.process_pc_pathsfromto(['MAP2K1'], ['MAPK1'])
     assert_pmids(bp.statements)

--- a/indra/tests/test_cbio_client.py
+++ b/indra/tests/test_cbio_client.py
@@ -1,36 +1,36 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.databases import cbio_client
-from nose.plugins.attrib import attr
+import pytest
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_cancer_studies():
     study_ids = cbio_client.get_cancer_studies('paad')
     assert len(study_ids) > 0
     assert 'paad_tcga' in study_ids
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_cancer_types():
     type_ids = cbio_client.get_cancer_types('lung')
     assert len(type_ids) > 0
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_genetic_profiles():
     genetic_profiles = \
         cbio_client.get_genetic_profiles('paad_icgc', 'mutation')
     assert len(genetic_profiles) > 0
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_num_sequenced():
     num_case = cbio_client.get_num_sequenced('paad_tcga')
     assert num_case > 0
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_send_request_ccle():
     """Sends a request and gets back a dataframe of all cases in ccle study.
 
@@ -42,7 +42,7 @@ def test_send_request_ccle():
     assert len(df) > 0
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_ccle_lines_for_mutation():
     """Check how many lines have BRAF V600E mutations.
 
@@ -53,7 +53,7 @@ def test_get_ccle_lines_for_mutation():
     assert len(cl_BRAF_V600E) == 55
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_ccle_mutations():
     muts = cbio_client.get_ccle_mutations(['BRAF', 'AKT1'],
                                           ['LOXIMVI_SKIN', 'A101D_SKIN'])
@@ -66,7 +66,7 @@ def test_get_ccle_mutations():
     assert len(muts['A101D_SKIN']['AKT1']) == 0
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_profile_data():
     profile_data = cbio_client.get_profile_data(cbio_client.ccle_study,
                                                 ['BRAF', 'PTEN'],
@@ -79,7 +79,7 @@ def test_get_profile_data():
     assert len(profile_data) > 0
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_ccle_cna():
     profile_data = cbio_client.get_ccle_cna(['BRAF', 'AKT1'],
                                             ['LOXIMVI_SKIN', 'SKMEL30_SKIN'])
@@ -90,7 +90,7 @@ def test_get_ccle_cna():
     assert len(profile_data) == 2
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_ccle_mrna():
     mrna = cbio_client.get_ccle_mrna(['XYZ', 'MAP2K1'], ['A375_SKIN'])
     assert 'A375_SKIN' in mrna
@@ -102,7 +102,7 @@ def test_get_ccle_mrna():
     assert mrna['XXX'] is None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_ccle_cna_big():
     """
     Get the CNA data on 124 genes in 4 cell lines. Expect to have CNA values

--- a/indra/tests/test_chebi_client.py
+++ b/indra/tests/test_chebi_client.py
@@ -1,6 +1,6 @@
 from indra.databases import chebi_client
 from indra.util import unicode_strs
-from nose.plugins.attrib import attr
+import pytest
 
 
 def test_read_chebi_to_pubchem():
@@ -46,7 +46,7 @@ def test_chebi_name_to_id():
     assert cid == 'CHEBI:63637', cid
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_chebi_name_from_web():
     name = chebi_client.get_chebi_name_from_id_web('63637')
     assert name == 'vemurafenib'
@@ -54,7 +54,7 @@ def test_chebi_name_from_web():
     assert name == 'NAD zwitterion'
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_inchi_key():
     ik = chebi_client.get_inchi_key('2150')
     assert ik == 'NVKAWKQGWWIWPM-MISPCMORSA-N'

--- a/indra/tests/test_chembl_client.py
+++ b/indra/tests/test_chembl_client.py
@@ -33,7 +33,7 @@ def test_get_inhibitions():
         assert ev.source_id
 
 
-@attr('webservice', 'notravis')
+@attr('webservice', 'nogha')
 def test_activity_query():
     res = chembl_client.send_query(query_dict_vem_activity)
     assert res['page_meta']['total_count'] == len(res['activities'])
@@ -49,7 +49,7 @@ def test_target_query():
     assert target['target_type'] == 'SINGLE PROTEIN'
 
 
-@attr('webservice', 'slow', 'notravis')
+@attr('webservice', 'slow', 'nogha')
 def test_get_drug_inhibition_stmts_vem():
     stmts = chembl_client.get_drug_inhibition_stmts(vem)
     assert len(stmts) > 0
@@ -63,7 +63,7 @@ def test_get_drug_inhibition_stmts_vem():
             assert ev.source_id
 
 
-@attr('webservice', 'slow', 'notravis')
+@attr('webservice', 'slow', 'nogha')
 def test_get_drug_inhibition_stmts_az628():
     stmts = chembl_client.get_drug_inhibition_stmts(az628)
     assert len(stmts) > 0

--- a/indra/tests/test_chembl_client.py
+++ b/indra/tests/test_chembl_client.py
@@ -3,7 +3,7 @@ from builtins import dict, str
 from indra.statements import Agent
 from indra.databases import chembl_client
 from indra.util import unicode_strs
-from nose.plugins.attrib import attr
+import pytest
 import unittest
 
 vem = Agent('VEMURAFENIB', db_refs={'CHEBI': '63637', 'TEXT': 'VEMURAFENIB'})
@@ -20,7 +20,8 @@ query_dict_BRAF_target = {'query': 'target',
                                      'limit': 1}}
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_get_inhibitions():
     stmt = chembl_client.get_inhibition(vem, braf)
     assert stmt is not None
@@ -33,7 +34,8 @@ def test_get_inhibitions():
         assert ev.source_id
 
 
-@attr('webservice', 'nogha')
+@pytest.mark.webservice
+@pytest.mark.nogha
 def test_activity_query():
     res = chembl_client.send_query(query_dict_vem_activity)
     assert res['page_meta']['total_count'] == len(res['activities'])
@@ -43,13 +45,15 @@ def test_activity_query():
         assert e_t in assay_types
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_target_query():
     target = chembl_client.query_target(braf_chembl_id)
     assert target['target_type'] == 'SINGLE PROTEIN'
 
 
-@attr('webservice', 'slow', 'nogha')
+@pytest.mark.webservice
+@pytest.mark.slow
+@pytest.mark.nogha
 def test_get_drug_inhibition_stmts_vem():
     stmts = chembl_client.get_drug_inhibition_stmts(vem)
     assert len(stmts) > 0
@@ -63,7 +67,9 @@ def test_get_drug_inhibition_stmts_vem():
             assert ev.source_id
 
 
-@attr('webservice', 'slow', 'nogha')
+@pytest.mark.webservice
+@pytest.mark.slow
+@pytest.mark.nogha
 def test_get_drug_inhibition_stmts_az628():
     stmts = chembl_client.get_drug_inhibition_stmts(az628)
     assert len(stmts) > 0

--- a/indra/tests/test_context.py
+++ b/indra/tests/test_context.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.databases import context_client
 from indra.util import unicode_strs
-from nose.plugins.attrib import attr
+import pytest
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_protein_expression():
     res = context_client.get_protein_expression(['EGFR'], ['BT20_BREAST'])
     assert res is not None
@@ -14,7 +14,7 @@ def test_get_protein_expression():
     assert unicode_strs(res)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_mutations():
     res = context_client.get_mutations(['BRAF'], ['A375_SKIN'])
     assert res is not None
@@ -24,7 +24,7 @@ def test_get_mutations():
     assert unicode_strs(res)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_protein_expression_gene_missing():
     protein_amounts = context_client.get_protein_expression(['EGFR', 'XYZ'],
                                                             ['BT20_BREAST'])
@@ -33,7 +33,7 @@ def test_get_protein_expression_gene_missing():
     assert protein_amounts['BT20_BREAST']['XYZ'] is None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_protein_expression_cell_type_missing():
     protein_amounts = context_client.get_protein_expression(['EGFR'],
                                                             ['BT20_BREAST', 'XYZ'])
@@ -43,7 +43,7 @@ def test_get_protein_expression_cell_type_missing():
     assert protein_amounts['XYZ'] is None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_mutations_gene_missing():
     mutations = context_client.get_mutations(['BRAF', 'XYZ'], ['A375_SKIN'])
     assert 'A375_SKIN' in mutations
@@ -51,7 +51,7 @@ def test_get_mutations_gene_missing():
     assert not mutations['A375_SKIN']['XYZ']
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_mutations_cell_type_missing():
     mutations = context_client.get_mutations(['BRAF'], ['A375_SKIN', 'XYZ'])
     assert 'A375_SKIN' in mutations

--- a/indra/tests/test_crossref_client.py
+++ b/indra/tests/test_crossref_client.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.literature import crossref_client
 from indra.util import unicode_strs
-from nose.plugins.attrib import attr
+import pytest
 
 test_doi = '10.1016/j.ccell.2016.02.010'
 
@@ -11,14 +11,14 @@ example_ids = {'pmid': '25361007',
                'doi': '10.18632/oncotarget.2555'}
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_doi_query():
     mapped_doi = crossref_client.doi_query(example_ids['pmid'])
     assert mapped_doi == example_ids['doi']
     assert unicode_strs(mapped_doi)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_metadata():
     metadata = crossref_client.get_metadata(test_doi)
     assert metadata['DOI'] == test_doi
@@ -27,7 +27,7 @@ def test_get_metadata():
     assert metadata is None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_publisher():
     publisher = crossref_client.get_publisher(test_doi)
     assert publisher == 'Elsevier BV'
@@ -36,7 +36,7 @@ def test_get_publisher():
     assert publisher is None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_fulltext_links():
     links = crossref_client.get_fulltext_links(test_doi)
     content_types = [l.get('content-type') for l in links]
@@ -47,7 +47,7 @@ def test_get_fulltext_links():
     assert links is None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_license_links():
     links = crossref_client.get_license_links(test_doi)
     assert links[0] == 'https://www.elsevier.com/tdm/userlicense/1.0/'
@@ -56,7 +56,7 @@ def test_get_license_links():
     assert links is None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_url():
     url = crossref_client.get_url(test_doi)
     assert url == 'http://dx.doi.org/10.1016/j.ccell.2016.02.010'

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from time import sleep
 from unittest import SkipTest
 
-from nose.plugins.attrib import attr
+import pytest
 from indra.sources import indra_db_rest as dbr
 from indra.sources.indra_db_rest.api import get_statement_queries
 from indra.sources.indra_db_rest.query import HasAgent, HasEvidenceBound
@@ -24,17 +24,17 @@ def __check_request(seconds, *args, **kwargs):
     return resp
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_simple_request():
     __check_request(6, 'MAP2K1', 'MAPK1', stmt_type='Phosphorylation')
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_request_for_complex():
     __check_request(30, agents=['MEK@FPLX', 'ERK@FPLX'], stmt_type='Complex')
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_null_request():
     try:
         dbr.get_statements()
@@ -55,7 +55,7 @@ def test_bigger_request():
     __check_request(60, agents=['MAPK1'])
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_timeout_no_persist_agent():
     candidates = ['TP53', 'NFkappaB@FPLX', 'AKT@FPLX']
     agent = random.choice(candidates)
@@ -66,7 +66,7 @@ def test_timeout_no_persist_agent():
     assert len(resp.statements) > 0.9*EXPECTED_BATCH_SIZE, len(resp.statements)
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_timeout_no_persist_type_object():
     candidates = ['TP53', 'NFkappaB@FPLX', 'AKT@FPLX']
     agent = random.choice(candidates)
@@ -129,7 +129,7 @@ def test_too_big_request_persist_no_block():
     return
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_famplex_namespace():
     p = dbr.get_statements('PDGF@FPLX', 'FOS', stmt_type='IncreaseAmount')
     stmts = p.statements
@@ -156,7 +156,7 @@ def test_paper_query():
     assert len(p.get_ev_counts())
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_regulate_amount():
     idbp = dbr.get_statements('FOS', stmt_type='RegulateAmount')
     stmts = idbp.statements
@@ -168,7 +168,7 @@ def test_regulate_amount():
         stmt_types
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_get_statements_by_hash():
     hash_list = [30674674032092136, -22289282229858243, -25056605420392180]
     p = dbr.get_statements_by_hash(hash_list)
@@ -184,13 +184,13 @@ def test_get_statements_by_hash():
     return
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_get_statements_by_hash_no_hash():
     p = dbr.get_statements_by_hash([])
     assert not p.statements, "Got statements without giving a hash."
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_curation_submission():
     from indra.config import get_config
     api_key = get_config('INDRA_DB_REST_API_KEY', failure_ok=True)
@@ -201,7 +201,7 @@ def test_curation_submission():
     assert res['result'] == 'test passed', res
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_get_curations():
     from indra.config import get_config
     api_key = get_config('INDRA_DB_REST_API_KEY', failure_ok=True)
@@ -216,7 +216,7 @@ def test_get_curations():
                for c in res)
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_get_statement_queries():
     ag = Agent('MAP2K1', db_refs={})
     stmt = Phosphorylation(None, ag)
@@ -239,7 +239,7 @@ def test_get_statement_queries():
                                                        (x.name, 'XXX'))
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_get_statements_end_on_limit():
     p = dbr.get_statements(subject="TNF", limit=1400, timeout=1)
     try:
@@ -259,7 +259,7 @@ def test_get_statements_end_on_limit():
         p.wait_until_done()
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_get_statements_evidence_bounded():
     query = HasAgent('MEK') & HasEvidenceBound(["< 10"])
     p = dbr.get_statements_from_query(query, limit=10)
@@ -268,7 +268,7 @@ def test_get_statements_evidence_bounded():
     assert all(c < 10 for c in p.get_ev_counts().values())
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_get_statements_strict_stop_short():
     start = datetime.now()
     p = dbr.get_statements("TNF", timeout=1, strict_stop=True)
@@ -281,7 +281,7 @@ def test_get_statements_strict_stop_short():
     assert not p.statements_sample
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_get_statements_strict_stop_long():
     timeout = 31
     start = datetime.now()
@@ -313,7 +313,7 @@ def test_filter_ev():
         f"{incorrect_source} unfiltered sources vs. {correct_source} filtered."
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_sort_by_belief():
     p = dbr.get_statements(object="MEK", stmt_type="Inhibition",
                                   sort_by='belief', limit=10)
@@ -324,7 +324,7 @@ def test_sort_by_belief():
         f"belief_dict: {p.get_belief_scores()}"
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_sort_by_ev_count():
     p = dbr.get_statements(object="MEK", stmt_type="Inhibition",
                            sort_by='ev_count', limit=10, ev_limit=None)
@@ -334,7 +334,7 @@ def test_sort_by_ev_count():
         f"Counts mis-ordered!\ncounts: {counts}\nev_counts: {p.get_ev_counts()}"
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 @unittest.skip('This query test fails intermittently')
 def test_namespace_only_agent_query():
     q = HasAgent("MEK") & HasAgent(namespace="CHEBI")

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -87,7 +87,7 @@ def test_too_big_request_no_persist():
     return resp_some
 
 
-@attr('nonpublic', 'slow', 'notravis')
+@attr('nonpublic', 'slow', 'nogha')
 @unittest.skip('skipping')
 def test_too_big_request_persist_and_block():
     resp_all1 = __check_request(200, agents=['TP53'], persist=True,
@@ -98,7 +98,7 @@ def test_too_big_request_persist_and_block():
     return resp_all1
 
 
-@attr('nonpublic', 'slow', 'notravis')
+@attr('nonpublic', 'slow', 'nogha')
 def test_too_big_request_persist_no_block():
     resp_some = test_too_big_request_no_persist()
     resp_all1 = test_too_big_request_persist_and_block()
@@ -142,7 +142,7 @@ def test_famplex_namespace():
         + ', '.join({s.agent_list()[1].name for s in stmts})
 
 
-@attr('nonpublic', 'notravis')
+@attr('nonpublic', 'nogha')
 def test_paper_query():
     p = dbr.get_statements_for_papers([('pmcid', 'PMC5770457'),
                                        ('pmid', '27014235')])
@@ -294,7 +294,7 @@ def test_get_statements_strict_stop_long():
     assert p.statements
 
 
-@attr('nonpublic', 'notravis')
+@attr('nonpublic', 'nogha')
 def test_filter_ev():
     ids = [('pmcid', 'PMC5770457'), ('pmid', '27014235')]
     p = dbr.get_statements_for_papers(ids)

--- a/indra/tests/test_db_rest.py
+++ b/indra/tests/test_db_rest.py
@@ -45,12 +45,14 @@ def test_null_request():
     assert False, "Null request did not raise any exception."
 
 
-@attr('nonpublic', 'slow')
+@pytest.mark.nonpublic
+@pytest.mark.slow
 def test_large_request():
     __check_request(40, agents=['AKT1'])
 
 
-@attr('nonpublic', 'slow')
+@pytest.mark.nonpublic
+@pytest.mark.slow
 def test_bigger_request():
     __check_request(60, agents=['MAPK1'])
 
@@ -78,7 +80,8 @@ def test_timeout_no_persist_type_object():
     assert len(resp.statements) > 0.9*EXPECTED_BATCH_SIZE, len(resp.statements)
 
 
-@attr('nonpublic', 'slow')
+@pytest.mark.nonpublic
+@pytest.mark.slow
 def test_too_big_request_no_persist():
     resp_some = __check_request(60, agents=['TP53'], persist=False)
     assert sum(resp_some.get_ev_count(s) is not None
@@ -87,7 +90,9 @@ def test_too_big_request_no_persist():
     return resp_some
 
 
-@attr('nonpublic', 'slow', 'nogha')
+@pytest.mark.nonpublic
+@pytest.mark.slow
+@pytest.mark.nogha
 @unittest.skip('skipping')
 def test_too_big_request_persist_and_block():
     resp_all1 = __check_request(200, agents=['TP53'], persist=True,
@@ -98,7 +103,9 @@ def test_too_big_request_persist_and_block():
     return resp_all1
 
 
-@attr('nonpublic', 'slow', 'nogha')
+@pytest.mark.nonpublic
+@pytest.mark.slow
+@pytest.mark.nogha
 def test_too_big_request_persist_no_block():
     resp_some = test_too_big_request_no_persist()
     resp_all1 = test_too_big_request_persist_and_block()
@@ -142,7 +149,8 @@ def test_famplex_namespace():
         + ', '.join({s.agent_list()[1].name for s in stmts})
 
 
-@attr('nonpublic', 'nogha')
+@pytest.mark.nonpublic
+@pytest.mark.nogha
 def test_paper_query():
     p = dbr.get_statements_for_papers([('pmcid', 'PMC5770457'),
                                        ('pmid', '27014235')])
@@ -294,7 +302,8 @@ def test_get_statements_strict_stop_long():
     assert p.statements
 
 
-@attr('nonpublic', 'nogha')
+@pytest.mark.nonpublic
+@pytest.mark.nogha
 def test_filter_ev():
     ids = [('pmcid', 'PMC5770457'), ('pmid', '27014235')]
     p = dbr.get_statements_for_papers(ids)

--- a/indra/tests/test_delta.py
+++ b/indra/tests/test_delta.py
@@ -1,5 +1,5 @@
 from indra.statements.delta import *
-from nose.tools import assert_raises
+import pytest
 from datetime import date, timedelta
 
 
@@ -92,10 +92,10 @@ def test_quantitative_conversions():
     assert QuantitativeState.convert_unit(
         'absolute', 'week', 70, source_period=abs_period) == 14
     # Convert to or from absolute value without providing a total period
-    assert_raises(ValueError, QuantitativeState.convert_unit,
-                  'absolute', 'week', 70)
-    assert_raises(ValueError, QuantitativeState.convert_unit,
-                  'day', 'absolute', 2)
+    with pytest.raises(ValueError):
+        QuantitativeState.convert_unit('absolute', 'week', 70)
+    with pytest.raises(ValueError):
+        QuantitativeState.convert_unit('day', 'absolute', 2)
 
 
 def test_arithmetic_operations():
@@ -130,6 +130,8 @@ def test_arithmetic_operations():
     assert qs2 == qs4
     assert qs1 != qs3
     # Operations with different entities
-    assert_raises(ValueError, qs1.__add__, qs5)
+    with pytest.raises(ValueError):
+        qs1 + qs5
     # Operations with absolute unit when absolute period not provided
-    assert_raises(ValueError, qs1.__add__, qs6)
+    with pytest.raises(ValueError):
+        qs1 + qs6

--- a/indra/tests/test_docs_code.py
+++ b/indra/tests/test_docs_code.py
@@ -52,7 +52,7 @@ def test_readme_using_indra1():
 
 
 # From 2nd example under "Using INDRA"
-@attr('notravis')  # This test takes 10+ minutes, stalling Travis
+@pytest.mark.nogha  # This test takes 10+ minutes, stalling Travis
 def test_readme_using_indra2():
     from indra.sources import reach
     reach_processor = reach.process_pmc('PMC8511698', url=reach.local_nxml_url)
@@ -60,7 +60,7 @@ def test_readme_using_indra2():
 
 
 # From 3rd example under "Using INDRA"
-@attr('slow', 'notravis')
+@attr('slow', 'nogha')
 def test_readme_using_indra3():
     from indra.sources import reach
     from indra.literature import pubmed_client
@@ -77,7 +77,7 @@ def test_readme_using_indra3():
 
 
 # From 4th example under "Using INDRA"
-@attr('slow')
+@pytest.mark.slow
 def test_readme_using_indra4():
     from indra.sources import bel
     # Process the neighborhood of BRAF and MAP2K1
@@ -86,7 +86,7 @@ def test_readme_using_indra4():
 
 
 # From 5th example under "Using INDRA"
-@attr('slow')
+@pytest.mark.slow
 def test_readme_using_indra5():
     from indra.sources import biopax
     # Process the neighborhood of BRAF and MAP2K1
@@ -145,7 +145,7 @@ def test_nl_modeling():
 
 
 # CODE IN gene_network.rst
-@attr('slow', 'notravis')
+@attr('slow', 'nogha')
 def test_gene_network():
     # Chunk 1: this is tested in _get_gene_network_stmts
     # from indra.tools.gene_network import GeneNetwork
@@ -243,7 +243,7 @@ def test_getting_started4():
     assert reach_processor.statements
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_getting_started5():
     # Chunk 5
     from indra.sources import bel
@@ -260,7 +260,7 @@ def test_getting_started6():
     assert stmt
 
 
-@attr('notravis')
+@pytest.mark.nogha
 def test_getting_started7_8():
     # Chunk 7
     stmts = gn_stmts  # Added only in this test, not in docs

--- a/indra/tests/test_docs_code.py
+++ b/indra/tests/test_docs_code.py
@@ -6,9 +6,7 @@ occurence to the tests.
 
 In general, try to separate tests to one test per chunk of interdependent code
 """
-import copy
-from indra.statements import Event, Concept, Influence, Evidence
-from nose.plugins.attrib import attr
+import pytest
 from unittest import skip
 
 
@@ -60,7 +58,8 @@ def test_readme_using_indra2():
 
 
 # From 3rd example under "Using INDRA"
-@attr('slow', 'nogha')
+@pytest.mark.slow
+@pytest.mark.nogha
 def test_readme_using_indra3():
     from indra.sources import reach
     from indra.literature import pubmed_client
@@ -145,7 +144,8 @@ def test_nl_modeling():
 
 
 # CODE IN gene_network.rst
-@attr('slow', 'nogha')
+@pytest.mark.slow
+@pytest.mark.nogha
 def test_gene_network():
     # Chunk 1: this is tested in _get_gene_network_stmts
     # from indra.tools.gene_network import GeneNetwork

--- a/indra/tests/test_elsevier_client.py
+++ b/indra/tests/test_elsevier_client.py
@@ -4,7 +4,7 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
-raise pytest.skip('Elsevier credentials currently not operational.')
+pytest.skip('Elsevier credentials currently not operational.')
 
 
 @pytest.mark.nonpublic

--- a/indra/tests/test_elsevier_client.py
+++ b/indra/tests/test_elsevier_client.py
@@ -1,14 +1,14 @@
 import logging
 from indra.literature import elsevier_client as ec
-from nose.plugins.attrib import attr
-from nose.plugins.skip import SkipTest
+import pytest
 
 logger = logging.getLogger(__name__)
 
-raise SkipTest('Elsevier credentials currently not operational.')
+raise pytest.skip('Elsevier credentials currently not operational.')
 
 
-@attr('nonpublic', 'webservice')
+@pytest.mark.nonpublic
+@pytest.mark.webservice
 def test_get_fulltext_article():
     # This article is not open access so in order to get a full text response
     # with a body element requires full text access keys to be correctly
@@ -18,7 +18,8 @@ def test_get_fulltext_article():
     assert text is not None
 
 
-@attr('nonpublic', 'webservice')
+@pytest.mark.nonpublic
+@pytest.mark.webservice
 def test_get_abstract():
     # If we have an API key but are not on an approved IP or don't have a
     # necessary institution key, we should still be able to get the abstract.
@@ -29,7 +30,8 @@ def test_get_abstract():
     assert text is not None
 
 
-@attr('nonpublic', 'webservice')
+@pytest.mark.nonpublic
+@pytest.mark.webservice
 def test_get_converted_article_body():
     """Make sure we can get fulltext of an article that has
     ja:converted-article as its principal sub-element."""
@@ -43,7 +45,8 @@ def test_get_converted_article_body():
     assert body
 
 
-@attr('nonpublic', 'webservice')
+@pytest.mark.nonpublic
+@pytest.mark.webservice
 def test_get_rawtext():
     """Make sure we can get content of an article that has content in
     xocs:rawtext"""
@@ -57,7 +60,8 @@ def test_get_rawtext():
     assert body
 
 
-@attr('nonpublic', 'webservice')
+@pytest.mark.nonpublic
+@pytest.mark.webservice
 def test_article():
     # PMID: 11302724
     doi = '10.1006/bbrc.2001.4693'

--- a/indra/tests/test_elsevier_client.py
+++ b/indra/tests/test_elsevier_client.py
@@ -4,11 +4,10 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
-pytest.skip('Elsevier credentials currently not operational.')
-
 
 @pytest.mark.nonpublic
 @pytest.mark.webservice
+@pytest.mark.nogha
 def test_get_fulltext_article():
     # This article is not open access so in order to get a full text response
     # with a body element requires full text access keys to be correctly
@@ -20,6 +19,7 @@ def test_get_fulltext_article():
 
 @pytest.mark.nonpublic
 @pytest.mark.webservice
+@pytest.mark.nogha
 def test_get_abstract():
     # If we have an API key but are not on an approved IP or don't have a
     # necessary institution key, we should still be able to get the abstract.
@@ -32,6 +32,7 @@ def test_get_abstract():
 
 @pytest.mark.nonpublic
 @pytest.mark.webservice
+@pytest.mark.nogha
 def test_get_converted_article_body():
     """Make sure we can get fulltext of an article that has
     ja:converted-article as its principal sub-element."""
@@ -47,6 +48,7 @@ def test_get_converted_article_body():
 
 @pytest.mark.nonpublic
 @pytest.mark.webservice
+@pytest.mark.nogha
 def test_get_rawtext():
     """Make sure we can get content of an article that has content in
     xocs:rawtext"""
@@ -62,6 +64,7 @@ def test_get_rawtext():
 
 @pytest.mark.nonpublic
 @pytest.mark.webservice
+@pytest.mark.nogha
 def test_article():
     # PMID: 11302724
     doi = '10.1006/bbrc.2001.4693'

--- a/indra/tests/test_groundingmapper.py
+++ b/indra/tests/test_groundingmapper.py
@@ -6,8 +6,7 @@ from indra.preassembler.grounding_mapper.gilda import ground_statements, \
 from indra.statements import Agent, Phosphorylation, Complex, Inhibition, \
     Evidence, BoundCondition
 from indra.util import unicode_strs
-from nose.tools import raises
-from nose.plugins.attrib import attr
+import pytest
 
 
 def test_simple_mapping():
@@ -206,21 +205,21 @@ def test_hgnc_but_not_up():
     assert mapped_erk.db_refs['UP'] == 'P28482'
 
 
-@raises(ValueError)
 def test_hgnc_sym_with_no_id():
     erk = Agent('ERK1', db_refs={'TEXT': 'ERK1'})
     stmt = Phosphorylation(None, erk)
     g_map = {'ERK1': {'TEXT': 'ERK1', 'HGNC': 'foobar'}}
-    gm = GroundingMapper(g_map)
-    mapped_stmts = gm.map_stmts([stmt])
+    with pytest.raises(ValueError):
+        gm = GroundingMapper(g_map)
+        mapped_stmts = gm.map_stmts([stmt])
 
 
-@raises(ValueError)
 def test_up_and_invalid_hgnc_sym():
     erk = Agent('ERK1', db_refs={'TEXT': 'ERK1'})
     stmt = Phosphorylation(None, erk)
     g_map = {'ERK1': {'TEXT': 'ERK1', 'UP': 'P28482', 'HGNC': 'foobar'}}
-    gm = GroundingMapper(g_map)
+    with pytest.raises(ValueError):
+        gm = GroundingMapper(g_map)
 
 
 def test_up_with_no_gene_name_with_hgnc_sym():
@@ -309,7 +308,7 @@ def test_map_agent():
     assert mapped_ag.db_refs.get('FPLX') == 'ERK'
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_adeft_mapping():
     er1 = Agent('ER', db_refs={'TEXT': 'ER'})
     pmid1 = '30775882'
@@ -430,7 +429,7 @@ def test_get_gilda_models():
     assert 'NDR1' in models
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_gilda_disambiguation():
     gm.gilda_mode = 'web'
     er1 = Agent('NDR1', db_refs={'TEXT': 'NDR1'})
@@ -466,7 +465,7 @@ def test_gilda_disambiguation():
     assert annotations['agents']['gilda'][1] is not None
 
 
-@attr('nonpublic')
+@pytest.mark.nonpublic
 def test_gilda_disambiguation_local():
     gm.gilda_mode = 'local'
     er1 = Agent('NDR1', db_refs={'TEXT': 'NDR1'})

--- a/indra/tests/test_hgnc_client.py
+++ b/indra/tests/test_hgnc_client.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.databases import hgnc_client
 from indra.util import unicode_strs
-from nose.plugins.attrib import attr
+import pytest
 
 
 def test_get_uniprot_id():
@@ -26,7 +26,7 @@ def test_get_hgnc_name():
     assert unicode_strs(hgnc_name)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_hgnc_name_nonexistent():
     hgnc_id = '123456'
     hgnc_name = hgnc_client.get_hgnc_name(hgnc_id)

--- a/indra/tests/test_hprd.py
+++ b/indra/tests/test_hprd.py
@@ -1,5 +1,5 @@
 from os.path import join, abspath, dirname
-from nose.tools import raises
+import pytest
 from indra.statements import Complex, Phosphorylation
 from indra.sources import hprd
 
@@ -91,9 +91,8 @@ def test_process_ppis():
                                      '&isoform_name=Isoform_1')
 
 
-@raises(ValueError)
 def test_process_ptms_no_seq():
-    ptm_file = join(test_dir, 'POST_TRANSLATIONAL_MODIFICATIONS.txt')
-    hp = hprd.process_flat_files(id_file, ptm_file=ptm_file)
-
+    with pytest.raises(ValueError):
+        ptm_file = join(test_dir, 'POST_TRANSLATIONAL_MODIFICATIONS.txt')
+        hp = hprd.process_flat_files(id_file, ptm_file=ptm_file)
 

--- a/indra/tests/test_hypothesis.py
+++ b/indra/tests/test_hypothesis.py
@@ -1,4 +1,4 @@
-from nose.plugins.attrib import attr
+import pytest
 from gilda import ground
 from indra.sources import hypothesis
 from indra.sources import trips
@@ -9,7 +9,9 @@ from indra.sources.hypothesis.annotator import statement_to_annotations, \
     evidence_to_annotation, get_annotation_text
 
 
-@attr('nonpublic', 'slow', 'nogha')
+@pytest.mark.nonpublic
+@pytest.mark.slow
+@pytest.mark.nogha
 def test_process_indra_annnotations():
     hp = hypothesis.process_annotations(reader=trips.process_text)
     assert hp.statements
@@ -25,7 +27,7 @@ def test_grounding_annotation():
     assert hp.groundings['Plaquenil'] == {'CHEBI': 'CHEBI:5801'}
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_statement_annotation():
     hp = HypothesisProcessor(annotations=[statement_annot_example],
                              reader=trips.process_text)

--- a/indra/tests/test_hypothesis.py
+++ b/indra/tests/test_hypothesis.py
@@ -9,7 +9,7 @@ from indra.sources.hypothesis.annotator import statement_to_annotations, \
     evidence_to_annotation, get_annotation_text
 
 
-@attr('nonpublic', 'slow', 'notravis')
+@attr('nonpublic', 'slow', 'nogha')
 def test_process_indra_annnotations():
     hp = hypothesis.process_annotations(reader=trips.process_text)
     assert hp.statements

--- a/indra/tests/test_json_schema.py
+++ b/indra/tests/test_json_schema.py
@@ -1,7 +1,7 @@
 import json
 import jsonschema
 import os
-from nose.tools import assert_raises
+import pytest
 from jsonschema.exceptions import ValidationError
 
 dir_this = os.path.dirname(__file__)
@@ -89,19 +89,23 @@ def test_valid_modification():
 def test_invalid_phosphorylation():
     s = {'enz': valid_agent1, 'sub': valid_agent2, 'type': 'Phosphorylation',
          'id': '5', 'residue': 5}  # residue should be a string
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'enz': valid_agent1, 'sub': invalid_agent1, 'type': 'Phosphorylation',
          'id': '5'}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'enz': valid_agent1, 'sub': invalid_agent2, 'type': 'Phosphorylation',
          'id': '5'}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'enz': valid_agent1, 'sub': invalid_agent3, 'type': 'Phosphorylation',
          'id': '5'}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     invalid_evidence = {'source_api': 42}
     s = {'enz': valid_agent1, 'sub': valid_agent2, 'type': 'Phosphorylation',
@@ -117,23 +121,28 @@ def test_valid_active_form():
 def test_invalid_active_form():
     s = {'agent': invalid_agent1, 'activity': 'kinase', 'is_active': True,
          'type': 'ActiveForm', 'id': '6'}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'agent': valid_agent1, 'activity': 'kinase', 'is_active': 'moo',
          'type': 'ActiveForm', 'id': '6'}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'agent': valid_agent1, 'activity': 'kinase', 'is_active': True,
          'type': 'ActiveForm', 'id': 42}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'agent': valid_agent1, 'activity': 'kinase', 'is_active': True,
          'type': 'MOO', 'id': '6'}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'agent': valid_agent1, 'activity': {'cow': False}, 'is_active': True,
          'type': 'ActiveForm', 'id': '6'}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
 
 def test_valid_complex():
@@ -147,11 +156,13 @@ def test_valid_complex():
 def test_invalid_complex():
     s = {'members': [invalid_agent1, valid_agent2], 'type': 'Complex',
          'id': '3'}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'members': [valid_agent1, invalid_agent2], 'type': 'Complex',
          'id': '3'}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
 
 def test_valid_event():
@@ -167,23 +178,28 @@ def test_valid_influence():
 def test_invalid_influence():
     s = {'subj': invalid_concept1, 'obj': valid_concept2, 'subj_delta': None,
          'obj_delta': None, 'type': 'Influence', 'id': '10'}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'subj': valid_concept1, 'obj': invalid_concept2, 'subj_delta': None,
          'obj_delta': None, 'type': 'Influence', 'id': '10'}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'subj': valid_concept1, 'obj': valid_concept2, 'subj_delta': None,
          'obj_delta': 'Henry', 'type': 'Influence', 'id': '10'}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'subj': valid_concept1, 'obj': valid_concept2, 'subj_delta': 'Larry',
          'obj_delta': None, 'type': 'Influence', 'id': '10'}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'subj': valid_concept1, 'obj': valid_concept2, 'subj_delta': None,
          'obj_delta': None, 'type': 'Influence', 'id': 10}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
 
 def test_valid_conversion():
@@ -195,20 +211,24 @@ def test_valid_conversion():
 def test_invalid_conversion():
     s = {'type': 'Conversion', 'id': '11', 'subj': valid_agent1,
          'obj_from': [12, valid_agent3], 'obj_to': [valid_agent3]}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'type': 'Conversion', 'id': '11', 'subj': valid_agent1,
          'obj_from': [valid_agent2, valid_agent3],
          'obj_to': [valid_agent3, 12]}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'type': 'Conversion', 'id': '11', 'subj': 'dog',
          'obj_from': [valid_agent2, valid_agent3], 'obj_to': [valid_agent3]}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
     s = {'type': 'Conversion', 'id': '11', 'subj': valid_agent1,
          'obj_from': 'banana', 'obj_to': [valid_agent3]}
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
 
 def test_self_modifications():
@@ -235,7 +255,8 @@ def test_translocation():
     jsonschema.validate([s], schema)
 
     s['to_location'] = 3
-    assert_raises(ValidationError, val, s)
+    with pytest.raises(ValidationError):
+        val(s)
 
 
 def test_gef():

--- a/indra/tests/test_lincs_client.py
+++ b/indra/tests/test_lincs_client.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
-import unittest
-from nose.plugins.attrib import attr
+import pytest
 from indra.databases.lincs_client import get_drug_target_data, LincsClient
 
 
 lc = LincsClient()
 
 
-@attr('webservice')
+@pytest.mark.webservice
 @unittest.skip('LINCS web service very unreliable.')
 def test_get_drug_target_data():
     data_list = get_drug_target_data()

--- a/indra/tests/test_lincs_client.py
+++ b/indra/tests/test_lincs_client.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, print_function, unicode_literals
+import unittest
 
 import pytest
 from indra.databases.lincs_client import get_drug_target_data, LincsClient

--- a/indra/tests/test_literature.py
+++ b/indra/tests/test_literature.py
@@ -1,10 +1,10 @@
 import time
 from indra.literature import id_lookup, get_full_text
 from indra.util import unicode_strs
-from nose.plugins.attrib import attr
+import pytest
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_full_text_pmc():
     txt, txt_format = get_full_text('PMC4322985', 'pmcid')
     assert txt_format == 'pmc_oa_xml'
@@ -12,7 +12,7 @@ def test_get_full_text_pmc():
     assert unicode_strs((txt, txt_format))
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_full_text_doi():
     txt, txt_format = get_full_text('10.18632/oncotarget.2555', 'doi')
     assert txt_format == 'pmc_oa_xml'
@@ -20,7 +20,7 @@ def test_get_full_text_doi():
     assert unicode_strs((txt, txt_format))
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_full_text_pubmed_abstract():
     # DOI lookup in CrossRef fails for this one because of page mismatch
     txt, txt_format = get_full_text('27075779', 'pmid')
@@ -29,14 +29,14 @@ def test_get_full_text_pubmed_abstract():
     assert unicode_strs((txt, txt_format))
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_id_lookup():
     time.sleep(0.5)
     res = id_lookup('17513615', 'pmid')
     assert res['doi'] == '10.1158/1535-7163.MCT-06-0807'
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_id_lookup_no_pmid():
     """Look up a paper that has a PMCID and DOI but not PMID."""
     time.sleep(0.5)

--- a/indra/tests/test_medscan.py
+++ b/indra/tests/test_medscan.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from os.path import join, dirname
-from nose.tools import raises
 
 from indra.statements import *
 from indra.sources.medscan.processor import *

--- a/indra/tests/test_ndex_client.py
+++ b/indra/tests/test_ndex_client.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 from indra.databases import ndex_client
-from nose.plugins.attrib import attr
 
 
 def test_ndex_ver():

--- a/indra/tests/test_ndex_cx_processor.py
+++ b/indra/tests/test_ndex_cx_processor.py
@@ -3,11 +3,9 @@ from builtins import dict, str
 import os
 from indra.sources.ndex_cx import process_cx_file, process_ndex_network
 from indra.sources.ndex_cx.processor import NdexCxProcessor
-from indra.databases import hgnc_client
 from indra.statements import Agent, Statement
 from requests.exceptions import HTTPError
-from nose.tools import raises
-from nose.plugins.attrib import attr
+import pytest
 
 
 path_this = os.path.dirname(os.path.abspath(__file__))
@@ -67,14 +65,14 @@ def test_get_statements():
             assert ev.source_api == 'ndex'
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_cx_from_ndex():
     # Ras Machine network
     ncp = process_ndex_network('fc56fe8d-1b60-11e8-b939-0ac135e8bacf')
 
 
-@raises(HTTPError)
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_cx_from_ndex_unauth():
     # This network should error because unauthorized without username/pwd
-    ncp = process_ndex_network('df1fea48-8cfb-11e7-a10d-0ac135e8bacf')
+    with pytest.raises(HTTPError):
+        ncp = process_ndex_network('df1fea48-8cfb-11e7-a10d-0ac135e8bacf')

--- a/indra/tests/test_pmc_client.py
+++ b/indra/tests/test_pmc_client.py
@@ -1,16 +1,15 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
+import pytest
 from indra.literature import pmc_client
-from nose.tools import raises
 from indra.util import unicode_strs
-from nose.plugins.attrib import attr
 
 example_ids = {'pmid': '25361007',
                'pmcid': 'PMC4322985',
                'doi': '10.18632/oncotarget.2555'}
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_id_lookup_pmid_no_prefix_no_idtype():
     ids = pmc_client.id_lookup('25361007')
     assert ids['doi'] == example_ids['doi']
@@ -19,7 +18,7 @@ def test_id_lookup_pmid_no_prefix_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_id_lookup_pmid_with_prefix_no_idtype():
     ids = pmc_client.id_lookup('PMID25361007')
     assert ids['doi'] == example_ids['doi']
@@ -28,7 +27,7 @@ def test_id_lookup_pmid_with_prefix_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_id_lookup_pmcid_no_idtype():
     ids = pmc_client.id_lookup('PMC4322985')
     assert ids['doi'] == example_ids['doi']
@@ -37,7 +36,7 @@ def test_id_lookup_pmcid_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_id_lookup_pmcid_idtype():
     ids = pmc_client.id_lookup('PMC4322985', idtype='pmcid')
     assert ids['doi'] == example_ids['doi']
@@ -46,7 +45,7 @@ def test_id_lookup_pmcid_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_id_lookup_pmcid_no_prefix_idtype():
     ids = pmc_client.id_lookup('4322985', idtype='pmcid')
     assert ids['doi'] == example_ids['doi']
@@ -55,7 +54,7 @@ def test_id_lookup_pmcid_no_prefix_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_id_lookup_doi_no_prefix_no_idtype():
     ids = pmc_client.id_lookup('10.18632/oncotarget.2555')
     assert ids['doi'] == example_ids['doi']
@@ -64,7 +63,7 @@ def test_id_lookup_doi_no_prefix_no_idtype():
     assert unicode_strs(ids)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_id_lookup_doi_prefix_no_idtype():
     ids = pmc_client.id_lookup('DOI10.18632/oncotarget.2555')
     assert ids['doi'] == example_ids['doi']
@@ -73,12 +72,12 @@ def test_id_lookup_doi_prefix_no_idtype():
     assert unicode_strs(ids)
 
 
-@raises(ValueError)
 def test_invalid_idtype():
-    ids = pmc_client.id_lookup('DOI10.18632/oncotarget.2555', idtype='foo')
+    with pytest.raises(ValueError):
+        ids = pmc_client.id_lookup('DOI10.18632/oncotarget.2555', idtype='foo')
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_xml():
     pmc_id = '4322985'
     xml_str = pmc_client.get_xml(pmc_id)
@@ -86,7 +85,7 @@ def test_get_xml():
     assert unicode_strs((pmc_id, xml_str))
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_xml_PMC():
     pmc_id = 'PMC4322985'
     xml_str = pmc_client.get_xml(pmc_id)
@@ -94,14 +93,14 @@ def test_get_xml_PMC():
     assert unicode_strs((pmc_id, xml_str))
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_xml_invalid():
     pmc_id = '9999999'
     xml_str = pmc_client.get_xml(pmc_id)
     assert xml_str is None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_extract_text():
     pmc_id = '4322985'
     xml_str = pmc_client.get_xml(pmc_id)
@@ -111,7 +110,7 @@ def test_extract_text():
     assert unicode_strs(text)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_extract_text2():
     xml_str = '<article><body><p><p>some text</p>a</p></body></article>'
     text = pmc_client.extract_text(xml_str)
@@ -119,7 +118,7 @@ def test_extract_text2():
     assert unicode_strs(text)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_title():
     title = pmc_client.get_title('PMC4322985')
     assert title == (

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -1,23 +1,23 @@
 import time
 from indra.literature import pubmed_client
-from nose.plugins.attrib import attr
+import pytest
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_ids1():
     time.sleep(0.5)
     ids = pubmed_client.get_ids('braf', retmax=10, db='pubmed')
     assert len(ids) == 10
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_no_ids():
     time.sleep(0.5)
     ids = pubmed_client.get_ids('UUuXNWMCusRpcVTX', retmax=10, db='pubmed')
     assert not ids
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_ids2():
     time.sleep(0.5)
     ids1 = pubmed_client.get_ids('JUN', use_text_word=False, reldate=365)
@@ -25,7 +25,7 @@ def test_get_ids2():
     assert len(ids1) > len(ids2)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_id_count():
     time.sleep(0.5)
     id_count = pubmed_client.get_id_count('SDLFKJSLDKJH')
@@ -34,7 +34,7 @@ def test_get_id_count():
     assert id_count > 0
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_id_mesh():
     time.sleep(0.5)
     ids = pubmed_client.get_ids_for_mesh('D009101', reldate=365)
@@ -44,21 +44,21 @@ def test_get_id_mesh():
     assert len(ids_maj) < len(ids)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_id_mesh_supc():
     time.sleep(0.5)
     ids = pubmed_client.get_ids_for_mesh('D000086382')
     assert len(ids) > 100, len(ids)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_pmc_ids():
     time.sleep(0.5)
     ids = pubmed_client.get_ids('braf', retmax=10, db='pmc')
     assert len(ids) == 10
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_title():
     time.sleep(0.5)
     title = pubmed_client.get_title('27754804')
@@ -66,7 +66,7 @@ def test_get_title():
     assert title.lower().startswith('targeting autophagy')
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_title_prefix():
     time.sleep(0.5)
     title = pubmed_client.get_title('PMID27754804')
@@ -74,7 +74,7 @@ def test_get_title_prefix():
     assert title.lower().startswith('targeting autophagy')
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_complex_title():
     time.sleep(0.5)
     title = pubmed_client.get_title('33463523')
@@ -82,7 +82,7 @@ def test_get_complex_title():
     assert title.lower().startswith('atomic structures')
     assert title.lower().endswith('vascular plants.')
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_expand_pagination():
     time.sleep(0.5)
     pages = '456-7'
@@ -90,7 +90,7 @@ def test_expand_pagination():
     assert new_pages == '456-457'
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_abstract_notitle():
     time.sleep(0.5)
     abstract = pubmed_client.get_abstract('27754804', prepend_title=False)
@@ -98,7 +98,7 @@ def test_get_abstract_notitle():
     assert abstract.endswith('vemurafenib.')
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_abstract_title():
     time.sleep(0.5)
     abstract = pubmed_client.get_abstract('27754804', prepend_title=True)
@@ -106,35 +106,35 @@ def test_get_abstract_title():
     assert abstract.endswith('vemurafenib.')
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_abstract2():
     time.sleep(0.5)
     # Try another one
     abstract = pubmed_client.get_abstract('27123883')
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_no_abstract():
     time.sleep(0.5)
     abstract = pubmed_client.get_abstract('xx')
     assert abstract is None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_ids_for_gene():
     time.sleep(0.5)
     ids = pubmed_client.get_ids_for_gene('EXOC1')
     assert ids
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_metadata_for_ids():
     time.sleep(0.5)
     pmids = ['27123883', '27121204', '27115606']
     metadata = pubmed_client.get_metadata_for_ids(pmids)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_pub_date():
     time.sleep(0.5)
     pmids = ['27123883', '27121204', '27115606']
@@ -150,21 +150,21 @@ def test_get_pub_date():
     assert metadata[pmids[2]]['publication_date']['day'] == 27
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_send_request_invalid():
     time.sleep(0.5)
     res = pubmed_client.send_request('http://xxxxxxx', data={})
     assert res is None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_abstract_with_html_embedded():
     time.sleep(0.5)
     res = pubmed_client.get_abstract('25484845')
     assert len(res) > 4, res
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_pmid_27821631():
     time.sleep(0.5)
     pmid = '27821631'
@@ -175,7 +175,7 @@ def test_pmid_27821631():
     assert len(res[pmid]['abstract']) > 50
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_annotations():
     time.sleep(0.5)
     pmid = '30971'
@@ -190,7 +190,7 @@ def test_get_annotations():
     assert any(d['major_topic'] for d in me_ans)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_supplementary_annotations():
     time.sleep(0.5)
     pmid = '30105248'
@@ -206,7 +206,7 @@ def test_get_supplementary_annotations():
     assert supp_ann['text'] == 'Tomato yellow leaf curl virus'
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_substance_annotations():
     pmid = '27959613'
     mesh_ids = pubmed_client.get_substance_annotations(pmid)

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -8,7 +8,7 @@ from indra.assemblers.pysb.kappa_util import get_cm_cycles
 from indra.statements import *
 from pysb import bng, WILD, Monomer, Annotation
 from pysb.testing import with_model
-from nose.tools import raises
+import pytest
 
 
 def test_pysb_assembler_complex1():
@@ -1211,12 +1211,12 @@ def test_policy_parameters():
     assert model.parameters['c'].value == 3.0
 
 
-@raises(pa.UnknownPolicyError)
 def test_policy_object_invalid():
-    stmt = Phosphorylation(Agent('a'), Agent('b'))
-    pa = PysbAssembler([stmt])
-    model = pa.make_model(policies={'xyz': Policy('two_step')})
-    assert len(model.rules) == 3
+    with pytest.raises(pa.UnknownPolicyError):
+        stmt = Phosphorylation(Agent('a'), Agent('b'))
+        pa = PysbAssembler([stmt])
+        model = pa.make_model(policies={'xyz': Policy('two_step')})
+        assert len(model.rules) == 3
 
 
 def test_mod_parameter():

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -1,7 +1,7 @@
 import xml.etree.ElementTree as ET
 from indra.assemblers.pysb import PysbAssembler
 import indra.assemblers.pysb.assembler as pa
-from indra.assemblers.pysb.assembler import Policy, Param
+from indra.assemblers.pysb.assembler import Policy, Param, UnknownPolicyError
 from indra.assemblers.pysb.preassembler import PysbPreassembler
 from indra.assemblers.pysb.export import export_cm_network
 from indra.assemblers.pysb.kappa_util import get_cm_cycles
@@ -1212,7 +1212,7 @@ def test_policy_parameters():
 
 
 def test_policy_object_invalid():
-    with pytest.raises(pa.UnknownPolicyError):
+    with pytest.raises(UnknownPolicyError):
         stmt = Phosphorylation(Agent('a'), Agent('b'))
         pa = PysbAssembler([stmt])
         model = pa.make_model(policies={'xyz': Policy('two_step')})

--- a/indra/tests/test_reach.py
+++ b/indra/tests/test_reach.py
@@ -1,5 +1,5 @@
 import os
-from nose.plugins.attrib import attr
+import pytest
 from indra.sources import reach
 from indra.sources.reach.processor import ReachProcessor, normalize_section
 from indra.util import unicode_strs
@@ -298,7 +298,7 @@ def test_process_unicode():
         assert unicode_strs(rp.statements)
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_process_pmc():
     for offline in offline_modes:
         rp = reach.process_pmc('PMC4338247', offline=offline)

--- a/indra/tests/test_rest_api.py
+++ b/indra/tests/test_rest_api.py
@@ -792,7 +792,7 @@ def test_options():
         "Unexpected content: %s" % res_json
 
 
-@attr('notravis')
+@attr('nogha')
 def test_trips_process_text():
     res = _call_api('post', 'trips/process_text',
                     json={'text': 'MEK phosphorylates ERK.'})
@@ -822,7 +822,7 @@ def test_trips_process_xml():
     assert stmt.sub.name == 'ERK', stmt.sub
 
 
-@attr('notravis')
+@attr('nogha')
 def test_reach_process_text():
     res = _call_api('post', 'reach/process_text',
                     json={'text': 'MEK phosphorylates ERK.'})
@@ -851,7 +851,7 @@ def test_reach_process_json():
     assert stmts[0].obj is not None
 
 
-@attr('notravis')
+@attr('nogha')
 def test_reach_process_pmc():
     res = _call_api('post', 'reach/process_pmc', json={'pmcid': 'PMC4338247'})
     res_json = json.loads(res.get_data())

--- a/indra/tests/test_rest_api.py
+++ b/indra/tests/test_rest_api.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime
 from copy import deepcopy
-from nose.plugins.attrib import attr
+import pytest
 from os import path
 from rest_api.api import api
 from indra.statements import *
@@ -792,7 +792,7 @@ def test_options():
         "Unexpected content: %s" % res_json
 
 
-@attr('nogha')
+@pytest.mark.nogha
 def test_trips_process_text():
     res = _call_api('post', 'trips/process_text',
                     json={'text': 'MEK phosphorylates ERK.'})
@@ -822,7 +822,7 @@ def test_trips_process_xml():
     assert stmt.sub.name == 'ERK', stmt.sub
 
 
-@attr('nogha')
+@pytest.mark.nogha
 def test_reach_process_text():
     res = _call_api('post', 'reach/process_text',
                     json={'text': 'MEK phosphorylates ERK.'})
@@ -851,7 +851,7 @@ def test_reach_process_json():
     assert stmts[0].obj is not None
 
 
-@attr('nogha')
+@pytest.mark.nogha
 def test_reach_process_pmc():
     res = _call_api('post', 'reach/process_pmc', json={'pmcid': 'PMC4338247'})
     res_json = json.loads(res.get_data())
@@ -996,7 +996,7 @@ def test_pipeline():
     assert len(res_json['statements']) == 1
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_ccle_mrna():
     res = _call_api('post', 'databases/cbio/get_ccle_mrna',
                     json={'gene_list': ['XYZ', 'MAP2K1'],
@@ -1018,7 +1018,7 @@ def test_ccle_mrna():
     assert mrna['XXX'] is None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_ccle_cna():
     res = _call_api('post', 'databases/cbio/get_ccle_cna',
                     json={'gene_list': ['BRAF', 'AKT1'],
@@ -1033,7 +1033,7 @@ def test_ccle_cna():
     assert len(cna) == 2
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_ccle_mutations():
     res = _call_api('post', 'databases/cbio/get_ccle_mutations',
                     json={'gene_list': ['BRAF', 'AKT1'],

--- a/indra/tests/test_s3_client.py
+++ b/indra/tests/test_s3_client.py
@@ -8,7 +8,7 @@ import pytest
 
 @pytest.mark.webservice
 @pytest.mark.nonpublic
-@pytest.maerk.cron
+@pytest.mark.cron
 def test_check_pmid():
     pmid = s3_client.check_pmid(12345)
     assert pmid == 'PMID12345'
@@ -23,7 +23,7 @@ def test_check_pmid():
 
 @pytest.mark.webservice
 @pytest.mark.nonpublic
-@pytest.maerk.cron
+@pytest.mark.cron
 def test_get_pmid_key():
     pmid = '12345'
     pmid_key = s3_client.get_pmid_key(pmid)
@@ -33,7 +33,7 @@ def test_get_pmid_key():
 
 @pytest.mark.webservice
 @pytest.mark.nonpublic
-@pytest.maerk.cron
+@pytest.mark.cron
 def test_filter_keys():
     pmid_key = s3_client.get_pmid_key('1001287')
     key_list = s3_client.filter_keys(pmid_key)
@@ -42,7 +42,7 @@ def test_filter_keys():
 
 @pytest.mark.webservice
 @pytest.mark.nonpublic
-@pytest.maerk.cron
+@pytest.mark.cron
 def test_get_gz_object():
     # Get XML
     key = 'papers/PMID27297883/fulltext/txt'
@@ -56,7 +56,7 @@ def test_get_gz_object():
 
 @pytest.mark.webservice
 @pytest.mark.nonpublic
-@pytest.maerk.cron
+@pytest.mark.cron
 def test_get_gz_object_nosuchkey():
     obj = s3_client.get_gz_object('foobar')
     assert obj is None
@@ -64,7 +64,7 @@ def test_get_gz_object_nosuchkey():
 
 @pytest.mark.webservice
 @pytest.mark.nonpublic
-@pytest.maerk.cron
+@pytest.mark.cron
 def test_get_full_text():
     (content, content_type) = s3_client.get_full_text('27297883')
     assert unicode_strs((content, content_type))
@@ -82,7 +82,7 @@ def test_get_full_text():
 
 @pytest.mark.webservice
 @pytest.mark.nonpublic
-@pytest.maerk.cron
+@pytest.mark.cron
 def test_put_full_text():
     full_text = 'test_put_full_text'
     pmid_test = 'PMID000test1'
@@ -96,7 +96,7 @@ def test_put_full_text():
 
 @pytest.mark.webservice
 @pytest.mark.nonpublic
-@pytest.maerk.cron
+@pytest.mark.cron
 def test_put_abstract():
     abstract = 'test_put_abstract'
     pmid_test = 'PMID000test2'
@@ -110,7 +110,7 @@ def test_put_abstract():
 
 @pytest.mark.webservice
 @pytest.mark.nonpublic
-@pytest.maerk.cron
+@pytest.mark.cron
 def test_reach_output():
     # Test put_reach_output
     reach_data = {'foo': 1, 'bar': {'baz': 2}}
@@ -140,7 +140,7 @@ def test_gzip_string():
 
 @pytest.mark.webservice
 @pytest.mark.nonpublic
-@pytest.maerk.cron
+@pytest.mark.cron
 def test_get_upload_content():
     pmid_s3_no_content = 'PMID000foobar'
     (ct, ct_type) = s3_client.get_upload_content(pmid_s3_no_content)

--- a/indra/tests/test_s3_client.py
+++ b/indra/tests/test_s3_client.py
@@ -3,10 +3,12 @@ from builtins import dict, str
 from indra.literature import s3_client
 from indra.util import unicode_strs
 import zlib
-from nose.plugins.attrib import attr
+import pytest
 
 
-@attr('webservice', 'nonpublic', 'cron')
+@pytest.mark.webservice
+@pytest.mark.nonpublic
+@pytest.maerk.cron
 def test_check_pmid():
     pmid = s3_client.check_pmid(12345)
     assert pmid == 'PMID12345'
@@ -19,7 +21,9 @@ def test_check_pmid():
     assert unicode_strs(pmid)
 
 
-@attr('webservice', 'nonpublic', 'cron')
+@pytest.mark.webservice
+@pytest.mark.nonpublic
+@pytest.maerk.cron
 def test_get_pmid_key():
     pmid = '12345'
     pmid_key = s3_client.get_pmid_key(pmid)
@@ -27,14 +31,18 @@ def test_get_pmid_key():
     assert unicode_strs(pmid_key)
 
 
-@attr('webservice', 'nonpublic', 'cron')
+@pytest.mark.webservice
+@pytest.mark.nonpublic
+@pytest.maerk.cron
 def test_filter_keys():
     pmid_key = s3_client.get_pmid_key('1001287')
     key_list = s3_client.filter_keys(pmid_key)
     assert len(key_list) == 4
 
 
-@attr('webservice', 'nonpublic', 'cron')
+@pytest.mark.webservice
+@pytest.mark.nonpublic
+@pytest.maerk.cron
 def test_get_gz_object():
     # Get XML
     key = 'papers/PMID27297883/fulltext/txt'
@@ -46,13 +54,17 @@ def test_get_gz_object():
     assert unicode_strs(obj)
 
 
-@attr('webservice', 'nonpublic', 'cron')
+@pytest.mark.webservice
+@pytest.mark.nonpublic
+@pytest.maerk.cron
 def test_get_gz_object_nosuchkey():
     obj = s3_client.get_gz_object('foobar')
     assert obj is None
 
 
-@attr('webservice', 'nonpublic', 'cron')
+@pytest.mark.webservice
+@pytest.mark.nonpublic
+@pytest.maerk.cron
 def test_get_full_text():
     (content, content_type) = s3_client.get_full_text('27297883')
     assert unicode_strs((content, content_type))
@@ -68,7 +80,9 @@ def test_get_full_text():
     assert content is None and content_type is None
 
 
-@attr('webservice', 'nonpublic', 'cron')
+@pytest.mark.webservice
+@pytest.mark.nonpublic
+@pytest.maerk.cron
 def test_put_full_text():
     full_text = 'test_put_full_text'
     pmid_test = 'PMID000test1'
@@ -80,7 +94,9 @@ def test_put_full_text():
     assert unicode_strs(content)
 
 
-@attr('webservice', 'nonpublic', 'cron')
+@pytest.mark.webservice
+@pytest.mark.nonpublic
+@pytest.maerk.cron
 def test_put_abstract():
     abstract = 'test_put_abstract'
     pmid_test = 'PMID000test2'
@@ -92,7 +108,9 @@ def test_put_abstract():
     assert unicode_strs(content)
 
 
-@attr('webservice', 'nonpublic', 'cron')
+@pytest.mark.webservice
+@pytest.mark.nonpublic
+@pytest.maerk.cron
 def test_reach_output():
     # Test put_reach_output
     reach_data = {'foo': 1, 'bar': {'baz': 2}}
@@ -120,7 +138,9 @@ def test_gzip_string():
     assert content == content_dec_uni
 
 
-@attr('webservice', 'nonpublic', 'cron')
+@pytest.mark.webservice
+@pytest.mark.nonpublic
+@pytest.maerk.cron
 def test_get_upload_content():
     pmid_s3_no_content = 'PMID000foobar'
     (ct, ct_type) = s3_client.get_upload_content(pmid_s3_no_content)

--- a/indra/tests/test_signor.py
+++ b/indra/tests/test_signor.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 
 from os.path import join, dirname
-from nose.tools import raises
-from nose.plugins.attrib import attr
+import pytest
 
 from indra.statements import *
 from indra.databases import hgnc_client
@@ -51,7 +50,8 @@ def test_parse_csv_from_file():
     assert sp.complex_map == {}
 
 
-@attr('webservice', 'slow') 
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_parse_csv_from_web():
     sp = process_from_web()
     assert isinstance(sp._data, list)
@@ -98,11 +98,11 @@ def test_get_agent():
     assert test_ag.matches(sp_ag)
 
 
-@raises(KeyError)
 def test_get_agent_keyerror():
     # Create an empty Signor processor
-    sp = SignorProcessor([])
-    sp_ag = sp._get_agent('foo', 'bar', None, None)
+    with pytest.raises(KeyError):
+        sp = SignorProcessor([])
+        sp_ag = sp._get_agent('foo', 'bar', None, None)
 
 
 def test_get_evidence():

--- a/indra/tests/test_sparser_xml.py
+++ b/indra/tests/test_sparser_xml.py
@@ -1,5 +1,5 @@
 from indra.sources import sparser
-from nose.plugins.attrib import attr
+import pytest
 
 
 def test_invalid_xml():
@@ -20,7 +20,8 @@ def test_phosphorylation():
 
 
 # This test uses some slow UniPtot web queries to standardize agent names
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_phosphorylation2():
     sp = sparser.process_xml(xml_str2)
     assert len(sp.statements) == 1

--- a/indra/tests/test_statement_validate.py
+++ b/indra/tests/test_statement_validate.py
@@ -72,7 +72,6 @@ def test_statement_validate():
     assert validate_statement(stmt)
     assert_valid_statement(stmt)
     stmt = Phosphorylation(None, Agent('ERK', db_refs={'XXX': 'ERK'}))
-    # Pytest implementations of the above assert_raises
     with pytest.raises(UnknownNamespace):
         assert_valid_statement(stmt)
     assert not validate_statement(stmt)

--- a/indra/tests/test_statement_validate.py
+++ b/indra/tests/test_statement_validate.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_raises
+import pytest
 from indra.statements.validate import *
 
 
@@ -14,19 +14,19 @@ def test_db_refs_validate():
 
     assert_valid_id('NXPFA', '1234')
     assert_valid_id('TEXT', 'hello')
-    assert_raises(UnknownIdentifier, assert_valid_id,
-                  'XXX', 'ABCD1')
+    with pytest.raises(UnknownIdentifier):
+        assert_valid_id('XXX', 'ABCD1')
 
 
 def test_text_refs_validate():
-    assert_raises(InvalidTextRefs, assert_valid_text_refs,
-                  {'pmid': '123'})
-    assert_raises(InvalidTextRefs, assert_valid_text_refs,
-                  {'PMID': 'api123'})
-    assert_raises(InvalidTextRefs, assert_valid_text_refs,
-                  {'DOI': 'https://xyz'})
-    assert_raises(InvalidTextRefs, assert_valid_text_refs,
-                  {'PMCID': '12345'})
+    with pytest.raises(InvalidTextRefs):
+        assert_valid_text_refs({'pmid': '123'})
+    with pytest.raises(InvalidTextRefs):
+        assert_valid_text_refs({'PMID': 'api123'})
+    with pytest.raises(InvalidTextRefs):
+        assert_valid_text_refs({'DOI': 'https://xyz'})
+    with pytest.raises(InvalidTextRefs):
+        assert_valid_text_refs({'PMCID': '12345'})
     assert_valid_text_refs({'PMID': '12345'})
     assert_valid_text_refs({'PMCID': 'PMC12345'})
     assert_valid_text_refs({'DOI': '10.15252/msb.20177651'})
@@ -37,32 +37,34 @@ def test_pmid_text_refs_validate():
     assert_valid_pmid_text_refs(Evidence(pmid='1234'))
     assert_valid_pmid_text_refs(Evidence(pmid='1234',
                                          text_refs={'PMID': '1234'}))
-    assert_raises(InvalidTextRefs, assert_valid_pmid_text_refs,
-                  Evidence(pmid='1234', text_refs={'PMID': '12345'}))
-    assert_raises(InvalidTextRefs, assert_valid_pmid_text_refs,
-                  Evidence(pmid=None, text_refs={'PMID': '123'}))
+    with pytest.raises(InvalidTextRefs):
+        assert_valid_pmid_text_refs(Evidence(pmid='1234',
+                                             text_refs={'PMID': '12345'}))
+    with pytest.raises(InvalidTextRefs):
+        assert_valid_pmid_text_refs(Evidence(pmid=None,
+                                             text_refs={'PMID': '123'}))
 
 
 def test_context_validate():
     assert_valid_context(
         BioContext(organ=RefContext('liver', {'MESH': 'D008099'})))
-    assert_raises(InvalidContext, assert_valid_context,
-                  BioContext())
-    assert_raises(InvalidContext, assert_valid_context,
-                  BioContext(organ='liver'))
-    assert_raises(UnknownNamespace, assert_valid_context,
-                  BioContext(organ=RefContext('liver', db_refs={'XXX': '1'})))
-
+    with pytest.raises(InvalidContext):
+        assert_valid_context(BioContext())
+    with pytest.raises(InvalidContext):
+        assert_valid_context(BioContext(organ='liver'))
+    with pytest.raises(UnknownNamespace):
+        assert_valid_context(BioContext(organ=RefContext('liver',
+                                                         db_refs={'XXX': '1'})))
     assert_valid_context(None)
 
 
 def test_evidence_validate():
     assert_valid_evidence(Evidence(pmid='1234'))
-    assert_raises(InvalidTextRefs, assert_valid_evidence,
-                  Evidence(pmid=None, text_refs={'PMID': '1234'}))
-    assert_raises(UnknownNamespace, assert_valid_evidence,
-                  Evidence(context=BioContext(
-                      organ=RefContext('liver', db_refs={'XXX': '1'}))))
+    with pytest.raises(InvalidTextRefs):
+        assert_valid_evidence(Evidence(pmid=None, text_refs={'PMID': '1234'}))
+    with pytest.raises(UnknownNamespace):
+        assert_valid_evidence(Evidence(context=BioContext(
+            organ=RefContext('liver', db_refs={'XXX': '1'}))))
 
 
 def test_statement_validate():
@@ -70,7 +72,9 @@ def test_statement_validate():
     assert validate_statement(stmt)
     assert_valid_statement(stmt)
     stmt = Phosphorylation(None, Agent('ERK', db_refs={'XXX': 'ERK'}))
-    assert_raises(UnknownNamespace, assert_valid_statement, stmt)
+    # Pytest implementations of the above assert_raises
+    with pytest.raises(UnknownNamespace):
+        assert_valid_statement(stmt)
     assert not validate_statement(stmt)
 
     assert not validate_statement(Phosphorylation(None, None))

--- a/indra/tests/test_statements.py
+++ b/indra/tests/test_statements.py
@@ -4,7 +4,7 @@ import os
 import json
 import unittest
 from copy import deepcopy
-from nose.tools import raises
+import pytest
 from indra.ontology.bio import bio_ontology
 from indra.statements import *
 from indra.util import unicode_strs
@@ -1256,19 +1256,19 @@ def test_mtor_rictor_refinement():
     assert not c2.refinement_of(c1, bio_ontology)
 
 
-@raises(InvalidResidueError)
 def test_residue_mod_condition():
-    ModCondition('phosphorylation', 'xyz')
+    with pytest.raises(InvalidResidueError):
+        ModCondition('phosphorylation', 'xyz')
 
 
-@raises(InvalidResidueError)
 def test_residue_mod():
-    Phosphorylation(Agent('a'), Agent('b'), 'xyz')
+    with pytest.raises(InvalidResidueError):
+        Phosphorylation(Agent('a'), Agent('b'), 'xyz')
 
 
-@raises(InvalidResidueError)
 def test_residue_selfmod():
-    Autophosphorylation(Agent('a'), 'xyz')
+    with pytest.raises(InvalidResidueError):
+        Autophosphorylation(Agent('a'), 'xyz')
 
 
 def test_valid_mod_residue():

--- a/indra/tests/test_tas.py
+++ b/indra/tests/test_tas.py
@@ -1,8 +1,8 @@
-from nose.plugins.attrib import attr
+import pytest
 from indra.sources.tas import process_from_web
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_processor():
     tp = process_from_web(affinity_class_limit=10)
     assert tp

--- a/indra/tests/test_tees.py
+++ b/indra/tests/test_tees.py
@@ -1,4 +1,4 @@
-from nose.plugins.attrib import attr
+import pytest
 from indra.statements import *
 from indra.sources.tees import api
 from indra.sources.tees.processor import TEESProcessor
@@ -7,7 +7,7 @@ _multiprocess_can_split_ = False
 _multiprocess_shared_ = False
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_process_phosphorylation():
     # Test the extraction of phosphorylation with a simple example.
     s = 'Ras leads to the phosphorylation of Braf.'
@@ -33,7 +33,7 @@ def test_process_phosphorylation():
     assert len(statements[0].evidence) == 1
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_process_dephosphorylation():
     # Test the extraction of a dephosphorylation sentence. This sentence is
     # processed into two INDRA statements, at least one of which is correct.
@@ -74,7 +74,7 @@ def test_process_dephosphorylation():
     assert some_statement_correct
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_process_increase_amount():
     # Test extraction of IncreaseAmount statements from a text description
     # of a substance increasing the expression of some gene.
@@ -104,7 +104,7 @@ def test_process_increase_amount():
     assert len(statements[0].evidence) == 1
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_process_decrease_amount():
     # Test extraction of DecreaseAmount statements from a text description
     # of a substance decreasing the expression of some gene.
@@ -133,7 +133,7 @@ def test_process_decrease_amount():
     assert len(statements[0].evidence) == 1
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_process_bind():
     # Test extracting of Complex statement from a text description of
     # substances binding to each other.
@@ -162,7 +162,7 @@ def test_process_bind():
     assert statement0.evidence[0].epistemics['direct']
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_evidence_text():
     # Test the ability of the processor to extract which sentence in particular
     # lead to the creation of the INDRA statement, amongst a corpus of text
@@ -190,7 +190,7 @@ def test_evidence_text():
     assert text == 'Ras leads to the phosphorylation of Raf.'
 
 
-@attr('slow')
+@pytest.mark.slow
 def test_evidence_pmid():
     # Test whether the pmid provided to the TEES processor is put into the
     # statement's evidence

--- a/indra/tests/test_trips.py
+++ b/indra/tests/test_trips.py
@@ -1,13 +1,12 @@
-import sys
 from os.path import dirname, join
 import indra.statements as ist
 from indra.sources import trips
 from indra.sources.trips.processor import sanitize_trips_name
-from indra.assemblers.pysb import PysbAssembler
 from indra.util import unicode_strs
-from nose.plugins.attrib import attr
+import pytest
 
 test_small_file = join(dirname(__file__), 'test_small.xml')
+
 
 def assert_if_hgnc_then_up(st):
     agents = st.agent_list()
@@ -28,7 +27,9 @@ def assert_grounding_value_or_none(st):
                 if not v:
                     assert v is None
 
-@attr('webservice', 'slow')
+
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_phosphorylation():
     tp = trips.process_text('BRAF phosphorylates MEK1 at Ser222.')
     assert len(tp.statements) == 1
@@ -43,7 +44,8 @@ def test_phosphorylation():
     assert unicode_strs((tp, st))
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_mod_cond():
     tp = trips.process_text('Phosphorylated BRAF binds ubiquitinated MAP2K1.')
     assert len(tp.statements) == 1
@@ -61,7 +63,8 @@ def test_mod_cond():
     assert st.evidence
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_ubiquitination():
     tp = trips.process_text('MDM2 ubiquitinates TP53.')
     assert len(tp.statements) == 1
@@ -73,7 +76,8 @@ def test_ubiquitination():
     assert st.evidence
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_phosphorylation_noresidue():
     tp = trips.process_text('BRAF phosphorylates MEK1.')
     assert len(tp.statements) == 1
@@ -87,7 +91,8 @@ def test_phosphorylation_noresidue():
     assert st.evidence
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_phosphorylation_nosite():
     tp = trips.process_text('BRAF phosphorylates MEK1 at Serine.')
     assert len(tp.statements) == 1
@@ -101,7 +106,8 @@ def test_phosphorylation_nosite():
     assert st.evidence
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_actmod():
     tp = trips.process_text('MEK1 phosphorylated at Ser222 is activated.')
     assert len(tp.statements) == 1
@@ -117,7 +123,8 @@ def test_actmod():
     assert st.evidence
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_actmods():
     tp = trips.process_text('MEK1 phosphorylated at Ser 218 and Ser222 is activated.')
     assert len(tp.statements) == 1
@@ -134,7 +141,8 @@ def test_actmods():
     assert st.evidence
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_actform_bound():
     tp = trips.process_text('HRAS bound to GTP is activated.')
     assert len(tp.statements) == 1
@@ -149,7 +157,8 @@ def test_actform_bound():
     assert st.evidence
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_actform_muts():
     tp = trips.process_text('BRAF V600E is activated.')
     assert len(tp.statements) == 1
@@ -165,7 +174,8 @@ def test_actform_muts():
     assert st.evidence
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_actmods2():
     tp = trips.process_text('BRAF phosphorylated at Ser536 binds MEK1.')
     assert len(tp.statements) == 1
@@ -181,7 +191,8 @@ def test_actmods2():
     assert st.evidence
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_synthesis():
     tp = trips.process_text('NFKB transcribes IKB.')
     assert len(tp.statements) == 1
@@ -195,7 +206,8 @@ def test_synthesis():
     assert st.evidence
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_degradation():
     tp = trips.process_text('MDM2 degrades TP53.')
     assert len(tp.statements) == 1
@@ -208,7 +220,8 @@ def test_degradation():
     assert_grounding_value_or_none(st)
     assert st.evidence
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_simple_decrease():
     tp = trips.process_text('Selumetinib decreases FOS.')
     assert len(tp.statements) == 1
@@ -224,7 +237,8 @@ def test_simple_decrease():
     assert st.evidence
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_no_shared_objects():
     """Make sure shared objects are not being created between statements"""
     verbs = ('phosphorylates', 'binds', 'activates',

--- a/indra/tests/test_trrust.py
+++ b/indra/tests/test_trrust.py
@@ -1,9 +1,10 @@
-from nose.plugins.attrib import attr
+import pytest
 from indra.sources import trrust
 from indra.statements import RegulateAmount
 
 
-@attr('slow', 'webservice')
+@pytest.mark.slow
+@pytest.mark.webservice
 def test_process_from_web():
     tp = trrust.process_from_web()
     assert len(tp.statements) > 6200

--- a/indra/tests/test_uniprot_client.py
+++ b/indra/tests/test_uniprot_client.py
@@ -1,21 +1,21 @@
 from indra.databases import uniprot_client
 from indra.util import unicode_strs
-from nose.plugins.attrib import attr
+import pytest
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_query_protein_exists():
     g = uniprot_client.query_protein('P00533')
     assert g is not None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_query_protein_nonexist():
     g = uniprot_client.query_protein('XXXX')
     assert g is None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_query_protein_deprecated():
     g = uniprot_client.query_protein('Q8NHX1')
     assert g is not None
@@ -27,7 +27,7 @@ def test_query_protein_deprecated():
     assert unicode_strs(gene_name)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_family_members():
     members = uniprot_client.get_family_members('RAF')
     assert 'ARAF' in members
@@ -82,7 +82,7 @@ def test_get_gene_name_unreviewed():
     assert unicode_strs(gene_name)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_gene_name_no_gene_name():
     gene_name = uniprot_client.get_gene_name('P04434', web_fallback=False)
     assert gene_name is None
@@ -107,14 +107,14 @@ def test_noentry_is_human():
     assert not uniprot_client.is_human('XXXX')
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_sequence():
     seq = uniprot_client.get_sequence('P00533')
     assert len(seq) > 1000
     assert unicode_strs(seq)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_modifications():
     mods = uniprot_client.get_modifications('P27361')
     assert ('Phosphothreonine', 202) in mods
@@ -122,7 +122,7 @@ def test_get_modifications():
     assert unicode_strs(mods)
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_verify_location():
     assert uniprot_client.verify_location('P27361', 'T', 202)
     assert not uniprot_client.verify_location('P27361', 'S', 202)
@@ -183,7 +183,7 @@ def test_rat_from_human():
 def test_length():
     assert uniprot_client.get_length('P15056') == 766
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_function():
     fun = uniprot_client.get_function('P15056')
     assert fun.startswith('Protein kinase involved in the transduction')

--- a/indra/tests/test_virhostnet.py
+++ b/indra/tests/test_virhostnet.py
@@ -1,5 +1,5 @@
 import pandas
-from nose.plugins.attrib import attr
+import pytest
 from indra.statements import Complex
 from indra.sources import virhostnet
 from indra.sources.virhostnet.api import data_columns
@@ -20,7 +20,8 @@ test_row = {k: v for k, v in zip(data_columns, test_row_str.split('\t'))}
 test_df = pandas.DataFrame.from_dict({k: [v] for k, v in test_row.items()})
 
 
-@attr('webservice', 'slow')
+@pytest.mark.webservice
+@pytest.mark.slow
 def test_process_from_web():
     vp = virhostnet.process_from_web(query='pubmed:8553588')
     assert len(vp.statements) == 5, len(vp.statements)

--- a/indra/tests/util.py
+++ b/indra/tests/util.py
@@ -1,6 +1,6 @@
 from sys import version_info
 from functools import wraps
-from nose import SkipTest
+import pytest
 
 IS_PY3 = True
 if version_info.major is not 3:
@@ -11,7 +11,7 @@ def needs_py3(func):
     @wraps(func)
     def test_with_py3_func(*args, **kwargs):
         if not IS_PY3:
-            raise SkipTest("This tests features only supported in Python 3.x")
+            raise pytest.skip("This tests features only supported in Python 3.x")
         return func(*args, **kwargs)
     return test_with_py3_func
 
@@ -24,7 +24,7 @@ def skip_if(condition, reason=None):
 
         def f(*args, **kwargs):
             if not condition:
-                raise SkipTest("'%s' skipped: %s" % (func_name, reason))
+                raise pytest.skip("'%s' skipped: %s" % (func_name, reason))
             else:
                 return func(*args, **kwargs)
         return f

--- a/indra/tests/util.py
+++ b/indra/tests/util.py
@@ -3,7 +3,7 @@ from functools import wraps
 import pytest
 
 IS_PY3 = True
-if version_info.major is not 3:
+if version_info.major != 3:
     IS_PY3 = False
 
 


### PR DESCRIPTION
This PR migrates INDRA from nosetests to pytest. This is becoming necessary because nosetests is deprecated and is incompatible with recent Python versions (as far as I could tell, it breaks on 3.10+). Still, it seems like 3.10+ compatibility in INDRA overall will require further changes since several dependencies of INDRA error when attempting to run tests on 3.10+.

Other than changing the main command used to run tests, necessary changes include:
- changing all test attr decorators to marks
- changing the way expected exceptions are tested
- changing the way tests are skipped