### PR TITLE
Networkx 3 compatibility 

### DIFF
--- a/indra/assemblers/pysb/kappa_util.py
+++ b/indra/assemblers/pysb/kappa_util.py
@@ -109,13 +109,16 @@ def cm_json_to_networkx(cm_json):
     return graph
 
 
-def get_cm_cycles(cm_graph):
+def get_cm_cycles(cm_graph, root_node=None):
     """Return cycles from a model's Kappa contact map graph representation.
 
     Parameters
     ----------
     cm_graph : networkx.Graph
         A networkx graph produced by cm_json_to_networkx.
+    root_node : Optional[str]
+        The root node of the graph. If None, the root node will be determined
+        by networkx.cycle_basis.
 
     Returns
     -------
@@ -123,7 +126,7 @@ def get_cm_cycles(cm_graph):
         A list of base cycles found in the contact map graph. Each cycle
         is represented as a list of strings of the form Monomer(site).
     """
-    cycles = cycle_basis(cm_graph)
+    cycles = cycle_basis(cm_graph, root_node)
     processed_cycles = []
     for cycle in cycles:
         processed_cycle = []

--- a/indra/pipeline/pipeline.py
+++ b/indra/pipeline/pipeline.py
@@ -320,7 +320,7 @@ class AssemblyPipeline():
             new_kwargs['statements'] = statements
         if kwargs:
             for k, v in kwargs.items():
-                if k not in new_kwargs and k in inspect.getargspec(func).args:
+                if k not in new_kwargs and k in inspect.getfullargspec(func).args:
                     new_kwargs[k] = v
         return self.run_simple_function(func, *new_args, **new_kwargs)
 

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -1272,7 +1272,9 @@ def test_contact_map_cycles_1():
     assert len(graph.nodes()) == 9, len(graph.nodes)
     assert len(graph.edges()) == 9, len(graph.edges)
 
-    cycles = get_cm_cycles(graph)
+    # Specify the root node to be 0 - corresponding to Agent 'a' - to
+    # ensure that the order of the output cycles is predictable
+    cycles = get_cm_cycles(graph, root_node=0)
     assert len(cycles) == 1, cycles
     assert cycles[0] == ['a(b)', 'b(a)', 'b(c)', 'c(b)', 'c(a)', 'a(c)']
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,9 @@ def main():
                       'api': ['flask<2.0', 'flask_restx<0.4', 'flask_cors',
                               'docstring-parser', 'gunicorn',
                               'markupsafe<2.1.0'],
-                      'sklearn_belief': ['scikit-learn'],
+                      # scikit-learn 1.5.0 breaks DisambManager.run_adeft_disambiguation
+                      # see: https://github.com/gyorilab/adeft/issues/80
+                      'sklearn_belief': ['scikit-learn<1.5.0'],
                       'owl': ['pronto'],
                       'tests':
                         ['pytest',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(readme_path, 'r', encoding='utf-8') as fh:
 def main():
     install_list = ['pysb>=1.3.0', 'objectpath',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
-                    'networkx>=2,<3', 'pandas', 'ndex2==2.0.1', 'jinja2',
+                    'networkx', 'pandas', 'ndex2==2.0.1', 'jinja2',
                     'protmapper>=0.0.29', 'obonet',
                     'tqdm', 'pybiopax>=0.0.5']
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(readme_path, 'r', encoding='utf-8') as fh:
 def main():
     install_list = ['pysb>=1.3.0', 'objectpath',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
-                    'networkx', 'pandas', 'ndex2==2.0.1', 'jinja2',
+                    'networkx>=3', 'pandas>=2', 'ndex2==2.0.1', 'jinja2',
                     'protmapper>=0.0.29', 'obonet',
                     'tqdm', 'pybiopax>=0.0.5']
 


### PR DESCRIPTION
I've done with a deeper investigation of upgrading to networkx3. For the downstream repositories listed below I checked any usage of networkx and cross checked any function calls with the [full repository diff between 2.0.0 and 3.3](https://github.com/networkx/networkx/compare/networkx-2.0...networkx-3.3) to see if any update might be needed, tested the code in some cases where it wasn't clear if the update would disrupt its implementation and ran the tests for the repository with networkx 3.3 installed.

Investigated repositories:

- trialsynth
- indra_network_search
- indra_world
- indra_reading
- protmapper
- emmaa
- indra_db
- indra_cogex

No issues related to removing the networkx<3 constraint were found in the investigation.

Resolves #1442 and #1445.