### PR TITLE
Reimplement cBioPortal client for new API

### DIFF
--- a/indra/databases/cbio_client.py
+++ b/indra/databases/cbio_client.py
@@ -21,7 +21,7 @@ cbio_url = 'https://www.cbioportal.org/api'
 ccle_study = 'cellline_ccle_broad'
 
 # TODO: implement caching with json_data made immutable
-def send_request(method, endpoint, json_data):
+def send_request(method, endpoint, json_data=None):
     """Return the results of a web service request to cBio portal.
 
     Sends a web service request to the cBio portal with a specific endpoint,
@@ -113,6 +113,8 @@ def get_case_lists(study_id):
         A dict keyed to cases containing a dict keyed to genes
         containing int
     """
+    res = send_request('post', 'sample-lists/fetch',
+                       {'studyIds': [study_id]})
     data = {'cmd': 'getCaseLists',
             'cancer_study_id': study_id}
     df = send_request(**data)
@@ -236,8 +238,7 @@ def get_genetic_profiles(study_id, profile_filter=None):
     genetic_profiles : list[str]
         A list of genetic profiles available  for the given study.
     """
-    res = send_request('post', 'molecular-profiles/fetch',
-                       {'studyIds': [study_id]})
+    res = send_request('get', f'studies/{study_id}/molecular-profiles')
     if profile_filter:
         res = [prof for prof in res
                if (profile_filter.casefold()

--- a/indra/databases/cbio_client.py
+++ b/indra/databases/cbio_client.py
@@ -266,11 +266,11 @@ def get_cancer_studies(study_filter=None):
         of study IDs with paad in their name like "paad_icgc", "paad_tcga",
         etc.
     """
-    data = {'cmd': 'getCancerStudies'}
-    df = send_request(**data)
-    res = _filter_data_frame(df, ['cancer_study_id'],
-                             'cancer_study_id', study_filter)
-    study_ids = list(res['cancer_study_id'].values())
+    studies = send_request('get', 'studies')
+    if study_filter:
+        studies = [s for s in studies
+                   if study_filter.casefold() in s['studyId'].casefold()]
+    study_ids = [s['studyId'] for s in studies]
     return study_ids
 
 

--- a/indra/databases/cbio_client.py
+++ b/indra/databases/cbio_client.py
@@ -460,11 +460,6 @@ def get_ccle_mrna(gene_list, cell_lines=None):
     """
     profile_data = get_profile_data(ccle_study, gene_list,
                                     'MRNA_EXPRESSION', 'all')
-    # FIXME: we need a data structure like this
-    #         assert mrna['A375_SKIN'] is not None
-    #         assert mrna['A375_SKIN']['MAP2K1'] > 10
-    # >       assert mrna['A375_SKIN']['XYZ'] is None
-    # E       KeyError: 'XYZ'
     mrna_amounts = {cell_line: value
                     for cell_line, value in profile_data.items()
                     if cell_lines is None or cell_line in cell_lines}
@@ -475,4 +470,8 @@ def get_ccle_mrna(gene_list, cell_lines=None):
         for cell_line in cell_lines:
             if cell_line not in mrna_amounts:
                 mrna_amounts[cell_line] = None
+            else:
+                for gene in gene_list:
+                    if gene not in mrna_amounts[cell_line]:
+                        mrna_amounts[cell_line][gene] = None
     return mrna_amounts

--- a/indra/databases/cbio_client.py
+++ b/indra/databases/cbio_client.py
@@ -63,7 +63,6 @@ def send_request(method, endpoint, json_data=None):
     return res.json()
 
 
-@lru_cache(maxsize=1000)
 def get_mutations(study_id, gene_list=None, mutation_type=None,
                   case_id=None):
     """Return mutations as a list of genes and list of amino acid changes.
@@ -104,7 +103,7 @@ def get_mutations(study_id, gene_list=None, mutation_type=None,
                               'entrezGeneIds': entrez_ids})
 
     if case_id:
