### PR TITLE
Make SqliteOntology thread safe

### DIFF
--- a/indra/ontology/bio/sqlite_ontology.py
+++ b/indra/ontology/bio/sqlite_ontology.py
@@ -23,12 +23,13 @@ class SqliteOntology(IndraOntology):
         self.db_path = db_path
         build_sqlite_ontology(db_path)
         self._local = threading.local()
+        self._local.conn = None
         self.cur = self._get_cursor()
         self._initialized = True
 
     def _get_cursor(self):
         """Return a thread-local SQLite cursor, creating a connection on first use."""
-        if not hasattr(self._local, "conn"):
+        if self._local.conn is None:
             conn = sqlite3.connect(self.db_path)
             self._local.conn = conn
             self._local.cur = conn.cursor()


### PR DESCRIPTION
This PR updates the SQLite Ontology in two ways:
1. Add a `_get_cursor` helper that returns a cursor
2. Save the pointer to that cursor locally per thread to avoid cross-thread usage