### PR TITLE
Remove lib2to3 logging patch

### DIFF
--- a/indra/__init__.py
+++ b/indra/__init__.py
@@ -18,14 +18,6 @@ logging.getLogger('rdflib').setLevel(logging.ERROR)
 logging.getLogger('boto3').setLevel(logging.CRITICAL)
 logging.getLogger('botocore').setLevel(logging.CRITICAL)
 
-# This is specifically to suppress lib2to3 logging from networkx
-import lib2to3.pgen2.driver
-class Lib2to3LoggingModuleShim(object):
-    def getLogger(self):
-        return logging.getLogger('lib2to3')
-lib2to3.pgen2.driver.logging = Lib2to3LoggingModuleShim()  # type: ignore
-logging.getLogger('lib2to3').setLevel(logging.ERROR)
-
 logger = logging.getLogger('indra')
 
 from .config import get_config, has_config


### PR DESCRIPTION
This PR removes a logging configuration that was necessary to suppress verbose logging from lib2to3, at the time, a dependency of networkx, see old discussion at https://github.com/sorgerlab/indra/issues/188. In any case, this doesn't seem to be an issue anymore so the code can be removed.