### PR TITLE
Optimize sqlite ontology build size

### DIFF
--- a/indra/ontology/bio/sqlite_ontology.py
+++ b/indra/ontology/bio/sqlite_ontology.py
@@ -3,6 +3,7 @@ INDRA BioOntology."""
 
 import os
 import json
+import zlib
 import sqlite3
 import logging
 import threading
@@ -15,6 +16,14 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_SQLITE_ONTOLOGY = os.path.join(CACHE_DIR, 'bio_ontology.db')
+
+
+def _zip(text):
+    return zlib.compress(text.encode('utf-8'))
+
+
+def _unzip(blob):
+    return zlib.decompress(blob).decode('utf-8')
 
 
 class SqliteOntology(IndraOntology):
@@ -53,7 +62,7 @@ class SqliteOntology(IndraOntology):
         res = self.cur.fetchone()
         if res is None:
             return False
-        return '%s:%s|isa_or_partof' % (ns2, id2) in res[0].split(',')
+        return '%s:%s|isa_or_partof' % (ns2, id2) in _unzip(res[0]).split(',')
 
     def child_rel(self, ns, id, rel_types):
         q = """SELECT children FROM child_lookup
@@ -66,7 +75,7 @@ class SqliteOntology(IndraOntology):
         if res is None:
             yield from []
         else:
-            children = res[0].split(',')
+            children = _unzip(res[0]).split(',')
             for child in children:
                 curie, rel_type = child.split('|', 1)
                 if rel_type in rel_types:
@@ -97,7 +106,7 @@ class SqliteOntology(IndraOntology):
         if res is None:
             yield from []
         else:
-            parents = res[0].split(',')
+            parents = _unzip(res[0]).split(',')
             for parent in parents:
                 curie, rel_type = parent.split('|', 1)
                 if rel_type in rel_types:
@@ -114,8 +123,27 @@ class SqliteOntology(IndraOntology):
         props = json.loads(res[0])
         return props.get(property)
 
+    def get_name(self, ns, id):
+        q = """SELECT name FROM node_properties
+               WHERE id=? AND ns=?
+               LIMIT 1;"""
+        self.cur.execute(q, (id, ns))
+        res = self.cur.fetchone()
+        return res[0] if res is not None else None
+
     def get_id_from_name(self, ns, name):
+        q = """SELECT id, properties FROM node_properties
+               WHERE ns=? AND name=?;"""
+        self.cur.execute(q, (ns, name))
+        for node_id, props in self.cur.fetchall():
+            if not json.loads(props).get('obsolete', False):
+                return (ns, node_id)
         return None
+
+    def nodes_from_suffix(self, suffix):
+        self.cur.execute("SELECT ns, id FROM node_properties;")
+        return [self.label(ns, id) for ns, id in self.cur.fetchall()
+                if self.label(ns, id).endswith(suffix)]
 
 
 def build_sqlite_ontology(db_path=DEFAULT_SQLITE_ONTOLOGY, force=False):
@@ -176,25 +204,25 @@ def build_sqlite_ontology(db_path=DEFAULT_SQLITE_ONTOLOGY, force=False):
     q = """CREATE TABLE child_lookup (
         parent_id TEXT NOT NULL,
         parent_ns TEXT NOT NULL,
-        children TEXT NOT NULL,
-        UNIQUE (parent_id, parent_ns)
-    );"""
+        children BLOB NOT NULL,
+        PRIMARY KEY (parent_id, parent_ns)
+    ) WITHOUT ROWID;"""
     cur.execute(q)
     q = """CREATE TABLE parent_lookup (
         child_id TEXT NOT NULL,
         child_ns TEXT NOT NULL,
-        parents TEXT NOT NULL,
-        UNIQUE (child_id, child_ns)
-    );"""
+        parents BLOB NOT NULL,
+        PRIMARY KEY (child_id, child_ns)
+    ) WITHOUT ROWID;"""
     cur.execute(q)
     for (pid, pns), children in all_children.items():
         cur.execute("INSERT INTO child_lookup (parent_id, parent_ns, children) "
                     "VALUES (?, ?, ?);",
-                    (pid, pns, ','.join(children)))
+                    (pid, pns, _zip(','.join(children))))
     for (cid, cns), parents in all_parents.items():
         cur.execute("INSERT INTO parent_lookup (child_id, child_ns, parents) "
                     "VALUES (?, ?, ?);",
-                    (cid, cns, ','.join(parents)))
+                    (cid, cns, _zip(','.join(parents))))
 
     # Create node property table
     # Here we just keep track of the namespace and ID,
