### PR TITLE
Add Python 3.10 testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -256,10 +256,10 @@ Molecular Systems Biology, e11325.
 For detailed installation instructions,
 [see the documentation](http://indra.readthedocs.io/en/latest/installation.html).
 
-INDRA currently supports Python 3.8 and 3.9. The last release of INDRA compatible
+INDRA currently supports Python 3.8-3.10. The last release of INDRA compatible
 with Python 2.7 is 1.10, the last release fully compatible with Python 3.5
 is 1.17. Most usages of INDRA will work with other Python versions, however,
-full compatibility is currently only tested with 3.8 and 3.9.
+full compatibility is currently only tested with 3.8-3.10.
 
 The preferred way to install INDRA is by pointing pip to the source repository
 as

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ def main():
             'License :: OSI Approved :: BSD License',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.10',
             'Topic :: Scientific/Engineering :: Bio-Informatics',
             'Topic :: Scientific/Engineering :: Chemistry',
             'Topic :: Scientific/Engineering :: Mathematics',


### PR DESCRIPTION
Given https://github.com/Kappa-Dev/KappaTools/issues/652, we can now extend testing and support to Python 3.10 as done in this PR.