### PR TITLE
Add KLIFS kinase-ligand database processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Biological pathway databases:
 | UbiBrowser                 | [`indra.sources.ubibrowser`](https://indra.readthedocs.io/en/latest/modules/sources/ubibrowser.html) | http://ubibrowser.ncpsb.org.cn/                |
 | ACSN                       | [`indra.sources.acsn`](https://indra.readthedocs.io/en/latest/modules/sources/acsn.html) | https://acsn.curie.fr/ACSN2/ACSN2.html   |
 | WormBase                       | [`indra.sources.wormbase`](https://indra.readthedocs.io/en/latest/modules/sources/wormbase.html) | https://www.wormbase.org   |
+| KLIFS                       | [`indra.sources.klifs`](https://indra.readthedocs.io/en/latest/modules/sources/klifs/index.html) | https://klifs.net/   |
 
 Custom knowledge bases:
 

--- a/indra/resources/default_belief_probs.json
+++ b/indra/resources/default_belief_probs.json
@@ -35,7 +35,8 @@
     "ubibrowser": 0.01,
     "acsn": 0.01,
     "semrep": 0.05,
-    "tkg": 0.05
+    "tkg": 0.05,
+    "klifs": 0.01
   },
   "rand": {
     "eidos": 0.3,
@@ -74,6 +75,7 @@
     "acsn": 0.1,
     "semrep": 0.3,
     "wormbase": 0.1,
-    "tkg": 0.3
+    "tkg": 0.3,
+    "klifs": 0.1
   }
 }

--- a/indra/resources/source_info.json
+++ b/indra/resources/source_info.json
@@ -348,5 +348,15 @@
             "color": "white",
             "background-color": "#ffb3ba"
         }
+    },
+    "klifs": {
+        "name": "KLIFS",
+        "link": "https://klifs.net/",
+        "type": "database",
+        "domain": "biology",
+        "default_style": {
+            "color": "black",
+            "background-color": "#ff9966"
+        }
     }
 }

--- a/indra/sources/klifs/__init__.py
+++ b/indra/sources/klifs/__init__.py
@@ -4,6 +4,6 @@ and Structures).
 Public API is primarily a thin, Swagger-mirroring layer defined in .api.
 """
 
-from .api import process_ligand
+from .api import process_kinase
 
-__all__ = ["process_ligand"]
+__all__ = ["process_kinase"]

--- a/indra/sources/klifs/__init__.py
+++ b/indra/sources/klifs/__init__.py
@@ -1,157 +1,29 @@
-"""KLIFS kinase-inhibitor database integration for INDRA.
+# indra/sources/klifs/__init__.py
 
-KLIFS (Kinase-Ligand Interaction Fingerprints and Structures) is a database
-that collects and disseminates structural kinase-inhibitor interaction data.
+"""INDRA source integration for KLIFS (Kinase–Ligand Interaction Fingerprints
+and Structures).
+
+Public API is primarily a thin, Swagger-mirroring layer defined in .api.
 """
 
-from .api import KlifsClient
-from .processor import KlifsProcessor
-import logging
+from .api import (
+    get_kinase_groups,
+    get_kinase_families,
+    get_kinase_names,
+    get_kinase_information,
+    get_kinase_id,
+    get_ligands_list,
+    get_bioactivities_for_ligand,
+    process_bioactivities_for_ligand,
+)
 
-logger = logging.getLogger(__name__)
-
-def process_from_web(kinase_names=None, include_drugs=True, min_activity=None):
-    """Process KLIFS data from the web API into INDRA statements.
-    
-    Parameters
-    ----------
-    kinase_names : list or str, optional
-        Specific kinase(s) to process. If None, processes all.
-    include_drugs : bool
-        Whether to include approved drug information
-    min_activity : float, optional
-        Minimum activity threshold (e.g., pIC50 > 6)
-    
-    Returns
-    -------
-    list
-        List of INDRA statements
-    """
-    client = KlifsClient()
-    
-    # Convert single kinase to list
-    if isinstance(kinase_names, str):
-        kinase_names = [kinase_names]
-    
-    # Collect data
-    all_bioactivities = []
-    all_ligands = []
-    all_kinases = []
-    
-    if kinase_names:
-        # Process specific kinases
-        for kinase_name in kinase_names:
-            logger.info(f'Fetching data for {kinase_name}')
-            
-            # Get bioactivities for this kinase
-            bioactivities = client.get_bioactivities(
-                kinase_name=kinase_name,
-                min_activity=min_activity
-            )
-            all_bioactivities.extend(bioactivities)
-            
-            # Get ligands for this kinase
-            ligands = client.get_ligands_list(kinase_name=kinase_name)
-            all_ligands.extend(ligands)
-            
-            # Get kinase info
-            kinase_info = client.get_kinase_info(kinase_name=kinase_name)
-            all_kinases.extend(kinase_info)
-    else:
-        # Get all data
-        logger.info('Fetching all KLIFS data (this may take a while)')
-        all_bioactivities = client.get_bioactivities(min_activity=min_activity)
-        all_ligands = client.get_ligands_list()
-        all_kinases = client.get_kinase_info()
-    
-    # Get drug info if requested
-    drugs = []
-    if include_drugs:
-        drugs = client.get_drugs()
-    
-    # Remove duplicates from ligands and kinases
-    seen_ligands = set()
-    unique_ligands = []
-    for ligand in all_ligands:
-        lig_id = ligand.get('ligand_id') or ligand.get('id')
-        if lig_id and lig_id not in seen_ligands:
-            seen_ligands.add(lig_id)
-            unique_ligands.append(ligand)
-    
-    seen_kinases = set()
-    unique_kinases = []
-    for kinase in all_kinases:
-        kinase_name = kinase.get('kinase_name') or kinase.get('name')
-        if kinase_name and kinase_name not in seen_kinases:
-            seen_kinases.add(kinase_name)
-            unique_kinases.append(kinase)
-    
-    logger.info(f'Retrieved {len(all_bioactivities)} bioactivities, '
-                f'{len(unique_ligands)} ligands, {len(unique_kinases)} kinases')
-    
-    # Process into statements
-    processor = KlifsProcessor(
-        bioactivities=all_bioactivities,
-        ligands=unique_ligands,
-        kinases=unique_kinases,
-        drugs=drugs
-    )
-    
-    statements = processor.process_bioactivities()
-    
-    return statements
-
-
-def process_from_dump(bioactivities_file=None, ligands_file=None, 
-                     kinases_file=None, drugs_file=None):
-    """Process KLIFS data from downloaded JSON files.
-    
-    Parameters
-    ----------
-    bioactivities_file : str
-        Path to bioactivities JSON file
-    ligands_file : str
-        Path to ligands JSON file
-    kinases_file : str
-        Path to kinases JSON file  
-    drugs_file : str, optional
-        Path to drugs JSON file
-        
-    Returns
-    -------
-    list
-        List of INDRA statements
-    """
-    import json
-    
-    bioactivities = []
-    ligands = []
-    kinases = []
-    drugs = []
-    
-    if bioactivities_file:
-        with open(bioactivities_file) as f:
-            bioactivities = json.load(f)
-    
-    if ligands_file:
-        with open(ligands_file) as f:
-            ligands = json.load(f)
-    
-    if kinases_file:
-        with open(kinases_file) as f:
-            kinases = json.load(f)
-    
-    if drugs_file:
-        with open(drugs_file) as f:
-            drugs = json.load(f)
-    
-    processor = KlifsProcessor(
-        bioactivities=bioactivities,
-        ligands=ligands,
-        kinases=kinases,
-        drugs=drugs
-    )
-    
-    statements = processor.process_bioactivities()
-    
-    return statements
+__all__ = [
+    "get_kinase_groups",
+    "get_kinase_families",
+    "get_kinase_names",
+    "get_kinase_information",
+    "get_kinase_id",
+    "get_ligands_list",
+    "get_bioactivities_for_ligand",
+    "process_bioactivities_for_ligand",
+]

--- a/indra/sources/klifs/__init__.py
+++ b/indra/sources/klifs/__init__.py
@@ -1,29 +1,9 @@
-# indra/sources/klifs/__init__.py
-
 """INDRA source integration for KLIFS (Kinase–Ligand Interaction Fingerprints
 and Structures).
 
 Public API is primarily a thin, Swagger-mirroring layer defined in .api.
 """
 
-from .api import (
-    get_kinase_groups,
-    get_kinase_families,
-    get_kinase_names,
-    get_kinase_information,
-    get_kinase_id,
-    get_ligands_list,
-    get_bioactivities_for_ligand,
-    process_bioactivities_for_ligand,
-)
+from .api import process_ligand
 
-__all__ = [
-    "get_kinase_groups",
-    "get_kinase_families",
-    "get_kinase_names",
-    "get_kinase_information",
-    "get_kinase_id",
-    "get_ligands_list",
-    "get_bioactivities_for_ligand",
-    "process_bioactivities_for_ligand",
-]
+__all__ = ["process_ligand"]

--- a/indra/sources/klifs/__init__.py
+++ b/indra/sources/klifs/__init__.py
@@ -1,0 +1,157 @@
+"""KLIFS kinase-inhibitor database integration for INDRA.
+
+KLIFS (Kinase-Ligand Interaction Fingerprints and Structures) is a database
+that collects and disseminates structural kinase-inhibitor interaction data.
+"""
+
+from .api import KlifsClient
+from .processor import KlifsProcessor
+import logging
+
+logger = logging.getLogger(__name__)
+
+def process_from_web(kinase_names=None, include_drugs=True, min_activity=None):
+    """Process KLIFS data from the web API into INDRA statements.
+    
+    Parameters
+    ----------
+    kinase_names : list or str, optional
+        Specific kinase(s) to process. If None, processes all.
+    include_drugs : bool
+        Whether to include approved drug information
+    min_activity : float, optional
+        Minimum activity threshold (e.g., pIC50 > 6)
+    
+    Returns
+    -------
+    list
+        List of INDRA statements
+    """
+    client = KlifsClient()
+    
+    # Convert single kinase to list
+    if isinstance(kinase_names, str):
+        kinase_names = [kinase_names]
+    
+    # Collect data
+    all_bioactivities = []
+    all_ligands = []
+    all_kinases = []
+    
+    if kinase_names:
+        # Process specific kinases
+        for kinase_name in kinase_names:
+            logger.info(f'Fetching data for {kinase_name}')
+            
+            # Get bioactivities for this kinase
+            bioactivities = client.get_bioactivities(
+                kinase_name=kinase_name,
+                min_activity=min_activity
+            )
+            all_bioactivities.extend(bioactivities)
+            
+            # Get ligands for this kinase
+            ligands = client.get_ligands_list(kinase_name=kinase_name)
+            all_ligands.extend(ligands)
+            
+            # Get kinase info
+            kinase_info = client.get_kinase_info(kinase_name=kinase_name)
+            all_kinases.extend(kinase_info)
+    else:
+        # Get all data
+        logger.info('Fetching all KLIFS data (this may take a while)')
+        all_bioactivities = client.get_bioactivities(min_activity=min_activity)
+        all_ligands = client.get_ligands_list()
+        all_kinases = client.get_kinase_info()
+    
+    # Get drug info if requested
+    drugs = []
+    if include_drugs:
+        drugs = client.get_drugs()
+    
+    # Remove duplicates from ligands and kinases
+    seen_ligands = set()
+    unique_ligands = []
+    for ligand in all_ligands:
+        lig_id = ligand.get('ligand_id') or ligand.get('id')
+        if lig_id and lig_id not in seen_ligands:
+            seen_ligands.add(lig_id)
+            unique_ligands.append(ligand)
+    
+    seen_kinases = set()
+    unique_kinases = []
+    for kinase in all_kinases:
+        kinase_name = kinase.get('kinase_name') or kinase.get('name')
+        if kinase_name and kinase_name not in seen_kinases:
+            seen_kinases.add(kinase_name)
+            unique_kinases.append(kinase)
+    
+    logger.info(f'Retrieved {len(all_bioactivities)} bioactivities, '
+                f'{len(unique_ligands)} ligands, {len(unique_kinases)} kinases')
+    
+    # Process into statements
+    processor = KlifsProcessor(
+        bioactivities=all_bioactivities,
+        ligands=unique_ligands,
+        kinases=unique_kinases,
+        drugs=drugs
+    )
+    
+    statements = processor.process_bioactivities()
+    
+    return statements
+
+
+def process_from_dump(bioactivities_file=None, ligands_file=None, 
+                     kinases_file=None, drugs_file=None):
+    """Process KLIFS data from downloaded JSON files.
+    
+    Parameters
+    ----------
+    bioactivities_file : str
+        Path to bioactivities JSON file
+    ligands_file : str
+        Path to ligands JSON file
+    kinases_file : str
+        Path to kinases JSON file  
+    drugs_file : str, optional
+        Path to drugs JSON file
+        
+    Returns
+    -------
+    list
+        List of INDRA statements
+    """
+    import json
+    
+    bioactivities = []
+    ligands = []
+    kinases = []
+    drugs = []
+    
+    if bioactivities_file:
+        with open(bioactivities_file) as f:
+            bioactivities = json.load(f)
+    
+    if ligands_file:
+        with open(ligands_file) as f:
+            ligands = json.load(f)
+    
+    if kinases_file:
+        with open(kinases_file) as f:
+            kinases = json.load(f)
+    
+    if drugs_file:
+        with open(drugs_file) as f:
+            drugs = json.load(f)
+    
+    processor = KlifsProcessor(
+        bioactivities=bioactivities,
+        ligands=ligands,
+        kinases=kinases,
+        drugs=drugs
+    )
+    
+    statements = processor.process_bioactivities()
+    
+    return statements

