### PR TITLE
Update PMC FTP adress

### DIFF
--- a/indra/literature/elsevier_client.py
+++ b/indra/literature/elsevier_client.py
@@ -479,7 +479,7 @@ def _get_article_body(full_text_elem):
     for pth in possible_paths:
         main_body = full_text_elem.find(pth, elsevier_ns)
         if main_body is not None:
-            logger.info("Found main body element: \"%s\"" % pth)
+            logger.debug("Found main body element: \"%s\"" % pth)
             return _get_sections(main_body)
         logger.info("Could not find main body element: \"%s\"." % pth)
     return None
@@ -492,9 +492,9 @@ def _get_sections(main_body_elem):
     for pth in possible_paths:
         sections = main_body_elem.findall(pth, elsevier_ns)
         if len(sections):
-            logger.info("Found sections in main body using \"%s\"" % pth)
+            logger.debug("Found sections in main body using \"%s\"" % pth)
             break
-        logger.info("Found no sections in main body with \"%s\"" % pth)
+        logger.debug("Found no sections in main body with \"%s\"" % pth)
     else:
         return None
 

--- a/indra/literature/pubmed_client.py
+++ b/indra/literature/pubmed_client.py
@@ -32,7 +32,11 @@ pubmed_fetch = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi'
 pubmed_archive = "https://ftp.ncbi.nlm.nih.gov/pubmed"
 pubmed_archive_baseline = pubmed_archive + "/baseline/"
 pubmed_archive_update = pubmed_archive + "/updatefiles/"
-pmid_to_pmc_download_url = "https://ftp.ncbi.nlm.nih.gov/pub/pmc/oa_file_list.csv"
+# As of 2026-04-13, PMC moved these legacy FTP files under /deprecated/
+# and the service is slated for full removal in August 2026. A follow-up
+# migration to the PMC Cloud S3 bucket (s3://pmc-oa-opendata/) is planned.
+pmc_ftp_base_url = "https://ftp.ncbi.nlm.nih.gov/pub/pmc/deprecated"
+pmid_to_pmc_download_url = f"{pmc_ftp_base_url}/oa_file_list.csv"
 RETRACTIONS_FILE = os.path.join(RESOURCES_PATH, "pubmed_retractions.tsv")
 
 
@@ -1438,8 +1442,8 @@ def get_pmid_to_package_url_mapping(fname=None) -> Dict[str, str]:
     fname : Optional[str]
         Optional path to a CSV file containing the mappings data file
         serving as a cache. It can be obtained from
-        https://ftp.ncbi.nlm.nih.gov/pub/pmc/oa_file_list.csv. If not
-        provided, it is downloaded from this URL.
+        https://ftp.ncbi.nlm.nih.gov/pub/pmc/deprecated/oa_file_list.csv.
+        If not provided, it is downloaded from this URL.
 
     Returns
     -------
@@ -1454,7 +1458,7 @@ def get_pmid_to_package_url_mapping(fname=None) -> Dict[str, str]:
         res.raise_for_status()
         reader = csv.DictReader(StringIO(res.text))
     mapping = {
-        row["PMID"]: f"https://ftp.ncbi.nlm.nih.gov/pub/pmc/{row['File']}"
+        row["PMID"]: f"{pmc_ftp_base_url}/{row['File']}"
         for row in tqdm.tqdm(reader, desc="Generating PMID to PMC URL mapping")
     }
     return mapping
@@ -1473,7 +1477,8 @@ def download_package_for_pmid(pmid: str, out_dir: str,
     mapping : Optional[Dict[str, str]]
         A mapping from PMIDs to PMC package URLs. If None, the mapping
         is fetched from the NCBI FTP server (slow). The mapping can be
-        obtained from https://ftp.ncbi.nlm.nih.gov/pub/pmc/oa_file_list.csv
+        obtained from
+        https://ftp.ncbi.nlm.nih.gov/pub/pmc/deprecated/oa_file_list.csv
         and loaded using `get_pmid_to_package_url_mapping`.
 
     Returns
@@ -1515,7 +1520,8 @@ def download_package_for_pmids(pmid_list: List[str], out_dir: str,
     mapping : Optional[Dict[str, str]]
         A mapping from PMIDs to PMC package URLs. If None, the mapping
         is fetched from the NCBI FTP server (slow). The mapping can be
-        obtained from https://ftp.ncbi.nlm.nih.gov/pub/pmc/oa_file_list.csv
+        obtained from
+        https://ftp.ncbi.nlm.nih.gov/pub/pmc/deprecated/oa_file_list.csv
         and loaded using `get_pmid_to_package_url_mapping`.
 
     Returns

--- a/indra/sources/minerva/minerva_client.py
+++ b/indra/sources/minerva/minerva_client.py
@@ -1,8 +1,8 @@
-import requests
 import csv
 import re
-import requests
 from collections import defaultdict
+from functools import lru_cache
+import requests
 
 default_map_name = 'covid19map'
 base_url = 'https://%s.elixir-luxembourg.org/minerva/api/'
@@ -10,7 +10,9 @@ resource_url = ('http://git-r3lab.uni.lu/covid/models/-/raw/master/'
                 'Integration/MINERVA_build/resources.csv')
 
 
+@lru_cache(maxsize=None)
 def get_config(map_name=default_map_name):
+    """Return MINERVA map-level configuration including various metadata."""
     url = (base_url % map_name) + 'configuration/'
     res = requests.get(url)
     res.raise_for_status()
@@ -42,13 +44,16 @@ def get_latest_project_id(map_name=default_map_name):
 
 
 def get_models(project_id, map_name=default_map_name):
+    """Return all models in a given project within a map."""
     url = (base_url % map_name) + ('projects/%s/models/' % project_id)
     res = requests.get(url)
     res.raise_for_status()
     return res.json()
 
 
+@lru_cache(maxsize=None)
 def get_model_elements(model_id, project_id, map_name=default_map_name):
+    """Return all elements in a given model within a project in a ma.p"""
     url = (base_url % map_name) + \
         ('projects/%s/models/%s/' % (project_id, model_id)) + \
         'bioEntities/elements/?columns=id,name,type,elementId,complexId,references'
@@ -106,6 +111,7 @@ def get_ids_to_refs(model_id, map_name=default_map_name):
     return ids_to_refs, complex_members
 
 
+@lru_cache(maxsize=None)
 def get_model_ids(map_name=default_map_name):
     project_id = get_latest_project_id(map_name)
     models = get_models(project_id, map_name)
@@ -115,6 +121,7 @@ def get_model_ids(map_name=default_map_name):
     return model_names_to_ids
 
 
+@lru_cache(maxsize=None)
 def get_sif_filenames_to_ids(map_name=default_map_name):
     model_names_to_ids = get_model_ids(map_name=map_name)
     filenames_to_ids = {}


### PR DESCRIPTION
PMC is deprecating its FTP server (https://pmc.ncbi.nlm.nih.gov/tools/ftp/). Temporarily this PR reroutes the address to one that will keep working, a bigger migration will come in a follow-up PR.