### PR TITLE
Detailed pubmed dates

### DIFF
--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -438,6 +438,9 @@ def get_abstract(pubmed_id, prepend_title=True):
 
 # A function to get the text for the element, or None if not found
 def _find_elem_text(root, xpath_string):
+    if root is None:
+        logger.warning("Root is None when trying to find element with xpath: %s" % xpath_string)
+        return None
     elem = root.find(xpath_string)
     return None if elem is None else elem.text
 

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -357,6 +357,15 @@ def get_full_xml_by_pmids(
     ------
     RuntimeError
         If the edirect CLI utilities are not installed or not found on PATH.
+
+    Notes
+    -----
+    - This function requires the edirect command line utilities to be installed
+      and visible on your PATH. See https://www.ncbi.nlm.nih.gov/books/NBK179288/
+      for instructions.
+    - Note that the output is sorted by PMID numerically e.g.,
+      10, 11, 20, 22, 1000 (and not lexicographically e.g., 10, 1000, 11, 20, 22)
+      without regard to the order in which the pmids are passed in.
     """
     # Have to use lxml.etree because the XML returned by efetch is not properly
     # formatted for ET.XML
@@ -375,11 +384,10 @@ def get_full_xml_by_pmids(
                            "for instructions.")
 
     tree = lxml_etree.fromstring(xml_bytes, parser=parser)
+    if tree is None:
+        raise RuntimeError("Could not parse XML returned by efetch.")
     # Each article is in a <PubmedArticle> tag, encapsulated in a
     # <PubmedArticleSet> tag.
-    # Note that the <PubmedArticle> tags are sorted by PMID numerically e.g.,
-    # 10, 11, 20, 1000, and not lexicographically e.g., 10, 1000, 11, 20,
-    # regardless of the order in which the pmids are passed
     if fname is not None:
         pretty_save_xml(tree, fname)
     return tree
@@ -768,7 +776,11 @@ def get_metadata_from_pubmed_article(
 
     Returns
     -------
-
+    : Dict
+        A dict containing the following fields: 'doi', 'title', 'authors',
+        'journal_title', 'journal_abbrev', 'journal_nlm_id', 'issn_list',
+        'page', 'volume', 'issue', 'issue_pub_date', 'mesh_annotations',
+        'publication_date', 'abstract', 'publication_types' and 'references'.
     """
     medline_citation = pubmed_article.find('./MedlineCitation')
     pubmed_data = pubmed_article.find('PubmedData')

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -6,6 +6,8 @@ import glob
 import gzip
 import os
 import re
+from datetime import datetime
+
 import time
 from io import StringIO
 
@@ -599,6 +601,80 @@ def _get_journal_info(medline_citation, get_issns_from_nlm: bool):
     }
 
 
