### PR TITLE
Extend MeSH-PubMed and NCBI Taxonomy connection

### DIFF
--- a/indra/databases/mesh_client.py
+++ b/indra/databases/mesh_client.py
@@ -22,6 +22,8 @@ mesh_name_to_id = {}
 mesh_name_to_id_name = {}
 mesh_id_to_tree_numbers = {}
 mesh_supp_to_primary = {}
+mesh_to_ncbitaxon = {}
+ncbitaxon_to_mesh = {}
 
 
 def _load_mesh_file(path, supplementary):
@@ -31,7 +33,15 @@ def _load_mesh_file(path, supplementary):
             mesh_id, mesh_label, mesh_terms_str, mapped_to_str = terms
             mesh_supp_to_primary[mesh_id] = mapped_to_str.split(',')
         else:
-            mesh_id, mesh_label, mesh_terms_str, tree_number_str = terms
+            mesh_id, mesh_label, mesh_terms_str, \
+                tree_number_str, taxon_ids = terms
+            if taxon_ids:
+                taxon_ids = taxon_ids.split('|')
+                for taxon_id in taxon_ids:
+                    # Note that these seem to be one-to-one so
+                    # we don't need to worry about overwriting
+                    ncbitaxon_to_mesh[taxon_id] = mesh_id
+                mesh_to_ncbitaxon[mesh_id] = taxon_ids
             # This is a rare corner case where an entry is outside the
             # tree structure, e.g., D005260, D008297
             if not tree_number_str:

--- a/indra/resources/update_resources.py
+++ b/indra/resources/update_resources.py
@@ -631,11 +631,16 @@ def update_mesh_names():
     for record in et.iterfind('DescriptorRecord'):
         # We first get the ID and the name
         uid = record.find('DescriptorUI').text
+        txid_tags = record.findall('ConceptList/Concept/RelatedRegistry'
+                                   'NumberList/RelatedRegistryNumber')
+        txids = [txid.text[4:] for txid in txid_tags
+                 if txid.text.startswith('txid')]
+        txids_str = '|'.join(txids)
         name = record.find('DescriptorName/String').text
         term_name_str = _get_term_name_str(record, name)
         tree_numbers = record.findall('TreeNumberList/TreeNumber')
         tree_numbers_str = '|'.join([t.text for t in tree_numbers])
-        rows.append((uid, name, term_name_str, tree_numbers_str))
+        rows.append((uid, name, term_name_str, tree_numbers_str, txids_str))
 
     fname = os.path.join(path, 'mesh_id_label_mappings.tsv')
     write_unicode_csv(fname, sorted(rows), delimiter='\t')

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -47,8 +47,8 @@ def test_get_id_mesh():
 @pytest.mark.webservice
 def test_get_id_mesh_supc():
     time.sleep(0.5)
-    ids = pubmed_client.get_ids_for_mesh('D000086382')
-    assert len(ids) > 100, len(ids)
+    ids = pubmed_client.get_ids_for_mesh('C000111')
+    assert len(ids) > 8, len(ids)
 
 
 @pytest.mark.webservice


### PR DESCRIPTION
This PR adds better search functions by MeSH terms in the PubMed client. It also extends the MeSH resource file to include NCBI taxonomy mappings and makes these available via the MeSH client.