### PR TITLE
Set an option to skip pubmed to save time

### DIFF
--- a/indra/preassembler/grounding_mapper/disambiguate.py
+++ b/indra/preassembler/grounding_mapper/disambiguate.py
@@ -45,7 +45,7 @@ class DisambManager(object):
             logger.debug('Could not connect to the DB: %s' % e)
             self.__tc = None
 
-    def run_adeft_disambiguation(self, stmt, agent, idx, agent_txt):
+    def run_adeft_disambiguation(self, stmt, agent, idx, agent_txt, **kwargs):
         """Run Adeft disambiguation on an Agent in a given Statement.
 
         This function looks at the evidence of the given Statement and attempts
@@ -93,7 +93,7 @@ class DisambManager(object):
                     {'adeft': [None for _ in stmt.agent_list()]}
         else:
             annots['agents'] = {'adeft': [None for _ in stmt.agent_list()]}
-        grounding_text = self._get_text_for_grounding(stmt, agent_txt)
+        grounding_text = self._get_text_for_grounding(stmt, agent_txt, **kwargs)
 
         def apply_grounding(agent, agent_txt, ns_and_id):
             db_ns, db_id = ns_and_id.split(':', maxsplit=1)
@@ -212,7 +212,7 @@ class DisambManager(object):
                 success = True
         return success
 
-    def _get_text_for_grounding(self, stmt, agent_text):
+    def _get_text_for_grounding(self, stmt, agent_text, **kwargs):
         """Get text context for Adeft disambiguation
 
         If the INDRA database is available, attempts to get the fulltext from
@@ -234,7 +234,7 @@ class DisambManager(object):
         text : str
             Text for Adeft disambiguation
         """
-        skip_pubmed = os.getenv("MAPPING_SKIP_PUBMED") is not None
+        use_pubmed = kwargs.get('use_pubmed', True)
         text = None
         # First we will try to get content from a local text content DB if
         # available since this is the fastest option
@@ -281,7 +281,7 @@ class DisambManager(object):
                 logger.info('Could not get text for disambiguation from DB: %s'
                             % e)
         # If that doesn't work, we try PubMed next trying to fetch an abstract
-        if text is None and not skip_pubmed:
+        if text is None and use_pubmed:
             from indra.literature import pubmed_client
             pmid = stmt.evidence[0].pmid
             if pmid:

--- a/indra/preassembler/grounding_mapper/disambiguate.py
+++ b/indra/preassembler/grounding_mapper/disambiguate.py
@@ -91,7 +91,8 @@ class DisambManager(object):
                     {'adeft': [None for _ in stmt.agent_list()]}
         else:
             annots['agents'] = {'adeft': [None for _ in stmt.agent_list()]}
-        grounding_text = self._get_text_for_grounding(stmt, agent_txt)
+        grounding_text = self._get_text_for_grounding(stmt, agent_txt,
+                                                      use_pubmed=True)
 
         def apply_grounding(agent, agent_txt, ns_and_id):
             db_ns, db_id = ns_and_id.split(':', maxsplit=1)
@@ -210,7 +211,7 @@ class DisambManager(object):
                 success = True
         return success
 
-    def _get_text_for_grounding(self, stmt, agent_text):
+    def _get_text_for_grounding(self, stmt, agent_text, use_pubmed=True):
         """Get text context for Adeft disambiguation
 
         If the INDRA database is available, attempts to get the fulltext from
@@ -226,6 +227,10 @@ class DisambManager(object):
 
         agent_text : str
            Agent text that needs to be disambiguated
+
+        use_pubmed : bool
+        If False, skip using PubMed client
+
 
         Returns
         -------
@@ -278,7 +283,7 @@ class DisambManager(object):
                 logger.info('Could not get text for disambiguation from DB: %s'
                             % e)
         # If that doesn't work, we try PubMed next trying to fetch an abstract
-        if text is None:
+        if text is None and use_pubmed:
             from indra.literature import pubmed_client
             pmid = stmt.evidence[0].pmid
             if pmid:

--- a/indra/preassembler/grounding_mapper/disambiguate.py
+++ b/indra/preassembler/grounding_mapper/disambiguate.py
@@ -93,8 +93,7 @@ class DisambManager(object):
                     {'adeft': [None for _ in stmt.agent_list()]}
         else:
             annots['agents'] = {'adeft': [None for _ in stmt.agent_list()]}
