### PR TITLE
Add coordinate info to Agent extraction endpoints from readers

### DIFF
--- a/indra/sources/eidos/api.py
+++ b/indra/sources/eidos/api.py
@@ -95,7 +95,7 @@ def process_json_bio(json_dict, grounder=None):
     return ep
 
 
-def process_json_bio_entities(json_dict, grounder=None):
+def process_json_bio_entities(json_dict, grounder=None, with_coords=False):
     """Return INDRA Agents grounded to biological ontologies extracted
     from Eidos JSON-LD.
 
@@ -106,6 +106,9 @@ def process_json_bio_entities(json_dict, grounder=None):
     grounder : Optional[function]
         A function which takes a text and an optional context as argument
         and returns a dict of groundings.
+    with_coords : Optional[bool]
+        If True, the Agents will have their coordinates returned along
+        with them in a tuple. Default: False
 
     Returns
     -------
@@ -125,7 +128,13 @@ def process_json_bio_entities(json_dict, grounder=None):
         context = event.evidence[0].text
         agent = get_agent_bio(event.concept, context=context,
                               grounder=grounder)
-        agents.append(agent)
+        if with_coords:
+            prov = event.evidence[0].annotations['provenance']
+            pos = prov[0]['documentCharPositions']
+            start_coord, end_coord = pos[0]['start'], pos[0]['end']
+            agents.append((agent, (start_coord, end_coord)))
+        else:
+            agents.append(agent)
     return agents
 
 

--- a/indra/sources/reach/api.py
+++ b/indra/sources/reach/api.py
@@ -443,7 +443,7 @@ def process_json_str(json_str, citation=None, organism_priority=None):
     return rp
 
 
-def process_agents_from_entities(file_name, organism_priority=None):
+def process_agents_from_entities(file_name, organism_priority=None, with_coordinates=False):
     """Return INDRA Agents extracted from all entites, eve ones not appearing
     in Statements.
 
@@ -456,6 +456,9 @@ def process_agents_from_entities(file_name, organism_priority=None):
         when choosing protein grounding. If not given, the default behavior
         takes the first match produced by Reach, which is prioritized to be
         a human protein if such a match exists.
+    with_coordinates : Optional[bool]
+        If True, the Agents will be returned in a tuple with their
+        coordinates. Default: False
 
     Returns
     -------
@@ -466,7 +469,10 @@ def process_agents_from_entities(file_name, organism_priority=None):
         json_str = fh.read().decode('utf-8')
     json_dict = _preprocess_json_str(json_str)
     rp = ReachProcessor(json_dict, organism_priority=organism_priority)
-    return rp.get_agents_from_entities()
+    if with_coordinates:
+        return rp.get_agents_from_entities_with_coords()
+    else:
+        return rp.get_agents_from_entities()
 
 
 def _preprocess_json_str(json_str):

--- a/indra/sources/reach/processor.py
+++ b/indra/sources/reach/processor.py
@@ -100,6 +100,17 @@ class ReachProcessor(object):
         agents = [a for a in agents if a is not None]
         return agents
 
+    def get_agents_from_entities_with_coords(self, sentence_coords=False):
+        """Return INDRA Agents extracted from all entities, along with
+        global document-level coordinates, even ones not part of events."""
+        entities = self.get_all_entities()
+        agents_coords = [
+            self._get_agent_from_entity(e['frame_id'], sentence_coords=sentence_coords)
+            for e in entities
+        ]
+        agents_coords = [a for a in agents_coords if a[0] is not None]
+        return agents_coords
+
     def print_regulations(self):
         qstr = "$.events.frames[(@.type is 'regulation')]"
         res = self.tree.execute(qstr)


### PR DESCRIPTION
This PR allows for extracting coordinate info along with Agents when extracting just entities from TRIPS, Reach and Eidos.