+def _get_article_dates(pubmed_article_data: ET.Element) -> dict:
+    # Get the article dates from an XML <PubmedArticle> element
+    # In MedlineCitation, get, if available:
+    #  - DateRevised (contains XML elements <Year>, <Month>, <Day>)
+    #  - DateCompleted (contains XML elements <Year>, <Month>, <Day>)
+    #  - Article
+    #    - ArticleDate
+    #    - Journal -> JournalIssue -> PubDate (contains up to three elements:
+    #                                          <Year>, <Month>, <Day>)
+    # In PubmedData, under History, get all PubMedPubDate elements with their
+    # PubStatus attribute, each of which contains XML elements <Year>, <Month>,
+    # <Day> and possibly <Hour> and <Minute>
+
+    results = {}
+
+    # Get the dates from the MedlineCitation element
+    date_revised = pubmed_article_data.find("./MedlineCitation/DateRevised")
+    date_completed = pubmed_article_data.find("./MedlineCitation/DateCompleted")
+    article_date = pubmed_article_data.find("./MedlineCitation/Article/ArticleDate")
+    journal_pub_date = pubmed_article_data.find("./MedlineCitation/Article/Journal/JournalIssue/PubDate")
+    for date_type, dt in [
+        ("date_completed", date_completed),
+        ("date_revised", date_revised),
+        ("article_date", article_date),
+        ("journal_pub_date", journal_pub_date),
+    ]:
+        if dt is None:
+            continue
+        res = {}
+        if year := _find_elem_text(dt, "Year"):
+            res["year"] = int(year)
+        if month := _find_elem_text(dt, "Month"):
+            if isinstance(month, str):
+                # Month mya be spelled out as "Jul" or "Aug" etc, or may be zero
+                # padded, e.g. 03 for March. Convert to integer
+                if month.isdigit():
+                    month = int(month)
+                else:
+                    datetime_object = datetime.strptime(month, "%b")
+                    month = datetime_object.month
+            res["month"] = month
+        if day := _find_elem_text(dt, "Day"):
+            res["day"] = int(day)
+        results[date_type] = res
+
+    # Get dates from History element
+    pubmedpuddates = pubmed_article_data.findall("./PubmedData/History/PubMedPubDate")
+    results["pubmed_pubdates"] = {}
+    for pmpd in pubmedpuddates:
+        pub_status = pmpd.attrib.get("PubStatus", None)
+        if pub_status is not None:
+            res = {}
+            if year := _find_elem_text(pmpd, "Year"):
+                res["year"] = int(year)
+            if month := _find_elem_text(pmpd, "Month"):
+                if isinstance(month, str):
+                    # Month mya be spelled out as "Jul" or "Aug" etc, or is zero
+                    # padded, e.g. 03 for March. Convert to integer
+                    if month.isdigit():
+                        res["month"] = int(month)
+                    else:
+                        datetime_object = datetime.strptime(month, "%b")
+                        res["month"] = datetime_object.month
+            if day := _find_elem_text(pmpd, "Day"):
+                res["day"] = int(day)
+            if hour := _find_elem_text(pmpd, "Hour"):
+                res["hour"] = int(hour)
+            if minute := _find_elem_text(pmpd, "Minute"):
+                res["minute"] = int(minute)
+            results["pubmed_pubdates"][pub_status] = res
+
+    return results
+
+
 def _get_pubmed_publication_date(pubmed_data):
     date_dict = dict.fromkeys(['year', 'month', 'day'])
 
