### PR TITLE
Update Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ENV VENV_PATH=$DIRPATH/venv
 RUN python3 -m venv $VENV_PATH
 ENV PATH="$VENV_PATH/bin:$PATH"
+ENV PIP_NO_CACHE_DIR=1
 
 # Install INDRA and dependencies
 RUN git clone https://github.com/gyorilab/indra.git && \
@@ -82,5 +83,6 @@ COPY reach-1.6.3-e48717.jar $REACHPATH
 
 # MTI
 COPY mti_jars.zip $DIRPATH
-RUN mkdir $DIRPATH/mti_jars && \
-    unzip $DIRPATH/mti_jars.zip -d $DIRPATH/mti_jars/
+RUN mkdir -p $DIRPATH/mti_jars && \
+    unzip $DIRPATH/mti_jars.zip -d $DIRPATH/mti_jars/ && \
+    rm $DIRPATH/mti_jars.zip

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILD_BRANCH
 ARG READING_BRANCH
 
 # Set working folder
-ENV DIRPATH /sw
+ENV DIRPATH=/sw
 WORKDIR $DIRPATH
 
 RUN apt-get update && \
@@ -18,13 +18,13 @@ RUN apt-get update && \
 # Set default character encoding
 # See http://stackoverflow.com/questions/27931668/encoding-problems-when-running-an-app-in-docker-python-java-ruby-with-u/27931669
 # See http://stackoverflow.com/questions/39760663/docker-ubuntu-bin-sh-1-locale-gen-not-found
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 # Set environment variables
 ENV BNGPATH=$DIRPATH/BioNetGen-2.4.0
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 # Create python virtual environment
 ENV VENV_PATH=$DIRPATH/venv
@@ -36,13 +36,11 @@ RUN git clone https://github.com/gyorilab/indra.git && \
     cd indra && \
     git checkout $BUILD_BRANCH && \
     git branch && \
-    mkdir /root/.config && \
-    mkdir /root/.config/indra && \
+    mkdir -p /root/.config/indra && \
     echo "[indra]" > /root/.config/indra/config.ini && \
     # Install Python dependencies
     pip install --upgrade pip setuptools wheel && \
     pip install -e .[all] && \
-    pip uninstall -y enum34 && \
     # Pre-build the bio ontology
     python -m indra.ontology.bio build && \
     # Download Adeft models
@@ -66,9 +64,9 @@ RUN git clone https://github.com/indralab/indra_reading.git && \
 # ------------------------------
 # SPARSER
 ENV SPARSERPATH=$DIRPATH/sparser
-ADD r3.core $SPARSERPATH/r3.core
-ADD save-semantics.sh $SPARSERPATH/save-semantics.sh
-ADD version.txt $SPARSERPATH/version.txt
+COPY r3.core $SPARSERPATH/r3.core
+COPY save-semantics.sh $SPARSERPATH/save-semantics.sh
+COPY version.txt $SPARSERPATH/version.txt
 RUN chmod +x $SPARSERPATH/save-semantics.sh && \
     chmod +x $SPARSERPATH/r3.core
 
@@ -76,13 +74,13 @@ RUN chmod +x $SPARSERPATH/save-semantics.sh && \
 # Default character encoding for Java in Docker is not UTF-8, which
 # leads to problems with REACH; so we set option
 # See https://github.com/docker-library/openjdk/issues/32
-ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
+ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 ENV REACHDIR=$DIRPATH/reach
 ENV REACHPATH=$REACHDIR/reach-1.6.3-e48717.jar
 ENV REACH_VERSION=1.6.3-e48717
-ADD reach-1.6.3-e48717.jar $REACHPATH
+COPY reach-1.6.3-e48717.jar $REACHPATH
 
 # MTI
-ADD mti_jars.zip $DIRPATH
+COPY mti_jars.zip $DIRPATH
 RUN mkdir $DIRPATH/mti_jars && \
     unzip $DIRPATH/mti_jars.zip -d $DIRPATH/mti_jars/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,17 +8,16 @@ ENV DIRPATH /sw
 WORKDIR $DIRPATH
 
 RUN apt-get update && \
-    # Install Java
-    apt-get install -y openjdk-8-jdk && \
-    apt-get install -y git wget zip unzip bzip2 gcc graphviz graphviz-dev \
-        pkg-config python3 python3-pip python3.12-venv && \
-    ln -s /usr/bin/python3 /usr/bin/python
+    apt-get install -y openjdk-8-jdk git wget zip unzip bzip2 gcc \
+        graphviz graphviz-dev pkg-config python3 python3-pip \
+        python3.12-venv locales && \
+    locale-gen en_US.UTF-8 && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set default character encoding
 # See http://stackoverflow.com/questions/27931668/encoding-problems-when-running-an-app-in-docker-python-java-ruby-with-u/27931669
 # See http://stackoverflow.com/questions/39760663/docker-ubuntu-bin-sh-1-locale-gen-not-found
-RUN apt-get install -y locales && \
-    locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,5 +84,4 @@ COPY reach-1.6.3-e48717.jar $REACHPATH
 # MTI
 COPY mti_jars.zip $DIRPATH
 RUN mkdir -p $DIRPATH/mti_jars && \
-    unzip $DIRPATH/mti_jars.zip -d $DIRPATH/mti_jars/ && \
-    rm $DIRPATH/mti_jars.zip
+    unzip $DIRPATH/mti_jars.zip -d $DIRPATH/mti_jars/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR $DIRPATH
 RUN apt-get update && \
     # Install Java
     apt-get install -y openjdk-8-jdk && \
-    # jnius-indra requires cython which requires gcc
     apt-get install -y git wget zip unzip bzip2 gcc graphviz graphviz-dev \
         pkg-config python3 python3-pip python3.12-venv && \
     ln -s /usr/bin/python3 /usr/bin/python
@@ -22,7 +21,7 @@ RUN apt-get install -y locales && \
     locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8  #
+ENV LC_ALL en_US.UTF-8
 
 # Set environment variables
 ENV BNGPATH=$DIRPATH/BioNetGen-2.4.0
@@ -55,9 +54,7 @@ RUN git clone https://github.com/gyorilab/indra.git && \
     cd $DIRPATH && \
     wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" \
         -O bionetgen.tar.gz -nv && \
-    tar xzf bionetgen.tar.gz && \
-    # Install things related to API deployment
-    pip install gunicorn
+    tar xzf bionetgen.tar.gz
 
 # Install indra_reading
 RUN git clone https://github.com/indralab/indra_reading.git && \


### PR DESCRIPTION
This PR does some minor cleanup on the Docker build as a follow-up to #1503. Specifically
- Change ADD to COPY
- Consolidate apt installs and avoid putting apt and pip cache into image
- Remove some unnecessary/outdated explicit installs
- Update deprecated ENV usage