### PR TITLE
Remove pandas version restriction

### DIFF
--- a/indra/tests/test_belief_sklearn.py
+++ b/indra/tests/test_belief_sklearn.py
@@ -1,6 +1,7 @@
 import random
 import pickle
 import numpy as np
+import pandas as pd
 from copy import copy
 from os.path import join, abspath, dirname
 from collections import defaultdict, Counter
@@ -37,8 +38,7 @@ with open(test_stmt_cur_path, 'rb') as f:
     test_stmts_cur, y_arr_stmts_cur = pickle.load(f)
 
 
-with open(test_df_path, 'rb') as f:
-    test_df, y_arr_df = pickle.load(f)
+test_df, y_arr_df = pd.read_pickle(test_df_path)
 
 
 # A set of statements derived from Signor used for testing purposes.

--- a/indra/tests/test_docs_code.py
+++ b/indra/tests/test_docs_code.py
@@ -16,13 +16,11 @@ def _get_gene_network_stmts():
     return gn.get_statements()
 
 
-gn_stmts = _get_gene_network_stmts()
-
 # CODE IN README.md #
 
 # From stmt assembly pipeline description in README.md
 def test_readme_pipeline():
-    stmts = gn_stmts  # Added only here, not in docs
+    stmts = _get_gene_network_stmts()  # Added only here, not in docs
     from indra.tools import assemble_corpus as ac
     stmts = ac.filter_no_hypothesis(stmts)
     stmts = ac.map_grounding(stmts)
@@ -180,7 +178,7 @@ def test_gene_network():
     # Chunk 6
     from indra.tools import assemble_corpus as ac
     # stmts = biopax_stmts + bel_stmts + literature_stmts  # tested elsewhere
-    stmts = gn_stmts + literature_stmts  # Added instead of above line
+    stmts = _get_gene_network_stmts() + literature_stmts  # Added instead of above line
     stmts = ac.map_grounding(stmts)
     stmts = ac.map_sequence(stmts)
     stmts = ac.run_preassembly(stmts)
@@ -263,7 +261,7 @@ def test_getting_started6():
 @pytest.mark.nogha
 def test_getting_started7_8():
     # Chunk 7
-    stmts = gn_stmts  # Added only in this test, not in docs
+    stmts = _get_gene_network_stmts()  # Added only in this test, not in docs
     from indra.assemblers.pysb import PysbAssembler
     pa = PysbAssembler()
     pa.add_statements(stmts)
@@ -281,7 +279,7 @@ def test_getting_started9_10():
 
     # Chunk 10
     from indra.assemblers.indranet import IndraNetAssembler
-    indranet_assembler = IndraNetAssembler(statements=gn_stmts)
+    indranet_assembler = IndraNetAssembler(statements=_get_gene_network_stmts())
     indranet = indranet_assembler.make_model(method='df')
     assert len(indranet.nodes) > 0, 'indranet contains no nodes'
     assert len(indranet.edges) > 0, 'indranet contains no edges'

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(readme_path, 'r', encoding='utf-8') as fh:
 def main():
     install_list = ['pysb>=1.3.0', 'objectpath',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
-                    'networkx>=2,<3', 'pandas<2', 'ndex2==2.0.1', 'jinja2',
+                    'networkx>=2,<3', 'pandas', 'ndex2==2.0.1', 'jinja2',
                     'protmapper>=0.0.29', 'obonet',
                     'tqdm', 'pybiopax>=0.0.5']
 


### PR DESCRIPTION
This PR removes a version constraint on pandas. Based on the tests, the only change necessary was to loading a pickle file containing a data frame used only in testing. It doesn't immediately appear like any other issues are caused by upgrading to a newer version.