### PR TITLE
Remove mesh cycle from bio-ontology

### DIFF
--- a/indra/ontology/bio/ontology.py
+++ b/indra/ontology/bio/ontology.py
@@ -26,7 +26,7 @@ class BioOntology(IndraOntology):
     # should be incremented to "force" rebuilding the ontology to be consistent
     # with the underlying resource files.
     name = 'bio'
-    version = '1.31'
+    version = '1.32'
     ontology_namespaces = [
         'go', 'efo', 'hp', 'doid', 'chebi', 'ido', 'mondo', 'eccode',
     ]

--- a/indra/ontology/bio/ontology.py
+++ b/indra/ontology/bio/ontology.py
@@ -12,6 +12,13 @@ from indra.statements.validate import assert_valid_db_refs
 logger = logging.getLogger(__name__)
 
 
+EDGES_BLACKLIST = [
+    # Skips a relation in the 2024 MeSH hierarchy containing
+    # MESH:D015835 -[isa]-> MESH:D013285 -[isa]-> MESH:D015835
+    ('MESH:D015835', 'MESH:D013285', 'isa')
+]
+
+
 class BioOntology(IndraOntology):
     """Represents the ontology used for biology applications."""
     # The version is used to determine if the cached pickle is still valid

--- a/indra/ontology/bio/ontology.py
+++ b/indra/ontology/bio/ontology.py
@@ -97,6 +97,9 @@ class BioOntology(IndraOntology):
         logger.info('Adding replacements...')
         self.add_uniprot_replacements()
         self.add_obo_replacements()
+        # Remove blacklisted edges
+        logger.info('Removing blacklisted edges...')
+        self.remove_edges(EDGES_BLACKLIST)
 
         # The graph is now initialized
         self._initialized = True
@@ -640,6 +643,21 @@ class BioOntology(IndraOntology):
             assert_valid_db_refs({db_ns: db_id})
         except Exception as e:
             logger.warning(e)
+
+    def remove_edges(self, edges_to_remove):
+        initial_edge_count = len(self.edges)
+        for source, target, e_type in edges_to_remove:
+            if (source, target) in self.edges:
+                # Check that the edge type matches
+                if self.edges[source, target]['type'] != e_type:
+                    continue
+
+                # Remove the edge
+                self.remove_edge(source, target)
+
+        final_edge_count = len(self.edges)
+        logger.info('Removed %d edges from the ontology' %
+                    (initial_edge_count - final_edge_count))
 
 
 def _get_uniprot_type(uc, uid):

--- a/indra/tools/analyze_ontology.py
+++ b/indra/tools/analyze_ontology.py
@@ -24,6 +24,7 @@ def print_cycle(cycle):
             )
         )
 
+
 if __name__ == '__main__':
     # First, find strongly connected components in the xref graph where
     # a given namespace appears more than once.
@@ -52,13 +53,15 @@ if __name__ == '__main__':
     for ns, problems_ns in problems_by_ns.items():
         print(ns, len(problems_ns))
 
-
     # Next, find cycles in the isa/partof subgraph meaning circular
     # hierarchical relationships.
     hierarchy = [(e[0], e[1]) for e in bio_ontology.edges(data=True) if
                  e[2]['type'] in {'isa', 'partof'}]
     hierarchyg = bio_ontology.edge_subgraph(hierarchy)
     cycles = networkx.simple_cycles(hierarchyg)
-    for cycle in cycles:
+    if cycles:
         print('---')
-        print_cycle(cycle)
+        print('Hierarchical cycles')
+        for cycle in cycles:
+            print('---')
+            print_cycle(cycle)


### PR DESCRIPTION
This PR adds functionality to remove edges from the bio ontology and does that for one edge in the MeSH 2024 data. The edge removed is `MESH:D015835 -[isa]-> MESH:D013285` which prevents a circular hierarchy structure since `MESH:D013285 -[isa]-> MESH:D015835` is already a relation. See https://meshb.nlm.nih.gov/record/ui?ui=D015835 under the MeSH Tree Structure tab then check the branch for `Nervous System Diseases [C10]` where the hierarchical path `MESH:D015835 -> MESH:D013285 -> MESH:D015835` is present, creating an `is_a/partof` cycle.

The bio ontology version is bumped to 1.32 with this PR.