### PR TITLE
Extend to Python 3.12 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.8", "3.12"]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
         #export NOSE_IGNORE_FILES="find_full_text_sentence.py";
         #- cd $TRAVIS_BUILD_DIR
         # Now run all INDRA tests
-        pytest -v -m "$PYTESTMARKS" --ignore-glob='*tees*' --ignore-glob='*isi*' --ignore-glob='*test_reach*' --cov=indra --cov-report=term-missing --doctest-modules --durations=10 indra/tests
+        pytest -v -m "$PYTESTMARKS" --ignore-glob='*tees*' --ignore-glob='*isi*' --ignore-glob='*test_reach*' --cov=indra --cov-report=term-missing --doctest-modules --durations=10 --continue-on-collection-errors indra/tests
         pytest -v -m "$PYTESTMARKS" indra/tests/test_reach.py
         # TEES tests
         #- python -m nose_notify indra/tests/test_tees.py --slack_hook $SLACK_NOTIFY_HOOK

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,8 @@ def main():
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
+            'Programming Language :: Python :: 3.12',
             'Topic :: Scientific/Engineering :: Bio-Informatics',
             'Topic :: Scientific/Engineering :: Chemistry',
             'Topic :: Scientific/Engineering :: Mathematics',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,12 @@ def main():
                               'markupsafe<2.1.0'],
                       'sklearn_belief': ['scikit-learn'],
                       'owl': ['pronto'],
-                      'tests': ['pytest', 'pytest-cov'],
+                      'tests':
+                        ['pytest',
+                         'pytest-cov',
+                         'pynose'  # This is needed for PySB with_model in
+                                   # some tests
+                        ],
                       }
     extras_require['all'] = list({dep for deps in extras_require.values()
                                   for dep in deps})


### PR DESCRIPTION
This PR extends testing to Python 3.12. This required publishing some new kappy wheels on PyPI and adding a test requirement for PySB. Otherwise things seem to be working other than some unrelates test failures due to ACSN.