--- a/indra/sources/klifs/api.py
+++ b/indra/sources/klifs/api.py
@@ -1,149 +1,15 @@
-# indra/sources/klifs/api.py
+from typing import Any, Dict, Optional
 
-from __future__ import annotations
-
-from typing import Any, Dict, Iterable, List, Optional, Union
-
-from .client import KlifsClient
 from .processor import KlifsProcessor
 
-__all__ = [
-    "get_kinase_groups",
-    "get_kinase_families",
-    "get_kinase_names",
-    "get_kinase_information",
-    "get_kinase_id",
-    "get_ligands_list",
-    "get_bioactivities_for_ligand",
-    "process_bioactivities_for_ligand",
-]
-
-_default_client = KlifsClient()
+__all__ = ["process_ligand"]
 
 
-# -----------------
-# Kinase Information
-# -----------------
-def get_kinase_groups(client: KlifsClient = _default_client) -> List[str]:
-    """Get the list of kinase groups from KLIFS.
 
-    Swagger mapping: GET /kinase_groups
-    """
-    return client.kinase_groups()
-
-
-def get_kinase_families(
-    kinase_group: Optional[Union[str, Iterable[str]]] = None,
-    client: KlifsClient = _default_client,
-) -> List[str]:
-    """Get the list of kinase families from KLIFS.
-
-    Swagger mapping: GET /kinase_families
-    """
-    return client.kinase_families(kinase_group=kinase_group)
-
-
-def get_kinase_names(
-    kinase_group: Optional[Union[str, Iterable[str]]] = None,
-    kinase_family: Optional[Union[str, Iterable[str]]] = None,
-    species: Optional[str] = None,
-    client: KlifsClient = _default_client,
-) -> List[Dict[str, Any]]:
-    """Get kinase names (HGNC gene symbols) and associated IDs from KLIFS.
-
-    Swagger mapping: GET /kinase_names
-    """
-    return client.kinase_names(
-        kinase_group=kinase_group,
-        kinase_family=kinase_family,
-        species=species,
-    )
-
-
-def get_kinase_information(
-    kinase_ids: Optional[Union[int, Iterable[int]]] = None,
-    species: Optional[str] = None,
-    client: KlifsClient = _default_client,
-) -> List[Dict[str, Any]]:
-    """Get kinase information records from KLIFS.
-
-    Swagger mapping: GET /kinase_information
-    """
-    return client.kinase_information(kinase_id=kinase_ids, species=species)
-
-
-def get_kinase_id(
-    kinase_name: Union[str, Iterable[str]],
-    species: Optional[str] = None,
-    client: KlifsClient = _default_client,
-) -> List[int]:
-    """Resolve one or more kinase names to KLIFS kinase_ID integers.
-
-    Swagger mapping: GET /kinase_ID
-
-    Notes
-    -----
-    The Swagger endpoint returns KinaseInformation-like records; this helper
-    extracts and returns only the `kinase_ID` integer(s).
-    """
-    rows = client.kinase_id(kinase_name=kinase_name, species=species)
-    out: List[int] = []
-    for row in rows or []:
-        kid = row.get("kinase_ID")
-        if kid is not None:
-            out.append(int(kid))
-    return out
-
-
-# -----------------
-# Ligand Information
-# -----------------
-def get_ligands_list(
-    kinase_id: Optional[Union[int, Iterable[int]]] = None,
-    client: KlifsClient = _default_client,
-) -> List[Dict[str, Any]]:
-    """Get ligandDetails records from KLIFS.
-
-    Swagger mapping: GET /ligands_list
-    """
-    return client.ligands_list(kinase_id=kinase_id)
-
-
-# -----------------
-# Bioactivities (IC50, Kd, Ki, etc.)
-# -----------------
-def get_bioactivities_for_ligand(
-    ligand_id: Optional[int] = None,
-    ligand_pdb: Optional[str] = None,
-    client: KlifsClient = _default_client,
-) -> List[Dict[str, Any]]:
-    """Get bioactivity records for a ligand from KLIFS.
-
-    KLIFS exposes two separate Swagger endpoints that return the same *kind* of
-    record (BioactivityDetails) for a ligand, differing only by identifier:
-
-    - GET /bioactivity_list_id   (use when `ligand_id` is provided)
-    - GET /bioactivity_list_pdb  (use when `ligand_pdb` is provided)
-
-    This convenience function dispatches to the correct endpoint.
-
-    Raises
-    ------
-    ValueError
-        If neither `ligand_id` nor `ligand_pdb` is provided.
-    """
-    if ligand_id is not None:
-        return client.bioactivity_list_id(ligand_id)
-    if ligand_pdb is not None:
-        return client.bioactivity_list_pdb(ligand_pdb)
-    raise ValueError("Provide ligand_id or ligand_pdb.")
-
-
-def process_bioactivities_for_ligand(
+def process_ligand(
     ligand_id: Optional[int] = None,
     ligand_pdb: Optional[str] = None,
     ligand_details: Optional[Dict[str, Any]] = None,
-    client: KlifsClient = _default_client,
 ) -> KlifsProcessor:
     """Fetch ligand bioactivities and convert them into INDRA Statements.
 
@@ -161,13 +27,7 @@ def process_bioactivities_for_ligand(
         A KlifsProcessor instance with extracted INDRA Statements available
         in its `statements` attribute.
     """
-    bio = get_bioactivities_for_ligand(
-        ligand_id=ligand_id,
-        ligand_pdb=ligand_pdb,
-        client=client,
-    )
     kp = KlifsProcessor(
-        bioactivities=bio,
         ligand_id=ligand_id,
         ligand_pdb=ligand_pdb,
         ligand_details=ligand_details,

--- a/indra/sources/klifs/api.py
+++ b/indra/sources/klifs/api.py
@@ -1,0 +1,207 @@
+# indra/sources/klifs/api.py
+
+import requests
+from typing import List, Dict, Optional, Union
+import logging
+
+logger = logging.getLogger(__name__)
+
+class KlifsClient:
+    """Client for KLIFS API based on official Swagger documentation."""
+    
+    # The documented base URL from Swagger
+    BASE_URL = 'https://klifs.net/api'
+    
+    def __init__(self):
+        self.session = requests.Session()
+        self._kinase_cache = {}
+        
+    # ========== Information Endpoints ==========
+    
+    def get_kinase_groups(self) -> List[str]:
+        """Get list of kinase groups."""
+        res = self.session.get(f'{self.BASE_URL}/kinase_groups')
+        res.raise_for_status()
+        return res.json()
+    
+    def get_kinase_families(self, kinase_group: Optional[str] = None) -> List[str]:
+        """Get list of kinase families, optionally filtered by group."""
+        params = {}
+        if kinase_group:
+            params['kinase_group'] = kinase_group
+        res = self.session.get(f'{self.BASE_URL}/kinase_families', params=params)
+        res.raise_for_status()
+        return res.json()
+    
+    def get_kinase_names(self, 
+                        kinase_group: Optional[str] = None,
+                        kinase_family: Optional[str] = None,
+                        species: Optional[str] = None) -> List[Dict]:
+        """Get list of kinases with IDs and names.
+        
+        Returns list of dicts with: kinase_ID, name, full_name, species
+        """
+        params = {}
+        if kinase_group:
+            params['kinase_group'] = kinase_group
+        if kinase_family:
+            params['kinase_family'] = kinase_family
+        if species:
+            params['species'] = species.upper()  # HUMAN, MOUSE
+            
+        res = self.session.get(f'{self.BASE_URL}/kinase_names', params=params)
+        res.raise_for_status()
+        return res.json()
+    
+    def get_kinase_information(self, 
+                              kinase_ids: Optional[List[int]] = None,
+                              species: Optional[str] = None) -> List[Dict]:
+        """Get detailed kinase information.
+        
+        Returns KinaseInformation objects with HGNC, UniProt, pocket sequence, etc.
+        """
+        params = {}
+        if kinase_ids:
+            # API expects comma-separated IDs
+            params['kinase_ID'] = ','.join(map(str, kinase_ids))
+        if species:
+            params['species'] = species.upper()
+            
+        res = self.session.get(f'{self.BASE_URL}/kinase_information', params=params)
+        res.raise_for_status()
+        return res.json()
+    
+    def get_kinase_id(self, kinase_name: str, species: Optional[str] = None) -> List[Dict]:
+        """Get kinase ID(s) for a given kinase name.
+        
+        Parameters
+        ----------
+        kinase_name : str
+            Kinase name (e.g., 'EGFR', 'ABL1') or UniProt ID
+        species : str, optional
+            Species filter (HUMAN, MOUSE)
+            
+        Returns
+        -------
+        list
+            List of matching kinases with their IDs
+        """
+        params = {'kinase_name': kinase_name}
+        if species:
+            params['species'] = species.upper()
+            
+        res = self.session.get(f'{self.BASE_URL}/kinase_ID', params=params)
+        res.raise_for_status()
+        return res.json()
+    
+    # ========== Ligands Endpoints ==========
+    
+    def get_ligands_list(self, kinase_ids: Optional[List[int]] = None) -> List[Dict]:
+        """Get all co-crystallized ligands, optionally filtered by kinase IDs.
+        
+        Returns ligandDetails objects with: ligand_ID, PDB-code, Name, SMILES, InChIKey
+        """
+        params = {}
+        if kinase_ids:
+            params['kinase_ID'] = ','.join(map(str, kinase_ids))
+            
+        res = self.session.get(f'{self.BASE_URL}/ligands_list', params=params)
+        res.raise_for_status()
+        return res.json()
+    
+    def get_bioactivity_by_ligand_id(self, ligand_id: int) -> List[Dict]:
+        """Get all ChEMBL bioactivities for a specific ligand.
+        
+        Returns BioactivityDetails with: pref_name, accession, standard_type,
+        standard_value, standard_units, pchembl_value, etc.
+        """
+        params = {'ligand_ID': ligand_id}
+        res = self.session.get(f'{self.BASE_URL}/bioactivity_list_id', params=params)
+        res.raise_for_status()
+        return res.json()
+    
+    def get_bioactivity_by_pdb(self, ligand_pdb: str) -> List[Dict]:
+        """Get all ChEMBL bioactivities for a ligand by PDB code."""
+        params = {'ligand_PDB': ligand_pdb}
+        res = self.session.get(f'{self.BASE_URL}/bioactivity_list_pdb', params=params)
+        res.raise_for_status()
+        return res.json()
+    
+    # ========== Structures Endpoints ==========
+    
+    def get_structures_by_kinase(self, kinase_ids: List[int]) -> List[Dict]:
+        """Get all structures for given kinase ID(s).
+        
+        Returns structureDetails objects.
+        """
+        params = {'kinase_ID': ','.join(map(str, kinase_ids))}
+        res = self.session.get(f'{self.BASE_URL}/structures_list', params=params)
+        res.raise_for_status()
+        return res.json()
+    
+    # ========== Helper Methods ==========
+    
+    def get_kinase_bioactivities(self, kinase_name: str, species: str = 'HUMAN') -> List[Dict]:
+        """Helper to get all bioactivities for a specific kinase.
+        
+        This combines multiple API calls:
+        1. Get kinase ID from name
+        2. Get ligands for that kinase
+        3. Get bioactivities for each ligand
+        
+        Parameters
+        ----------
+        kinase_name : str
+            Kinase name (e.g., 'EGFR')
+        species : str
+            Species (default: 'HUMAN')
+            
+        Returns
+        -------
+        list
+            All bioactivity data for the kinase with ligand info included
+        """
+        # Step 1: Get kinase ID
+        kinase_info = self.get_kinase_id(kinase_name, species=species)
+        if not kinase_info:
+            logger.warning(f"Kinase '{kinase_name}' not found")
+            return []
+        
+        kinase_id = kinase_info[0]['kinase_ID']
+        logger.info(f"Found {kinase_name}: ID {kinase_id}")
+        
+        # Step 2: Get ligands for this kinase
+        ligands = self.get_ligands_list(kinase_ids=[kinase_id])
+        logger.info(f"Found {len(ligands)} ligands for {kinase_name}")
+        
+        # Step 3: Get bioactivities for each ligand
+        all_bioactivities = []
+        for ligand in ligands:
+            ligand_id = ligand.get('ligand_ID')
+            if not ligand_id:
+                continue
+                
+            try:
+                bioactivities = self.get_bioactivity_by_ligand_id(ligand_id)
+                
+                # Add ligand and kinase info to each bioactivity
+                for bio in bioactivities:
+                    # Add ligand info
+                    bio['ligand_ID'] = ligand_id
+                    bio['ligand_name'] = ligand.get('Name')
+                    bio['ligand_SMILES'] = ligand.get('SMILES')
+                    bio['ligand_InChIKey'] = ligand.get('InChIKey')
+                    bio['ligand_PDB'] = ligand.get('PDB-code')
+                    
+                    # Add kinase info
+                    bio['kinase_ID'] = kinase_id
+                    bio['kinase_name'] = kinase_name
+                    
+                all_bioactivities.extend(bioactivities)
+                
+            except Exception as e:
+                logger.debug(f"No bioactivity for ligand {ligand_id}: {e}")
+                continue
+        
+        logger.info(f"Found {len(all_bioactivities)} total bioactivities for {kinase_name}")
+        return all_bioactivities

--- a/indra/sources/klifs/api.py
+++ b/indra/sources/klifs/api.py
@@ -2,24 +2,15 @@ from typing import Any, Dict, Optional
 
 from .processor import KlifsProcessor
 
-__all__ = ["process_ligand"]
+__all__ = ["process_kinase"]
 
 
 
-def process_ligand(
-    ligand_id: Optional[int] = None,
-    ligand_pdb: Optional[str] = None,
-    ligand_details: Optional[Dict[str, Any]] = None,
+def process_kinase(
+    kinase_gene_name: Optional[int] = None,
+    kinase_uniprot: Optional[str] = None,
 ) -> KlifsProcessor:
-    """Fetch ligand bioactivities and convert them into INDRA Statements.
-
-    NOTE: This is meant to be analogous to process_from_web style functions in other INDRA sources
-
-    This is a standard INDRA convenience pipeline that combines:
-    1) A Swagger fetch via one of:
-       - GET /bioactivity_list_id
-       - GET /bioactivity_list_pdb
-    2) INDRA-side transformation via KlifsProcessor
+    """
 
     Returns
     -------
@@ -28,9 +19,8 @@ def process_ligand(
         in its `statements` attribute.
     """
     kp = KlifsProcessor(
-        ligand_id=ligand_id,
-        ligand_pdb=ligand_pdb,
-        ligand_details=ligand_details,
+        kinase_gene_name=kinase_gene_name,
+        kinase_uniprot=kinase_uniprot,
     )
     kp.extract_statements()
     return kp

--- a/indra/sources/klifs/api.py
+++ b/indra/sources/klifs/api.py
@@ -1,207 +1,176 @@
 # indra/sources/klifs/api.py
 
-import requests
-from typing import List, Dict, Optional, Union
-import logging
+from __future__ import annotations
 
-logger = logging.getLogger(__name__)
+from typing import Any, Dict, Iterable, List, Optional, Union
 
-class KlifsClient:
-    """Client for KLIFS API based on official Swagger documentation."""
-    
-    # The documented base URL from Swagger
-    BASE_URL = 'https://klifs.net/api'
-    
-    def __init__(self):
-        self.session = requests.Session()
-        self._kinase_cache = {}
-        
-    # ========== Information Endpoints ==========
-    
-    def get_kinase_groups(self) -> List[str]:
-        """Get list of kinase groups."""
-        res = self.session.get(f'{self.BASE_URL}/kinase_groups')
-        res.raise_for_status()
-        return res.json()
-    
-    def get_kinase_families(self, kinase_group: Optional[str] = None) -> List[str]:
-        """Get list of kinase families, optionally filtered by group."""
-        params = {}
-        if kinase_group:
-            params['kinase_group'] = kinase_group
-        res = self.session.get(f'{self.BASE_URL}/kinase_families', params=params)
-        res.raise_for_status()
-        return res.json()
-    
-    def get_kinase_names(self, 
-                        kinase_group: Optional[str] = None,
-                        kinase_family: Optional[str] = None,
-                        species: Optional[str] = None) -> List[Dict]:
-        """Get list of kinases with IDs and names.
-        
-        Returns list of dicts with: kinase_ID, name, full_name, species
-        """
-        params = {}
-        if kinase_group:
-            params['kinase_group'] = kinase_group
-        if kinase_family:
-            params['kinase_family'] = kinase_family
-        if species:
-            params['species'] = species.upper()  # HUMAN, MOUSE
-            
-        res = self.session.get(f'{self.BASE_URL}/kinase_names', params=params)
-        res.raise_for_status()
-        return res.json()
-    
-    def get_kinase_information(self, 
-                              kinase_ids: Optional[List[int]] = None,
-                              species: Optional[str] = None) -> List[Dict]:
-        """Get detailed kinase information.
-        
-        Returns KinaseInformation objects with HGNC, UniProt, pocket sequence, etc.
-        """
-        params = {}
-        if kinase_ids:
-            # API expects comma-separated IDs
-            params['kinase_ID'] = ','.join(map(str, kinase_ids))
-        if species:
-            params['species'] = species.upper()
-            
-        res = self.session.get(f'{self.BASE_URL}/kinase_information', params=params)
-        res.raise_for_status()
-        return res.json()
-    
-    def get_kinase_id(self, kinase_name: str, species: Optional[str] = None) -> List[Dict]:
-        """Get kinase ID(s) for a given kinase name.
-        
-        Parameters
-        ----------
-        kinase_name : str
-            Kinase name (e.g., 'EGFR', 'ABL1') or UniProt ID
-        species : str, optional
-            Species filter (HUMAN, MOUSE)
-            
-        Returns
-        -------
-        list
-            List of matching kinases with their IDs
-        """
-        params = {'kinase_name': kinase_name}
-        if species:
-            params['species'] = species.upper()
-            
-        res = self.session.get(f'{self.BASE_URL}/kinase_ID', params=params)
-        res.raise_for_status()
-        return res.json()
-    
-    # ========== Ligands Endpoints ==========
-    
-    def get_ligands_list(self, kinase_ids: Optional[List[int]] = None) -> List[Dict]:
-        """Get all co-crystallized ligands, optionally filtered by kinase IDs.
-        
-        Returns ligandDetails objects with: ligand_ID, PDB-code, Name, SMILES, InChIKey
-        """
-        params = {}
-        if kinase_ids:
-            params['kinase_ID'] = ','.join(map(str, kinase_ids))
-            
-        res = self.session.get(f'{self.BASE_URL}/ligands_list', params=params)
-        res.raise_for_status()
-        return res.json()
-    
-    def get_bioactivity_by_ligand_id(self, ligand_id: int) -> List[Dict]:
-        """Get all ChEMBL bioactivities for a specific ligand.
-        
-        Returns BioactivityDetails with: pref_name, accession, standard_type,
-        standard_value, standard_units, pchembl_value, etc.
-        """
-        params = {'ligand_ID': ligand_id}
-        res = self.session.get(f'{self.BASE_URL}/bioactivity_list_id', params=params)
-        res.raise_for_status()
-        return res.json()
-    
-    def get_bioactivity_by_pdb(self, ligand_pdb: str) -> List[Dict]:
-        """Get all ChEMBL bioactivities for a ligand by PDB code."""
-        params = {'ligand_PDB': ligand_pdb}
-        res = self.session.get(f'{self.BASE_URL}/bioactivity_list_pdb', params=params)
-        res.raise_for_status()
-        return res.json()
-    
-    # ========== Structures Endpoints ==========
-    
-    def get_structures_by_kinase(self, kinase_ids: List[int]) -> List[Dict]:
-        """Get all structures for given kinase ID(s).
-        
-        Returns structureDetails objects.
-        """
-        params = {'kinase_ID': ','.join(map(str, kinase_ids))}
-        res = self.session.get(f'{self.BASE_URL}/structures_list', params=params)
-        res.raise_for_status()
-        return res.json()
-    
-    # ========== Helper Methods ==========
-    
-    def get_kinase_bioactivities(self, kinase_name: str, species: str = 'HUMAN') -> List[Dict]:
-        """Helper to get all bioactivities for a specific kinase.
-        
-        This combines multiple API calls:
-        1. Get kinase ID from name
-        2. Get ligands for that kinase
-        3. Get bioactivities for each ligand
-        
-        Parameters
-        ----------
-        kinase_name : str
-            Kinase name (e.g., 'EGFR')
-        species : str
-            Species (default: 'HUMAN')
-            
-        Returns
-        -------
-        list
-            All bioactivity data for the kinase with ligand info included
-        """
-        # Step 1: Get kinase ID
-        kinase_info = self.get_kinase_id(kinase_name, species=species)
-        if not kinase_info:
-            logger.warning(f"Kinase '{kinase_name}' not found")
-            return []
-        
-        kinase_id = kinase_info[0]['kinase_ID']
-        logger.info(f"Found {kinase_name}: ID {kinase_id}")
-        
-        # Step 2: Get ligands for this kinase
-        ligands = self.get_ligands_list(kinase_ids=[kinase_id])
-        logger.info(f"Found {len(ligands)} ligands for {kinase_name}")
-        
-        # Step 3: Get bioactivities for each ligand
-        all_bioactivities = []
-        for ligand in ligands:
-            ligand_id = ligand.get('ligand_ID')
-            if not ligand_id:
-                continue
-                
-            try:
-                bioactivities = self.get_bioactivity_by_ligand_id(ligand_id)
-                
-                # Add ligand and kinase info to each bioactivity
-                for bio in bioactivities:
-                    # Add ligand info
-                    bio['ligand_ID'] = ligand_id
-                    bio['ligand_name'] = ligand.get('Name')
-                    bio['ligand_SMILES'] = ligand.get('SMILES')
-                    bio['ligand_InChIKey'] = ligand.get('InChIKey')
-                    bio['ligand_PDB'] = ligand.get('PDB-code')
-                    
-                    # Add kinase info
-                    bio['kinase_ID'] = kinase_id
-                    bio['kinase_name'] = kinase_name
-                    
-                all_bioactivities.extend(bioactivities)
-                
-            except Exception as e:
-                logger.debug(f"No bioactivity for ligand {ligand_id}: {e}")
-                continue
-        
-        logger.info(f"Found {len(all_bioactivities)} total bioactivities for {kinase_name}")
-        return all_bioactivities
+from .client import KlifsClient
+from .processor import KlifsProcessor
+
+__all__ = [
+    "get_kinase_groups",
+    "get_kinase_families",
+    "get_kinase_names",
+    "get_kinase_information",
+    "get_kinase_id",
+    "get_ligands_list",
+    "get_bioactivities_for_ligand",
+    "process_bioactivities_for_ligand",
+]
+
+_default_client = KlifsClient()
+
+
+# -----------------
+# Kinase Information
+# -----------------
+def get_kinase_groups(client: KlifsClient = _default_client) -> List[str]:
+    """Get the list of kinase groups from KLIFS.
+
+    Swagger mapping: GET /kinase_groups
+    """
+    return client.kinase_groups()
+
+
+def get_kinase_families(
+    kinase_group: Optional[Union[str, Iterable[str]]] = None,
+    client: KlifsClient = _default_client,
+) -> List[str]:
+    """Get the list of kinase families from KLIFS.
+
+    Swagger mapping: GET /kinase_families
+    """
+    return client.kinase_families(kinase_group=kinase_group)
+
+
+def get_kinase_names(
+    kinase_group: Optional[Union[str, Iterable[str]]] = None,
+    kinase_family: Optional[Union[str, Iterable[str]]] = None,
+    species: Optional[str] = None,
+    client: KlifsClient = _default_client,
+) -> List[Dict[str, Any]]:
+    """Get kinase names (HGNC gene symbols) and associated IDs from KLIFS.
+
+    Swagger mapping: GET /kinase_names
+    """
+    return client.kinase_names(
+        kinase_group=kinase_group,
+        kinase_family=kinase_family,
+        species=species,
+    )
+
+
+def get_kinase_information(
+    kinase_ids: Optional[Union[int, Iterable[int]]] = None,
+    species: Optional[str] = None,
+    client: KlifsClient = _default_client,
+) -> List[Dict[str, Any]]:
+    """Get kinase information records from KLIFS.
+
+    Swagger mapping: GET /kinase_information
+    """
+    return client.kinase_information(kinase_id=kinase_ids, species=species)
+
+
+def get_kinase_id(
+    kinase_name: Union[str, Iterable[str]],
+    species: Optional[str] = None,
+    client: KlifsClient = _default_client,
+) -> List[int]:
+    """Resolve one or more kinase names to KLIFS kinase_ID integers.
+
+    Swagger mapping: GET /kinase_ID
+
+    Notes
+    -----
+    The Swagger endpoint returns KinaseInformation-like records; this helper
+    extracts and returns only the `kinase_ID` integer(s).
+    """
+    rows = client.kinase_id(kinase_name=kinase_name, species=species)
+    out: List[int] = []
+    for row in rows or []:
+        kid = row.get("kinase_ID")
+        if kid is not None:
+            out.append(int(kid))
+    return out
+
+
+# -----------------
+# Ligand Information
+# -----------------
+def get_ligands_list(
+    kinase_id: Optional[Union[int, Iterable[int]]] = None,
+    client: KlifsClient = _default_client,
+) -> List[Dict[str, Any]]:
+    """Get ligandDetails records from KLIFS.
+
+    Swagger mapping: GET /ligands_list
+    """
+    return client.ligands_list(kinase_id=kinase_id)
+
+
+# -----------------
+# Bioactivities (IC50, Kd, Ki, etc.)
+# -----------------
+def get_bioactivities_for_ligand(
+    ligand_id: Optional[int] = None,
+    ligand_pdb: Optional[str] = None,
+    client: KlifsClient = _default_client,
+) -> List[Dict[str, Any]]:
+    """Get bioactivity records for a ligand from KLIFS.
+
+    KLIFS exposes two separate Swagger endpoints that return the same *kind* of
+    record (BioactivityDetails) for a ligand, differing only by identifier:
+
+    - GET /bioactivity_list_id   (use when `ligand_id` is provided)
+    - GET /bioactivity_list_pdb  (use when `ligand_pdb` is provided)
+
+    This convenience function dispatches to the correct endpoint.
+
+    Raises
+    ------
+    ValueError
+        If neither `ligand_id` nor `ligand_pdb` is provided.
+    """
+    if ligand_id is not None:
+        return client.bioactivity_list_id(ligand_id)
+    if ligand_pdb is not None:
+        return client.bioactivity_list_pdb(ligand_pdb)
+    raise ValueError("Provide ligand_id or ligand_pdb.")
+
+
+def process_bioactivities_for_ligand(
+    ligand_id: Optional[int] = None,
+    ligand_pdb: Optional[str] = None,
+    ligand_details: Optional[Dict[str, Any]] = None,
+    client: KlifsClient = _default_client,
+) -> KlifsProcessor:
+    """Fetch ligand bioactivities and convert them into INDRA Statements.
+
+    NOTE: This is meant to be analogous to process_from_web style functions in other INDRA sources
+
+    This is a standard INDRA convenience pipeline that combines:
+    1) A Swagger fetch via one of:
+       - GET /bioactivity_list_id
+       - GET /bioactivity_list_pdb
+    2) INDRA-side transformation via KlifsProcessor
+
+    Returns
+    -------
+    :
+        A KlifsProcessor instance with extracted INDRA Statements available
+        in its `statements` attribute.
+    """
+    bio = get_bioactivities_for_ligand(
+        ligand_id=ligand_id,
+        ligand_pdb=ligand_pdb,
+        client=client,
+    )
+    kp = KlifsProcessor(
+        bioactivities=bio,
+        ligand_id=ligand_id,
+        ligand_pdb=ligand_pdb,
+        ligand_details=ligand_details,
+    )
+    kp.extract_statements()
+    return kp

--- a/indra/sources/klifs/client.py
+++ b/indra/sources/klifs/client.py
@@ -1,7 +1,3 @@
-# indra/sources/klifs/client.py
-
-from __future__ import annotations
-
 import logging
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Union

--- a/indra/sources/klifs/client.py
+++ b/indra/sources/klifs/client.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 import requests
@@ -16,7 +15,6 @@ def _comma_list(x: Any) -> Optional[str]:
     return str(x)
 
 
-@dataclass
 class KlifsClient:
     """Thin KLIFS REST client reflecting the Swagger endpoints.
 
@@ -30,59 +28,38 @@ class KlifsClient:
         Optional requests session to reuse HTTP connections.
     """
 
-    base_url: str = "https://klifs.net/api"
+    base_url: str = "https://klifs.net/api/"
     timeout: int = 30
-    session: Optional[requests.Session] = None
 
-    def _session(self) -> requests.Session:
-        """Get a cached requests.Session for connection reuse."""
-        if self.session is None:
-            self.session = requests.Session()
-        return self.session
-
-    def _get(
-        self,
-        path: str,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> requests.Response:
-        sess = self._session()
-        url = self.base_url + path
-        clean_params = {k: v for k, v in (params or {}).items() if v is not None}
-        logger.debug("KLIFS GET %s params=%s", url, clean_params)
-        res = sess.get(url, params=clean_params, timeout=self.timeout)
-        res.raise_for_status()
+    def send_request(self, endpoint, param=None):
+        res = requests.get(
+            self.base_url + endpoint,
+            params=param,
+            timeout=self.timeout,
+        )
         return res
 
-    def _get_json(
-        self,
-        path: str,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Any:
-        res = self._get(path, params=params)
+    def get_json(self, endpoint, param=None):
+        res = self.send_request(endpoint, param)
+        res.raise_for_status()
         return res.json()
 
-    def _get_bytes(
-        self,
-        path: str,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> bytes:
-        res = self._get(path, params=params)
+    def get_content(self, endpoint, param=None):
+        res = self.send_request(endpoint, param)
+        res.raise_for_status()
         return res.content
 
-    # -----------------
-    # Information (Swagger paths)
-    # -----------------
     def kinase_groups(self) -> List[str]:
         """GET /kinase_groups"""
-        return self._get_json("/kinase_groups")
+        return self.get_json('kinase_groups')
 
     def kinase_families(
         self,
         kinase_group: Optional[Union[str, Iterable[str]]] = None,
     ) -> List[str]:
         """GET /kinase_families"""
-        return self._get_json(
-            "/kinase_families",
+        return self.get_json(
+            "kinase_families",
             {"kinase_group": _comma_list(kinase_group)},
         )
 
@@ -93,8 +70,8 @@ class KlifsClient:
         species: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """GET /kinase_names"""
-        return self._get_json(
-            "/kinase_names",
+        return self.get_json(
+            "kinase_names",
             {
                 "kinase_group": _comma_list(kinase_group),
                 "kinase_family": _comma_list(kinase_family),
@@ -108,8 +85,8 @@ class KlifsClient:
         species: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """GET /kinase_information"""
-        return self._get_json(
-            "/kinase_information",
+        return self.get_json(
+            "kinase_information",
             {"kinase_ID": _comma_list(kinase_id), "species": species},
         )
 
@@ -119,69 +96,63 @@ class KlifsClient:
         species: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """GET /kinase_ID"""
-        return self._get_json(
-            "/kinase_ID",
+        return self.get_json(
+            "kinase_ID",
             {"kinase_name": _comma_list(kinase_name), "species": species},
         )
 
-    # -----------------
-    # Ligands (Swagger paths)
-    # -----------------
     def ligands_list(
         self,
         kinase_id: Optional[Union[int, Iterable[int]]] = None,
     ) -> List[Dict[str, Any]]:
         """GET /ligands_list"""
-        return self._get_json(
-            "/ligands_list",
+        return self.get_json(
+            "ligands_list",
             {"kinase_ID": _comma_list(kinase_id)},
         )
 
     def bioactivity_list_id(self, ligand_id: int) -> List[Dict[str, Any]]:
         """GET /bioactivity_list_id"""
-        return self._get_json("/bioactivity_list_id", {"ligand_ID": ligand_id})
+        return self.get_json("bioactivity_list_id", {"ligand_ID": ligand_id})
 
     def bioactivity_list_pdb(self, ligand_pdb: str) -> List[Dict[str, Any]]:
         """GET /bioactivity_list_pdb"""
-        return self._get_json(
-            "/bioactivity_list_pdb",
+        return self.get_json(
+            "bioactivity_list_pdb",
             {"ligand_PDB": ligand_pdb},
         )
 
-    # -----------------
-    # File-return endpoints (Swagger paths; bytes)
-    # -----------------
     def structure_get_pdb_complex(self, structure_id: int) -> bytes:
         """GET /structure_get_pdb_complex (chemical/x-pdb)"""
-        return self._get_bytes(
-            "/structure_get_pdb_complex",
+        return self.get_content(
+            "structure_get_pdb_complex",
             {"structure_ID": structure_id},
         )
 
     def structure_get_complex_mol2(self, structure_id: int) -> bytes:
         """GET /structure_get_complex (chemical/x-mol2)"""
-        return self._get_bytes(
-            "/structure_get_complex",
+        return self.get_content(
+            "structure_get_complex",
             {"structure_ID": structure_id},
         )
 
     def structure_get_protein_mol2(self, structure_id: int) -> bytes:
         """GET /structure_get_protein (chemical/x-mol2)"""
-        return self._get_bytes(
-            "/structure_get_protein",
+        return self.get_content(
+            "structure_get_protein",
             {"structure_ID": structure_id},
         )
 
     def structure_get_pocket_mol2(self, structure_id: int) -> bytes:
         """GET /structure_get_pocket (chemical/x-mol2)"""
-        return self._get_bytes(
-            "/structure_get_pocket",
+        return self.get_content(
+            "structure_get_pocket",
             {"structure_ID": structure_id},
         )
 
     def structure_get_ligand_mol2(self, structure_id: int) -> bytes:
         """GET /structure_get_ligand (chemical/x-mol2)"""
-        return self._get_bytes(
-            "/structure_get_ligand",
+        return self.get_content(
+            "structure_get_ligand",
             {"structure_ID": structure_id},
         )

--- a/indra/sources/klifs/client.py
+++ b/indra/sources/klifs/client.py
@@ -1,0 +1,191 @@
+# indra/sources/klifs/client.py
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Union
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def _comma_list(x: Any) -> Optional[str]:
+    """Convert iterables to comma-separated strings for query parameters."""
+    if x is None:
+        return None
+    if isinstance(x, (list, tuple, set)):
+        return ",".join(str(i) for i in x)
+    return str(x)
+
+
+@dataclass
+class KlifsClient:
+    """Thin KLIFS REST client reflecting the Swagger endpoints.
+
+    Parameters
+    ----------
+    base_url :
+        Base URL for KLIFS API (Swagger: schemes + host + basePath).
+    timeout :
+        Request timeout in seconds.
+    session :
+        Optional requests session to reuse HTTP connections.
+    """
+
+    base_url: str = "https://klifs.net/api"
+    timeout: int = 30
+    session: Optional[requests.Session] = None
+
+    def _session(self) -> requests.Session:
+        """Get a cached requests.Session for connection reuse."""
+        if self.session is None:
+            self.session = requests.Session()
+        return self.session
+
+    def _get(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> requests.Response:
+        sess = self._session()
+        url = self.base_url + path
+        clean_params = {k: v for k, v in (params or {}).items() if v is not None}
+        logger.debug("KLIFS GET %s params=%s", url, clean_params)
+        res = sess.get(url, params=clean_params, timeout=self.timeout)
+        res.raise_for_status()
+        return res
+
+    def _get_json(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        res = self._get(path, params=params)
+        return res.json()
+
+    def _get_bytes(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> bytes:
+        res = self._get(path, params=params)
+        return res.content
+
+    # -----------------
+    # Information (Swagger paths)
+    # -----------------
+    def kinase_groups(self) -> List[str]:
+        """GET /kinase_groups"""
+        return self._get_json("/kinase_groups")
+
+    def kinase_families(
+        self,
+        kinase_group: Optional[Union[str, Iterable[str]]] = None,
+    ) -> List[str]:
+        """GET /kinase_families"""
+        return self._get_json(
+            "/kinase_families",
+            {"kinase_group": _comma_list(kinase_group)},
+        )
+
+    def kinase_names(
+        self,
+        kinase_group: Optional[Union[str, Iterable[str]]] = None,
+        kinase_family: Optional[Union[str, Iterable[str]]] = None,
+        species: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """GET /kinase_names"""
+        return self._get_json(
+            "/kinase_names",
+            {
+                "kinase_group": _comma_list(kinase_group),
+                "kinase_family": _comma_list(kinase_family),
+                "species": species,
+            },
+        )
+
+    def kinase_information(
+        self,
+        kinase_id: Optional[Union[int, Iterable[int]]] = None,
+        species: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """GET /kinase_information"""
+        return self._get_json(
+            "/kinase_information",
+            {"kinase_ID": _comma_list(kinase_id), "species": species},
+        )
+
+    def kinase_id(
+        self,
+        kinase_name: Union[str, Iterable[str]],
+        species: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """GET /kinase_ID"""
+        return self._get_json(
+            "/kinase_ID",
+            {"kinase_name": _comma_list(kinase_name), "species": species},
+        )
+
+    # -----------------
+    # Ligands (Swagger paths)
+    # -----------------
+    def ligands_list(
+        self,
+        kinase_id: Optional[Union[int, Iterable[int]]] = None,
+    ) -> List[Dict[str, Any]]:
+        """GET /ligands_list"""
+        return self._get_json(
+            "/ligands_list",
+            {"kinase_ID": _comma_list(kinase_id)},
+        )
+
+    def bioactivity_list_id(self, ligand_id: int) -> List[Dict[str, Any]]:
+        """GET /bioactivity_list_id"""
+        return self._get_json("/bioactivity_list_id", {"ligand_ID": ligand_id})
+
+    def bioactivity_list_pdb(self, ligand_pdb: str) -> List[Dict[str, Any]]:
+        """GET /bioactivity_list_pdb"""
+        return self._get_json(
+            "/bioactivity_list_pdb",
+            {"ligand_PDB": ligand_pdb},
+        )
+
+    # -----------------
+    # File-return endpoints (Swagger paths; bytes)
+    # -----------------
+    def structure_get_pdb_complex(self, structure_id: int) -> bytes:
+        """GET /structure_get_pdb_complex (chemical/x-pdb)"""
+        return self._get_bytes(
+            "/structure_get_pdb_complex",
+            {"structure_ID": structure_id},
+        )
+
+    def structure_get_complex_mol2(self, structure_id: int) -> bytes:
+        """GET /structure_get_complex (chemical/x-mol2)"""
+        return self._get_bytes(
+            "/structure_get_complex",
+            {"structure_ID": structure_id},
+        )
+
+    def structure_get_protein_mol2(self, structure_id: int) -> bytes:
+        """GET /structure_get_protein (chemical/x-mol2)"""
+        return self._get_bytes(
+            "/structure_get_protein",
+            {"structure_ID": structure_id},
+        )
+
+    def structure_get_pocket_mol2(self, structure_id: int) -> bytes:
+        """GET /structure_get_pocket (chemical/x-mol2)"""
+        return self._get_bytes(
+            "/structure_get_pocket",
+            {"structure_ID": structure_id},
+        )
+
+    def structure_get_ligand_mol2(self, structure_id: int) -> bytes:
+        """GET /structure_get_ligand (chemical/x-mol2)"""
+        return self._get_bytes(
+            "/structure_get_ligand",
+            {"structure_ID": structure_id},
+        )

--- a/indra/sources/klifs/processor.py
+++ b/indra/sources/klifs/processor.py
@@ -1,9 +1,12 @@
 from typing import Any, Dict, List, Optional, Union, Iterable
+import logging
 
 import html
 
 from indra.statements import Agent, Complex, Evidence, Inhibition, Statement
 from .client import KlifsClient
+
+logger = logging.getLogger(__name__)
 
 
 def _safe_str(x: Any) -> Optional[str]:
@@ -46,39 +49,40 @@ class KlifsProcessor:
     """
 
 
-    def __init__(self, ligand_id, ligand_pdb, ligand_details):
-        self.ligand_id = ligand_id
-        self.ligand_pdb = ligand_pdb
-        self.ligand_details = ligand_details
-
-        self. bioactivities = bioactivities = get_bioactivities_for_ligand(
-            ligand_id=ligand_id,
-            ligand_pdb=ligand_pdb,
-            client=_default_client,
-        )
+    def __init__(self, kinase_gene_name, kinase_uniprot):
+        self.client = _default_client
+        self.kinase_gene_name = kinase_gene_name
+        self.kinase_uniprot = kinase_uniprot
+        self.kinase_info = self.client.kinase_id(self.kinase_gene_name)[0]
+        self.kinase_id = self.kinase_info['kinase_ID']
 
         self.statements = []
+
 
     def extract_statements(self) -> None:
         """Extract INDRA Statements into `self.statements`."""
-        self.statements = []
-        ligand = self._make_ligand_agent()
-        if ligand is None:
-            return
-
-        for rec in self.bioactivities or []:
-            kinase = self._make_kinase_agent(rec)
-            if kinase is None:
+        ligands = self.client.ligands_list(self.kinase_id)
+        for ligand in ligands:
+            ligand_agent = self._make_ligand_agent(ligand)
+            try:
+                bioactivities = self.client.bioactivity_list_id(ligand['ligand_ID'])
+            except Exception as e:
+                logger.warning("Failed to get bioactivities for ligand %s: %s")
                 continue
 
-            ev = Evidence(
-                source_api="klifs",
-                annotations=self._make_annotations(rec),
-            )
+            for rec in bioactivities or []:
+                kinase_agent = self._make_kinase_agent(rec)
+                if kinase_agent is None:
+                    continue
 
-            stmt = self._make_statement(ligand, kinase, rec, ev)
-            if stmt is not None:
-                self.statements.append(stmt)
+                ev = Evidence(
+                    source_api="klifs",
+                    annotations=self._make_annotations(rec),
+                )
+
+                stmt = self._make_statement(ligand_agent, kinase_agent, rec, ev)
+                if stmt is not None:
+                    self.statements.append(stmt)
 
     def _make_statement(
         self,
@@ -99,25 +103,15 @@ class KlifsProcessor:
         ev.annotations["klifs_interpretation"] = "default_complex_unknown_type"
         return Complex([ligand, kinase], evidence=[ev])
 
-    def _make_ligand_agent(self) -> Optional[Agent]:
-        ld = self.ligand_details or {}
+    def _make_ligand_agent(self, ligand) -> Optional[Agent]:
+        name = _safe_str(ligand['Name'])
 
-        name = (
-            _safe_str(ld.get("Name"))
-            or _safe_str(ld.get("PDB-code"))
-            or (f"KLIFS_LIGAND_{self.ligand_id}" if self.ligand_id is not None else None)
-            or (_safe_str(self.ligand_pdb) if self.ligand_pdb else None)
-        )
-        if name is None:
-            return None
+        db_refs = {}
+        inchikey = _safe_str(ligand.get("InChIKey"))
+        smiles = _safe_str(ligand.get("SMILES"))
+        pdb_code = _safe_str(ligand.get("PDB-code"))
 
-        db_refs: Dict[str, Any] = {}
-        inchikey = _safe_str(ld.get("InChIKey"))
-        smiles = _safe_str(ld.get("SMILES"))
-        pdb_code = _safe_str(ld.get("PDB-code"))
-
-        if self.ligand_id is not None:
-            db_refs["KLIFS_LIGAND"] = str(self.ligand_id)
+        db_refs["KLIFS_LIGAND"] = str(ligand['ligand_ID'])
         if pdb_code is not None:
             db_refs["PDB"] = pdb_code
         if inchikey is not None:
@@ -139,11 +133,7 @@ class KlifsProcessor:
         return Agent(name, db_refs=db_refs)
 
     def _make_annotations(self, rec: Dict[str, Any]) -> Dict[str, Any]:
-        ann: Dict[str, Any] = {
-            "klifs_ligand_id": self.ligand_id,
-            "klifs_ligand_pdb": self.ligand_pdb,
-        }
-
+        ann = {}
         for k in [
             "standard_type",
             "standard_relation",

--- a/indra/sources/klifs/processor.py
+++ b/indra/sources/klifs/processor.py
@@ -1,316 +1,156 @@
-"""Processor for KLIFS kinase-inhibitor data."""
+# indra/sources/klifs/processor.py
 
-from typing import List, Dict, Optional
-import logging
-from collections import defaultdict
+from __future__ import annotations
 
-from indra.statements import Inhibition, Agent, Evidence
-from indra.databases import hgnc_client, chebi_client, uniprot_client
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
-logger = logging.getLogger(__name__)
+from indra.statements import Agent, Complex, Evidence, Inhibition, Statement
 
+import html
+
+
+def _safe_str(x: Any) -> Optional[str]:
+    if x is None:
+        return None
+    s = html.unescape(str(x).strip())
+    return s or None
+
+
+def _norm_measurement_type(x: Any) -> Optional[str]:
+    """Normalize measurement type strings (e.g., 'IC50', 'Kd', 'Ki')."""
+    s = _safe_str(x)
+    if s is None:
+        return None
+    return s.upper().replace(" ", "")
+
+
+@dataclass
 class KlifsProcessor:
-    """Process KLIFS data into INDRA statements.
-    
-    Parameters
-    ----------
-    bioactivities : list
-        List of bioactivity data from KLIFS
-    ligands : list
-        List of ligand information from KLIFS  
-    kinases : list
-        List of kinase information from KLIFS
-    drugs : list
-        List of approved drugs from KLIFS
+    """Processor for turning KLIFS BioactivityDetails into INDRA Statements.
+
+    Current focus
+    -------------
+    Convert KLIFS BioactivityDetails records (from /bioactivity_list_id or
+    /bioactivity_list_pdb) into INDRA Statements.
+
+    Interpretation
+    --------------
+    KLIFS provides assay measurements (IC50/Ki/Kd/etc.), not explicit claims.
+    This processor interprets:
+    - IC50 measurements as evidence for Inhibition(chemical, kinase)
+    - Ki/Kd measurements as evidence for Complex(chemical, kinase)
+
+    Any other/unknown measurement types default to Complex with an explicit
+    annotation describing the fallback behavior.
+
+    All quantitative fields are preserved in Evidence annotations.
     """
-    
-    def __init__(self, bioactivities=None, ligands=None, kinases=None, drugs=None):
-        self.bioactivities = bioactivities or []
-        self.ligands = ligands or []
-        self.kinases = kinases or []
-        self.drugs = drugs or []
+
+    bioactivities: List[Dict[str, Any]]
+    ligand_id: Optional[int] = None
+    ligand_pdb: Optional[str] = None
+    ligand_details: Optional[Dict[str, Any]] = None
+
+    statements: List[Statement] = field(default_factory=list)
+
+    def extract_statements(self) -> None:
+        """Extract INDRA Statements into `self.statements`."""
         self.statements = []
-        
-        # Build lookup tables
-        self._build_lookups()
-        
-    def _build_lookups(self):
-        """Build lookup dictionaries for efficient processing."""
-        # Ligand ID to ligand info
-        self.ligand_lookup = {}
-        for ligand in self.ligands:
-            lig_id = ligand.get('ligand_id') or ligand.get('id')
-            if lig_id:
-                self.ligand_lookup[lig_id] = ligand
-        
-        # Kinase name to kinase info  
-        self.kinase_lookup = {}
-        for kinase in self.kinases:
-            name = kinase.get('kinase_name') or kinase.get('name')
-            if name:
-                self.kinase_lookup[name] = kinase
-        
-        # Drug name to drug info
-        self.drug_lookup = {}
-        for drug in self.drugs:
-            name = drug.get('drug_name') or drug.get('name')
-            if name:
-                self.drug_lookup[name.lower()] = drug
-    
-    def process_bioactivities(self):
-        """Process bioactivity data into Inhibition statements.
-        
-        Returns
-        -------
-        list
-            List of INDRA statements
-        """
-        logger.info(f'Processing {len(self.bioactivities)} bioactivities')
-        
-        for activity in self.bioactivities:
-            stmt = self._process_single_activity(activity)
-            if stmt:
+        ligand = self._make_ligand_agent()
+        if ligand is None:
+            return
+
+        for rec in self.bioactivities or []:
+            kinase = self._make_kinase_agent(rec)
+            if kinase is None:
+                continue
+
+            ev = Evidence(
+                source_api="klifs",
+                annotations=self._make_annotations(rec),
+            )
+
+            stmt = self._make_statement(ligand, kinase, rec, ev)
+            if stmt is not None:
                 self.statements.append(stmt)
-        
-        logger.info(f'Generated {len(self.statements)} statements')
-        return self.statements
-    
-    def _process_single_activity(self, activity: Dict) -> Optional[Inhibition]:
-        """Process a single bioactivity entry into a statement.
-        
-        Parameters
-        ----------
-        activity : dict
-            Bioactivity data from KLIFS
-            
-        Returns
-        -------
-        Inhibition or None
-            INDRA statement if processing successful
-        """
-        # Get ligand/drug agent
-        ligand_agent = self._make_ligand_agent(activity)
-        if not ligand_agent:
-            return None
-            
-        # Get kinase agent
-        kinase_agent = self._make_kinase_agent(activity)
-        if not kinase_agent:
-            return None
-        
-        # Create evidence
-        evidence = self._make_evidence(activity)
-        
-        # Create inhibition statement
-        # (Most kinase-ligand interactions in KLIFS are inhibitory)
-        stmt = Inhibition(ligand_agent, kinase_agent, evidence=[evidence])
-        
-        return stmt
-    
-    def _make_ligand_agent(self, activity: Dict) -> Optional[Agent]:
-        """Create an Agent for the ligand/drug.
-        
-        Parameters
-        ----------
-        activity : dict
-            Activity data containing ligand information
-            
-        Returns
-        -------
-        Agent or None
-            Grounded ligand agent
-        """
-        # Get ligand ID and look up full info
-        ligand_id = activity.get('ligand_id')
-        ligand_info = self.ligand_lookup.get(ligand_id, {})
-        
-        # Try to get identifiers
-        db_refs = {}
-        name = None
-        
-        # Check for ChEMBL ID (preferred for compounds)
-        chembl_id = (activity.get('chembl_id') or 
-                    ligand_info.get('chembl_id') or
-                    ligand_info.get('compound_chembl_id'))
-        
-        if chembl_id:
-            # Clean ChEMBL ID format
-            if not chembl_id.startswith('CHEMBL'):
-                chembl_id = f'CHEMBL{chembl_id}'
-            db_refs['CHEMBL'] = chembl_id
-            
-            # Try to get CHEBI from ChEMBL
-            chebi_id = chebi_client.get_chebi_id_from_chembl(chembl_id)
-            if chebi_id:
-                db_refs['CHEBI'] = chebi_id
-        
-        # Check for PubChem
-        pubchem_id = ligand_info.get('pubchem_id')
-        if pubchem_id:
-            db_refs['PUBCHEM'] = str(pubchem_id)
-        
-        # Add SMILES if available
-        smiles = ligand_info.get('smiles')
-        if smiles:
-            db_refs['SMILES'] = smiles
-        
-        # InChI key
-        inchi_key = ligand_info.get('inchi_key')
-        if inchi_key:
-            db_refs['INCHIKEY'] = inchi_key
-        
-        # Get name
-        name = (activity.get('ligand_name') or 
-                ligand_info.get('ligand_name') or
-                ligand_info.get('name') or
-                ligand_info.get('compound_name'))
-        
-        # Check if it's an approved drug
-        if name:
-            drug_info = self.drug_lookup.get(name.lower())
-            if drug_info:
-                # Add drug-specific identifiers
-                if drug_info.get('drugbank_id'):
-                    db_refs['DRUGBANK'] = drug_info['drugbank_id']
-        
-        # Store KLIFS ID
-        if ligand_id:
-            db_refs['KLIFS_LIGAND'] = str(ligand_id)
-        
-        # If still no name, use ChEMBL ID or generic name
-        if not name:
-            if chembl_id:
-                name = chembl_id
-            elif ligand_id:
-                name = f'KLIFS_ligand_{ligand_id}'
-            else:
-                logger.warning(f'Could not determine name for ligand in activity: {activity}')
-                return None
-        
-        return Agent(name, db_refs=db_refs)
-    
-    def _make_kinase_agent(self, activity: Dict) -> Optional[Agent]:
-        """Create an Agent for the kinase.
-        
-        Parameters
-        ----------
-        activity : dict
-            Activity data containing kinase information
-            
-        Returns
-        -------
-        Agent or None
-            Grounded kinase agent
-        """
-        # Get kinase name
-        kinase_name = activity.get('kinase_name') or activity.get('kinase')
-        if not kinase_name:
-            logger.warning(f'No kinase name in activity: {activity}')
-            return None
-        
-        # Get full kinase info
-        kinase_info = self.kinase_lookup.get(kinase_name, {})
-        
-        db_refs = {}
-        
-        # Try HGNC (preferred for human kinases)
-        hgnc_symbol = (kinase_info.get('hgnc_symbol') or 
-                      kinase_info.get('gene_name') or
-                      kinase_name)
-        
-        if hgnc_symbol:
-            hgnc_id = hgnc_client.get_current_hgnc_id(hgnc_symbol)
-            if hgnc_id:
-                db_refs['HGNC'] = hgnc_id
-                
-                # Get UniProt from HGNC
-                up_id = hgnc_client.get_uniprot_id(hgnc_id)
-                if up_id:
-                    db_refs['UP'] = up_id
-        
-        # Try UniProt directly if no HGNC
-        if not db_refs.get('HGNC'):
-            uniprot_id = (kinase_info.get('uniprot_id') or
-                         kinase_info.get('uniprot'))
-            if uniprot_id:
-                db_refs['UP'] = uniprot_id
-                
-                # Try to get gene name from UniProt
-                gene_name = uniprot_client.get_gene_name(uniprot_id)
-                if gene_name:
-                    hgnc_id = hgnc_client.get_current_hgnc_id(gene_name)
-                    if hgnc_id:
-                        db_refs['HGNC'] = hgnc_id
-        
-        # Store KLIFS kinase ID
-        klifs_kinase_id = kinase_info.get('kinase_id')
-        if klifs_kinase_id:
-            db_refs['KLIFS_KINASE'] = str(klifs_kinase_id)
-        
-        # Check if it's a family name
-        if kinase_name in ['AKT', 'RAF', 'SRC', 'CDK', 'MAPK', 'PKC']:
-            db_refs['FPLX'] = kinase_name
-        
-        return Agent(kinase_name, db_refs=db_refs)
-    
-    def _make_evidence(self, activity: Dict) -> Evidence:
-        """Create Evidence object with activity details.
-        
-        Parameters
-        ----------
-        activity : dict
-            Activity data from KLIFS
-            
-        Returns
-        -------
-        Evidence
-            Evidence object with annotations
-        """
-        # Build annotations with all available data
-        annotations = {}
-        
-        # Activity measurements
-        if 'activity_type' in activity:
-            annotations['activity_type'] = activity['activity_type']
-        if 'activity_value' in activity:
-            annotations['activity_value'] = activity['activity_value']
-        if 'activity_unit' in activity:
-            annotations['activity_unit'] = activity['activity_unit']
-            
-        # Often KLIFS has pIC50 or pKi
-        if 'pic50' in activity:
-            annotations['pIC50'] = activity['pic50']
-        if 'pki' in activity:
-            annotations['pKi'] = activity['pki']
-        if 'pkd' in activity:
-            annotations['pKd'] = activity['pkd']
-            
-        # Experimental details
-        if 'assay_type' in activity:
-            annotations['assay_type'] = activity['assay_type']
-        if 'cell_line' in activity:
-            annotations['cell_line'] = activity['cell_line']
-            
-        # Structure info if available
-        if 'pdb_id' in activity:
-            annotations['pdb_id'] = activity['pdb_id']
-        if 'structure_id' in activity:
-            annotations['structure_id'] = activity['structure_id']
-            
-        # Original IDs for back-reference
-        if 'ligand_id' in activity:
-            annotations['klifs_ligand_id'] = activity['ligand_id']
-        if 'bioactivity_id' in activity:
-            annotations['klifs_bioactivity_id'] = activity['bioactivity_id']
-        
-        # Clean up None values
-        annotations = {k: v for k, v in annotations.items() if v is not None}
-        
-        # Create evidence
-        evidence = Evidence(
-            source_api='klifs',
-            pmid=activity.get('pmid'),
-            annotations=annotations
+
+    def _make_statement(
+        self,
+        ligand: Agent,
+        kinase: Agent,
+        rec: Dict[str, Any],
+        ev: Evidence,
+    ) -> Optional[Statement]:
+        stype = _norm_measurement_type(rec.get("standard_type"))
+
+        if stype == "IC50":
+            return Inhibition(ligand, kinase, evidence=[ev])
+
+        if stype in {"KD", "KI"}:
+            return Complex([ligand, kinase], evidence=[ev])
+
+        # Default: treat as binding/association, but keep type annotated
+        ev.annotations["klifs_interpretation"] = "default_complex_unknown_type"
+        return Complex([ligand, kinase], evidence=[ev])
+
+    def _make_ligand_agent(self) -> Optional[Agent]:
+        ld = self.ligand_details or {}
+
+        name = (
+            _safe_str(ld.get("Name"))
+            or _safe_str(ld.get("PDB-code"))
+            or (f"KLIFS_LIGAND_{self.ligand_id}" if self.ligand_id is not None else None)
+            or (_safe_str(self.ligand_pdb) if self.ligand_pdb else None)
         )
-        
-        return evidence
+        if name is None:
+            return None
+
+        db_refs: Dict[str, Any] = {}
+        inchikey = _safe_str(ld.get("InChIKey"))
+        smiles = _safe_str(ld.get("SMILES"))
+        pdb_code = _safe_str(ld.get("PDB-code"))
+
+        if self.ligand_id is not None:
+            db_refs["KLIFS_LIGAND"] = str(self.ligand_id)
+        if pdb_code is not None:
+            db_refs["PDB"] = pdb_code
+        if inchikey is not None:
+            db_refs["INCHIKEY"] = inchikey
+        if smiles is not None:
+            db_refs["SMILES"] = smiles
+
+        return Agent(name, db_refs=db_refs)
+
+    def _make_kinase_agent(self, rec: Dict[str, Any]) -> Optional[Agent]:
+        accession = _safe_str(rec.get("accession"))
+        name = _safe_str(rec.get("pref_name")) or accession
+        if name is None:
+            return None
+
+        db_refs: Dict[str, Any] = {}
+        if accession is not None:
+            db_refs["UP"] = accession
+        return Agent(name, db_refs=db_refs)
+
+    def _make_annotations(self, rec: Dict[str, Any]) -> Dict[str, Any]:
+        ann: Dict[str, Any] = {
+            "klifs_ligand_id": self.ligand_id,
+            "klifs_ligand_pdb": self.ligand_pdb,
+        }
+
+        for k in [
+            "standard_type",
+            "standard_relation",
+            "standard_value",
+            "standard_units",
+            "pchembl_value",
+            "organism",
+            "pref_name",
+            "accession",
+        ]:
+            v = rec.get(k)
+            if v is not None and v != "":
+                ann[k] = v
+
+        return ann

--- a/indra/sources/klifs/processor.py
+++ b/indra/sources/klifs/processor.py
@@ -1,0 +1,316 @@
+"""Processor for KLIFS kinase-inhibitor data."""
+
+from typing import List, Dict, Optional
+import logging
+from collections import defaultdict
+
+from indra.statements import Inhibition, Agent, Evidence
+from indra.databases import hgnc_client, chebi_client, uniprot_client
+
+logger = logging.getLogger(__name__)
+
+class KlifsProcessor:
+    """Process KLIFS data into INDRA statements.
+    
+    Parameters
+    ----------
+    bioactivities : list
+        List of bioactivity data from KLIFS
+    ligands : list
+        List of ligand information from KLIFS  
+    kinases : list
+        List of kinase information from KLIFS
+    drugs : list
+        List of approved drugs from KLIFS
+    """
+    
+    def __init__(self, bioactivities=None, ligands=None, kinases=None, drugs=None):
+        self.bioactivities = bioactivities or []
+        self.ligands = ligands or []
+        self.kinases = kinases or []
+        self.drugs = drugs or []
+        self.statements = []
+        
+        # Build lookup tables
+        self._build_lookups()
+        
+    def _build_lookups(self):
+        """Build lookup dictionaries for efficient processing."""
+        # Ligand ID to ligand info
+        self.ligand_lookup = {}
+        for ligand in self.ligands:
+            lig_id = ligand.get('ligand_id') or ligand.get('id')
+            if lig_id:
+                self.ligand_lookup[lig_id] = ligand
+        
+        # Kinase name to kinase info  
+        self.kinase_lookup = {}
+        for kinase in self.kinases:
+            name = kinase.get('kinase_name') or kinase.get('name')
+            if name:
+                self.kinase_lookup[name] = kinase
+        
+        # Drug name to drug info
+        self.drug_lookup = {}
+        for drug in self.drugs:
+            name = drug.get('drug_name') or drug.get('name')
+            if name:
+                self.drug_lookup[name.lower()] = drug
+    
+    def process_bioactivities(self):
+        """Process bioactivity data into Inhibition statements.
+        
+        Returns
+        -------
+        list
+            List of INDRA statements
+        """
+        logger.info(f'Processing {len(self.bioactivities)} bioactivities')
+        
+        for activity in self.bioactivities:
+            stmt = self._process_single_activity(activity)
+            if stmt:
+                self.statements.append(stmt)
+        
+        logger.info(f'Generated {len(self.statements)} statements')
+        return self.statements
+    
+    def _process_single_activity(self, activity: Dict) -> Optional[Inhibition]:
+        """Process a single bioactivity entry into a statement.
+        
+        Parameters
+        ----------
+        activity : dict
+            Bioactivity data from KLIFS
+            
+        Returns
+        -------
+        Inhibition or None
+            INDRA statement if processing successful
+        """
+        # Get ligand/drug agent
+        ligand_agent = self._make_ligand_agent(activity)
+        if not ligand_agent:
+            return None
+            
+        # Get kinase agent
+        kinase_agent = self._make_kinase_agent(activity)
+        if not kinase_agent:
+            return None
+        
+        # Create evidence
+        evidence = self._make_evidence(activity)
+        
+        # Create inhibition statement
+        # (Most kinase-ligand interactions in KLIFS are inhibitory)
+        stmt = Inhibition(ligand_agent, kinase_agent, evidence=[evidence])
+        
+        return stmt
+    
+    def _make_ligand_agent(self, activity: Dict) -> Optional[Agent]:
+        """Create an Agent for the ligand/drug.
+        
+        Parameters
+        ----------
+        activity : dict
+            Activity data containing ligand information
+            
+        Returns
+        -------
+        Agent or None
+            Grounded ligand agent
+        """
+        # Get ligand ID and look up full info
+        ligand_id = activity.get('ligand_id')
+        ligand_info = self.ligand_lookup.get(ligand_id, {})
+        
+        # Try to get identifiers
+        db_refs = {}
+        name = None
+        
+        # Check for ChEMBL ID (preferred for compounds)
+        chembl_id = (activity.get('chembl_id') or 
+                    ligand_info.get('chembl_id') or
+                    ligand_info.get('compound_chembl_id'))
+        
+        if chembl_id:
+            # Clean ChEMBL ID format
+            if not chembl_id.startswith('CHEMBL'):
+                chembl_id = f'CHEMBL{chembl_id}'
+            db_refs['CHEMBL'] = chembl_id
+            
+            # Try to get CHEBI from ChEMBL
+            chebi_id = chebi_client.get_chebi_id_from_chembl(chembl_id)
+            if chebi_id:
+                db_refs['CHEBI'] = chebi_id
+        
+        # Check for PubChem
+        pubchem_id = ligand_info.get('pubchem_id')
+        if pubchem_id:
+            db_refs['PUBCHEM'] = str(pubchem_id)
+        
+        # Add SMILES if available
+        smiles = ligand_info.get('smiles')
+        if smiles:
+            db_refs['SMILES'] = smiles
+        
+        # InChI key
+        inchi_key = ligand_info.get('inchi_key')
+        if inchi_key:
+            db_refs['INCHIKEY'] = inchi_key
+        
+        # Get name
+        name = (activity.get('ligand_name') or 
+                ligand_info.get('ligand_name') or
+                ligand_info.get('name') or
+                ligand_info.get('compound_name'))
+        
+        # Check if it's an approved drug
+        if name:
+            drug_info = self.drug_lookup.get(name.lower())
+            if drug_info:
+                # Add drug-specific identifiers
+                if drug_info.get('drugbank_id'):
+                    db_refs['DRUGBANK'] = drug_info['drugbank_id']
+        
+        # Store KLIFS ID
+        if ligand_id:
+            db_refs['KLIFS_LIGAND'] = str(ligand_id)
+        
+        # If still no name, use ChEMBL ID or generic name
+        if not name:
+            if chembl_id:
+                name = chembl_id
+            elif ligand_id:
+                name = f'KLIFS_ligand_{ligand_id}'
+            else:
+                logger.warning(f'Could not determine name for ligand in activity: {activity}')
+                return None
+        
+        return Agent(name, db_refs=db_refs)
+    
+    def _make_kinase_agent(self, activity: Dict) -> Optional[Agent]:
+        """Create an Agent for the kinase.
+        
+        Parameters
+        ----------
+        activity : dict
+            Activity data containing kinase information
+            
+        Returns
+        -------
+        Agent or None
+            Grounded kinase agent
+        """
+        # Get kinase name
+        kinase_name = activity.get('kinase_name') or activity.get('kinase')
+        if not kinase_name:
+            logger.warning(f'No kinase name in activity: {activity}')
+            return None
+        
+        # Get full kinase info
+        kinase_info = self.kinase_lookup.get(kinase_name, {})
+        
+        db_refs = {}
+        
+        # Try HGNC (preferred for human kinases)
+        hgnc_symbol = (kinase_info.get('hgnc_symbol') or 
+                      kinase_info.get('gene_name') or
+                      kinase_name)
+        
+        if hgnc_symbol:
+            hgnc_id = hgnc_client.get_current_hgnc_id(hgnc_symbol)
+            if hgnc_id:
+                db_refs['HGNC'] = hgnc_id
+                
+                # Get UniProt from HGNC
+                up_id = hgnc_client.get_uniprot_id(hgnc_id)
+                if up_id:
+                    db_refs['UP'] = up_id
+        
+        # Try UniProt directly if no HGNC
+        if not db_refs.get('HGNC'):
+            uniprot_id = (kinase_info.get('uniprot_id') or
+                         kinase_info.get('uniprot'))
+            if uniprot_id:
+                db_refs['UP'] = uniprot_id
+                
+                # Try to get gene name from UniProt
+                gene_name = uniprot_client.get_gene_name(uniprot_id)
+                if gene_name:
+                    hgnc_id = hgnc_client.get_current_hgnc_id(gene_name)
+                    if hgnc_id:
+                        db_refs['HGNC'] = hgnc_id
+        
+        # Store KLIFS kinase ID
+        klifs_kinase_id = kinase_info.get('kinase_id')
+        if klifs_kinase_id:
+            db_refs['KLIFS_KINASE'] = str(klifs_kinase_id)
+        
+        # Check if it's a family name
+        if kinase_name in ['AKT', 'RAF', 'SRC', 'CDK', 'MAPK', 'PKC']:
+            db_refs['FPLX'] = kinase_name
+        
+        return Agent(kinase_name, db_refs=db_refs)
+    
+    def _make_evidence(self, activity: Dict) -> Evidence:
+        """Create Evidence object with activity details.
+        
+        Parameters
+        ----------
+        activity : dict
+            Activity data from KLIFS
+            
+        Returns
+        -------
+        Evidence
+            Evidence object with annotations
+        """
+        # Build annotations with all available data
+        annotations = {}
+        
+        # Activity measurements
+        if 'activity_type' in activity:
+            annotations['activity_type'] = activity['activity_type']
+        if 'activity_value' in activity:
+            annotations['activity_value'] = activity['activity_value']
+        if 'activity_unit' in activity:
+            annotations['activity_unit'] = activity['activity_unit']
+            
+        # Often KLIFS has pIC50 or pKi
+        if 'pic50' in activity:
+            annotations['pIC50'] = activity['pic50']
+        if 'pki' in activity:
+            annotations['pKi'] = activity['pki']
+        if 'pkd' in activity:
+            annotations['pKd'] = activity['pkd']
+            
+        # Experimental details
+        if 'assay_type' in activity:
+            annotations['assay_type'] = activity['assay_type']
+        if 'cell_line' in activity:
+            annotations['cell_line'] = activity['cell_line']
+            
+        # Structure info if available
+        if 'pdb_id' in activity:
+            annotations['pdb_id'] = activity['pdb_id']
+        if 'structure_id' in activity:
+            annotations['structure_id'] = activity['structure_id']
+            
+        # Original IDs for back-reference
+        if 'ligand_id' in activity:
+            annotations['klifs_ligand_id'] = activity['ligand_id']
+        if 'bioactivity_id' in activity:
+            annotations['klifs_bioactivity_id'] = activity['bioactivity_id']
+        
+        # Clean up None values
+        annotations = {k: v for k, v in annotations.items() if v is not None}
+        
+        # Create evidence
+        evidence = Evidence(
+            source_api='klifs',
+            pmid=activity.get('pmid'),
+            annotations=annotations
+        )
+        
+        return evidence

--- a/indra/sources/klifs/processor.py
+++ b/indra/sources/klifs/processor.py
@@ -1,13 +1,9 @@
-# indra/sources/klifs/processor.py
-
-from __future__ import annotations
-
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
-
-from indra.statements import Agent, Complex, Evidence, Inhibition, Statement
+from typing import Any, Dict, List, Optional, Union, Iterable
 
 import html
+
+from indra.statements import Agent, Complex, Evidence, Inhibition, Statement
+from .client import KlifsClient
 
 
 def _safe_str(x: Any) -> Optional[str]:
@@ -25,7 +21,9 @@ def _norm_measurement_type(x: Any) -> Optional[str]:
     return s.upper().replace(" ", "")
 
 
-@dataclass
+_default_client = KlifsClient()
+
+
 class KlifsProcessor:
     """Processor for turning KLIFS BioactivityDetails into INDRA Statements.
 
@@ -47,12 +45,19 @@ class KlifsProcessor:
     All quantitative fields are preserved in Evidence annotations.
     """
 
-    bioactivities: List[Dict[str, Any]]
-    ligand_id: Optional[int] = None
-    ligand_pdb: Optional[str] = None
-    ligand_details: Optional[Dict[str, Any]] = None
 
-    statements: List[Statement] = field(default_factory=list)
+    def __init__(self, ligand_id, ligand_pdb, ligand_details):
+        self.ligand_id = ligand_id
+        self.ligand_pdb = ligand_pdb
+        self.ligand_details = ligand_details
+
+        self. bioactivities = bioactivities = get_bioactivities_for_ligand(
+            ligand_id=ligand_id,
+            ligand_pdb=ligand_pdb,
+            client=_default_client,
+        )
+
+        self.statements = []
 
     def extract_statements(self) -> None:
         """Extract INDRA Statements into `self.statements`."""
@@ -154,3 +159,106 @@ class KlifsProcessor:
                 ann[k] = v
 
         return ann
+
+
+def get_kinase_families(
+        kinase_group: Optional[Union[str, Iterable[str]]] = None,
+        client: KlifsClient = _default_client,
+) -> List[str]:
+    """Get the list of kinase families from KLIFS.
+
+    Swagger mapping: GET /kinase_families
+    """
+    return client.kinase_families(kinase_group=kinase_group)
+
+
+def get_kinase_names(
+        kinase_group: Optional[Union[str, Iterable[str]]] = None,
+        kinase_family: Optional[Union[str, Iterable[str]]] = None,
+        species: Optional[str] = None,
+        client: KlifsClient = _default_client,
+) -> List[Dict[str, Any]]:
+    """Get kinase names (HGNC gene symbols) and associated IDs from KLIFS.
+
+    Swagger mapping: GET /kinase_names
+    """
+    return client.kinase_names(
+        kinase_group=kinase_group,
+        kinase_family=kinase_family,
+        species=species,
+    )
+
+
+def get_kinase_information(
+        kinase_ids: Optional[Union[int, Iterable[int]]] = None,
+        species: Optional[str] = None,
+        client: KlifsClient = _default_client,
+) -> List[Dict[str, Any]]:
+    """Get kinase information records from KLIFS.
+
+    Swagger mapping: GET /kinase_information
+    """
+    return client.kinase_information(kinase_id=kinase_ids, species=species)
+
+
+def get_kinase_id(
+        kinase_name: Union[str, Iterable[str]],
+        species: Optional[str] = None,
+        client: KlifsClient = _default_client,
+) -> List[int]:
+    """Resolve one or more kinase names to KLIFS kinase_ID integers.
+
+    Swagger mapping: GET /kinase_ID
+
+    Notes
+    -----
+    The Swagger endpoint returns KinaseInformation-like records; this helper
+    extracts and returns only the `kinase_ID` integer(s).
+    """
+    rows = client.kinase_id(kinase_name=kinase_name, species=species)
+    out: List[int] = []
+    for row in rows or []:
+        kid = row.get("kinase_ID")
+        if kid is not None:
+            out.append(int(kid))
+    return out
+
+
+def get_ligands_list(
+        kinase_id: Optional[Union[int, Iterable[int]]] = None,
+        client: KlifsClient = _default_client,
+) -> List[Dict[str, Any]]:
+    """Get ligandDetails records from KLIFS.
+
+    Swagger mapping: GET /ligands_list
+    """
+    return client.ligands_list(kinase_id=kinase_id)
+
+
+def get_bioactivities_for_ligand(
+        ligand_id: Optional[int] = None,
+        ligand_pdb: Optional[str] = None,
+        client: KlifsClient = _default_client,
+) -> List[Dict[str, Any]]:
+    """Get bioactivity records for a ligand from KLIFS.
+
+    KLIFS exposes two separate Swagger endpoints that return the same *kind* of
+    record (BioactivityDetails) for a ligand, differing only by identifier:
+
+    - GET /bioactivity_list_id   (use when `ligand_id` is provided)
+    - GET /bioactivity_list_pdb  (use when `ligand_pdb` is provided)
+
+    This convenience function dispatches to the correct endpoint.
+
+    Raises
+    ------
+    ValueError
+        If neither `ligand_id` nor `ligand_pdb` is provided.
+    """
+    if ligand_id is not None:
+        return client.bioactivity_list_id(ligand_id)
+    if ligand_pdb is not None:
+        return client.bioactivity_list_pdb(ligand_pdb)
+    raise ValueError("Provide ligand_id or ligand_pdb.")
+
+

--- a/indra/tests/test_klifs.py
+++ b/indra/tests/test_klifs.py
@@ -1,15 +1,17 @@
 import pytest
 
+from indra.sources import klifs
 from indra.sources.klifs.processor import KlifsProcessor
 from indra.statements import Complex, Inhibition
 
 
 def make_processor(rec, ligand_id=1, ligand_details=None):
     kp = KlifsProcessor(
-        bioactivities=[rec],
         ligand_id=ligand_id,
         ligand_details=ligand_details or {"Name": "TEST_LIG"},
+        ligand_pdb=None
     )
+    kp.bioactivities = rec
     kp.extract_statements()
     return kp
 
@@ -117,3 +119,7 @@ def test_ligand_agent_has_expected_db_refs():
     assert ligand.db_refs["PDB"] == "STU"
     assert ligand.db_refs["INCHIKEY"] == "ABCDEFGHIJKLMN"
     assert ligand.db_refs["SMILES"] == "CCO"
+
+
+def test_process_ligand():
+    klifs.process_ligand(ligand_id='k-252a')

--- a/indra/tests/test_klifs.py
+++ b/indra/tests/test_klifs.py
@@ -1,90 +1,119 @@
 import pytest
-from indra.sources.klifs.api import KlifsClient
+
 from indra.sources.klifs.processor import KlifsProcessor
-from indra.statements import Inhibition
+from indra.statements import Complex, Inhibition
 
 
-# ========== Processor Tests (no network) ==========
+def make_processor(rec, ligand_id=1, ligand_details=None):
+    kp = KlifsProcessor(
+        bioactivities=[rec],
+        ligand_id=ligand_id,
+        ligand_details=ligand_details or {"Name": "TEST_LIG"},
+    )
+    kp.extract_statements()
+    return kp
 
-def test_processor_init():
-    """Test processor initializes correctly."""
-    processor = KlifsProcessor()
-    assert processor.statements == []
-    assert processor.bioactivities == []
 
-
-def test_process_bioactivity():
-    """Test processing a bioactivity into a statement."""
-    bioactivity = {
-        'ligand_id': 123,
-        'ligand_name': 'gefitinib',
-        'kinase_name': 'EGFR',
+def test_ic50_produces_inhibition_statement():
+    rec = {
+        "standard_type": "IC50",
+        "standard_value": 12.3,
+        "standard_units": "nM",
+        "accession": "P00519",
+        "pref_name": "ABL1",
     }
-    processor = KlifsProcessor(bioactivities=[bioactivity])
-    stmts = processor.process_bioactivities()
-    
-    assert len(stmts) == 1
-    assert isinstance(stmts[0], Inhibition)
-    assert stmts[0].subj.name == 'gefitinib'
-    assert stmts[0].obj.name == 'EGFR'
+    kp = make_processor(rec)
+
+    assert len(kp.statements) == 1
+    stmt = kp.statements[0]
+
+    assert isinstance(stmt, Inhibition)
+    assert stmt.subj.name == "TEST_LIG"
+    assert stmt.obj.db_refs["UP"] == "P00519"
+
+    ev = stmt.evidence[0]
+    assert ev.source_api == "klifs"
+    assert ev.annotations["standard_type"] == "IC50"
+    assert ev.annotations["standard_units"] == "nM"
 
 
-def test_process_empty():
-    """Test processor handles empty input."""
-    processor = KlifsProcessor(bioactivities=[])
-    stmts = processor.process_bioactivities()
-    assert stmts == []
-
-
-def test_evidence_creation():
-    """Test evidence is created with correct source."""
-    bioactivity = {
-        'ligand_name': 'imatinib',
-        'kinase_name': 'ABL1',
+@pytest.mark.parametrize("standard_type", ["Kd", "KD", "Ki", "KI"])
+def test_kd_ki_produce_complex_statement(standard_type):
+    rec = {
+        "standard_type": standard_type,
+        "standard_value": 50.0,
+        "standard_units": "nM",
+        "accession": "P00519",
+        "pref_name": "ABL1",
     }
-    processor = KlifsProcessor(bioactivities=[bioactivity])
-    stmts = processor.process_bioactivities()
-    
-    assert len(stmts) == 1
-    assert stmts[0].evidence[0].source_api == 'klifs'
+    kp = make_processor(rec)
+
+    assert len(kp.statements) == 1
+    stmt = kp.statements[0]
+    assert isinstance(stmt, Complex)
 
 
-# ========== API Tests (network) ==========
+def test_unknown_activity_type_defaults_to_complex():
+    rec = {
+        "standard_type": "FOO",
+        "standard_value": 1.0,
+        "standard_units": "nM",
+        "accession": "P00519",
+        "pref_name": "ABL1",
+    }
+    kp = make_processor(rec)
 
-@pytest.mark.webservice
-def test_get_kinase_names():
-    """Test that kinase names can be retrieved."""
-    client = KlifsClient()
-    kinase_names = client.get_kinase_names()
-    assert isinstance(kinase_names, list)
-    assert len(kinase_names) > 0
-    assert 'kinase_ID' in kinase_names[0]
+    assert len(kp.statements) == 1
+    stmt = kp.statements[0]
+    assert isinstance(stmt, Complex)
 
-
-@pytest.mark.webservice
-def test_get_ligands_list():
-    """Test that ligands list can be retrieved."""
-    client = KlifsClient()
-    ligands = client.get_ligands_list()
-    assert isinstance(ligands, list)
-    assert len(ligands) > 0
+    ev = stmt.evidence[0]
+    assert ev.annotations["klifs_interpretation"] == "default_complex_unknown_type"
 
 
-@pytest.mark.webservice
-def test_get_kinase_id():
-    """Test that kinase ID can be retrieved for EGFR."""
-    client = KlifsClient()
-    result = client.get_kinase_id('EGFR')
-    assert isinstance(result, list)
-    assert len(result) > 0
+def test_kinase_agent_grounding_uses_uniprot():
+    rec = {
+        "standard_type": "IC50",
+        "standard_value": 1.0,
+        "standard_units": "nM",
+        "accession": "P00519",
+        "pref_name": "ABL1",
+    }
+    kp = make_processor(rec)
+
+    assert len(kp.statements) == 1
+    stmt = kp.statements[0]
+    kinase = stmt.obj
+    assert kinase.db_refs["UP"] == "P00519"
 
 
-@pytest.mark.webservice
-def test_get_egfr_ligands():
-    """Test retrieving ligands for a specific kinase."""
-    client = KlifsClient()
-    egfr_info = client.get_kinase_id('EGFR')
-    egfr_id = egfr_info[0]['kinase_ID']
-    ligands = client.get_ligands_list(kinase_ids=[egfr_id])
-    assert isinstance(ligands, list)
-    assert len(ligands) > 0
+def test_ligand_agent_has_expected_db_refs():
+    rec = {
+        "standard_type": "Kd",
+        "standard_value": 10.0,
+        "standard_units": "nM",
+        "accession": "P00519",
+        "pref_name": "ABL1",
+    }
+    ligand_details = {
+        "Name": "LIGX",
+        "PDB-code": "STU",
+        "InChIKey": "ABCDEFGHIJKLMN",
+        "SMILES": "CCO",
+    }
+
+    kp = make_processor(rec, ligand_id=123, ligand_details=ligand_details)
+
+    assert len(kp.statements) == 1
+    stmt = kp.statements[0]
+    assert isinstance(stmt, Complex)
+
+    # Don't rely on ordering in Complex.members
+    ligands = [a for a in stmt.members if a.db_refs.get("KLIFS_LIGAND") == "123"]
+    assert len(ligands) == 1
+    ligand = ligands[0]
+
+    assert ligand.db_refs["KLIFS_LIGAND"] == "123"
+    assert ligand.db_refs["PDB"] == "STU"
+    assert ligand.db_refs["INCHIKEY"] == "ABCDEFGHIJKLMN"
+    assert ligand.db_refs["SMILES"] == "CCO"

--- a/indra/tests/test_klifs.py
+++ b/indra/tests/test_klifs.py
@@ -1,0 +1,90 @@
+import pytest
+from indra.sources.klifs.api import KlifsClient
+from indra.sources.klifs.processor import KlifsProcessor
+from indra.statements import Inhibition
+
+
+# ========== Processor Tests (no network) ==========
+
+def test_processor_init():
+    """Test processor initializes correctly."""
+    processor = KlifsProcessor()
+    assert processor.statements == []
+    assert processor.bioactivities == []
+
+
+def test_process_bioactivity():
+    """Test processing a bioactivity into a statement."""
+    bioactivity = {
+        'ligand_id': 123,
+        'ligand_name': 'gefitinib',
+        'kinase_name': 'EGFR',
+    }
+    processor = KlifsProcessor(bioactivities=[bioactivity])
+    stmts = processor.process_bioactivities()
+    
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], Inhibition)
+    assert stmts[0].subj.name == 'gefitinib'
+    assert stmts[0].obj.name == 'EGFR'
+
+
+def test_process_empty():
+    """Test processor handles empty input."""
+    processor = KlifsProcessor(bioactivities=[])
+    stmts = processor.process_bioactivities()
+    assert stmts == []
+
+
+def test_evidence_creation():
+    """Test evidence is created with correct source."""
+    bioactivity = {
+        'ligand_name': 'imatinib',
+        'kinase_name': 'ABL1',
+    }
+    processor = KlifsProcessor(bioactivities=[bioactivity])
+    stmts = processor.process_bioactivities()
+    
+    assert len(stmts) == 1
+    assert stmts[0].evidence[0].source_api == 'klifs'
+
+
+# ========== API Tests (network) ==========
+
+@pytest.mark.webservice
+def test_get_kinase_names():
+    """Test that kinase names can be retrieved."""
+    client = KlifsClient()
+    kinase_names = client.get_kinase_names()
+    assert isinstance(kinase_names, list)
+    assert len(kinase_names) > 0
+    assert 'kinase_ID' in kinase_names[0]
+
+
+@pytest.mark.webservice
+def test_get_ligands_list():
+    """Test that ligands list can be retrieved."""
+    client = KlifsClient()
+    ligands = client.get_ligands_list()
+    assert isinstance(ligands, list)
+    assert len(ligands) > 0
+
+
+@pytest.mark.webservice
+def test_get_kinase_id():
+    """Test that kinase ID can be retrieved for EGFR."""
+    client = KlifsClient()
+    result = client.get_kinase_id('EGFR')
+    assert isinstance(result, list)
+    assert len(result) > 0
+
+
+@pytest.mark.webservice
+def test_get_egfr_ligands():
+    """Test retrieving ligands for a specific kinase."""
+    client = KlifsClient()
+    egfr_info = client.get_kinase_id('EGFR')
+    egfr_id = egfr_info[0]['kinase_ID']
+    ligands = client.get_ligands_list(kinase_ids=[egfr_id])
+    assert isinstance(ligands, list)
+    assert len(ligands) > 0

--- a/indra/util/statement_presentation.py
+++ b/indra/util/statement_presentation.py
@@ -121,7 +121,7 @@ logger = logging.getLogger(__name__)
 db_sources = ['psp', 'cbn', 'pc', 'bel_lc', 'signor', 'biogrid',
               'tas', 'hprd', 'trrust', 'ctd', 'vhn', 'pe', 'drugbank',
               'omnipath', 'conib', 'crog', 'dgi', 'minerva', 'creeds',
-              'ubibrowser', 'acsn', 'wormbase']
+              'ubibrowser', 'acsn', 'wormbase', 'klifs']
 """Database source names as they appear in the DB"""
 
 reader_sources = ['geneways', 'tees', 'gnbr', 'semrep', 'isi', 'tkg', 'trips',

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ def main():
                     'indra.sources.hprd', 'indra.sources.hypothesis',
                     'indra.sources.index_cards',
                     'indra.sources.indra_db_rest', 'indra.sources.isi',
+                    'indra.sources.klifs',
                     'indra.sources.minerva', 'indra.sources.ndex_cx',
                     'indra.sources.reach', 'indra.sources.omnipath',
                     'indra.sources.phosphoelm',


### PR DESCRIPTION
This adds a new source module for KLIFS (Kinase-Ligand Interaction Fingerprints and Structures), a database of curated structural data on kinase-inhibitor binding.

Changes:

New indra.sources.klifs module with API client and processor
Generates Inhibition statements from kinase-ligand co-crystallization data
Kinases grounded to HGNC/UniProt
Ligands grounded to ChEMBL/ChEBI where available
Unit tests for processor logic and API integration included
Added source to source_info.json, default_belief_probs.json, statement_presentation.py, setup.py, and README.md

Belief priors: Set to match similar drug-target databases (syst: 0.01, rand: 0.1). Open to feedback on these values.
Note: The processor assumes kinase-ligand interactions are inhibitory, which is typical for KLIFS data but not universally true. This is reflected in the rand prior.