### PR TITLE
Statement Classification Model

### DIFF
--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -113,25 +113,17 @@ def _make_agent_pair_consensus_summary(record):
     primary = record.get('primary') or {}
     steps = []
 
-    mechanism_types = primary.get('mechanism_types') or []
-    if 'Complex' in mechanism_types:
-        steps.append('Binding')
-    for mechanism_type in mechanism_types:
-        if mechanism_type == 'Complex':
-            continue
-        if mechanism_type not in steps:
-            steps.append(mechanism_type)
-
-    for effect_type in primary.get('effect_types') or []:
-        if effect_type not in steps:
-            steps.append(effect_type)
+    for step in (
+        primary.get('mechanism_types', [])
+        + primary.get('effect_types', [])
+    ):
+        if step not in steps:
+            steps.append(step)
 
     if not steps:
         return None
 
-    return {
-        'steps': steps,
-    }
+    return {'steps': steps}
 
 
 def generate_source_css(fname: str,

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -4,12 +4,14 @@ supports curation.
 """
 import re
 import uuid
+import gzip
+import json
 import logging
 import itertools
 from html import escape
 from typing import Union, Dict, Optional
 from collections import OrderedDict, defaultdict
-from os.path import abspath, dirname, join
+from os.path import abspath, dirname, exists, join
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -39,6 +41,11 @@ loader = FileSystemLoader(join(HERE, 'templates'))
 env = Environment(loader=loader)
 
 default_template = env.get_template('indra/statements_view.html')
+
+AGENT_PAIR_CONSENSUS_CACHE = join(
+    dirname(dirname(dirname(HERE))), 'agent_pair_consensus_cache.json.gz'
+)
+_agent_pair_consensus_cache = None
 
 DB_TEXT_COLOR = 'black'
 """The text color for database sources when shown as source count badges"""
@@ -88,6 +95,40 @@ def _source_info_to_source_colors(
 
 
 DEFAULT_SOURCE_COLORS = _source_info_to_source_colors(SOURCE_INFO)
+
+
+def _load_agent_pair_consensus_cache():
+    global _agent_pair_consensus_cache
+    if _agent_pair_consensus_cache is not None:
+        return _agent_pair_consensus_cache
+    if not exists(AGENT_PAIR_CONSENSUS_CACHE):
+        _agent_pair_consensus_cache = {}
+        return _agent_pair_consensus_cache
+    with gzip.open(AGENT_PAIR_CONSENSUS_CACHE, 'rt') as fh:
+        _agent_pair_consensus_cache = json.load(fh)
+    return _agent_pair_consensus_cache
+
+
+def _make_agent_pair_consensus_summary(record):
+    primary = record.get('primary') or {}
+    effect = primary.get('effect')
+    if not effect:
+        return None
+
+    mechanisms = [str(m) for m in primary.get('mechanisms') or []]
+    mechanism_labels = []
+    if any('binding' in mechanism.lower() for mechanism in mechanisms):
+        mechanism_labels.append('binding')
+    for mechanism in mechanisms:
+        mechanism_label = mechanism.replace('binding-associated ', '', 1)
+        if mechanism_label != 'binding' and \
+                mechanism_label not in mechanism_labels:
+            mechanism_labels.append(mechanism_label)
+
+    return {
+        'effect': effect,
+        'mechanisms': mechanism_labels,
+    }
 
 
 def generate_source_css(fname: str,
@@ -237,7 +278,8 @@ class HtmlAssembler(object):
                  ev_counts=None, beliefs=None, source_counts=None,
                  curation_dict=None, title='INDRA Results', db_rest_url=None,
                  sort_by='default', custom_stats=None,
-                 custom_sources: Optional[SourceInfo] = None):
+                 custom_sources: Optional[SourceInfo] = None,
+                 agent_pair_consensus=None):
         if custom_sources is not None:
             custom_source_list = list(custom_sources)
         else:
@@ -266,6 +308,9 @@ class HtmlAssembler(object):
         self.custom_stats = [] if custom_stats is None else custom_stats
         self.source_colors: Optional[SourceColors] = \
             _source_info_to_source_colors(custom_sources)
+        self.agent_pair_consensus = agent_pair_consensus if \
+            agent_pair_consensus is not None else \
+            _load_agent_pair_consensus_cache()
 
     def add_statements(self, statements):
         """Add a list of Statements to the assembler.
@@ -530,6 +575,12 @@ class HtmlAssembler(object):
                 agp_label = make_top_level_label_from_names_key(tlg['names'])
                 agp_label = re.sub("<b>(.*?)</b>", r"\1", agp_label)
                 agp_label = tag_agents(agp_label, agent_pair_agents)
+                if len(tlg['names']) == 2:
+                    pair_key = '|'.join(str(name) for name in tlg['names'])
+                    consensus = self.agent_pair_consensus.get(pair_key)
+                    if consensus:
+                        tlg['affect_summary'] = \
+                            _make_agent_pair_consensus_summary(consensus)
                 tlg['label'] = agp_label
 
         return stmts

--- a/indra/assemblers/html/assembler.py
+++ b/indra/assemblers/html/assembler.py
@@ -111,23 +111,26 @@ def _load_agent_pair_consensus_cache():
 
 def _make_agent_pair_consensus_summary(record):
     primary = record.get('primary') or {}
-    effect = primary.get('effect')
-    if not effect:
+    steps = []
+
+    mechanism_types = primary.get('mechanism_types') or []
+    if 'Complex' in mechanism_types:
+        steps.append('Binding')
+    for mechanism_type in mechanism_types:
+        if mechanism_type == 'Complex':
+            continue
+        if mechanism_type not in steps:
+            steps.append(mechanism_type)
+
+    for effect_type in primary.get('effect_types') or []:
+        if effect_type not in steps:
+            steps.append(effect_type)
+
+    if not steps:
         return None
 
-    mechanisms = [str(m) for m in primary.get('mechanisms') or []]
-    mechanism_labels = []
-    if any('binding' in mechanism.lower() for mechanism in mechanisms):
-        mechanism_labels.append('binding')
-    for mechanism in mechanisms:
-        mechanism_label = mechanism.replace('binding-associated ', '', 1)
-        if mechanism_label != 'binding' and \
-                mechanism_label not in mechanism_labels:
-            mechanism_labels.append(mechanism_label)
-
     return {
-        'effect': effect,
-        'mechanisms': mechanism_labels,
+        'steps': steps,
     }
 
 

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -211,12 +211,55 @@
         background-color: #f2f2f2;
     }
 
