### PR TITLE
Allow enhanced author parsing

### DIFF
--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -456,8 +456,9 @@ def get_metadata_from_xml_tree(tree, get_issns_from_nlm=False,
         If True, extract mesh annotations from the pubmed entries and include
         in the returned data. If false, don't. Default: True
     detailed_authors : Optional[bool]
-        If True, extract as many of the author details as possible, such as firt
-        name, identifiers, and institutions. If false, don't. Default: False
+        If True, extract as many of the author details as possible, such as
+        first name, identifiers, and institutions. If false, only last names
+        are returned. Default: False
 
     Returns
     -------
@@ -564,7 +565,8 @@ def _get_annotations(medline_citation):
 
 
 def get_metadata_for_ids(pmid_list, get_issns_from_nlm=False,
-                         get_abstracts=False, prepend_title=False):
+                         get_abstracts=False, prepend_title=False,
+                         detailed_authors=False):
     """Get article metadata for up to 200 PMIDs from the Pubmed database.
 
     Parameters
@@ -580,6 +582,10 @@ def get_metadata_for_ids(pmid_list, get_issns_from_nlm=False,
     prepend_title : bool
         If get_abstracts is True, specifies whether the article title should
         be prepended to the abstract text.
+    detailed_authors : bool
+        If True, extract as many of the author details as possible, such as
+        first name, identifiers, and institutions. If false, only last names
+        are returned. Default: False
 
     Returns
     -------
@@ -597,7 +603,8 @@ def get_metadata_for_ids(pmid_list, get_issns_from_nlm=False,
     if tree is None:
         return None
     return get_metadata_from_xml_tree(tree, get_issns_from_nlm, get_abstracts,
-                                      prepend_title)
+                                      prepend_title,
+                                      detailed_authors=detailed_authors)
 
 
 @lru_cache(maxsize=1000)

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -367,7 +367,7 @@ def _get_pubmed_publication_date(pubmed_data):
 
 def _parse_author(author_info, include_details=False):
     if not include_details:
-        return author_info.find("LastName")
+        return author_info.find("LastName").text
 
     parsed_info = {
         "last_name": None,

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -130,8 +130,18 @@ def test_get_ids_for_gene():
 @pytest.mark.webservice
 def test_get_metadata_for_ids():
     time.sleep(0.5)
-    pmids = ['27123883', '27121204', '27115606']
-    metadata = pubmed_client.get_metadata_for_ids(pmids)
+    pmids1 = ['27123883', '27121204', '27115606']
+    metadata1 = pubmed_client.get_metadata_for_ids(pmids1)
+    pmids2 = ['27123883']
+    time.sleep(0.5)
+    metadata2 = pubmed_client.get_metadata_for_ids(pmids2,
+                                                   detailed_authors=True)
+    assert all(isinstance(a, str) for a in metadata1[pmids1[0]]['authors'])
+    assert all(isinstance(a, dict) for a in metadata2[pmids2[0]]['authors'])
+    assert metadata1[pmids1[0]]['authors'][0] == 'Le Rhun'
+    assert metadata2[pmids1[0]]['authors'][0]['last_name'] == 'Le Rhun'
+    assert 'Lille' in \
+        metadata2[pmids1[0]]['authors'][0]['affiliations'][0]['name']
 
 
 @pytest.mark.webservice


### PR DESCRIPTION
This is a small PR that adds the option to get full details given about an author in PubMed XMLs. The default behavior remains the same, however there is a new keyword argument in the `get_metadata_from_xml_tree` function called `detailed_authors` that can be set to True to get this behavior.