### PR TITLE
Fixed Pybel processor to process negative modification type

### DIFF
--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -240,7 +240,10 @@ class PybelProcessor(object):
             self.unhandled.append((u_data, v_data, k, edge_data))
             return
         for mod in mods:
-            modclass = modtype_to_modclass[mod.mod_type]
+            mod_type = mod.mod_type
+            if edge_data[pc.RELATION] not in pc.CAUSAL_INCREASE_RELATIONS:
+                mod_type = modtype_to_inverse.get(mod_type)
+            modclass = modtype_to_modclass[mod_type]
             ev = self._get_evidence(u_data, v_data, k, edge_data)
             stmt = modclass(subj_agent, obj_agent, mod.residue, mod.position,
                             evidence=[ev])

--- a/indra/sources/bel/processor.py
+++ b/indra/sources/bel/processor.py
@@ -241,7 +241,7 @@ class PybelProcessor(object):
             return
         for mod in mods:
             mod_type = mod.mod_type
-            if edge_data[pc.RELATION] not in pc.CAUSAL_INCREASE_RELATIONS:
+            if edge_data[pc.RELATION] in pc.CAUSAL_DECREASE_RELATIONS:
                 mod_type = modtype_to_inverse.get(mod_type)
             modclass = modtype_to_modclass[mod_type]
             ev = self._get_evidence(u_data, v_data, k, edge_data)

--- a/indra/tests/test_pybel_api.py
+++ b/indra/tests/test_pybel_api.py
@@ -816,3 +816,42 @@ def test_process_bel_stmts():
     assert isinstance(bp.statements[0], Activation), bp.statements
     assert bp.statements[0].subj.name == 'lipoprotein', bp.statements
     assert bp.statements[0].obj.name == 'inflammatory response', bp.statements
+
+
+def test_dephosphorylation():
+    mek = Protein(name='DUSP4', namespace='HGNC')
+    erk = Protein(name='MAPK1', namespace='HGNC',
+                  variants=[pmod('Ph', position=185, code='Thr')])
+    g = BELGraph()
+    g.annotation_list['TextLocation'] = {'Abstract'}
+    ev_text = 'Some evidence.'
+    ev_pmid = '123456'
+    edge_hash = g.add_directly_decreases(
+        mek, erk, evidence=ev_text,
+        citation=ev_pmid,
+        annotations={"TextLocation": 'Abstract'},
+    )
+    pbp = bel.process_pybel_graph(g)
+    assert pbp.statements
+    assert len(pbp.statements) == 1
+    assert isinstance(pbp.statements[0], Dephosphorylation), pbp.statements
+    assert pbp.statements[0].residue == 'T'
+    assert pbp.statements[0].position == '185'
+    enz = pbp.statements[0].enz
+    sub = pbp.statements[0].sub
+    assert enz.name == 'DUSP4'
+    assert enz.mods == []
+    assert sub.name == 'MAPK1'
+    assert sub.mods == []
+    # Check evidence
+    assert len(pbp.statements[0].evidence) == 1
+    ev = pbp.statements[0].evidence[0]
+    assert ev.source_api == 'bel'
+    assert ev.source_id == edge_hash
+    assert ev.pmid == ev_pmid, (ev.pmid, ev_pmid)
+    assert ev.text == ev_text
+    assert ev.annotations == {
+        'bel': 'p(HGNC:DUSP4) directlyDecreases '
+               'p(HGNC:MAPK1, pmod(go:0006468 ! "protein phosphorylation", Thr, 185))'
+    }
+    assert ev.epistemics == {'direct': True, 'section_type': 'abstract'}


### PR DESCRIPTION
This PR makes _get_modification() in PybelProcessor take edge information (e.g., decrease) into account, so that statement types like dephosphorylation can be captured. 