### PR TITLE
Get article references, either just PMIDs or details

### DIFF
--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -456,7 +456,7 @@ def _get_article_info(medline_citation, pubmed_data, detailed_authors=False):
 def get_metadata_from_xml_tree(tree, get_issns_from_nlm=False,
                                get_abstracts=False, prepend_title=False,
                                mesh_annotations=True, detailed_authors=False,
-                               citations_included=None):
+                               references_included=None):
     """Get metadata for an XML tree containing PubmedArticle elements.
 
     Documentation on the XML structure can be found at:
@@ -484,9 +484,9 @@ def get_metadata_from_xml_tree(tree, get_issns_from_nlm=False,
         If True, extract as many of the author details as possible, such as
         first name, identifiers, and institutions. If false, only last names
         are returned. Default: False
-    citations_included : Optional[str]
-        If 'detailed', include detailed citations in the results. If 'pmid', only include
-        the PMID of the citation. If None, don't include citations. Default: None
+    references_included : Optional[str]
+        If 'detailed', include detailed references in the results. If 'pmid', only include
+        the PMID of the reference. If None, don't include references. Default: None
 
     Returns
     -------
@@ -511,10 +511,10 @@ def get_metadata_from_xml_tree(tree, get_issns_from_nlm=False,
         if mesh_annotations:
             context_info = _get_annotations(medline_citation)
             result.update(context_info)
-        if citations_included:
-            citations = _get_references(pubmed_data.find('ReferenceList'),
-                                        only_pmid=(citations_included == 'pmid'))
-            result['citations'] = citations
+        if references_included:
+            references = _get_references(pubmed_data.find('ReferenceList'),
+                                         only_pmid=(references_included == 'pmid'))
+            result['references'] = references
 
         publication_date = _get_pubmed_publication_date(pubmed_data)
         result['publication_date'] = publication_date
@@ -599,7 +599,7 @@ def _get_annotations(medline_citation):
 
 def get_metadata_for_ids(pmid_list, get_issns_from_nlm=False,
                          get_abstracts=False, prepend_title=False,
-                         detailed_authors=False):
+                         detailed_authors=False, references_included=None):
     """Get article metadata for up to 200 PMIDs from the Pubmed database.
 
     Parameters
@@ -619,6 +619,9 @@ def get_metadata_for_ids(pmid_list, get_issns_from_nlm=False,
         If True, extract as many of the author details as possible, such as
         first name, identifiers, and institutions. If false, only last names
         are returned. Default: False
+    references_included : Optional[str]
+        If 'detailed', include detailed references in the results. If 'pmid', only include
+        the PMID of the reference. If None, don't include references. Default: None
 
     Returns
     -------
@@ -637,7 +640,8 @@ def get_metadata_for_ids(pmid_list, get_issns_from_nlm=False,
         return None
     return get_metadata_from_xml_tree(tree, get_issns_from_nlm, get_abstracts,
                                       prepend_title,
-                                      detailed_authors=detailed_authors)
+                                      detailed_authors=detailed_authors,
+                                      references_included=references_included)
 
 
 @lru_cache(maxsize=1000)

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -367,7 +367,10 @@ def _get_pubmed_publication_date(pubmed_data):
 
 def _parse_author(author_info, include_details=False):
     if not include_details:
-        return author_info.find("LastName").text
+        last_name = author_info.find("LastName")
+        if last_name is None:
+            return None
+        return last_name.text
 
     parsed_info = {
         "last_name": None,

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -82,6 +82,7 @@ def test_get_complex_title():
     assert title.lower().startswith('atomic structures')
     assert title.lower().endswith('vascular plants.')
 
+
 @pytest.mark.webservice
 def test_expand_pagination():
     time.sleep(0.5)
@@ -142,6 +143,21 @@ def test_get_metadata_for_ids():
     assert metadata2[pmids1[0]]['authors'][0]['last_name'] == 'Le Rhun'
     assert 'Lille' in \
         metadata2[pmids1[0]]['authors'][0]['affiliations'][0]['name']
+
+
+@pytest.mark.webservice
+def test_get_paper_references():
+    time.sleep(0.5)
+    pmids = ['27123883', '27121204', '27115606']
+    test_pmid = '27121204'
+    referenced_pmid = '25439075'
+    metadata_1 = pubmed_client.get_metadata_for_ids(pmids, references_included='pmid')
+    assert len(metadata_1[test_pmid]['references']) != 0
+    assert metadata_1[test_pmid]['references'][0] == referenced_pmid
+
+    metadata_2 = pubmed_client.get_metadata_for_ids(pmids, references_included='detailed')
+    assert len(metadata_2[test_pmid]['references']) != 0
+    assert metadata_2[test_pmid]['references'][0]['pmid'] == referenced_pmid
 
 
 @pytest.mark.webservice


### PR DESCRIPTION
This is another small PR that:
1. Fixes a bug introduced in my last PR (sorry) where you sometimes get an error if an author's last name isn't given, and you chose the default name-only option for getting authors
2. Adds the ability to include references with the article data, with 3 options: None (no references), 'pmid' (just the pmids), or 'detailed' (getting everything available, more or less). The default is None, which maintains the status quo.

I also added a test for the new functionality.