### PR TITLE
Set sqlite cursor on first call, not on instantiation

### DIFF
--- a/indra/ontology/bio/sqlite_ontology.py
+++ b/indra/ontology/bio/sqlite_ontology.py
@@ -23,13 +23,18 @@ class SqliteOntology(IndraOntology):
         self.db_path = db_path
         build_sqlite_ontology(db_path)
         self._local = threading.local()
-        self._local.conn = None
-        self.cur = self._get_cursor()
         self._initialized = True
+
+    @property
+    def cur(self):
+        return self._get_cursor()
 
     def _get_cursor(self):
         """Return a thread-local SQLite cursor, creating a connection on first use."""
-        if self._local.conn is None:
+        # Use hasattr rather than checking for None because each thread has its own
+        # local instance of threading.local, which may or may not have the conn
+        # attribute set
+        if not hasattr(self._local, 'conn'):
             conn = sqlite3.connect(self.db_path)
             self._local.conn = conn
             self._local.cur = conn.cursor()


### PR DESCRIPTION
This PR fixes a subtle issue that arises from how the `bio_ontology` is imported: because an instance of the `BioOntology` or the `SqliteOntology` is created when importing `bio_ontology` from the module, the thread that does the import is the one that owns the `self._local` attribute. This is apparently a different thread than the ones makings calls to the sqlite database later in at least one multi threading setup that uses the `SqliteOntology`.

The fix sets `self.cur` as a property instead of an attribute. On first access to the cursor by a thread, that thread sets its local cursor.