### PR TITLE
Directly get source api set from statements in counts scorer

### DIFF
--- a/indra/belief/skl.py
+++ b/indra/belief/skl.py
@@ -657,8 +657,9 @@ class HybridScorer(BeliefScorer):
     ) -> None:
         """Check that sources in the set of statements are accounted for."""
         # Get all sources for the set of statements
-        sources = CountsScorer.get_all_sources(statements,
-                                               include_more_specific=True)
+        sources = set()
+        for stmt in statements:
+            sources |= set([ev.source_api for ev in stmt.evidence])
         non_cs_sources = set(sources).difference(
                                         set(self.counts_scorer.source_list))
         return self.simple_scorer._check_sources(non_cs_sources)

--- a/indra/belief/skl.py
+++ b/indra/belief/skl.py
@@ -657,9 +657,8 @@ class HybridScorer(BeliefScorer):
     ) -> None:
         """Check that sources in the set of statements are accounted for."""
         # Get all sources for the set of statements
-        sources = set()
-        for stmt in statements:
-            sources |= set([ev.source_api for ev in stmt.evidence])
+        sources = CountsScorer.get_all_sources(statements,
+                                               include_more_specific=True)
         non_cs_sources = set(sources).difference(
                                         set(self.counts_scorer.source_list))
         return self.simple_scorer._check_sources(non_cs_sources)

--- a/indra/ontology/bio/sqlite_ontology.py
+++ b/indra/ontology/bio/sqlite_ontology.py
@@ -25,6 +25,9 @@ class SqliteOntology(IndraOntology):
         conn = sqlite3.connect(db_path)
         self.cur = conn.cursor()
 
+    def initialize(self):
+        self._initialized = True
+
     def isa_or_partof(self, ns1, id1, ns2, id2):
         q = """SELECT 1 FROM relationships
                WHERE child_id=? AND child_ns=? AND parent_id=? AND parent_ns=?

--- a/indra/tests/test_pysb_assembler.py
+++ b/indra/tests/test_pysb_assembler.py
@@ -656,7 +656,6 @@ def test_assemble_export_sbgn():
     assert glyph_classes.count('macromolecule') == 6
     assert glyph_classes.count('complex') == 2
     assert glyph_classes.count('process') == 10
-    return pa
 
 
 def test_name_standardize():


### PR DESCRIPTION
- This PR follows the change in indra_db to get source_api from statements directly since each statement already has the support evidence and we don't need to access the support pa statement to get more evidence.

- Also add initialize() in sqlite_ontology 
