### PR TITLE
Correct the block in footer

### DIFF
--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -648,7 +648,7 @@ class HtmlAssembler(object):
 
         Parameters
         ----------
-        fname : str
+        fname : str | Path
             The path to the file to save the HTML into.
         """
         if self.model is None:

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -280,7 +280,7 @@
       title="Belief score for this statement">{{ belief_score }}</small>
 {%- endmacro %}
 
-{% block header_desc %}
+{% block footer_desc %}
   This page allows you to curate the loaded statements. For more information
   please see the
   <a href="https://indra.readthedocs.io/en/latest/tutorials/html_curation.html"

--- a/indra/assemblers/html/templates/indra/template.html
+++ b/indra/assemblers/html/templates/indra/template.html
@@ -71,7 +71,7 @@
             text-align: left;
             padding: 0.5em;
             box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
-            height: 110px;
+            height: 65;
         }
 
         .footer h4, .footer p, .footer a {
@@ -157,7 +157,7 @@
         {% if not simple %}
         .content {
           padding-top:85px;
-          padding-bottom: 110px
+          padding-bottom: 65px
         }
 
         @media (max-width: 1800px) {
@@ -254,6 +254,8 @@
   <div class="side-info-block">
     <div id="about-this-project">
       {% block header_desc %}
+      {% endblock %}
+      {% block additional_footer %}
       {% endblock %}
     </div>
   </div>

--- a/indra/assemblers/html/templates/indra/template.html
+++ b/indra/assemblers/html/templates/indra/template.html
@@ -253,9 +253,7 @@
 
   <div class="side-info-block">
     <div id="about-this-project">
-      {% block header_desc %}
-      {% endblock %}
-      {% block additional_footer %}
+      {% block footer_desc %}
       {% endblock %}
     </div>
   </div>

--- a/indra/tests/test_html_assembler.py
+++ b/indra/tests/test_html_assembler.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 
 from indra.assemblers.english import AgentWithCoordinates
 from indra.assemblers.html.assembler import HtmlAssembler, tag_text, loader, \
@@ -9,6 +10,8 @@ from indra.resources import load_resource_json
 from indra.statements import *
 from indra.util.statement_presentation import AveAggregator, StmtStat, \
     internal_source_mappings
+
+HERE = Path(__file__).parent
 
 
 def make_stmt():
@@ -92,12 +95,12 @@ def test_colors_in_html():
 
     stmt = Activation(ag_a, ag_b, evidence=evidences)
     ha = HtmlAssembler(statements=[stmt])
-    ha.save_model('./temp_simple.html')
+    ha.save_model(HERE / 'temp_simple.html')
     ha = HtmlAssembler(statements=[stmt])
-    ha.save_model('./temp_not_simple.html', simple=False)
-    with open('./temp_simple.html') as fh:
+    ha.save_model(HERE / 'temp_not_simple.html', simple=False)
+    with open(HERE / 'temp_simple.html') as fh:
         simple_html = fh.read()
-    with open('./temp_not_simple.html') as fh:
+    with open(HERE / 'temp_not_simple.html') as fh:
         not_simple_html = fh.read()
     assert all(color in simple_html for color in colors)
     assert all(color in not_simple_html for color in colors)
@@ -140,13 +143,13 @@ def test_custom_colors_in_html():
 
     stmt = Activation(ag_a, ag_b, evidence=evidences)
     ha = HtmlAssembler(statements=[stmt], custom_sources=custom_sources)
-    ha.save_model('./temp_custom_colors_simple.html')
-    with open('./temp_custom_colors_simple.html') as fh:
+    ha.save_model(HERE / 'temp_custom_colors_simple.html')
+    with open(HERE / 'temp_custom_colors_simple.html') as fh:
         simple_html = fh.read()
 
     ha = HtmlAssembler(statements=[stmt], custom_sources=custom_sources)
-    ha.save_model('./temp_not_simple.html', simple=False)
-    with open('./temp_custom_colors_simple.html') as fh:
+    ha.save_model(HERE / 'temp_not_simple.html', simple=False)
+    with open(HERE / 'temp_custom_colors_simple.html') as fh:
         not_simple_html = fh.read()
 
     # Check if style rule appears
@@ -175,19 +178,19 @@ def test_skip_sources_not_in_evidences():
                 not_in_html.append(source)
     stmt = Activation(ag_a, ag_b, evidence=evidences)
     ha = HtmlAssembler(statements=[stmt])
-    ha.save_model('./temp_simple.html')
-    with open('./temp_simple.html') as fh:
+    ha.save_model(HERE / 'temp_simple.html')
+    with open(HERE / 'temp_simple.html') as fh:
         simple_html = fh.read()
 
     ha = HtmlAssembler(statements=[stmt])
-    ha.save_model('./temp_not_simple.html', simple=False)
-    with open('./temp_not_simple.html') as fh:
+    ha.save_model(HERE / 'temp_not_simple.html', simple=False)
+    with open(HERE / 'temp_not_simple.html') as fh:
         not_simple_no_show_html = fh.read()
 
     ha = HtmlAssembler(statements=[stmt])
-    ha.save_model('./temp_not_simple_no_show.html',
+    ha.save_model(HERE / 'temp_not_simple_no_show.html',
                   show_only_available=True)
-    with open('./temp_not_simple_no_show.html') as fh:
+    with open(HERE / 'temp_not_simple_no_show.html') as fh:
         not_simple_html = fh.read()
     assert all(color in simple_html for color in colors)
     assert all(color in not_simple_html for color in colors)
@@ -215,9 +218,9 @@ def test_readers_only():
                 not_in_html.append(source)
     stmt = Activation(ag_a, ag_b, evidence=evidences)
     ha = HtmlAssembler(statements=[stmt])
-    ha.save_model('./temp_no_show_rd_only.html',
+    ha.save_model(HERE / 'temp_no_show_rd_only.html',
                   show_only_available=True)
-    with open('./temp_no_show_rd_only.html') as fh:
+    with open(HERE / 'temp_no_show_rd_only.html') as fh:
         no_show_html = fh.read()
     assert all(color in no_show_html for color in colors)
 
@@ -244,9 +247,9 @@ def test_databases_only():
                 not_in_html.append(source)
     stmt = Activation(ag_a, ag_b, evidence=evidences)
     ha = HtmlAssembler(statements=[stmt])
-    ha.save_model('./temp_no_show_db_only.html',
+    ha.save_model(HERE / 'temp_no_show_db_only.html',
                   show_only_available=True)
-    with open('./temp_no_show_db_only.html') as fh:
+    with open(HERE / 'temp_no_show_db_only.html') as fh:
         no_show_html = fh.read()
     assert all(color in no_show_html for color in colors)
 
@@ -336,8 +339,8 @@ def test_source_info_to_source_colors():
 def test_generate_source_css():
     source_info = source_json()
     src_col = _source_info_to_source_colors(source_info)
-    generate_source_css(fname='./temp.css', source_colors=src_col)
-    with open('./temp.css') as fh:
+    generate_source_css(fname=HERE / 'temp.css', source_colors=src_col)
+    with open(HERE / 'temp.css') as fh:
         css_str = fh.read()
 
     rule_string = '.source-{src} {{\n    background-color: {src_bg};\n    ' \
@@ -653,7 +656,7 @@ def test_sort_default():
 
     # Check to make sure the HTML assembler runs.
     model = ha.make_model()
-    with open('test_agent_pair.html', 'w') as f:
+    with open(HERE / 'test_agent_pair.html', 'w') as f:
         f.write(model)
 
 
@@ -668,7 +671,7 @@ def test_sort_group_by_relation():
 
     # Make sure the HTML assembles.
     model = ha.make_model(grouping_level='relation')
-    with open('test_relation.html', 'w') as f:
+    with open(HERE / 'test_relation.html', 'w') as f:
         f.write(model)
 
 


### PR DESCRIPTION
The block used in the footer was referenced incorrectly. This PR fixed the issue by showing the text and rearranging the size of the footer.