-    .consensus-sentence {
-        display: block;
-        margin-top: 4px;
+    .consensus-affect-summary {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.15rem;
+        margin-left: 0.75rem;
         color: #555;
-        font-size: 0.9rem;
-        font-weight: 400;
+        font-size: 0.58em;
+        font-weight: 500;
+        white-space: nowrap;
+        vertical-align: middle;
+    }
+
+    .consensus-affect-chip {
+        display: inline-block;
+        padding: 0.1rem 0.35rem;
+        border: 1px solid #ddd;
+        border-radius: 3px;
+        background-color: #fafafa;
+    }
+
+    .consensus-affect-bridge {
+        position: relative;
+        display: inline-block;
+        width: 0.65rem;
+        height: 1.1em;
+        margin: 0 -0.12rem;
+        vertical-align: middle;
+    }
+
+    .consensus-affect-bridge:before,
+    .consensus-affect-bridge:after {
+        content: "";
+        position: absolute;
+        top: 0.05em;
+        width: 0.38rem;
+        height: 1em;
+        border: 1px solid #777;
+    }
+
+    .consensus-affect-bridge:before {
+        left: 0;
+        border-left: none;
+        border-radius: 0 0.45rem 0.45rem 0;
+    }
+
+    .consensus-affect-bridge:after {
+        right: 0;
+        border-right: none;
+        border-radius: 0.45rem 0 0 0.45rem;
     }
 
     .badge-subject {
@@ -288,6 +331,21 @@
       title="Belief score for this statement">{{ belief_score }}</small>
 {%- endmacro %}
 
+{% macro affect_summary(summary) -%}
+  {% if summary %}
+  <span class="consensus-affect-summary"
+        {% if summary.get('title') %}title="{{ summary['title']|e }}"{% endif %}>
+    {% if summary.get('effect') %}
+      <span class="consensus-affect-chip">{{ summary['effect']|e }}</span>
+    {% endif %}
+    {% for mechanism in summary.get('mechanisms') or [] %}
+      <span class="consensus-affect-bridge"></span>
+      <span class="consensus-affect-chip">{{ mechanism|e }}</span>
+    {% endfor %}
+  </span>
+  {% endif %}
+{%- endmacro %}
+
 {% block footer_desc %}
   This page allows you to curate the loaded statements. For more information
   please see the
@@ -343,11 +401,7 @@
       <div class="col-auto nvp">
         <h5 class="align-middle">
           {{ results['label'] }}
-          {% if results.get('consensus') %}
-            <span class="consensus-sentence">
-              {{ results['consensus']['text'] }}
-            </span>
-          {% endif %}
+          {{ affect_summary(results.get('affect_summary')) }}
         </h5>
       </div>
       <div class="col text-right nvp">

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -211,6 +211,14 @@
         background-color: #f2f2f2;
     }
 
+    .consensus-sentence {
+        display: block;
+        margin-top: 4px;
+        color: #555;
+        font-size: 0.9rem;
+        font-weight: 400;
+    }
+
     .badge-subject {
         background-color: #4a36aa;
         color: #FFFFFF;
@@ -333,7 +341,14 @@
          id="tl-{{ results['html_key'] }}"
          onclick="toggler('tl-{{ results['html_key'] }}')">
       <div class="col-auto nvp">
-        <h5 class="align-middle">{{ results['label'] }}</h5>
+        <h5 class="align-middle">
+          {{ results['label'] }}
+          {% if results.get('consensus') %}
+            <span class="consensus-sentence">
+              {{ results['consensus']['text'] }}
+            </span>
+          {% endif %}
+        </h5>
       </div>
       <div class="col text-right nvp">
         {{ badges(results['source_counts'], available_sources) }}

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -231,35 +231,11 @@
         background-color: #fafafa;
     }
 
-    .consensus-affect-bridge {
-        position: relative;
+    .consensus-affect-arrow {
         display: inline-block;
-        width: 0.65rem;
-        height: 1.1em;
-        margin: 0 -0.12rem;
-        vertical-align: middle;
-    }
-
-    .consensus-affect-bridge:before,
-    .consensus-affect-bridge:after {
-        content: "";
-        position: absolute;
-        top: 0.05em;
-        width: 0.38rem;
-        height: 1em;
-        border: 1px solid #777;
-    }
-
-    .consensus-affect-bridge:before {
-        left: 0;
-        border-left: none;
-        border-radius: 0 0.45rem 0.45rem 0;
-    }
-
-    .consensus-affect-bridge:after {
-        right: 0;
-        border-right: none;
-        border-radius: 0.45rem 0 0 0.45rem;
+        margin: 0 0.1rem;
+        color: #777;
+        font-weight: 600;
     }
 
     .badge-subject {
@@ -334,12 +310,11 @@
 {% macro affect_summary(summary) -%}
   {% if summary %}
   <span class="consensus-affect-summary">
-    {% if summary.get('effect') %}
-      <span class="consensus-affect-chip">{{ summary['effect']|e }}</span>
-    {% endif %}
-    {% for mechanism in summary.get('mechanisms') or [] %}
-      <span class="consensus-affect-bridge"></span>
-      <span class="consensus-affect-chip">{{ mechanism|e }}</span>
+    {% for step in summary.get('steps') or [] %}
+      {% if not loop.first %}
+        <span class="consensus-affect-arrow">&rarr;</span>
+      {% endif %}
+      <span class="consensus-affect-chip">{{ step|e }}</span>
     {% endfor %}
   </span>
   {% endif %}

--- a/indra/assemblers/html/templates/indra/statements_view.html
+++ b/indra/assemblers/html/templates/indra/statements_view.html
@@ -333,8 +333,7 @@
 
 {% macro affect_summary(summary) -%}
   {% if summary %}
-  <span class="consensus-affect-summary"
-        {% if summary.get('title') %}title="{{ summary['title']|e }}"{% endif %}>
+  <span class="consensus-affect-summary">
     {% if summary.get('effect') %}
       <span class="consensus-affect-chip">{{ summary['effect']|e }}</span>
     {% endif %}

--- a/indra/statements/classifier.py
+++ b/indra/statements/classifier.py
@@ -529,12 +529,12 @@ class StatementTypeClassification:
             source_counts = pickle.load(fh)
 
         pair_to_rows = defaultdict(list)
+        hash_to_pair_keys = defaultdict(list)
 
         with gzip.open(unique_stmts_fpath, "rt") as fh:
             reader = csv.reader(fh, delimiter="\t")
-            reader = tqdm(reader, total=total)
 
-            for stmt_hash, stmt_json_str in reader:
+            for stmt_hash, stmt_json_str in tqdm(reader, total=48079265):
                 stmt_json = json_loader(stmt_json_str)
                 stmt = stmt_from_json(stmt_json)
                 agents = stmt.agent_list()
@@ -542,19 +542,32 @@ class StatementTypeClassification:
                     continue
 
                 sub, obj = agents[0].name, agents[1].name
-                stmt_hash = int(stmt_hash)
-                source_count = source_counts.get(stmt_hash)
-                row = self._make_stmt_row(
-                    sub,
-                    obj,
-                    stmt.__class__.__name__,
-                    stmt_hash,
-                    source_count,
-                )
-                pair_to_rows[(sub, obj)].append(row)
+                hash = int(stmt_hash)
+                source_count = source_counts.get(hash)
 
-        with open(pair_to_rows_fpath, "wb") as fh:
+                if stmt.__class__.__name__ == "Complex":
+                    pairs = [(sub, obj), (obj, sub)]
+                else:
+                    pairs = [(sub, obj)]
+
+                for row_sub, row_obj in pairs:
+                    pair_key = f"{row_sub}|{row_obj}"
+                    row = self._make_stmt_row(
+                        row_sub,
+                        row_obj,
+                        hash,
+                        stmt,
+                        source_count,
+                    )
+                    self._make_stmt_row[(row_sub, row_obj)].append(row)
+                    if pair_key not in hash_to_pair_keys[stmt_hash]:
+                        hash_to_pair_keys[stmt_hash].append(pair_key)
+
+        with open("pair_to_rows.pkl", "wb") as fh:
             pickle.dump(pair_to_rows, fh, protocol=pickle.HIGHEST_PROTOCOL)
+
+        with gzip.open("hash_to_pair_keys.json.gz", "wt") as fh:
+            json.dump(hash_to_pair_keys, fh)
 
         return pair_to_rows
 

--- a/indra/statements/classifier.py
+++ b/indra/statements/classifier.py
@@ -270,6 +270,22 @@ class StatementTypeClassification:
         return df
 
     def predict_from_rows(self, rows):
+        """
+        A list of relation records. Each record is a dict with keys:
+        ``subject`` (str), ``object`` (str), ``type`` (str),
+        ``hash`` (int), ``statement`` (str), and
+        ``source_count`` (dict[str, int]).
+        e.g. rows = [
+            {
+                "subject": "MAP2K1",
+                "object": "MAPK1",
+                "type": "Phosphorylation",
+                "hash": 123,
+                "statement": "MAP2K1 phosphorylates MAPK1.",
+                "source_count": {"reach": 3, "sparser": 1},
+            }, ...]
+        """
+
         df_input = self.build_input_from_rows(rows)
 
         if df_input.empty:

--- a/indra/statements/classifier.py
+++ b/indra/statements/classifier.py
@@ -234,7 +234,6 @@ class StatementTypeClassification:
 
         df = df.groupby(["subject", "object", "type"], as_index=False).agg({
             "hash": list,
-            "statement": list,
             "source_count": self.merge_source_count_dicts,
             "rel_evidence": "sum",
             "in_signor": "max",
@@ -297,15 +296,13 @@ class StatementTypeClassification:
         """
         A list of relation records. Each record is a dict with keys:
         ``subject`` (str), ``object`` (str), ``type`` (str),
-        ``hash`` (int), ``statement`` (str), and
-        ``source_count`` (dict[str, int]).
+        ``hash`` (int), and ``source_count`` (dict[str, int]).
         e.g. rows = [
             {
                 "subject": "MAP2K1",
                 "object": "MAPK1",
                 "type": "Phosphorylation",
                 "hash": 123,
-                "statement": "MAP2K1 phosphorylates MAPK1.",
                 "source_count": {"reach": 3, "sparser": 1},
             }, ...]
         """
@@ -313,19 +310,22 @@ class StatementTypeClassification:
         df_input = self.build_input_from_rows(rows)
 
         if df_input.empty:
-            return df_input
+            return {}
 
         X = df_input[self.feature_cols].copy()
 
         df_input["pred_prob"] = self.model.predict_proba(X)[:, 1]
         df_input["pred_label"] = self.model.predict(X)
 
-        first_cols = ["subject", "object", "type", "pred_prob", "pred_label"]
-        other_cols = [col for col in df_input.columns if col not in first_cols]
-
-        df_input = df_input[first_cols + other_cols]
-
-        return df_input.sort_values("pred_prob", ascending=False)
+        hash_to_label = {}
+        for _, row in df_input.iterrows():
+            label = int(row["pred_label"])
+            hashes = row["hash"]
+            if not isinstance(hashes, list):
+                hashes = [hashes]
+            for stmt_hash in hashes:
+                hash_to_label[stmt_hash] = label
+        return hash_to_label
 
     def predict_from_hashes(self, hashes):
         """

--- a/indra/statements/classifier.py
+++ b/indra/statements/classifier.py
@@ -507,18 +507,6 @@ class StatementTypeClassification:
             for agent in agents
         )
 
-    @staticmethod
-    def pair_key(subject, obj):
-        return f"{subject}|{obj}"
-
-    @staticmethod
-    def parse_pair(pair):
-        if isinstance(pair, tuple) and len(pair) == 2:
-            return pair[0], pair[1]
-        if isinstance(pair, str) and "|" in pair:
-            return pair.split("|", 1)
-        return None, None
-
     def dump_pair_to_rows(
             self,
             unique_stmts_fpath,
@@ -573,11 +561,9 @@ class StatementTypeClassification:
         cache = {}
         pairs = tqdm(pair_to_rows.items(), total=len(pair_to_rows))
 
-        for pair, rows in pairs:
+        for (pair_subject, pair_object), rows in pairs:
             if not rows:
                 continue
-
-            pair_subject, pair_object = self.parse_pair(pair)
 
             records = self.consensus_from_rows(
                 rows,
@@ -589,7 +575,7 @@ class StatementTypeClassification:
                 continue
 
             for record in records:
-                key = self.pair_key(record["subject"], record["object"])
+                key = f'{record["subject"]}|{record["object"]}'
                 cache[key] = record
 
         with gzip.open(cache_fpath, "wt") as fh:

--- a/indra/statements/classifier.py
+++ b/indra/statements/classifier.py
@@ -1,8 +1,8 @@
 from collections import Counter
 from functools import lru_cache
-from io import BytesIO
-from urllib.request import urlopen
+from tempfile import NamedTemporaryFile
 
+import boto3
 import joblib
 import gilda
 import numpy as np
@@ -17,9 +17,8 @@ from indra.statements import modclass_to_inverse
 class StatementTypeClassification:
     """Predict whether a statement type is correct based on polarity and evidence patterns within an agent-agent group."""
 
-    MODEL_URL = (
-        "https://bigmech.s3.us-east-1.amazonaws.com/classification_model.joblib"
-    )
+    MODEL_BUCKET = "bigmech"
+    MODEL_KEY = "classification_model.joblib"
 
     def __init__(
             self,
@@ -53,8 +52,10 @@ class StatementTypeClassification:
         if model_path:
             return joblib.load(model_path)
 
-        with urlopen(self.MODEL_URL) as response:
-            return joblib.load(BytesIO(response.read()))
+        s3 = boto3.client("s3")
+        with NamedTemporaryFile(suffix=".joblib") as tmp:
+            s3.download_file(self.MODEL_BUCKET, self.MODEL_KEY, tmp.name)
+            return joblib.load(tmp.name)
 
     @staticmethod
     def _make_opposite_map():

--- a/indra/statements/classifier.py
+++ b/indra/statements/classifier.py
@@ -1,0 +1,326 @@
+from collections import Counter
+from functools import lru_cache
+
+import joblib
+import gilda
+import numpy as np
+import pandas as pd
+
+from indra.ontology.bio import bio_ontology
+from indra.sources import indra_db_rest
+from indra.statements import modclass_to_inverse
+
+
+
+class StatementTypeClassification:
+    """Predict whether a statement type is correct based on polarity and evidence patterns within an agent-agent group."""
+
+    def __init__(
+            self,
+            model_path="classification_model.joblib",
+            model=None,
+            feature_cols=None,
+            opposite_map=None,
+            db_client=indra_db_rest,
+    ):
+        if model is not None:
+            self.model = model
+        else:
+            self.model = joblib.load(model_path)
+
+        self.db_client = db_client
+
+        self.feature_cols = feature_cols or [
+            "rel_evidence_log",
+            "has_family_complex",
+            "evidence_proportion_in_group",
+            "supported_sources",
+            "has_oppo_type_in_group",
+            "oppo_type_count_ratio_in_pair",
+            "pair_total_evidence_log",
+        ]
+
+        self.opposite_map = opposite_map or self._make_opposite_map()
+
+    @staticmethod
+    def _make_opposite_map():
+        return {
+            **{k.__name__: v.__name__ for k, v in modclass_to_inverse.items()},
+
+            "Gef": "Gap",
+            "Gap": "Gef",
+
+            "AddModification": "RemoveModification",
+            "RemoveModification": "AddModification",
+
+            "Activation": "Inhibition",
+            "Inhibition": "Activation",
+
+            "IncreaseAmount": "DecreaseAmount",
+            "DecreaseAmount": "IncreaseAmount",
+        }
+
+    @staticmethod
+    def merge_source_count_dicts(dicts):
+        total = Counter()
+        for d in dicts:
+            total.update(d)
+        return dict(total)
+
+    @staticmethod
+    @lru_cache(maxsize=500000)
+    def is_family_complex(name):
+        scored_matches = gilda.ground(name)
+        if not scored_matches:
+            return False
+
+        ns, entity_id = scored_matches[0].term.get_curie().split(":")
+        ent_type = bio_ontology.get_type(ns.upper(), entity_id)
+        return ent_type == "protein_family_complex"
+
+    @staticmethod
+    def stmt_to_row(stmt, source_counts):
+        agents = stmt.agent_list()
+
+        if len(agents) != 2:
+            return None
+
+        if agents[0] is None or agents[1] is None:
+            return None
+
+        stmt_hash = stmt.get_hash()
+        source_count = source_counts.get(stmt_hash, {})
+
+        return {
+            "subject": agents[0].name,
+            "object": agents[1].name,
+            "type": stmt.__class__.__name__,
+            "hash": stmt_hash,
+            "statement": str(stmt),
+            "source_count": source_count,
+            "rel_evidence": sum(source_count.values()),
+            "in_signor": int("signor" in source_count),
+        }
+
+    def get_pair_df(self, subject, object):
+        res = self.db_client.get_statements(subject=subject, object=object, ev_limit=1)
+
+        source_counts = res.get_source_counts()
+        source_counts = {
+            stmt_hash: {
+                source: count
+                for source, count in source_dict.items()
+                if count != 0
+            }
+            for stmt_hash, source_dict in source_counts.items()
+        }
+        rows = []
+        for stmt in res.statements:
+            row = self.stmt_to_row(stmt, source_counts)
+            if row is not None:
+                rows.append(row)
+
+        return pd.DataFrame(rows)
+
+    def build_pair_input(self, subject, object):
+        df = self.get_pair_df(subject, object)
+
+        if df.empty:
+            return df
+
+        df = df.groupby(["subject", "object", "type"], as_index=False).agg({
+            "hash": list,
+            "statement": list,
+            "source_count": self.merge_source_count_dicts,
+            "rel_evidence": "sum",
+            "in_signor": "max",
+        })
+
+        df["has_family_complex"] = df.apply(
+            lambda row: int(
+                self.is_family_complex(row["subject"])
+                or self.is_family_complex(row["object"])
+            ),
+            axis=1,
+        )
+
+        df["supported_sources"] = df["source_count"].apply(lambda x: len(x))
+
+        df["pair_total_evidence"] = (
+            df.groupby(["subject", "object"])["rel_evidence"].transform("sum")
+        )
+
+        df["evidence_proportion_in_group"] = (
+                df["rel_evidence"] / df["pair_total_evidence"]
+        )
+
+        type_to_evidence = df.groupby("type")["rel_evidence"].sum().to_dict()
+
+        df["has_oppo_type_in_group"] = df["type"].apply(
+            lambda x: int(self.opposite_map.get(x) in type_to_evidence)
+        )
+
+        df["oppo_type_count_ratio_in_pair"] = df["type"].apply(
+            lambda x: (
+                df.loc[df["type"] == x, "rel_evidence"].iloc[0]
+                / type_to_evidence[self.opposite_map[x]]
+                if self.opposite_map.get(x) in type_to_evidence
+                else 0
+            )
+        )
+
+        df["rel_evidence_log"] = np.log1p(df["rel_evidence"])
+
+        # Doing this twice for feature engineering
+        df["pair_total_evidence_log"] = np.log1p(df["pair_total_evidence"])
+        df["pair_total_evidence_log"] = np.log1p(df["pair_total_evidence_log"])
+
+        df["supported_sources"] = np.log1p(df["supported_sources"])
+        df["oppo_type_count_ratio_in_pair"] = np.log1p(
+            df["oppo_type_count_ratio_in_pair"]
+        )
+
+        return df
+
+    def predict_pair(self, subject, object):
+        df_input = self.build_pair_input(subject, object)
+
+        if df_input.empty:
+            return df_input
+
+        X = df_input[self.feature_cols].copy()
+
+        df_input["pred_prob"] = self.model.predict_proba(X)[:, 1]
+        df_input["pred_label"] = self.model.predict(X)
+
+        first_cols = ["subject", "object", "type", "pred_prob", "pred_label"]
+        other_cols = [col for col in df_input.columns if col not in first_cols]
+        df_input = df_input[first_cols + other_cols]
+
+        return df_input.sort_values("pred_prob", ascending=False)
+
+    def build_input_from_rows(self, rows):
+        df = pd.DataFrame(rows)
+
+        if df.empty:
+            return df
+
+        df["rel_evidence"] = df["source_count"].apply(lambda x: sum(x.values()))
+        df["in_signor"] = df["source_count"].apply(lambda x: int("signor" in x))
+
+        df = df.groupby(["subject", "object", "type"], as_index=False).agg({
+            "hash": list,
+            "statement": list,
+            "source_count": self.merge_source_count_dicts,
+            "rel_evidence": "sum",
+            "in_signor": "max",
+        })
+
+        df["has_family_complex"] = df.apply(
+            lambda row: int(
+                self.is_family_complex(row["subject"])
+                or self.is_family_complex(row["object"])
+            ),
+            axis=1,
+        )
+
+        df["supported_sources"] = df["source_count"].apply(lambda x: len(x))
+
+        df["pair_total_evidence"] = (
+            df.groupby(["subject", "object"])["rel_evidence"].transform("sum")
+        )
+
+        df["evidence_proportion_in_group"] = (
+                df["rel_evidence"] / df["pair_total_evidence"]
+        )
+        # Here handles rows to have multiple subject-object pairs
+        df["opposite_type"] = df["type"].map(self.opposite_map)
+
+        oppo_df = df[["subject", "object", "type", "rel_evidence"]].rename(
+            columns={
+                "type": "opposite_type",
+                "rel_evidence": "opposite_rel_evidence",
+            }
+        )
+
+        df = df.merge(
+            oppo_df,
+            on=["subject", "object", "opposite_type"],
+            how="left",
+        )
+
+        df["has_oppo_type_in_group"] = (
+            df["opposite_rel_evidence"].notna().astype(int)
+        )
+
+        df["oppo_type_count_ratio_in_pair"] = (
+                df["rel_evidence"] / df["opposite_rel_evidence"]
+        ).fillna(0)
+
+        df["rel_evidence_log"] = np.log1p(df["rel_evidence"])
+
+        df["pair_total_evidence_log"] = np.log1p(df["pair_total_evidence"])
+        df["pair_total_evidence_log"] = np.log1p(df["pair_total_evidence_log"])
+
+        df["supported_sources"] = np.log1p(df["supported_sources"])
+        df["oppo_type_count_ratio_in_pair"] = np.log1p(
+            df["oppo_type_count_ratio_in_pair"]
+        )
+
+        return df
+
+    def predict_from_rows(self, rows):
+        df_input = self.build_input_from_rows(rows)
+
+        if df_input.empty:
+            return df_input
+
+        X = df_input[self.feature_cols].copy()
+
+        df_input["pred_prob"] = self.model.predict_proba(X)[:, 1]
+        df_input["pred_label"] = self.model.predict(X)
+
+        first_cols = ["subject", "object", "type", "pred_prob", "pred_label"]
+        other_cols = [col for col in df_input.columns if col not in first_cols]
+
+        df_input = df_input[first_cols + other_cols]
+
+        return df_input.sort_values("pred_prob", ascending=False)
+
+    def predict_from_hashes(self, hashes):
+        """
+        Given a list of statement hashes, return predicted labels in the same order.
+        """
+
+        hashes = [int(h) for h in hashes]
+
+        res = self.db_client.get_statements_by_hash(hashes)
+
+        hash_to_pair = {}
+
+        for stmt in res.statements:
+            agents = stmt.agent_list()
+
+            if len(agents) != 2 or agents[0] is None or agents[1] is None:
+                continue
+
+            stmt_hash = int(stmt.get_hash())
+            hash_to_pair[stmt_hash] = (agents[0].name, agents[1].name)
+
+        pair_to_pred_df = {}
+
+        for subject, obj in set(hash_to_pair.values()):
+            pair_to_pred_df[(subject, obj)] = self.predict_pair(subject, obj)
+
+        hash_to_label = {}
+
+        for pred_df in pair_to_pred_df.values():
+            if pred_df.empty:
+                continue
+
+            for _, row in pred_df.iterrows():
+                for stmt_hash in row["hash"]:
+                    hash_to_label[int(stmt_hash)] = int(row["pred_label"])
+
+        return {h: hash_to_label.get(h) for h in hashes}
+

--- a/indra/statements/classifier.py
+++ b/indra/statements/classifier.py
@@ -1,5 +1,7 @@
 from collections import Counter
 from functools import lru_cache
+from io import BytesIO
+from urllib.request import urlopen
 
 import joblib
 import gilda
@@ -15,9 +17,13 @@ from indra.statements import modclass_to_inverse
 class StatementTypeClassification:
     """Predict whether a statement type is correct based on polarity and evidence patterns within an agent-agent group."""
 
+    MODEL_URL = (
+        "https://bigmech.s3.us-east-1.amazonaws.com/classification_model.joblib"
+    )
+
     def __init__(
             self,
-            model_path="classification_model.joblib",
+            model_path=None,
             model=None,
             feature_cols=None,
             opposite_map=None,
@@ -26,7 +32,7 @@ class StatementTypeClassification:
         if model is not None:
             self.model = model
         else:
-            self.model = joblib.load(model_path)
+            self.model = self._load_model(model_path)
 
         self.db_client = db_client
 
@@ -41,6 +47,14 @@ class StatementTypeClassification:
         ]
 
         self.opposite_map = opposite_map or self._make_opposite_map()
+
+
+    def _load_model(self, model_path):
+        if model_path:
+            return joblib.load(model_path)
+
+        with urlopen(self.MODEL_URL) as response:
+            return joblib.load(BytesIO(response.read()))
 
     @staticmethod
     def _make_opposite_map():
@@ -339,4 +353,3 @@ class StatementTypeClassification:
                     hash_to_label[int(stmt_hash)] = int(row["pred_label"])
 
         return {h: hash_to_label.get(h) for h in hashes}
-

--- a/indra/statements/classifier.py
+++ b/indra/statements/classifier.py
@@ -1,4 +1,8 @@
-from collections import Counter
+import csv
+import gzip
+import json
+import pickle
+from collections import Counter, defaultdict
 from functools import lru_cache
 from tempfile import NamedTemporaryFile
 
@@ -10,7 +14,8 @@ import pandas as pd
 
 from indra.ontology.bio import bio_ontology
 from indra.sources import indra_db_rest
-from indra.statements import modclass_to_inverse
+from indra.statements import AddModification, RemoveModification, \
+    SelfModification, modclass_to_inverse
 
 
 
@@ -82,6 +87,45 @@ class StatementTypeClassification:
             total.update(d)
         return dict(total)
 
+    def _make_stmt_row(self, subject, obj, stmt_type, stmt_hash, source_count,
+                       statement=None):
+        rel_evidence = sum(source_count.values())
+        in_signor = int("signor" in source_count)
+        row = {
+            "subject": subject,
+            "object": obj,
+            "type": stmt_type,
+            "hash": stmt_hash,
+        }
+        if statement is not None:
+            row["statement"] = statement
+        row.update({
+            "source_count": source_count,
+            "rel_evidence": rel_evidence,
+            "in_signor": in_signor,
+        })
+        return row
+
+    def _add_predictions(self, df_input):
+        X = df_input[self.feature_cols].copy()
+        df_input["pred_prob"] = self.model.predict_proba(X)[:, 1]
+        df_input["pred_label"] = self.model.predict(X)
+        return df_input
+
+    @staticmethod
+    def _pred_df_to_hash_labels(pred_df, cast_hash=False):
+        hash_to_label = {}
+        for _, row in pred_df.iterrows():
+            label = int(row["pred_label"])
+            hashes = row["hash"]
+            if not isinstance(hashes, list):
+                hashes = [hashes]
+            for stmt_hash in hashes:
+                if cast_hash:
+                    stmt_hash = int(stmt_hash)
+                hash_to_label[stmt_hash] = label
+        return hash_to_label
+
     @staticmethod
     @lru_cache(maxsize=500000)
     def is_family_complex(name):
@@ -93,8 +137,7 @@ class StatementTypeClassification:
         ent_type = bio_ontology.get_type(ns.upper(), entity_id)
         return ent_type == "protein_family_complex"
 
-    @staticmethod
-    def stmt_to_row(stmt, source_counts):
+    def stmt_to_row(self, stmt, source_counts):
         agents = stmt.agent_list()
 
         if len(agents) != 2:
@@ -106,16 +149,14 @@ class StatementTypeClassification:
         stmt_hash = stmt.get_hash()
         source_count = source_counts.get(stmt_hash, {})
 
-        return {
-            "subject": agents[0].name,
-            "object": agents[1].name,
-            "type": stmt.__class__.__name__,
-            "hash": stmt_hash,
-            "statement": str(stmt),
-            "source_count": source_count,
-            "rel_evidence": sum(source_count.values()),
-            "in_signor": int("signor" in source_count),
-        }
+        return self._make_stmt_row(
+            agents[0].name,
+            agents[1].name,
+            stmt.__class__.__name__,
+            stmt_hash,
+            source_count,
+            statement=str(stmt),
+        )
 
     def get_pair_df(self, subject, object):
         res = self.db_client.get_statements(subject=subject, object=object, ev_limit=1)
@@ -137,85 +178,18 @@ class StatementTypeClassification:
 
         return pd.DataFrame(rows)
 
-    def build_pair_input(self, subject, object):
-        df = self.get_pair_df(subject, object)
-
-        if df.empty:
-            return df
-
-        df = df.groupby(["subject", "object", "type"], as_index=False).agg({
-            "hash": list,
-            "statement": list,
-            "source_count": self.merge_source_count_dicts,
-            "rel_evidence": "sum",
-            "in_signor": "max",
-        })
-
-        df["has_family_complex"] = df.apply(
-            lambda row: int(
-                self.is_family_complex(row["subject"])
-                or self.is_family_complex(row["object"])
-            ),
-            axis=1,
-        )
-
-        df["supported_sources"] = df["source_count"].apply(lambda x: len(x))
-
-        df["pair_total_evidence"] = (
-            df.groupby(["subject", "object"])["rel_evidence"].transform("sum")
-        )
-
-        df["evidence_proportion_in_group"] = (
-                df["rel_evidence"] / df["pair_total_evidence"]
-        )
-
-        type_to_evidence = df.groupby("type")["rel_evidence"].sum().to_dict()
-
-        df["has_oppo_type_in_group"] = df["type"].apply(
-            lambda x: int(self.opposite_map.get(x) in type_to_evidence)
-        )
-
-        df["oppo_type_count_ratio_in_pair"] = df["type"].apply(
-            lambda x: (
-                df.loc[df["type"] == x, "rel_evidence"].iloc[0]
-                / type_to_evidence[self.opposite_map[x]]
-                if self.opposite_map.get(x) in type_to_evidence
-                else 0
-            )
-        )
-
-        df["rel_evidence_log"] = np.log1p(df["rel_evidence"])
-
-        # Doing this twice for feature engineering
-        df["pair_total_evidence_log"] = np.log1p(df["pair_total_evidence"])
-        df["pair_total_evidence_log"] = np.log1p(df["pair_total_evidence_log"])
-
-        df["supported_sources"] = np.log1p(df["supported_sources"])
-        df["oppo_type_count_ratio_in_pair"] = np.log1p(
-            df["oppo_type_count_ratio_in_pair"]
-        )
-
-        return df
-
     def predict_pair(self, subject, object, simple_result=False):
-        df_input = self.build_pair_input(subject, object)
+        df_input = self.build_input_from_rows(
+            self.get_pair_df(subject, object)
+        )
 
         if df_input.empty:
             return {} if simple_result else df_input
 
-        X = df_input[self.feature_cols].copy()
-
-        df_input["pred_prob"] = self.model.predict_proba(X)[:, 1]
-        df_input["pred_label"] = self.model.predict(X)
+        df_input = self._add_predictions(df_input)
 
         if simple_result:
-            hash_to_label = {}
-            for _, row in df_input.iterrows():
-                label = int(row["pred_label"])
-                hashes = row["hash"]
-                for stmt_hash in hashes:
-                    hash_to_label[stmt_hash] = label
-            return hash_to_label
+            return self._pred_df_to_hash_labels(df_input)
 
         first_cols = ["subject", "object", "type", "pred_prob", "pred_label"]
         other_cols = [col for col in df_input.columns if col not in first_cols]
@@ -232,12 +206,18 @@ class StatementTypeClassification:
         df["rel_evidence"] = df["source_count"].apply(lambda x: sum(x.values()))
         df["in_signor"] = df["source_count"].apply(lambda x: int("signor" in x))
 
-        df = df.groupby(["subject", "object", "type"], as_index=False).agg({
+        agg_spec = {
             "hash": list,
             "source_count": self.merge_source_count_dicts,
             "rel_evidence": "sum",
             "in_signor": "max",
-        })
+        }
+        if "statement" in df.columns:
+            agg_spec["statement"] = list
+
+        df = df.groupby(["subject", "object", "type"], as_index=False).agg(
+            agg_spec
+        )
 
         df["has_family_complex"] = df.apply(
             lambda row: int(
@@ -312,20 +292,8 @@ class StatementTypeClassification:
         if df_input.empty:
             return {}
 
-        X = df_input[self.feature_cols].copy()
-
-        df_input["pred_prob"] = self.model.predict_proba(X)[:, 1]
-        df_input["pred_label"] = self.model.predict(X)
-
-        hash_to_label = {}
-        for _, row in df_input.iterrows():
-            label = int(row["pred_label"])
-            hashes = row["hash"]
-            if not isinstance(hashes, list):
-                hashes = [hashes]
-            for stmt_hash in hashes:
-                hash_to_label[stmt_hash] = label
-        return hash_to_label
+        df_input = self._add_predictions(df_input)
+        return self._pred_df_to_hash_labels(df_input)
 
     def predict_from_hashes(self, hashes):
         """
@@ -358,8 +326,294 @@ class StatementTypeClassification:
             if pred_df.empty:
                 continue
 
-            for _, row in pred_df.iterrows():
-                for stmt_hash in row["hash"]:
-                    hash_to_label[int(stmt_hash)] = int(row["pred_label"])
+            hash_to_label.update(
+                self._pred_df_to_hash_labels(pred_df, cast_hash=True)
+            )
 
         return {h: hash_to_label.get(h) for h in hashes}
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def get_ptm_types():
+        return {
+            cls.__name__
+            for cls in (
+                AddModification.__subclasses__()
+                + RemoveModification.__subclasses__()
+                + SelfModification.__subclasses__()
+            )
+        }
+
+    def get_consensus_rules(self):
+        ptm_types = self.get_ptm_types()
+        return [
+            {
+                "required_effect": {"Activation"},
+                "required_mechanism": ptm_types | {"Complex"},
+                "effect": "Activation",
+            },
+            {
+                "required_effect": {"Inhibition"},
+                "required_mechanism": ptm_types | {"Complex"},
+                "effect": "Inhibition",
+            },
+            {
+                "required_effect": {"IncreaseAmount"},
+                "required_mechanism": ptm_types,
+                "effect": "IncreaseAmount",
+            },
+            {
+                "required_effect": {"DecreaseAmount"},
+                "required_mechanism": ptm_types,
+                "effect": "DecreaseAmount",
+            },
+        ]
+
+    def resolve_opposite_mechanisms(self, mechanism_types, group):
+        mechanism_types = set(mechanism_types)
+
+        for mech in list(mechanism_types):
+            opposite = self.opposite_map.get(mech)
+            if opposite is None or opposite not in mechanism_types:
+                continue
+
+            mech_score = group[group["type"] == mech]["pred_prob"].max()
+            opposite_score = group[group["type"] == opposite]["pred_prob"].max()
+
+            if mech_score >= opposite_score:
+                mechanism_types.discard(opposite)
+            else:
+                mechanism_types.discard(mech)
+
+        return mechanism_types
+
+    def consensus_from_rows(self, rows, pair_subject=None, pair_object=None):
+        df = self.build_input_from_rows(rows)
+
+        if df.empty:
+            return None
+
+        if pair_subject is not None and pair_object is not None:
+            mask = (
+                (df["type"] == "Complex")
+                & (df["subject"] == pair_object)
+                & (df["object"] == pair_subject)
+            )
+            df.loc[mask, ["subject", "object"]] = [pair_subject, pair_object]
+
+        df = self._add_predictions(df)
+
+        true_df = df[df["pred_label"] == 1].copy()
+
+        if true_df.empty:
+            return None
+
+        records = []
+
+        for (subj, obj), group in true_df.groupby(["subject", "object"]):
+            true_types = set(group["type"])
+            candidates = []
+
+            for rule in self.get_consensus_rules():
+                effect_types = true_types & rule["required_effect"]
+                mechanism_types = true_types & rule["required_mechanism"]
+
+                if not effect_types:
+                    continue
+
+                mechanism_types = self.resolve_opposite_mechanisms(
+                    mechanism_types,
+                    group,
+                )
+
+                support_types = effect_types | mechanism_types
+                support = group[group["type"].isin(support_types)]
+
+                candidates.append(
+                    {
+                        "effect": rule["effect"],
+                        "support_score": float(support["pred_prob"].mean()),
+                        "effect_rel_evidence": int(
+                            group[
+                                group["type"].isin(effect_types)
+                            ]["rel_evidence"].sum()
+                        ),
+                        "mechanism_rel_evidence": int(
+                            group[
+                                group["type"].isin(mechanism_types)
+                            ]["rel_evidence"].sum()
+                        ),
+                        "effect_types": sorted(effect_types),
+                        "mechanism_types": sorted(mechanism_types),
+                    }
+                )
+
+            if not candidates and true_types == {"Complex"}:
+                complex_group = group[group["type"] == "Complex"]
+
+                candidates.append(
+                    {
+                        "effect": "Binding",
+                        "support_score": float(
+                            complex_group["pred_prob"].mean()
+                        ),
+                        "effect_rel_evidence": int(
+                            complex_group["rel_evidence"].sum()
+                        ),
+                        "mechanism_rel_evidence": 0,
+                        "effect_types": ["Complex"],
+                        "mechanism_types": [],
+                    }
+                )
+
+            if not candidates:
+                continue
+
+            primary = max(
+                candidates,
+                key=lambda x: (
+                    x["effect_rel_evidence"],
+                    x["mechanism_rel_evidence"],
+                    x["support_score"],
+                ),
+            )
+
+            records.append(
+                {
+                    "subject": subj,
+                    "object": obj,
+                    "primary": primary,
+                    "alternatives": [
+                        c for c in candidates
+                        if c != primary
+                    ],
+                    "true_types": sorted(true_types),
+                    "pair_total_evidence": int(
+                        group["pair_total_evidence"].max()
+                    ),
+                }
+            )
+
+        return records
+
+    @staticmethod
+    def agents_are_grounded(agents):
+        if len(agents) != 2:
+            return False
+        if agents[0] is None or agents[1] is None:
+            return False
+        return all(
+            set(agent.db_refs) - {"TEXT", "TEXT_NORM"}
+            for agent in agents
+        )
+
+    @staticmethod
+    def pair_key(subject, obj):
+        return f"{subject}|{obj}"
+
+    @staticmethod
+    def parse_pair(pair):
+        if isinstance(pair, tuple) and len(pair) == 2:
+            return pair[0], pair[1]
+        if isinstance(pair, str) and "|" in pair:
+            return pair.split("|", 1)
+        return None, None
+
+    def dump_pair_to_rows(
+            self,
+            unique_stmts_fpath,
+            source_counts_fpath,
+            pair_to_rows_fpath,
+            total=None,
+            json_loader=json.loads,
+    ):
+        from indra.statements import stmt_from_json
+        from tqdm import tqdm
+
+        with open(source_counts_fpath, "rb") as fh:
+            source_counts = pickle.load(fh)
+
+        pair_to_rows = defaultdict(list)
+
+        with gzip.open(unique_stmts_fpath, "rt") as fh:
+            reader = csv.reader(fh, delimiter="\t")
+            reader = tqdm(reader, total=total)
+
+            for stmt_hash, stmt_json_str in reader:
+                stmt_json = json_loader(stmt_json_str)
+                stmt = stmt_from_json(stmt_json)
+                agents = stmt.agent_list()
+                if not self.agents_are_grounded(agents):
+                    continue
+
+                sub, obj = agents[0].name, agents[1].name
+                stmt_hash = int(stmt_hash)
+                source_count = source_counts.get(stmt_hash)
+                row = self._make_stmt_row(
+                    sub,
+                    obj,
+                    stmt.__class__.__name__,
+                    stmt_hash,
+                    source_count,
+                )
+                pair_to_rows[(sub, obj)].append(row)
+
+        with open(pair_to_rows_fpath, "wb") as fh:
+            pickle.dump(pair_to_rows, fh, protocol=pickle.HIGHEST_PROTOCOL)
+
+        return pair_to_rows
+
+    def dump_agent_pair_consensus_cache(
+            self,
+            pair_to_rows,
+            cache_fpath,
+    ):
+        from tqdm import tqdm
+
+        cache = {}
+        pairs = tqdm(pair_to_rows.items(), total=len(pair_to_rows))
+
+        for pair, rows in pairs:
+            if not rows:
+                continue
+
+            pair_subject, pair_object = self.parse_pair(pair)
+
+            records = self.consensus_from_rows(
+                rows,
+                pair_subject=pair_subject,
+                pair_object=pair_object,
+            )
+
+            if not records:
+                continue
+
+            for record in records:
+                key = self.pair_key(record["subject"], record["object"])
+                cache[key] = record
+
+        with gzip.open(cache_fpath, "wt") as fh:
+            json.dump(cache, fh)
+
+        return cache
+
+    def all_stmt_prediction_dump(
+            self,
+            unique_stmts_fpath,
+            source_counts_fpath,
+            pair_to_rows_fpath,
+            cache_fpath,
+            total=None,
+            json_loader=json.loads,
+    ):
+        pair_to_rows = self.dump_pair_to_rows(
+            unique_stmts_fpath,
+            source_counts_fpath,
+            pair_to_rows_fpath,
+            total=total,
+            json_loader=json_loader,
+        )
+        return self.dump_agent_pair_consensus_cache(
+            pair_to_rows,
+            cache_fpath,
+        )

--- a/indra/statements/classifier.py
+++ b/indra/statements/classifier.py
@@ -180,7 +180,8 @@ class StatementTypeClassification:
 
     def predict_pair(self, subject, object, simple_result=False):
         df_input = self.build_input_from_rows(
-            self.get_pair_df(subject, object)
+            self.get_pair_df(subject, object),
+            pair_direction=(subject, object),
         )
 
         if df_input.empty:
@@ -197,11 +198,22 @@ class StatementTypeClassification:
 
         return df_input.sort_values("pred_prob", ascending=False)
 
-    def build_input_from_rows(self, rows):
+    def build_input_from_rows(self, rows, pair_direction=None):
         df = pd.DataFrame(rows)
 
         if df.empty:
             return df
+
+        if pair_direction is not None:
+            pair_subject, pair_object = pair_direction
+            mask = (
+                (df["type"] == "Complex")
+                & (df["subject"] == pair_object)
+                & (df["object"] == pair_subject)
+            )
+            df.loc[mask, ["subject", "object"]] = [
+                pair_subject, pair_object
+            ]
 
         df["rel_evidence"] = df["source_count"].apply(lambda x: sum(x.values()))
         df["in_signor"] = df["source_count"].apply(lambda x: int("signor" in x))
@@ -288,7 +300,6 @@ class StatementTypeClassification:
         """
 
         df_input = self.build_input_from_rows(rows)
-
         if df_input.empty:
             return {}
 
@@ -388,18 +399,14 @@ class StatementTypeClassification:
         return mechanism_types
 
     def consensus_from_rows(self, rows, pair_subject=None, pair_object=None):
-        df = self.build_input_from_rows(rows)
+        pair_direction = None
+        if pair_subject is not None and pair_object is not None:
+            pair_direction = (pair_subject, pair_object)
+
+        df = self.build_input_from_rows(rows, pair_direction=pair_direction)
 
         if df.empty:
             return None
-
-        if pair_subject is not None and pair_object is not None:
-            mask = (
-                (df["type"] == "Complex")
-                & (df["subject"] == pair_object)
-                & (df["object"] == pair_subject)
-            )
-            df.loc[mask, ["subject", "object"]] = [pair_subject, pair_object]
 
         df = self._add_predictions(df)
 

--- a/indra/statements/classifier.py
+++ b/indra/statements/classifier.py
@@ -197,16 +197,25 @@ class StatementTypeClassification:
 
         return df
 
-    def predict_pair(self, subject, object):
+    def predict_pair(self, subject, object, simple_result=False):
         df_input = self.build_pair_input(subject, object)
 
         if df_input.empty:
-            return df_input
+            return {} if simple_result else df_input
 
         X = df_input[self.feature_cols].copy()
 
         df_input["pred_prob"] = self.model.predict_proba(X)[:, 1]
         df_input["pred_label"] = self.model.predict(X)
+
+        if simple_result:
+            hash_to_label = {}
+            for _, row in df_input.iterrows():
+                label = int(row["pred_label"])
+                hashes = row["hash"]
+                for stmt_hash in hashes:
+                    hash_to_label[stmt_hash] = label
+            return hash_to_label
 
         first_cols = ["subject", "object", "type", "pred_prob", "pred_label"]
         other_cols = [col for col in df_input.columns if col not in first_cols]

--- a/indra/statements/classifier.py
+++ b/indra/statements/classifier.py
@@ -413,7 +413,25 @@ class StatementTypeClassification:
         true_df = df[df["pred_label"] == 1].copy()
 
         if true_df.empty:
-            return None
+            top = df.sort_values("pred_prob", ascending=False).head(1).copy()
+            row = top.iloc[0]
+            return [
+                {
+                    "subject": row["subject"],
+                    "object": row["object"],
+                    "primary": {
+                        "effect": row["type"],
+                        "support_score": float(row["pred_prob"]),
+                        "effect_rel_evidence": int(row["rel_evidence"]),
+                        "mechanism_rel_evidence": 0,
+                        "effect_types": [row["type"]],
+                        "mechanism_types": [],
+                    },
+                    "alternatives": [],
+                    "true_types": [row["type"]],
+                    "pair_total_evidence": int(row["pair_total_evidence"]),
+                }
+            ]
 
         records = []
 


### PR DESCRIPTION
This PR implements a statement classification model that predicts whether a statement type is correct based on subject-object pair group information. The features include:
- the evidence count for the statement
- whether either agent belongs to a protein family/complex
- the proportion of the statement evidence count within the total evidence count of the subject-object pair group
- the number of sources supporting the statement
- whether an opposite statement type exists within the subject-object pair group
- the ratio between the evidence count of the statement type and its opposite statement type within the pair group
- the total evidence count within the subject-object pair group

This classification class provides the following functionality:
- `predict_pair`: predict results from subject and object agent names
- `predict_from_rows`: predict results from formatted statement rows
- `predict_from_hashes`: predict results from a list of statement hashes


To implement this feature on db.indra.bio, we also have a large-scale process function that generates a dump file containing all consensus statements for each agent pair. We first generate a pair_to_rows cache file and then predict each pair accordingly. We then create another cache file that we can use when deploying the search page. We parse the information and pass it to the /statement and /search endpoints on db.indra.bio. An example tag looks like Binding-> Phosphorylation ->Activation. 