### PR TITLE
Implement retrieving more than 10k PMIDs and all metadata

### DIFF
--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -67,6 +67,10 @@ def get_ids(search_term, **kwargs):
     that can be changed via the corresponding keyword argument. Note also
     the retstart argument along with retmax to page across batches of IDs.
 
+    PubMed's REST API makes it difficult to retrieve more than 10k
+    PMIDs systematically. See the `get_all_ids` function in this module
+    for a way to retrieve more than 10k IDs using the PubMed edirect CLI.
+
     Parameters
     ----------
     search_term : str


### PR DESCRIPTION
This PR adds a simple wrapper around PubMed's edirect CLI (https://www.ncbi.nlm.nih.gov/books/NBK179288/) to retreive PMIDs such that we can easily get all PMIDs for queries that return more than 10k results (this turns out to be very convoluted to solve with the REST API even if not entirely impossible).

It also adds a wrapper around a function for getting metadata to allow for a single function call above the limit of 200 PMIDs per metadata request call.