-        grounding_text = self._get_text_for_grounding(stmt, agent_txt,
-                                                      use_pubmed=False)
+        grounding_text = self._get_text_for_grounding(stmt, agent_txt)
 
         def apply_grounding(agent, agent_txt, ns_and_id):
             db_ns, db_id = ns_and_id.split(':', maxsplit=1)
@@ -227,8 +226,8 @@ class DisambManager(object):
         stmt : py:class:`indra.statements.Statement`
             Statement with agent we seek to disambiguate.
 
-        use_pubmed : bool
-        If False, skip using PubMed client
+        agent_text : str
+            Agent text that needs to be disambiguated
 
         Returns
         -------

--- a/indra/preassembler/grounding_mapper/disambiguate.py
+++ b/indra/preassembler/grounding_mapper/disambiguate.py
@@ -282,7 +282,7 @@ class DisambManager(object):
                 logger.info('Could not get text for disambiguation from DB: %s'
                             % e)
         # If that doesn't work, we try PubMed next trying to fetch an abstract
-        if text is None and skip_pubmed:
+        if text is None and not skip_pubmed:
             from indra.literature import pubmed_client
             pmid = stmt.evidence[0].pmid
             if pmid:

--- a/indra/preassembler/grounding_mapper/disambiguate.py
+++ b/indra/preassembler/grounding_mapper/disambiguate.py
@@ -1,4 +1,6 @@
 import logging
+import os
+
 from indra.config import get_config, has_config
 from indra.ontology.standardize \
     import standardize_agent_name
@@ -211,7 +213,7 @@ class DisambManager(object):
                 success = True
         return success
 
-    def _get_text_for_grounding(self, stmt, agent_text, use_pubmed=True):
+    def _get_text_for_grounding(self, stmt, agent_text):
         """Get text context for Adeft disambiguation
 
         If the INDRA database is available, attempts to get the fulltext from
@@ -225,18 +227,15 @@ class DisambManager(object):
         stmt : py:class:`indra.statements.Statement`
             Statement with agent we seek to disambiguate.
 
-        agent_text : str
-           Agent text that needs to be disambiguated
-
         use_pubmed : bool
         If False, skip using PubMed client
-
 
         Returns
         -------
         text : str
             Text for Adeft disambiguation
         """
+        skip_pubmed = os.getenv("MAPPING_SKIP_PUBMED") is not None
         text = None
         # First we will try to get content from a local text content DB if
         # available since this is the fastest option
@@ -283,7 +282,7 @@ class DisambManager(object):
                 logger.info('Could not get text for disambiguation from DB: %s'
                             % e)
         # If that doesn't work, we try PubMed next trying to fetch an abstract
-        if text is None and use_pubmed:
+        if text is None and skip_pubmed:
             from indra.literature import pubmed_client
             pmid = stmt.evidence[0].pmid
             if pmid:

--- a/indra/preassembler/grounding_mapper/disambiguate.py
+++ b/indra/preassembler/grounding_mapper/disambiguate.py
@@ -68,6 +68,10 @@ class DisambManager(object):
         idx : int
             The index of the new Agent's position in the Statement's agent list
             (needed to set annotations correctly).
+        **kwargs :
+            Optional keyword arguments passed to `disamb_manager._get_text_for_grounding()`.
+            - use_pubmed (bool): If False, Querying content used for agent grounding
+            using pubmed api will be skipped. If True, it will not get skipped.
 
         Returns
         -------
@@ -228,6 +232,10 @@ class DisambManager(object):
 
         agent_text : str
             Agent text that needs to be disambiguated
+
+        **kwargs :
+            - use_pubmed (bool): If False, Querying content used for agent grounding
+            using pubmed api will be skipped. If True, it will not get skipped.
 
         Returns
         -------

--- a/indra/preassembler/grounding_mapper/disambiguate.py
+++ b/indra/preassembler/grounding_mapper/disambiguate.py
@@ -92,7 +92,7 @@ class DisambManager(object):
         else:
             annots['agents'] = {'adeft': [None for _ in stmt.agent_list()]}
         grounding_text = self._get_text_for_grounding(stmt, agent_txt,
-                                                      use_pubmed=True)
+                                                      use_pubmed=False)
 
         def apply_grounding(agent, agent_txt, ns_and_id):
             db_ns, db_id = ns_and_id.split(':', maxsplit=1)