@@ -805,6 +881,7 @@ def get_metadata_from_pubmed_article(
     if pubmed_data is not None:
         publication_date = _get_pubmed_publication_date(pubmed_data)
         result['publication_date'] = publication_date
+    result["detailed_publication_dates"] = _get_article_dates(pubmed_article)
 
     # Get the abstracts if requested
     if get_abstracts:
@@ -853,7 +930,7 @@ def get_metadata_from_xml_tree(tree, get_issns_from_nlm=False,
 
     Returns
     -------
-    dict of dicts
+    dict[str, dict]
         Dictionary indexed by PMID. Each value is a dict containing the
         following fields: 'doi', 'title', 'authors', 'journal_title',
         'journal_abbrev', 'journal_nlm_id', 'issn_list', 'page',
@@ -971,7 +1048,7 @@ def get_metadata_for_ids(pmid_list, get_issns_from_nlm=False,
 
     Returns
     -------
-    dict of dicts
+    dict[str, dict]
         Dictionary indexed by PMID. Each value is a dict containing the
         following fields: 'doi', 'title', 'authors', 'journal_title',
         'journal_abbrev', 'journal_nlm_id', 'issn_list', 'page'.

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -634,7 +634,7 @@ def _get_article_dates(pubmed_article_data: ET.Element) -> dict:
             res["year"] = int(year)
         if month := _find_elem_text(dt, "Month"):
             if isinstance(month, str):
-                # Month mya be spelled out as "Jul" or "Aug" etc, or may be zero
+                # Month may be spelled out as "Jul" or "Aug" etc, or may be zero
                 # padded, e.g. 03 for March. Convert to integer
                 if month.isdigit():
                     month = int(month)

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -596,6 +596,34 @@ def _get_journal_info(medline_citation, get_issns_from_nlm: bool):
     }
 
 
+def _parse_date_elem(date_elem, with_time=False):
+    # Parse a date XML element with <Year>, <Month>, <Day> children (and
+    # optionally <Hour>, <Minute>) into a dict of integers.
+    res = {}
+    year = _find_elem_text(date_elem, "Year")
+    if year is not None and year.isdigit():
+        res["year"] = int(year)
+    month = _find_elem_text(date_elem, "Month")
+    if month is not None:
+        # Month may be spelled out as "Jul" or "Aug" etc, or may be zero
+        # padded, e.g. 03 for March. Convert to integer in either case.
+        if month.isdigit():
+            res["month"] = int(month)
+        else:
+            res["month"] = datetime.strptime(month, "%b").month
+    day = _find_elem_text(date_elem, "Day")
+    if day is not None and day.isdigit():
+        res["day"] = int(day)
+    if with_time:
+        hour = _find_elem_text(date_elem, "Hour")
+        if hour is not None and hour.isdigit():
+            res["hour"] = int(hour)
+        minute = _find_elem_text(date_elem, "Minute")
+        if minute is not None and minute.isdigit():
+            res["minute"] = int(minute)
+    return res
+
+
 def _get_article_dates(pubmed_article_data: ET.Element) -> dict:
     # Get the article dates from an XML <PubmedArticle> element
     # In MedlineCitation, get, if available:
@@ -612,68 +640,29 @@ def _get_article_dates(pubmed_article_data: ET.Element) -> dict:
     results = {}
 
     # Get the dates from the MedlineCitation element
-    date_revised = pubmed_article_data.find("./MedlineCitation/DateRevised")
-    date_completed = pubmed_article_data.find("./MedlineCitation/DateCompleted")
-    article_date = pubmed_article_data.find("./MedlineCitation/Article/ArticleDate")
-    journal_pub_date = pubmed_article_data.find("./MedlineCitation/Article/Journal/JournalIssue/PubDate")
-    for date_type, dt in [
-        ("date_completed", date_completed),
-        ("date_revised", date_revised),
-        ("article_date", article_date),
-        ("journal_pub_date", journal_pub_date),
-    ]:
+    mc = "./MedlineCitation"
+    date_paths = [
+        ("date_completed", mc + "/DateCompleted"),
+        ("date_revised", mc + "/DateRevised"),
+        ("article_date", mc + "/Article/ArticleDate"),
+        ("journal_pub_date",
+         mc + "/Article/Journal/JournalIssue/PubDate"),
+    ]
+    for date_type, date_path in date_paths:
+        dt = pubmed_article_data.find(date_path)
         if dt is None:
             continue
-        res = {}
-        year = _find_elem_text(dt, "Year")
-        if year is not None:
-            res["year"] = int(year)
-        month = _find_elem_text(dt, "Month")
-        if month is not None:
-            if isinstance(month, str):
-                # Month may be spelled out as "Jul" or "Aug" etc, or may be zero
-                # padded, e.g. 03 for March. Convert to integer
-                if month.isdigit():
-                    month = int(month)
-                else:
-                    datetime_object = datetime.strptime(month, "%b")
-                    month = datetime_object.month
-            res["month"] = month
-        day = _find_elem_text(dt, "Day")
-        if day is not None:
-            res["day"] = int(day)
-        results[date_type] = res
+        results[date_type] = _parse_date_elem(dt)
 
     # Get dates from History element
-    pubmedpuddates = pubmed_article_data.findall("./PubmedData/History/PubMedPubDate")
+    pubmed_pub_dates = \
+        pubmed_article_data.findall("./PubmedData/History/PubMedPubDate")
     results["pubmed_pubdates"] = {}
-    for pmpd in pubmedpuddates:
+    for pmpd in pubmed_pub_dates:
         pub_status = pmpd.attrib.get("PubStatus", None)
         if pub_status is not None:
-            res = {}
-            year = _find_elem_text(pmpd, "Year")
-            if year is not None:
-                res["year"] = int(year)
-            month = _find_elem_text(pmpd, "Month")
-            if month is not None:
-                if isinstance(month, str):
-                    # Month mya be spelled out as "Jul" or "Aug" etc, or is zero
-                    # padded, e.g. 03 for March. Convert to integer
-                    if month.isdigit():
-                        res["month"] = int(month)
-                    else:
-                        datetime_object = datetime.strptime(month, "%b")
-                        res["month"] = datetime_object.month
-            day = _find_elem_text(pmpd, "Day")
-            if day is not None:
-                res["day"] = int(day)
-            hour = _find_elem_text(pmpd, "Hour")
-            if hour is not None and hour.isdigit():
-                res["hour"] = int(hour)
-            minute = _find_elem_text(pmpd, "Minute")
-            if minute is not None and minute.isdigit():
-                res["minute"] = int(minute)
-            results["pubmed_pubdates"][pub_status] = res
+            results["pubmed_pubdates"][pub_status] = \
+                _parse_date_elem(pmpd, with_time=True)
 
     return results
 
@@ -861,7 +850,8 @@ def get_metadata_from_pubmed_article(
         A dict containing the following fields: 'doi', 'title', 'authors',
         'journal_title', 'journal_abbrev', 'journal_nlm_id', 'issn_list',
         'page', 'volume', 'issue', 'issue_pub_date', 'mesh_annotations',
-        'publication_date', 'abstract', 'publication_types' and 'references'.
+        'publication_date', 'detailed_publication_dates', 'abstract',
+        'publication_types' and 'references'.
     """
     medline_citation = pubmed_article.find('./MedlineCitation')
     pubmed_data = pubmed_article.find('PubmedData')

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -386,8 +386,6 @@ def get_full_xml_by_pmids(
                            "for instructions.")
 
     tree = lxml_etree.fromstring(xml_bytes, parser=parser)
-    if tree is None:
-        raise RuntimeError("Could not parse XML returned by efetch.")
     # Each article is in a <PubmedArticle> tag, encapsulated in a
     # <PubmedArticleSet> tag.
     if fname is not None:
@@ -440,9 +438,6 @@ def get_abstract(pubmed_id, prepend_title=True):
 
 # A function to get the text for the element, or None if not found
 def _find_elem_text(root, xpath_string):
-    if root is None:
-        logger.warning("Root is None when trying to find element with xpath: %s" % xpath_string)
-        return None
     elem = root.find(xpath_string)
     return None if elem is None else elem.text
 
@@ -764,7 +759,7 @@ def _get_references(reference_list, only_pmid=True):
     return references
 
 
-def _get_article_info(medline_citation, pubmed_data=None, detailed_authors=False):
+def _get_article_info(medline_citation, pubmed_data, detailed_authors=False):
     article = medline_citation.find('Article')
     pmid = _find_elem_text(medline_citation, './PMID')
     pii = _find_elem_text(article,
@@ -775,12 +770,11 @@ def _get_article_info(medline_citation, pubmed_data=None, detailed_authors=False
                           './ELocationID[@EIdType="doi"][@ValidYN="Y"]')
 
     # ...and if that doesn't work, look in the ArticleIdList
-    if doi is None and pubmed_data is not None:
+    if doi is None:
         doi = _find_elem_text(pubmed_data, './/ArticleId[@IdType="doi"]')
 
     # Try to get the PMCID
-    if pubmed_data is not None:
-        pmcid = _find_elem_text(pubmed_data, './/ArticleId[@IdType="pmc"]')
+    pmcid = _find_elem_text(pubmed_data, './/ArticleId[@IdType="pmc"]')
 
     # Title
     title = _get_title_from_article_element(article)
@@ -873,14 +867,13 @@ def get_metadata_from_pubmed_article(
     if mesh_annotations:
         context_info = _get_annotations(medline_citation)
         result.update(context_info)
-    if references_included and pubmed_data is not None:
+    if references_included:
         references = _get_references(pubmed_data.find('ReferenceList'),
                                      only_pmid=(references_included == 'pmid'))
         result['references'] = references
 
-    if pubmed_data is not None:
-        publication_date = _get_pubmed_publication_date(pubmed_data)
-        result['publication_date'] = publication_date
+    publication_date = _get_pubmed_publication_date(pubmed_data)
+    result['publication_date'] = publication_date
     result["detailed_publication_dates"] = _get_article_dates(pubmed_article)
 
     # Get the abstracts if requested

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -677,7 +677,7 @@ def _get_references(reference_list, only_pmid=True):
     return references
 
 
-def _get_article_info(medline_citation, pubmed_data, detailed_authors=False):
+def _get_article_info(medline_citation, pubmed_data=None, detailed_authors=False):
     article = medline_citation.find('Article')
     pmid = _find_elem_text(medline_citation, './PMID')
     pii = _find_elem_text(article,
@@ -688,11 +688,12 @@ def _get_article_info(medline_citation, pubmed_data, detailed_authors=False):
                           './ELocationID[@EIdType="doi"][@ValidYN="Y"]')
 
     # ...and if that doesn't work, look in the ArticleIdList
-    if doi is None:
+    if doi is None and pubmed_data is not None:
         doi = _find_elem_text(pubmed_data, './/ArticleId[@IdType="doi"]')
 
     # Try to get the PMCID
-    pmcid = _find_elem_text(pubmed_data, './/ArticleId[@IdType="pmc"]')
+    if pubmed_data is not None:
+        pmcid = _find_elem_text(pubmed_data, './/ArticleId[@IdType="pmc"]')
 
     # Title
     title = _get_title_from_article_element(article)
@@ -781,13 +782,14 @@ def get_metadata_from_pubmed_article(
     if mesh_annotations:
         context_info = _get_annotations(medline_citation)
         result.update(context_info)
-    if references_included:
+    if references_included and pubmed_data is not None:
         references = _get_references(pubmed_data.find('ReferenceList'),
                                      only_pmid=(references_included == 'pmid'))
         result['references'] = references
 
-    publication_date = _get_pubmed_publication_date(pubmed_data)
-    result['publication_date'] = publication_date
+    if pubmed_data is not None:
+        publication_date = _get_pubmed_publication_date(pubmed_data)
+        result['publication_date'] = publication_date
 
     # Get the abstracts if requested
     if get_abstracts:

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -625,9 +625,11 @@ def _get_article_dates(pubmed_article_data: ET.Element) -> dict:
         if dt is None:
             continue
         res = {}
-        if year := _find_elem_text(dt, "Year"):
+        year = _find_elem_text(dt, "Year")
+        if year is not None:
             res["year"] = int(year)
-        if month := _find_elem_text(dt, "Month"):
+        month = _find_elem_text(dt, "Month")
+        if month is not None:
             if isinstance(month, str):
                 # Month may be spelled out as "Jul" or "Aug" etc, or may be zero
                 # padded, e.g. 03 for March. Convert to integer
@@ -637,7 +639,8 @@ def _get_article_dates(pubmed_article_data: ET.Element) -> dict:
                     datetime_object = datetime.strptime(month, "%b")
                     month = datetime_object.month
             res["month"] = month
-        if day := _find_elem_text(dt, "Day"):
+        day = _find_elem_text(dt, "Day")
+        if day is not None:
             res["day"] = int(day)
         results[date_type] = res
 
@@ -648,9 +651,11 @@ def _get_article_dates(pubmed_article_data: ET.Element) -> dict:
         pub_status = pmpd.attrib.get("PubStatus", None)
         if pub_status is not None:
             res = {}
-            if year := _find_elem_text(pmpd, "Year"):
+            year = _find_elem_text(pmpd, "Year")
+            if year is not None:
                 res["year"] = int(year)
-            if month := _find_elem_text(pmpd, "Month"):
+            month = _find_elem_text(pmpd, "Month")
+            if month is not None:
                 if isinstance(month, str):
                     # Month mya be spelled out as "Jul" or "Aug" etc, or is zero
                     # padded, e.g. 03 for March. Convert to integer
@@ -659,11 +664,14 @@ def _get_article_dates(pubmed_article_data: ET.Element) -> dict:
                     else:
                         datetime_object = datetime.strptime(month, "%b")
                         res["month"] = datetime_object.month
-            if day := _find_elem_text(pmpd, "Day"):
+            day = _find_elem_text(pmpd, "Day")
+            if day is not None:
                 res["day"] = int(day)
-            if hour := _find_elem_text(pmpd, "Hour"):
+            hour = _find_elem_text(pmpd, "Hour")
+            if hour is not None:
                 res["hour"] = int(hour)
-            if minute := _find_elem_text(pmpd, "Minute"):
+            minute = _find_elem_text(pmpd, "Minute")
+            if minute is not None:
                 res["minute"] = int(minute)
             results["pubmed_pubdates"][pub_status] = res
 

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -668,10 +668,10 @@ def _get_article_dates(pubmed_article_data: ET.Element) -> dict:
             if day is not None:
                 res["day"] = int(day)
             hour = _find_elem_text(pmpd, "Hour")
-            if hour is not None:
+            if hour is not None and hour.isdigit():
                 res["hour"] = int(hour)
             minute = _find_elem_text(pmpd, "Minute")
-            if minute is not None:
+            if minute is not None and minute.isdigit():
                 res["minute"] = int(minute)
             results["pubmed_pubdates"][pub_status] = res
 

--- a/indra/preassembler/grounding_mapper/gilda.py
+++ b/indra/preassembler/grounding_mapper/gilda.py
@@ -15,7 +15,7 @@ from indra.pipeline import register_pipeline
 logger = logging.getLogger(__name__)
 
 grounding_service_url = get_config('GILDA_URL', failure_ok=True) \
-    if has_config('GILDA_URL') else 'http://grounding.indra.bio/'
+    if has_config('GILDA_URL') else 'https://grounding.indra.bio/'
 
 
 def get_grounding(

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -176,6 +176,7 @@ def test_get_pub_date():
     assert metadata[pmids[2]]['publication_date']['day'] == 27
 
 
+@pytest.mark.webservice
 def test_get_detailed_dates():
     time.sleep(0.5)
     pmid = "23888980"

--- a/indra/tests/test_pubmed_client.py
+++ b/indra/tests/test_pubmed_client.py
@@ -176,6 +176,71 @@ def test_get_pub_date():
     assert metadata[pmids[2]]['publication_date']['day'] == 27
 
 
+def test_get_detailed_dates():
+    time.sleep(0.5)
+    pmid = "23888980"
+    metadata = pubmed_client.get_metadata_for_ids([pmid])[pmid]
+    detailed_dates = metadata["detailed_publication_dates"]
+    assert len(detailed_dates) == 5
+    assert detailed_dates["date_completed"]["year"] == 2014
+    assert detailed_dates["date_completed"]["month"] == 3
+    assert detailed_dates["date_completed"]["day"] == 20
+    assert detailed_dates["date_revised"]["year"] == 2022
+    assert detailed_dates["date_revised"]["month"] == 4
+    assert detailed_dates["date_revised"]["day"] == 8
+    assert detailed_dates["article_date"]["year"] == 2012
+    assert detailed_dates["article_date"]["month"] == 12
+    assert detailed_dates["article_date"]["day"] == 19
+    assert detailed_dates["journal_pub_date"]["year"] == 2013
+    assert detailed_dates["journal_pub_date"]["month"] == 8
+
+    # Now check the pubmedpubdate entries, which should come from this:
+    #         <PubMedPubDate PubStatus="accepted">
+    #           <Year>2012</Year>
+    #           <Month>11</Month>
+    #           <Day>13</Day>
+    #         </PubMedPubDate>
+    #         <PubMedPubDate PubStatus="entrez">
+    #           <Year>2013</Year>
+    #           <Month>7</Month>
+    #           <Day>30</Day>
+    #           <Hour>6</Hour>
+    #           <Minute>0</Minute>
+    #         </PubMedPubDate>
+    #         <PubMedPubDate PubStatus="pubmed">
+    #           <Year>2013</Year>
+    #           <Month>7</Month>
+    #           <Day>31</Day>
+    #           <Hour>6</Hour>
+    #           <Minute>0</Minute>
+    #         </PubMedPubDate>
+    #         <PubMedPubDate PubStatus="medline">
+    #           <Year>2014</Year>
+    #           <Month>3</Month>
+    #           <Day>22</Day>
+    #           <Hour>6</Hour>
+    #           <Minute>0</Minute>
+    #         </PubMedPubDate>
+    assert detailed_dates["pubmed_pubdates"]["accepted"]["year"] == 2012
+    assert detailed_dates["pubmed_pubdates"]["accepted"]["month"] == 11
+    assert detailed_dates["pubmed_pubdates"]["accepted"]["day"] == 13
+    assert detailed_dates["pubmed_pubdates"]["entrez"]["year"] == 2013
+    assert detailed_dates["pubmed_pubdates"]["entrez"]["month"] == 7
+    assert detailed_dates["pubmed_pubdates"]["entrez"]["day"] == 30
+    assert detailed_dates["pubmed_pubdates"]["entrez"]["hour"] == 6
+    assert detailed_dates["pubmed_pubdates"]["entrez"]["minute"] == 0
+    assert detailed_dates["pubmed_pubdates"]["pubmed"]["year"] == 2013
+    assert detailed_dates["pubmed_pubdates"]["pubmed"]["month"] == 7
+    assert detailed_dates["pubmed_pubdates"]["pubmed"]["day"] == 31
+    assert detailed_dates["pubmed_pubdates"]["pubmed"]["hour"] == 6
+    assert detailed_dates["pubmed_pubdates"]["pubmed"]["minute"] == 0
+    assert detailed_dates["pubmed_pubdates"]["medline"]["year"] == 2014
+    assert detailed_dates["pubmed_pubdates"]["medline"]["month"] == 3
+    assert detailed_dates["pubmed_pubdates"]["medline"]["day"] == 22
+    assert detailed_dates["pubmed_pubdates"]["medline"]["hour"] == 6
+    assert detailed_dates["pubmed_pubdates"]["medline"]["minute"] == 0
+
+
 @pytest.mark.webservice
 def test_send_request_invalid():
     time.sleep(0.5)


### PR DESCRIPTION
Note: Merging this PR will also merge #1491.

This PR adds another metadata entry in the pubmed client's `get_metadata_from_pubmed_article()`. The new entry is under `detailed_publication_dates` and contains date information from the following sections of the `<PubmedArticle>` element when available (date entries in **bold**):
-  `<MedlineCitation>`
   - **`<DateRevised>`**
   - **`<DateCompleted>`**
   - `<Article>`
     - **`<AricleDate>`**
     - `<Journal>`
        - `<JournalIssue>`
           - **`<PubDate>`**
- `<PubmedData>`
   - `<History>`
      - **`<PubMedPubDate PubStatus="X">`** where X is one of:
        1. `medline`
        2. `pubmed`
        3. `entrez`
        4. `accepted`
        5.  `received`
        6. `revised`