-        mutations = [m for m in mutations if m['case_id'] == case_id]
+        mutations = [m for m in mutations if m['sampleId'] == case_id]
 
     if mutation_type:
         mutations = [m for m in mutations if (mutation_type.casefold()
@@ -119,7 +118,6 @@ def get_mutations(study_id, gene_list=None, mutation_type=None,
     return mutations_dict
 
 
-@lru_cache(maxsize=1000)
 def get_entrez_mappings(gene_list):
     if gene_list:
         # First we need to get HGNC IDs from HGNC symbols
@@ -136,7 +134,6 @@ def get_entrez_mappings(gene_list):
     return entrez_to_gene_symbol
 
 
-@lru_cache(maxsize=1000)
 def get_case_lists(study_id):
     """Return a list of the case set ids for a particular study.
 
@@ -164,7 +161,6 @@ def get_case_lists(study_id):
     return [sl['sampleListId'] for sl in res]
 
 
-@lru_cache(maxsize=1000)
 def get_profile_data(study_id, gene_list,
                      profile_filter, case_set_filter=None):
     """Return dict of cases and genes and their respective values.
@@ -226,7 +222,6 @@ def get_profile_data(study_id, gene_list,
     return profile_data
 
 
-@lru_cache(maxsize=1000)
 def get_num_sequenced(study_id):
     """Return number of sequenced tumors for given study.
 
@@ -257,7 +252,6 @@ def get_num_sequenced(study_id):
     return num_case
 
 
-@lru_cache(maxsize=1000)
 def get_genetic_profiles(study_id, profile_filter=None):
     """Return all the genetic profiles (data sets) for a given study.
 
@@ -298,7 +292,6 @@ def get_genetic_profiles(study_id, profile_filter=None):
     return profile_ids
 
 
-@lru_cache(maxsize=1000)
 def get_cancer_studies(study_filter=None):
     """Return a list of cancer study identifiers, optionally filtered.
 
@@ -326,7 +319,6 @@ def get_cancer_studies(study_filter=None):
     return study_ids
 
 
-@lru_cache(maxsize=1000)
 def get_cancer_types(cancer_filter=None):
     """Return a list of cancer types, optionally filtered.
 
@@ -352,7 +344,6 @@ def get_cancer_types(cancer_filter=None):
     return type_ids
 
 
-@lru_cache(maxsize=1000)
 def get_ccle_mutations(gene_list, cell_lines, mutation_type=None):
     """Return a dict of mutations in given genes and cell lines from CCLE.
 
@@ -391,7 +382,6 @@ def get_ccle_mutations(gene_list, cell_lines, mutation_type=None):
     return mutations
 
 
-@lru_cache(maxsize=1000)
 def get_ccle_lines_for_mutation(gene, amino_acid_change):
     """Return cell lines with a given point mutation in a given gene.
 
@@ -418,7 +408,6 @@ def get_ccle_lines_for_mutation(gene, amino_acid_change):
     return sorted(cell_lines)
 
 
-@lru_cache(maxsize=1000)
 def get_ccle_cna(gene_list, cell_lines=None):
     """Return a dict of CNAs in given genes and cell lines from CCLE.
 
@@ -453,7 +442,6 @@ def get_ccle_cna(gene_list, cell_lines=None):
             if cell_lines is None or cell_line in cell_lines}
 
 
-@lru_cache(maxsize=1000)
 def get_ccle_mrna(gene_list, cell_lines=None):
     """Return a dict of mRNA amounts in given genes and cell lines from CCLE.
 
@@ -472,6 +460,11 @@ def get_ccle_mrna(gene_list, cell_lines=None):
     """
     profile_data = get_profile_data(ccle_study, gene_list,
                                     'MRNA_EXPRESSION', 'all')
+    # FIXME: we need a data structure like this
+    #         assert mrna['A375_SKIN'] is not None
+    #         assert mrna['A375_SKIN']['MAP2K1'] > 10
+    # >       assert mrna['A375_SKIN']['XYZ'] is None
+    # E       KeyError: 'XYZ'
     mrna_amounts = {cell_line: value
                     for cell_line, value in profile_data.items()
                     if cell_lines is None or cell_line in cell_lines}

--- a/indra/tests/test_cbio_client.py
+++ b/indra/tests/test_cbio_client.py
@@ -94,7 +94,7 @@ def test_get_ccle_mrna():
 def test_get_ccle_cna_big():
     """
     Get the CNA data on 124 genes in 4 cell lines. Expect to have CNA values
-    that are [None, -2.0, -1.0, 0.0, 1.0, 2.0] . This tests the function at
+    that are {-2.0, -1.0, 0.0, 1.0, 2.0}. This tests the function at
     a greater scale. Also, test the cell lines' BRAF CNAs
     """
     genes = ["FOSL1", "GRB2", "RPS6KA3", "EIF4EBP1", "DUSP1", "PLXNB1", "SHC2",
@@ -117,13 +117,11 @@ def test_get_ccle_cna_big():
              "PAK1", "RHEB"]
     cell_lines = ['COLO679_SKIN', 'A2058_SKIN', 'IGR39_SKIN', 'HS294T_SKIN']
     cna = cbio_client.get_ccle_cna(genes, cell_lines)
-    values = []
+    values = set()
     for cl in cna:
         for g in cna[cl]:
-            val = cna[cl][g]
-            values.append(val)
-    values = list(set(values))
-    assert len(values) == 6
+            values.add(cna[cl][g])
+    assert values == {-2.0, -1.0, 0.0, 1.0, 2.0}
     assert cna['COLO679_SKIN']['BRAF'] == 2
     assert cna['A2058_SKIN']['BRAF'] == 1
     assert cna['IGR39_SKIN']['BRAF'] == 1

--- a/indra/tests/test_cbio_client.py
+++ b/indra/tests/test_cbio_client.py
@@ -31,18 +31,6 @@ def test_get_num_sequenced():
 
 
 @pytest.mark.webservice
-def test_send_request_ccle():
-    """Sends a request and gets back a dataframe of all cases in ccle study.
-
-    Check that the dataframe is longer than one.
-    """
-    data = {'cmd': 'getCaseLists',
-            'cancer_study_id': 'cellline_ccle_broad'}
-    df = cbio_client.send_request(**data)
-    assert len(df) > 0
-
-
-@pytest.mark.webservice
 def test_get_ccle_lines_for_mutation():
     """Check how many lines have BRAF V600E mutations.
 


### PR DESCRIPTION
The cBioPortal has recently revamped its API and the original API for which a client was implemented in `indra.databases.cbio_client` was taken down. The new APi is completely different in terms of its endpoints, much of the nomenclature, and the data structures it returns, requiring effectively a new implementation of most functions. However, the PR aims to preserve the behavior of each client function for compatibility with various integrations.