@@ -202,16 +230,22 @@ def build_sqlite_ontology(db_path=DEFAULT_SQLITE_ONTOLOGY, force=False):
     q = """CREATE TABLE node_properties (
         id TEXT NOT NULL,
         ns TEXT NOT NULL,
+        name TEXT,
         properties TEXT NOT NULL,
-        UNIQUE (id, ns)
-    );"""
+        PRIMARY KEY (id, ns)
+    ) WITHOUT ROWID;"""
     cur.execute(q)
 
     for node in bio_ontology.nodes:
         ns, id = bio_ontology.get_ns_id(node)
-        props = json.dumps(bio_ontology.nodes[node])
-        cur.execute("INSERT INTO node_properties (id, ns, properties) "
-                    "VALUES (?, ?, ?);", (id, ns, props))
+        data = bio_ontology.nodes[node]
+        name = data.get('name')
+        props = {k: v for k, v in data.items() if k != 'name'}
+        cur.execute("INSERT INTO node_properties (id, ns, name, properties) "
+                    "VALUES (?, ?, ?, ?);", (id, ns, name, json.dumps(props)))
+
+    cur.execute("CREATE INDEX idx_node_name ON node_properties (ns, name) "
+                "WHERE name IS NOT NULL;")
 
     conn.commit()
     conn.execute("VACUUM")

--- a/indra/ontology/bio/sqlite_ontology.py
+++ b/indra/ontology/bio/sqlite_ontology.py
@@ -44,11 +44,16 @@ class SqliteOntology(IndraOntology):
         pass
 
     def isa_or_partof(self, ns1, id1, ns2, id2):
-        q = """SELECT 1 FROM relationships
-               WHERE child_id=? AND child_ns=? AND parent_id=? AND parent_ns=?
+        # Ontological parents (isa/partof ancestors) of a node are stored in
+        # child_lookup, keyed by that node (see get_parents/child_rel).
+        q = """SELECT children FROM child_lookup
+               WHERE parent_id=? AND parent_ns=?
                LIMIT 1;"""
-        self.cur.execute(q, (id1, ns1, id2, ns2))
-        return self.cur.fetchone() is not None
+        self.cur.execute(q, (id1, ns1))
+        res = self.cur.fetchone()
+        if res is None:
+            return False
+        return '%s:%s|isa_or_partof' % (ns2, id2) in res[0].split(',')
 
     def child_rel(self, ns, id, rel_types):
         q = """SELECT children FROM child_lookup
@@ -135,19 +140,7 @@ def build_sqlite_ontology(db_path=DEFAULT_SQLITE_ONTOLOGY, force=False):
     cur = conn.cursor()
 
     logger.info('Building SQLite ontology at %s' % db_path)
-    # First, we create the relationships table and populate
-    # it with child/parent pairs
-    q = """CREATE TABLE relationships (
-        child_id TEXT NOT NULL,
-        child_ns TEXT NOT NULL,
-        parent_id TEXT NOT NULL,
-        parent_ns TEXT NOT NULL,
-        rel_type TEXT NOT NULL,
-        UNIQUE (child_id, child_ns, parent_id, parent_ns)
-    );"""
-    cur.execute(q)
-
-    # Insert into the database in chunks
+    # Build the child/parent lookup contents in chunks
     chunk_size = 10000
     # Note: the transitive closure consists of pairs with the first element
     # being the ontological child and the second the parent. However,
@@ -167,10 +160,6 @@ def build_sqlite_ontology(db_path=DEFAULT_SQLITE_ONTOLOGY, force=False):
                 '%s:%s|%s' % (cns, cid, 'isa_or_partof'))
             all_parents[(cid, cns)].add(
                 '%s:%s|%s' % (pns, pid, 'isa_or_partof'))
-        cur.executemany("""INSERT INTO relationships (parent_id, 
-                            parent_ns, child_id, child_ns, rel_type)
-                            VALUES (?, ?, ?, ?, 'isa_or_partof');""",
-                        chunk_values)
 
     for parent, child, data in bio_ontology.edges(data=True):
         parent_ns, parent_id = bio_ontology.get_ns_id(parent)
@@ -182,14 +171,6 @@ def build_sqlite_ontology(db_path=DEFAULT_SQLITE_ONTOLOGY, force=False):
             '%s:%s|%s' % (child_ns, child_id, rel_type))
         all_parents[(child_id, child_ns)].add(
             '%s:%s|%s' % (parent_ns, parent_id, rel_type))
-        cur.execute("""INSERT INTO relationships (parent_id,
-                        parent_ns, child_id, child_ns, rel_type)
-                        VALUES (?, ?, ?, ?, ?);""",
-                    (parent_id, parent_ns, child_id, child_ns, rel_type))
-
-    q = """CREATE INDEX idx_child_parent ON relationships 
-        (child_id, child_ns, parent_id, parent_ns);"""
-    cur.execute(q)
 
     # Next, create child and parent lookup tables and populate them
     q = """CREATE TABLE child_lookup (
@@ -214,13 +195,6 @@ def build_sqlite_ontology(db_path=DEFAULT_SQLITE_ONTOLOGY, force=False):
         cur.execute("INSERT INTO parent_lookup (child_id, child_ns, parents) "
                     "VALUES (?, ?, ?);",
                     (cid, cns, ','.join(parents)))
-    # Now add indices to the lookup tables
-    q = """CREATE INDEX idx_child_lookup ON child_lookup 
-        (parent_id, parent_ns);"""
-    cur.execute(q)
-    q = """CREATE INDEX idx_parent_lookup ON parent_lookup 
-        (child_id, child_ns);"""
-    cur.execute(q)
 
     # Create node property table
     # Here we just keep track of the namespace and ID,
@@ -240,5 +214,6 @@ def build_sqlite_ontology(db_path=DEFAULT_SQLITE_ONTOLOGY, force=False):
                     "VALUES (?, ?, ?);", (id, ns, props))
 
     conn.commit()
+    conn.execute("VACUUM")
     conn.close()
     logger.info('Finished building SQLite ontology')


### PR DESCRIPTION
This PR makes improvements to the sqlite ontology backend to significantly decrease the size making it a better fit for Dockerized deployments. The changes are
- Remove redundant indexes that are already created via UNIQUE
- Compress child_lookup/parent_lookup values since these are often long lists of nodes
- Remove redundant relationships table
- Fix name lookup and isa_partof checking
- Add a vacuum at the end of the build

This decreases the .db's size from ~3.3 GB to ~710MB without a negative effect on performance.