### PR TITLE
Update Flask, Flask Restx, unpin Gilda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,7 @@ def main():
                       'plot': ['matplotlib'],
                       'isi': ['nltk<3.6', 'unidecode'],
                       'api': ['flask>=3.0,4.0', 'flask_restx<0.4', 'flask_cors',
-                              'docstring-parser', 'gunicorn',
-                              'markupsafe<2.1.0'],
+                              'docstring-parser', 'gunicorn'],
                       # scikit-learn 1.5.0 breaks DisambManager.run_adeft_disambiguation
                       # see: https://github.com/gyorilab/adeft/issues/80
                       'sklearn_belief': ['scikit-learn<1.5.0'],

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,11 @@ def main():
                       'graph': ['pygraphviz'],
                       'plot': ['matplotlib'],
                       'isi': ['nltk<3.6', 'unidecode'],
-                      'api': ['flask>=3.0,<4.0', 'flask_restx<0.4', 'flask_cors',
-                              'docstring-parser', 'gunicorn'],
+                      'api': ['flask>=3.0,<4.0',
+                              'flask_restx>=1.3.0',
+                              'flask_cors',
+                              'docstring-parser',
+                              'gunicorn'],
                       # scikit-learn 1.5.0 breaks DisambManager.run_adeft_disambiguation
                       # see: https://github.com/gyorilab/adeft/issues/80
                       'sklearn_belief': ['scikit-learn<1.5.0'],

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ def main():
     extras_require = {
                       # Inputs and outputs
                       'trips_offline': ['pykqml'],
-                      'reach_offline': ['cython<3', 'pyjnius==1.1.4'],
-                      'eidos_offline': ['cython<3', 'pyjnius==1.1.4'],
+                      'reach_offline': ['cython', 'pyjnius'],
+                      'eidos_offline': ['cython', 'pyjnius'],
                       'hypothesis': ['gilda>1.0.0'],
                       'geneways': ['stemming', 'nltk<3.6'],
                       'bel': ['pybel>=0.15.0,<0.16.0'],

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def main():
                       'graph': ['pygraphviz'],
                       'plot': ['matplotlib'],
                       'isi': ['nltk<3.6', 'unidecode'],
-                      'api': ['flask<2.0', 'flask_restx<0.4', 'flask_cors',
+                      'api': ['flask>=3.0,4.0', 'flask_restx<0.4', 'flask_cors',
                               'docstring-parser', 'gunicorn',
                               'markupsafe<2.1.0'],
                       # scikit-learn 1.5.0 breaks DisambManager.run_adeft_disambiguation

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def main():
                       'trips_offline': ['pykqml'],
                       'reach_offline': ['cython<3', 'pyjnius==1.1.4'],
                       'eidos_offline': ['cython<3', 'pyjnius==1.1.4'],
-                      'hypothesis': ['gilda>=0.10.2'],
+                      'hypothesis': ['gilda>1.0.0'],
                       'geneways': ['stemming', 'nltk<3.6'],
                       'bel': ['pybel>=0.15.0,<0.16.0'],
                       'sbml': ['python-libsbml'],
@@ -28,7 +28,7 @@ def main():
                       'machine': ['pytz', 'tzlocal', 'tweepy', 'pyyaml>=5.1.0',
                                   'click'],
                       'explanation': ['kappy==4.1.2', 'paths-graph'],
-                      'grounding': ['adeft', 'gilda>=0.10.2'],
+                      'grounding': ['adeft', 'gilda>1.0.0'],
                       # AWS interface and database
                       'aws': ['boto3', 'reportlab'],
                       # Utilities

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def main():
                       'graph': ['pygraphviz'],
                       'plot': ['matplotlib'],
                       'isi': ['nltk<3.6', 'unidecode'],
-                      'api': ['flask>=3.0,4.0', 'flask_restx<0.4', 'flask_cors',
+                      'api': ['flask>=3.0,<4.0', 'flask_restx<0.4', 'flask_cors',
                               'docstring-parser', 'gunicorn'],
                       # scikit-learn 1.5.0 breaks DisambManager.run_adeft_disambiguation
                       # see: https://github.com/gyorilab/adeft/issues/80

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ def main():
     extras_require = {
                       # Inputs and outputs
                       'trips_offline': ['pykqml'],
-                      'reach_offline': ['cython', 'pyjnius'],
-                      'eidos_offline': ['cython', 'pyjnius'],
+                      'reach_offline': ['cython<3', 'pyjnius==1.1.4'],
+                      'eidos_offline': ['cython<3', 'pyjnius==1.1.4'],
                       'hypothesis': ['gilda>1.0.0'],
                       'geneways': ['stemming', 'nltk<3.6'],
                       'bel': ['pybel>=0.15.0,<0.16.0'],


### PR DESCRIPTION
This PR updates the extras requirements in setup.py to resolve #1448. 

Resolves #1448.

**Todo**

- [x] ~Revisit the cython and pyjnius upgrade: It was necessary to get Python 3.10 working in https://github.com/gyorilab/indra_cogex/pull/172, but since downgrading to python 3.8 (via use of ubuntu 20 as base image) this might not be necessary any longer. Leaving the cython and pyjnius versions untouched would be the more conservative approach (_don't fix what ain't broken..._)~ _Fixed in https://github.com/sorgerlab/indra/pull/1452/commits/90eba2c756704355a1408fb50a6141e975ebdcf7_

_Update 7/8 2024_
Code is tested with https://github.com/gyorilab/indra_cogex/pull/172 and https://github.com/gyorilab/ui_util/pull/20, but not yet with https://github.com/gyorilab/emmaa/pull/280 or a new deployment of db.indra.bio on lambda+api gateway.

_Update 7/11 2024_
Code has been tested and is used in production for EMMAA using Python 3.9.

_Update 7/18 2024_
Code has been tested and is used in the dev deployment for INDRA DB.