### PR TITLE
Implement client for new PMC S3 content access

### DIFF
--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 pmc_url = 'https://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi'
 pmid_convert_url = 'https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/'
 pmc_s3_base_url = 'https://pmc-oa-opendata.s3.amazonaws.com'
+s3_nsmap = {'s3': 'http://s3.amazonaws.com/doc/2006-03-01/'}
 
 # Paths to resource files
 pmids_fulltext_path = os.path.join(os.path.dirname(__file__),
@@ -58,9 +59,8 @@ def get_s3_versions(pmcid):
     res = requests.get(pmc_s3_base_url, params=params)
     res.raise_for_status()
     tree = ET.fromstring(res.content)
-    ns = '{http://s3.amazonaws.com/doc/2006-03-01/}'
     versions = []
-    for prefix_el in tree.findall(f'{ns}CommonPrefixes/{ns}Prefix'):
+    for prefix_el in tree.findall('s3:CommonPrefixes/s3:Prefix', s3_nsmap):
         m = re.match(rf'{re.escape(pmcid)}\.(\d+)/', prefix_el.text or '')
         if m:
             versions.append(int(m.group(1)))
@@ -83,6 +83,48 @@ def get_latest_s3_version(pmcid):
     """
     versions = get_s3_versions(pmcid)
     return max(versions) if versions else None
+
+
+def list_article_files_s3(pmcid, version=None):
+    """List the S3 object keys for a PMC article on the PMC Cloud bucket.
+
+    Parameters
+    ----------
+    pmcid : str
+        A PubMed Central ID in 'PMC<digits>' form.
+    version : Optional[int]
+        The article version to list. If None, the latest available version
+        is used.
+
+    Returns
+    -------
+    list of str
+        List of S3 object keys under the PMC<id>.<version>/ prefix. Empty
+        if the article (or requested version) is not present.
+    """
+    if version is None:
+        version = get_latest_s3_version(pmcid)
+        if version is None:
+            return []
+    prefix = f'{pmcid}.{version}/'
+    keys = []
+    marker = ''
+    while True:
+        params = {'prefix': prefix, 'marker': marker}
+        res = requests.get(pmc_s3_base_url, params=params)
+        res.raise_for_status()
+        tree = ET.fromstring(res.content)
+        for contents in tree.findall('s3:Contents', s3_nsmap):
+            key = contents.findtext('s3:Key', namespaces=s3_nsmap)
+            if key:
+                keys.append(key)
+        truncated = tree.findtext('s3:IsTruncated', namespaces=s3_nsmap)
+        if not truncated == 'true':
+            break
+        marker = keys[-1] if keys else ''
+        if not marker:
+            break
+    return keys
 
 
 def id_lookup(paper_id, idtype=None):

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -224,6 +224,26 @@ def get_text_s3(pmcid, version=None):
     return res.text if res is not None else None
 
 
+def get_pdf_s3(pmcid, version=None):
+    """Return the PDF for a PMC article from the PMC Cloud S3 bucket.
+
+    Parameters
+    ----------
+    pmcid : str
+        A PubMed Central ID in 'PMC<digits>' form.
+    version : Optional[int]
+        The article version to fetch. If None, the latest available version
+        is used.
+
+    Returns
+    -------
+    Optional[str]
+        The PDF content or None if the article is not present on the bucket.
+    """
+    res = _get_s3_artifact(pmcid, 'pdf', version=version)
+    return res.content if res is not None else None
+
+
 def download_article_files_s3(pmcid, out_dir, version=None, include=None):
     """Download a PMC article's files from the PMC Cloud S3 bucket.
 

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import re
 import logging
-import os.path
+import os
 import requests
 from functools import lru_cache
 from lxml import etree
@@ -222,6 +222,57 @@ def get_text_s3(pmcid, version=None):
     """
     res = _get_s3_artifact(pmcid, 'txt', version=version)
     return res.text if res is not None else None
+
+
+def download_article_files_s3(pmcid, out_dir, version=None, include=None):
+    """Download a PMC article's files from the PMC Cloud S3 bucket.
+
+    Files are saved under ``<out_dir>/PMC<id>.<version>/<filename>``,
+    mirroring the bucket's prefix layout.
+
+    Parameters
+    ----------
+    pmcid : str
+        A PubMed Central ID in 'PMC<digits>' form.
+    out_dir : str
+        Local directory where files will be written. Created if missing.
+    version : Optional[int]
+        The article version to fetch. If None, the latest available version
+        is used.
+    include : Optional[Iterable[str]]
+        If given, only files whose lowercase extension matches one of these
+        strings are downloaded (e.g. ``['xml', 'txt']``). Extensions should
+        be given without the leading dot. If None, all files in the
+        article's prefix are downloaded.
+
+    Returns
+    -------
+    list of str
+        Paths to the downloaded files. Empty if the article (or requested
+        version) is not present on the bucket.
+    """
+    if version is None:
+        version = get_latest_s3_version(pmcid)
+        if version is None:
+            return []
+    keys = list_article_files_s3(pmcid, version=version)
+    if include is not None:
+        include = {ext.lower().lstrip('.') for ext in include}
+        keys = [k for k in keys if k.rsplit('.', 1)[-1].lower() in include]
+    article_dir = os.path.join(out_dir, f'{pmcid}.{version}')
+    os.makedirs(article_dir, exist_ok=True)
+    paths = []
+    for key in keys:
+        url = f'{pmc_s3_base_url}/{key}'
+        filename = key.rsplit('/', 1)[-1]
+        local_path = os.path.join(article_dir, filename)
+        res = requests.get(url, stream=True)
+        res.raise_for_status()
+        with open(local_path, 'wb') as f:
+            for chunk in res.iter_content(chunk_size=65536):
+                f.write(chunk)
+        paths.append(local_path)
+    return paths
 
 
 def id_lookup(paper_id, idtype=None):

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -127,6 +127,103 @@ def list_article_files_s3(pmcid, version=None):
     return keys
 
 
+def _get_s3_artifact(pmcid, ext, version=None):
+    """Fetch a named artifact for a PMC article from the PMC Cloud S3 bucket.
+
+    The artifact is fetched from the canonical key
+    ``PMC<id>.<version>/PMC<id>.<version>.<ext>``.
+
+    Parameters
+    ----------
+    pmcid : str
+        A PubMed Central ID in 'PMC<digits>' form.
+    ext : str
+        The artifact file extension, e.g. 'xml', 'txt', 'json', or 'pdf'.
+    version : Optional[int]
+        The article version to fetch. If None, the latest available version
+        is resolved via :func:`get_latest_s3_version`.
+
+    Returns
+    -------
+    Optional[requests.Response]
+        The HTTP response if the artifact was fetched successfully, or None
+        if the article is not present on the bucket.
+    """
+    if version is None:
+        version = get_latest_s3_version(pmcid)
+        if version is None:
+            return None
+    url = f'{pmc_s3_base_url}/{pmcid}.{version}/{pmcid}.{version}.{ext}'
+    res = requests.get(url)
+    res.raise_for_status()
+    return res
+
+
+def get_metadata_s3(pmcid, version=None):
+    """Return the JSON metadata for a PMC article from the PMC Cloud bucket.
+
+    Parameters
+    ----------
+    pmcid : str
+        A PubMed Central ID in 'PMC<digits>' form.
+    version : Optional[int]
+        The article version to fetch. If None, the latest available version
+        is used.
+
+    Returns
+    -------
+    Optional[dict]
+        The parsed JSON metadata dict, containing keys such as 'pmid',
+        'doi', 'title', 'citation', 'license_code', 'is_retracted', and
+        s3:// URLs for the text/xml/pdf/media files. None if the article
+        is not present on the bucket.
+    """
+    res = _get_s3_artifact(pmcid, 'json', version=version)
+    return res.json() if res is not None else None
+
+
+def get_xml_s3(pmcid, version=None):
+    """Return the NLM XML for a PMC article from the PMC Cloud S3 bucket.
+
+    Parameters
+    ----------
+    pmcid : str
+        A PubMed Central ID in 'PMC<digits>' form.
+    version : Optional[int]
+        The article version to fetch. If None, the latest available version
+        is used.
+
+    Returns
+    -------
+    Optional[str]
+        The XML content as a unicode string, or None if the article is not
+        present on the bucket.
+    """
+    res = _get_s3_artifact(pmcid, 'xml', version=version)
+    return res.text if res is not None else None
+
+
+def get_text_s3(pmcid, version=None):
+    """Return the plain text for a PMC article from the PMC Cloud S3 bucket.
+
+    Parameters
+    ----------
+    pmcid : str
+        A PubMed Central ID in 'PMC<digits>' form.
+    version : Optional[int]
+        The article version to fetch. If None, the latest available version
+        is used.
+
+    Returns
+    -------
+    Optional[str]
+        The plain-text content as a unicode string, or None if the article
+        is not present on the bucket.
+    """
+    res = _get_s3_artifact(pmcid, 'txt', version=version)
+    return res.text if res is not None else None
+
+
 def id_lookup(paper_id, idtype=None):
     """Return PMID, DOI and PMCID based on an input ID.
 

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -67,6 +67,24 @@ def get_s3_versions(pmcid):
     return tuple(sorted(versions))
 
 
+def get_latest_s3_version(pmcid):
+    """Return the latest available version of a PMC article on S3.
+
+    Parameters
+    ----------
+    pmcid : str
+        A PubMed Central ID in 'PMC<digits>' form.
+
+    Returns
+    -------
+    Optional[int]
+        The highest available version number, or None if the article is not
+        present on the bucket.
+    """
+    versions = get_s3_versions(pmcid)
+    return max(versions) if versions else None
+
+
 def id_lookup(paper_id, idtype=None):
     """Return PMID, DOI and PMCID based on an input ID.
 

--- a/indra/literature/pmc_client.py
+++ b/indra/literature/pmc_client.py
@@ -4,6 +4,7 @@ import re
 import logging
 import os.path
 import requests
+from functools import lru_cache
 from lxml import etree
 from lxml.etree import QName
 import xml.etree.ElementTree as ET
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 pmc_url = 'https://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi'
 pmid_convert_url = 'https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/'
+pmc_s3_base_url = 'https://pmc-oa-opendata.s3.amazonaws.com'
 
 # Paths to resource files
 pmids_fulltext_path = os.path.join(os.path.dirname(__file__),
@@ -35,6 +37,34 @@ pmids_auth_xml_path = os.path.join(os.path.dirname(__file__),
 # Define global dict containing lists of PMIDs among mineable PMCs
 # to be lazily initialized
 pmids_fulltext_dict = {}
+
+
+@lru_cache(maxsize=10000)
+def get_s3_versions(pmcid):
+    """Return available versions of a PMC article on the PMC Cloud S3 bucket.
+
+    Parameters
+    ----------
+    pmcid : str
+        A PubMed Central ID in 'PMC<digits>' form.
+
+    Returns
+    -------
+    tuple of int
+        Sorted tuple of available version numbers, or an empty tuple if the
+        article is not present on the bucket.
+    """
+    params = {'prefix': f'{pmcid}.', 'delimiter': '/'}
+    res = requests.get(pmc_s3_base_url, params=params)
+    res.raise_for_status()
+    tree = ET.fromstring(res.content)
+    ns = '{http://s3.amazonaws.com/doc/2006-03-01/}'
+    versions = []
+    for prefix_el in tree.findall(f'{ns}CommonPrefixes/{ns}Prefix'):
+        m = re.match(rf'{re.escape(pmcid)}\.(\d+)/', prefix_el.text or '')
+        if m:
+            versions.append(int(m.group(1)))
+    return tuple(sorted(versions))
 
 
 def id_lookup(paper_id, idtype=None):

--- a/indra/sources/omnipath/api.py
+++ b/indra/sources/omnipath/api.py
@@ -5,7 +5,7 @@ from .processor import OmniPathProcessor
 logger = logging.getLogger(__name__)
 
 
-op_url = 'http://omnipathdb.org'
+op_url = 'https://omnipathdb.org'
 
 
 def process_from_web():

--- a/indra/sources/omnipath/processor.py
+++ b/indra/sources/omnipath/processor.py
@@ -42,14 +42,24 @@ class OmniPathProcessor(object):
             return []
         for mod_entry in ptm_json:
             # Skip entries without references
-            if not mod_entry['references']:
+            references = mod_entry['references']
+            if not references:
                 continue
             enz = self._agent_from_up_id(mod_entry['enzyme'])
             sub = self._agent_from_up_id(mod_entry['substrate'])
             res = mod_entry['residue_type']
             pos = mod_entry['residue_offset']
             evidence = []
-            for source_pmid in mod_entry['references']:
+            if isinstance(references, str):
+                # Handle corner case with ;-separated references e.g.
+                # TRIP:11290752;TRIP:12601176;...
+                if ';' in references:
+                    references = references.split(';')
+                # Handle corner case with simple string reference e.g.,
+                # SIGNOR:11201744
+                else:
+                    references = [references]
+            for source_pmid in references:
                 source_db, pmid_ref = source_pmid.split(':', 1)
                 # Skip evidence from already known sources
                 if source_db.lower() in ignore_srcs:
@@ -96,7 +106,8 @@ class OmniPathProcessor(object):
             return ligrec_stmts
 
         for lr_entry in ligrec_json:
-            if not lr_entry['references']:
+            references = lr_entry['references']
+            if not references:
                 no_refs += 1
                 continue
             if len(lr_entry['sources']) == 1 and \
@@ -105,7 +116,16 @@ class OmniPathProcessor(object):
 
             # Assemble evidence
             evidence = []
-            for source_pmid in lr_entry['references']:
+            if isinstance(references, str):
+                # Handle corner case with ;-separated references e.g.
+                # TRIP:11290752;TRIP:12601176;...
+                if ';' in references:
+                    references = references.split(';')
+                # Handle corner case with simple string reference e.g.,
+                # SIGNOR:11201744
+                else:
+                    references = [references]
+            for source_pmid in references:
                 source_db, pmid = source_pmid.split(':')
                 # Skip evidence from already known sources
                 if source_db.lower() in ignore_srcs:

--- a/indra/sources/virhostnet/processor.py
+++ b/indra/sources/virhostnet/processor.py
@@ -82,6 +82,7 @@ def process_row(row, up_web_fallback=False):
 
 def get_agent_from_grounding(grounding, up_web_fallback=False):
     """Return an INDRA Agent based on a grounding annotation."""
+    breakpoint()
     db_ns, db_id = grounding.split(':')
     # Assume UniProt or RefSeq IDs
     assert db_ns in {'uniprotkb', 'refseq', 'ddbj/embl/genbank'}, db_ns

--- a/indra/sources/virhostnet/processor.py
+++ b/indra/sources/virhostnet/processor.py
@@ -82,7 +82,6 @@ def process_row(row, up_web_fallback=False):
 
 def get_agent_from_grounding(grounding, up_web_fallback=False):
     """Return an INDRA Agent based on a grounding annotation."""
-    breakpoint()
     db_ns, db_id = grounding.split(':')
     # Assume UniProt or RefSeq IDs
     assert db_ns in {'uniprotkb', 'refseq', 'ddbj/embl/genbank'}, db_ns

--- a/indra/sources/virhostnet/processor.py
+++ b/indra/sources/virhostnet/processor.py
@@ -1,5 +1,8 @@
 import re
 import logging
+
+import tqdm
+
 from indra.databases import uniprot_client
 from indra.statements import Agent, Complex, Evidence
 from indra.ontology.standardize import standardize_agent_name
@@ -29,7 +32,7 @@ class VirhostnetProcessor:
         self.statements = []
 
     def extract_statements(self):
-        for _, row in self.df.iterrows():
+        for _, row in tqdm.tqdm(self.df.iterrows()):
             stmt = process_row(row, up_web_fallback=self.up_web_fallback)
             if stmt:
                 self.statements.append(stmt)

--- a/indra/tests/test_omnipath.py
+++ b/indra/tests/test_omnipath.py
@@ -19,12 +19,6 @@ TRPC3_AG = Agent(None, db_refs={'UP': TRPC3_UPID})
 standardize_agent_name(TRPC3_AG)
 
 
-def test_omnipath_web_api():
-    query_url = '%s/queries' % op_url
-    res = requests.get(query_url)
-    assert res.status_code == 200
-
-
 def test_mods_from_web():
     params = {'format': 'json', 'substrates': JAK2_UPID,
               'fields': ['sources', 'references']}

--- a/indra/tests/test_virhostnet.py
+++ b/indra/tests/test_virhostnet.py
@@ -115,5 +115,5 @@ def test_get_uppro_name():
 def test_name_web_fallback():
     ag = get_agent_from_grounding('uniprotkb:Q174W8', up_web_fallback=False)
     assert ag.name == 'Q174W8'
-    ag = get_agent_from_grounding('uniprotkb:Q174W8', up_web_fallback=True)
-    assert ag.name == 'GPRFZ2'
+    ag = get_agent_from_grounding('uniprotkb:A0A0S1MMP8', up_web_fallback=True)
+    assert ag.name == 'COI'

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def main():
                     'requests>=2.11', 'lxml', 'ipython', 'future',
                     'networkx>=3', 'pandas>=2', 'ndex2', 'jinja2',
                     'protmapper>=0.0.29', 'obonet',
-                    'tqdm', 'pybiopax>=0.0.5']
+                    'tqdm', 'pybiopax>=0.0.5', 'setuptools']
 
     extras_require = {
                       # Inputs and outputs

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ def main():
                     'requests>=2.11', 'lxml', 'ipython', 'future',
                     'networkx>=3', 'pandas>=2', 'ndex2', 'jinja2',
                     'protmapper>=0.0.29', 'obonet',
-                    'tqdm', 'pybiopax>=0.0.5', 'setuptools']
+                    # pybel requires setuptools<81
+                    'tqdm', 'pybiopax>=0.0.5', 'setuptools<81']
 
     extras_require = {
                       # Inputs and outputs


### PR DESCRIPTION
This PR implements new client functions in `indra.literature.pmc_client` to migrate from the soon deprecated FTP-based content access to the new S3-based access (see https://pmc.ncbi.nlm.nih.gov/tools/pmcaws/). Previously, each article had a non-obvious FTP path that had to be looked up in a catalogue based on the PMID or PMC ID and then used to fetch a tar file with the "package" of files corresponding to the article. With S3, there is a fixed access path for a given PMC ID (+ version) and the list and type of files is available via a separate metadata request. The new client functions implement requests to get available (or latest) version, metadata, getter functions for different types of content, and a single function to download all article files into a given folder.