### PR TITLE
Extend Python version compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.11", "3.14"]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install libstdc++6 graphviz python3-dev libgraphviz-dev pkg-config
         # Install test/CI-specific dependencies not covered elsewhere
-        pip install --upgrade pip setuptools wheel
+        # setuptools 81+ drops pkg_resources, which pybel 0.15.x still imports.
+        pip install --upgrade pip "setuptools<81" wheel
         pip install pytest pytest-cov pydot jsonschema awscli pycodestyle
         mkdir -p $HOME/.pybel/data
         wget -nv https://bigmech.s3.amazonaws.com/travis/pybel_cache.db -O $HOME/.pybel/data/pybel_cache.db

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,8 +30,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libstdc++6 graphviz python3-dev libgraphviz-dev pkg-config
         # Install test/CI-specific dependencies not covered elsewhere
-        # setuptools 81+ drops pkg_resources, which pybel 0.15.x still imports.
-        pip install --upgrade pip "setuptools<81" wheel
+        pip install --upgrade pip setuptools wheel
         pip install pytest pytest-cov pydot jsonschema awscli pycodestyle
         mkdir -p $HOME/.pybel/data
         wget -nv https://bigmech.s3.amazonaws.com/travis/pybel_cache.db -O $HOME/.pybel/data/pybel_cache.db

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,9 +38,7 @@ jobs:
         wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" -O bionetgen.tar.gz -nv
         tar xzf bionetgen.tar.gz
         pip install git+https://github.com/pysb/pysb.git
-        # Temporary fix. Ensure cython is installed before pyjnius
-        pip install "cython<3"
-        pip install "pyjnius==1.1.4" --no-build-isolation
+        pip install "pyjnius>=1.6.1"
         # Now install INDRA with all its extras
         pip install .[all]
         # Run slow tests only if we're in the cron setting

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.13"]
+        python-version: ["3.8", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.14"]
+        python-version: ["3.11", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,6 @@ jobs:
         # PySB and dependencies
         wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" -O bionetgen.tar.gz -nv
         tar xzf bionetgen.tar.gz
-        pip install git+https://github.com/pysb/pysb.git
         pip install "pyjnius>=1.6.1"
         # Now install INDRA with all its extras
         pip install .[all]

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ def main():
     extras_require = {
                       # Inputs and outputs
                       'trips_offline': ['pykqml'],
-                      'reach_offline': ['cython<3', 'pyjnius==1.1.4'],
-                      'eidos_offline': ['cython<3', 'pyjnius==1.1.4'],
+                      'reach_offline': ['pyjnius>=1.6.1'],
+                      'eidos_offline': ['pyjnius>=1.6.1'],
                       'hypothesis': ['gilda>1.0.0'],
                       'geneways': ['stemming', 'nltk<3.6'],
                       'bel': ['pybel>=0.15.0,<0.16.0'],

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ def main():
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: 3.12',
+            'Programming Language :: Python :: 3.13',
             'Topic :: Scientific/Engineering :: Bio-Informatics',
             'Topic :: Scientific/Engineering :: Chemistry',
             'Topic :: Scientific/Engineering :: Mathematics',

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,7 @@ def main():
                               'flask_cors',
                               'docstring-parser',
                               'gunicorn'],
-                      # scikit-learn 1.5.0 breaks DisambManager.run_adeft_disambiguation
-                      # see: https://github.com/gyorilab/adeft/issues/80
-                      'sklearn_belief': ['scikit-learn<1.5.0'],
+                      'sklearn_belief': ['scikit-learn'],
                       'owl': ['pronto'],
                       'tests':
                         ['pytest',

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,10 @@ def main():
                       'hypothesis': ['gilda>1.0.0'],
                       'geneways': ['stemming', 'nltk<3.6'],
                       'bel': ['pybel>=0.15.0,<0.16.0'],
+                      # texttoknowledgegraph pins lxml==5.2.1 which has no Python
+                      # 3.13 wheels, so we skip it on 3.13 until upstream unpins.
                       'tkg': ['pybel>=0.15.0,<0.16.0',
-                              'texttoknowledgegraph; python_version >= "3.9"'],
+                              'texttoknowledgegraph; python_version >= "3.9" and python_version < "3.13"'],
                       'sbml': ['python-libsbml'],
                       # Tools and analysis
                       'machine': ['pytz', 'tzlocal', 'tweepy', 'pyyaml>=5.1.0',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(readme_path, 'r', encoding='utf-8') as fh:
 
 
 def main():
-    install_list = ['pysb @ git+https://github.com/pysb/pysb.git; '
+    install_list = ['pysb @ git+https://github.com/pysb/pysb.git ; '
                     'python_version >= "3.10"',
                     'pysb<=1.16.0; python_version < "3.10"',
                     'objectpath',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,10 @@ with open(readme_path, 'r', encoding='utf-8') as fh:
 
 
 def main():
-    install_list = ['pysb @ git+https://github.com/pysb/pysb.git', 'objectpath',
+    install_list = ['pysb @ git+https://github.com/pysb/pysb.git; '
+                    'python_version >= "3.10"',
+                    'pysb<=1.16.0; python_version < "3.10"',
+                    'objectpath',
                     'requests>=2.11', 'lxml', 'ipython', 'future',
                     'networkx>=3', 'pandas>=2', 'ndex2', 'jinja2',
                     'protmapper>=0.0.29', 'obonet',


### PR DESCRIPTION
This PR works through some changes to dependencies to allow for broader Python version compatibility (up to 3.13). In particular
- Upgrade to a newer pyjnius version. I tested this in different environments and found that it still appears to work as before.
- Remove scikit-learn constraint which is not necessary given updates to Adeft
- Add some other handling due to outdated or overly strict requirements from dependencies like `texttoknowledgegraph` or `pybel`

Unfortunately there are still many issues with dependencies like PySB (working on a fix in that repo) and third-party web services that result in test failures.