### PR TITLE
Refactor row creation as separate function in IndraNetAssembler

### DIFF
--- a/indra/assemblers/indranet/__init__.py
+++ b/indra/assemblers/indranet/__init__.py
@@ -2,4 +2,4 @@
 networkx graphs from INDRA Statements. It also allows exporting binary
 Statement information as a pandas DataFrame."""
 from .net import IndraNet
-from .assembler import IndraNetAssembler
+from .assembler import IndraNetAssembler, statement_to_rows

--- a/indra/tests/test_indranet_assembler.py
+++ b/indra/tests/test_indranet_assembler.py
@@ -3,7 +3,7 @@ import pandas as pd
 import networkx as nx
 from indra.statements import *
 from indra.assemblers.indranet.net import default_sign_dict
-from indra.assemblers.indranet import IndraNetAssembler, IndraNet
+from indra.assemblers.indranet import IndraNetAssembler, IndraNet, statement_to_rows
 
 
 ev1 = Evidence(pmid='1')
@@ -328,3 +328,12 @@ def test_self_loops():
     assert ('a', 'a') not in ug4.edges
     assert ('c', 'c') not in ug4.edges
     assert ('b', 'b') not in ug4.edges
+
+
+def test_stmt_to_rows():
+    ia = IndraNetAssembler([st1, st2, st3, st4, st5, st6, st9])
+
+    rows = statement_to_rows(st1)
+    assert len(rows) == 1
+    assert rows[0] == ['a', 'b', 'HGNC', '1', 'TEXT', 'b', None, None,
+                       'Activation', 1, 8197018847132618, 1, {None: 1}, None]


### PR DESCRIPTION
This PR refactors how the IndraNetAssembler creates a DataFrame from Statements by separating out the function that takes a single Statement as input and return zero or more rows generated from that Statement. This allows for accessing this function independently, making it possible to generate rows without keeping all Statements in memory at once.