--- a/indra/preassembler/grounding_mapper/mapper.py
+++ b/indra/preassembler/grounding_mapper/mapper.py
@@ -85,7 +85,7 @@ class GroundingMapper(object):
                 raise ValueError('HGNC:%s for key %s in the grounding map is '
                                  'not a valid ID' % (refs['HGNC'], key))
 
-    def map_stmts(self, stmts, do_rename=True):
+    def map_stmts(self, stmts, do_rename=True, **kwargs):
         """Return a new list of statements whose agents have been mapped
 
         Parameters
@@ -111,7 +111,7 @@ class GroundingMapper(object):
         import tqdm
         it = tqdm.tqdm(stmts) if len(stmts) > 1e5 else stmts
         for stmt in it:
-            mapped_stmt = self.map_agents_for_stmt(stmt, do_rename)
+            mapped_stmt = self.map_agents_for_stmt(stmt, do_rename, **kwargs)
             # Check if we should skip the statement
             if mapped_stmt is not None:
                 mapped_stmts.append(mapped_stmt)
@@ -120,7 +120,7 @@ class GroundingMapper(object):
         logger.info('%s statements filtered out' % num_skipped)
         return mapped_stmts
 
-    def map_agents_for_stmt(self, stmt, do_rename=True):
+    def map_agents_for_stmt(self, stmt, do_rename=True, **kwargs):
         """Return a new Statement whose agents have been grounding mapped.
 
         Parameters
@@ -165,7 +165,7 @@ class GroundingMapper(object):
                                            key=lambda x: len(x))[-1]
                     adeft_success = self.disamb_manager.\
                         run_adeft_disambiguation(mapped_stmt, agent, idx,
-                                                 txt_for_adeft)
+                                                 txt_for_adeft, **kwargs)
                 except Exception as e:
                     logger.error('There was an error during Adeft'
                                  ' disambiguation of %s.' % str(agent_txts))

--- a/indra/preassembler/grounding_mapper/mapper.py
+++ b/indra/preassembler/grounding_mapper/mapper.py
@@ -97,6 +97,10 @@ class GroundingMapper(object):
             If do_rename is True the priority for setting the name is
             FamPlex ID, HGNC symbol, then the gene name
             from Uniprot. Default: True
+        **kwargs :
+            Optional keyword arguments passed to `GroundingMapper.map_agents_for_stmt()`.
+            - use_pubmed (bool): If False, Querying content used for agent grounding
+            using pubmed api will be skipped. If True, it will not get skipped.
 
         Returns
         -------
@@ -132,6 +136,10 @@ class GroundingMapper(object):
             If do_rename is True the priority for setting the name is
             FamPlex ID, HGNC symbol, then the gene name
             from Uniprot. Default: True
+        **kwargs :
+            Optional keyword arguments passed to `disamb_manager.run_adeft_disambiguation()`.
+            - use_pubmed (bool): If False, Querying content used for agent grounding
+            using pubmed api will be skipped. If True, it will not get skipped.
 
         Returns
         -------

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -125,6 +125,11 @@ def map_grounding(stmts_in, do_rename=True, grounding_map=None,
     grounding_map_policy : Optional[str]
         If a grounding map is provided, use the policy to extend or replace
         a default grounding map. Default: 'replace'.
+    **kwargs :
+        Optional keyword arguments passed to `GroundingMapper.map_stmts()`.
+        - use_pubmed (bool): If False, Querying content used for agent grounding
+        using pubmed api will be skipped. If True, it will not get skipped.
+
 
     Returns
     -------

--- a/indra/tools/assemble_corpus.py
+++ b/indra/tools/assemble_corpus.py
@@ -148,7 +148,7 @@ def map_grounding(stmts_in, do_rename=True, grounding_map=None,
     gm = GroundingMapper(gm, agent_map=agent_map,
                          misgrounding_map=misgm, ignores=ignores,
                          use_adeft=use_adeft, gilda_mode=gilda_mode)
-    stmts_out = gm.map_stmts(stmts_in, do_rename=do_rename)
+    stmts_out = gm.map_stmts(stmts_in, do_rename=do_rename, **kwargs)
     # Patch wrong locations in Translocation statements
     for stmt in stmts_out:
         if isinstance(stmt, Translocation):


### PR DESCRIPTION
This PR creates an environment variable MAPPING_SKIP_PUBMED to skip PubMed when we get context for agent mapping during the weekly readonly update to save time. 
A full update will happen every 10 weeks by unsetting this environment variable (This code is in [https://github.com/gyorilab/indra_db/pull/238](https://github.com/gyorilab/indra_db/pull/238) )