### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         tar xzf bionetgen.tar.gz
         pip install git+https://github.com/pysb/pysb.git
         # Temporary fix. Ensure cython is installed before pyjnius
-        pip install cython
+        pip install "cython<3"
         # Now install INDRA with all its extras
         pip install .[all]
         # Run slow tests only if we're in the cron setting

--- a/indra/tests/test_uniprot_client.py
+++ b/indra/tests/test_uniprot_client.py
@@ -92,7 +92,7 @@ def test_get_gene_name_no_gene_name():
 
 def test_get_gene_name_multiple_gene_names():
     gene_name = uniprot_client.get_gene_name('Q5VWM5')
-    assert gene_name == 'PRAMEF9'
+    assert gene_name == 'PRAMEF15'
 
 
 def test_is_human():

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ def main():
     extras_require = {
                       # Inputs and outputs
                       'trips_offline': ['pykqml'],
-                      'reach_offline': ['cython', 'pyjnius==1.1.4'],
-                      'eidos_offline': ['cython', 'pyjnius==1.1.4'],
+                      'reach_offline': ['cython<3', 'pyjnius==1.1.4'],
+                      'eidos_offline': ['cython<3', 'pyjnius==1.1.4'],
                       'hypothesis': ['gilda>=0.10.2'],
                       'geneways': ['stemming', 'nltk<3.6'],
                       'bel': ['pybel>=0.15.0,<0.16.0'],

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def main():
                     'requests>=2.11', 'lxml', 'ipython', 'future',
                     'networkx>=2,<3', 'pandas<2', 'ndex2==2.0.1', 'jinja2',
                     'markupsafe<2.1.0',
-                    'protmapper>=0.0.27', 'obonet',
+                    'protmapper>=0.0.28', 'obonet',
                     'tqdm', 'pybiopax>=0.0.5']
 
     extras_require = {


### PR DESCRIPTION
This PR updates to the latest protmapper version (which uses the new UniProt API) and also makes other necessary changes: limit the cython version to < 3 which seems to be necessary to make jnius compilation work, and update a UniProt test where the content changed over time.